### PR TITLE
App Name Correction and Adding New App Chat Artifact

### DIFF
--- a/scripts/artifacts/ChessWithFriends.py
+++ b/scripts/artifacts/ChessWithFriends.py
@@ -4,7 +4,7 @@ import textwrap
 from scripts.artifact_report import ArtifactHtmlReport
 from scripts.ilapfuncs import logfunc, tsv, is_platform_windows
 
-def get_ChessWithFriendsChats(files_found, report_folder, seeker):
+def get_ChessWithFriends(files_found, report_folder, seeker):
     
     file_found = str(files_found[0])
     db = sqlite3.connect(file_found)
@@ -30,7 +30,7 @@ def get_ChessWithFriendsChats(files_found, report_folder, seeker):
     usageentries = len(all_rows)
     if usageentries > 0:
         report = ArtifactHtmlReport('Chats')
-        report.start_artifact_report(report_folder, 'Chess With Friends Chats')
+        report.start_artifact_report(report_folder, 'Chess With Friends')
         report.add_script()
         data_headers = ('Message_ID','User_Name','User_Email','Chat_Message','Chat_Message_Creation' ) # Don't remove the comma, that is required to make this a tuple as there is only 1 element
         data_list = []
@@ -43,7 +43,7 @@ def get_ChessWithFriendsChats(files_found, report_folder, seeker):
         tsvname = f'Chess With Friends Chats'
         tsv(report_folder, data_headers, data_list, tsvname)
     else:
-        logfunc('No Chess With Friends Chats data available')
+        logfunc('No Chess With Friends data available')
     
     db.close()
     return

--- a/scripts/artifacts/ChessWithFriendsChats.py
+++ b/scripts/artifacts/ChessWithFriendsChats.py
@@ -4,7 +4,7 @@ import textwrap
 from scripts.artifact_report import ArtifactHtmlReport
 from scripts.ilapfuncs import logfunc, tsv, is_platform_windows
 
-def get_zyngachessChats(files_found, report_folder, seeker):
+def get_ChessWithFriendsChats(files_found, report_folder, seeker):
     
     file_found = str(files_found[0])
     db = sqlite3.connect(file_found)
@@ -30,7 +30,7 @@ def get_zyngachessChats(files_found, report_folder, seeker):
     usageentries = len(all_rows)
     if usageentries > 0:
         report = ArtifactHtmlReport('Chats')
-        report.start_artifact_report(report_folder, 'Zynga Chess Chats')
+        report.start_artifact_report(report_folder, 'Chess With Friends Chats')
         report.add_script()
         data_headers = ('Message_ID','User_Name','User_Email','Chat_Message','Chat_Message_Creation' ) # Don't remove the comma, that is required to make this a tuple as there is only 1 element
         data_list = []
@@ -40,10 +40,10 @@ def get_zyngachessChats(files_found, report_folder, seeker):
         report.write_artifact_data_table(data_headers, data_list, file_found)
         report.end_artifact_report()
         
-        tsvname = f'zynga chess chats'
+        tsvname = f'Chess With Friends Chats'
         tsv(report_folder, data_headers, data_list, tsvname)
     else:
-        logfunc('No zynga chess chats data available')
+        logfunc('No Chess With Friends Chats data available')
     
     db.close()
     return

--- a/scripts/artifacts/WordsWithFriends.py
+++ b/scripts/artifacts/WordsWithFriends.py
@@ -15,7 +15,8 @@ def get_WordsWithFriends(files_found, report_folder, seeker):
 	users.name,
 	users.email_address,
 	messages.text,
-	messages(created_at / 1000000 + (strftime('%s', '1601-01-01')), "unixepoch")
+	messages.created_at
+	datetime(created_at/1000, 'unixepoch', 'localtime') as dates from messages
 	FROM
 	messages
 	INNER JOIN

--- a/scripts/artifacts/WordsWithFriends.py
+++ b/scripts/artifacts/WordsWithFriends.py
@@ -16,7 +16,7 @@ def get_WordsWithFriends(files_found, report_folder, seeker):
 	users.email_address,
 	messages.text,
 	messages.created_at
-	datetime(created_at/1000, 'unixepoch', 'localtime') as dates from messages
+	datetime(created_at/1000, 'unixepoch') as dates from messages
 	FROM
 	messages
 	INNER JOIN
@@ -24,7 +24,7 @@ def get_WordsWithFriends(files_found, report_folder, seeker):
 	ON
 	messages.user_zynga_id=users.zynga_account_id
 	ORDER BY
-	datetime DESC
+	dates DESC
     ''')
 
     all_rows = cursor.fetchall()

--- a/scripts/artifacts/WordsWithFriends.py
+++ b/scripts/artifacts/WordsWithFriends.py
@@ -16,6 +16,7 @@ def get_WordsWithFriends(files_found, report_folder, seeker):
 	users.email_address,
 	messages.text,
 	messages.created_at
+	datetime(messages.created_at / 1000000 + (strftime('%s', '1601-01-01')), "unixepoch")
 	FROM
 	messages
 	INNER JOIN
@@ -23,7 +24,7 @@ def get_WordsWithFriends(files_found, report_folder, seeker):
 	ON
 	messages.user_zynga_id=users.zynga_account_id
 	ORDER BY
-	messages.created_at DESC
+	datetime DESC
     ''')
 
     all_rows = cursor.fetchall()

--- a/scripts/artifacts/WordsWithFriends.py
+++ b/scripts/artifacts/WordsWithFriends.py
@@ -15,8 +15,7 @@ def get_WordsWithFriends(files_found, report_folder, seeker):
 	users.name,
 	users.email_address,
 	messages.text,
-	messages.created_at,
-	datetime(created_at/1000, 'unixepoch')
+	datetime(messages.created_at/1000, 'unixepoch')
 	FROM
 	messages
 	INNER JOIN

--- a/scripts/artifacts/WordsWithFriends.py
+++ b/scripts/artifacts/WordsWithFriends.py
@@ -11,19 +11,19 @@ def get_WordsWithFriends(files_found, report_folder, seeker):
     cursor = db.cursor()
     cursor.execute('''
     SELECT
-	chat_messages.chat_message_id,
+	messages.conv_id,
 	users.name,
 	users.email_address,
-	chat_messages.message,
-	chat_messages.created_at
+	messages.text,
+	messages.created_at
 	FROM
-	chat_messages
+	messages
 	INNER JOIN
 	users
 	ON
-	chat_messages.user_id=users.user_id
+	messages.user_zynga_id=users.zynga_account_id
 	ORDER BY
-	chat_messages.created_at DESC
+	messages.created_at DESC
     ''')
 
     all_rows = cursor.fetchall()

--- a/scripts/artifacts/WordsWithFriends.py
+++ b/scripts/artifacts/WordsWithFriends.py
@@ -1,0 +1,49 @@
+import sqlite3
+import textwrap
+
+from scripts.artifact_report import ArtifactHtmlReport
+from scripts.ilapfuncs import logfunc, tsv, is_platform_windows
+
+def get_WordsWithFriends(files_found, report_folder, seeker):
+    
+    file_found = str(files_found[0])
+    db = sqlite3.connect(file_found)
+    cursor = db.cursor()
+    cursor.execute('''
+    SELECT
+	chat_messages.chat_message_id,
+	users.name,
+	users.email_address,
+	chat_messages.message,
+	chat_messages.created_at
+	FROM
+	chat_messages
+	INNER JOIN
+	users
+	ON
+	chat_messages.user_id=users.user_id
+	ORDER BY
+	chat_messages.created_at DESC
+    ''')
+
+    all_rows = cursor.fetchall()
+    usageentries = len(all_rows)
+    if usageentries > 0:
+        report = ArtifactHtmlReport('Chats')
+        report.start_artifact_report(report_folder, 'Words With Friends')
+        report.add_script()
+        data_headers = ('Message_ID','User_Name','User_Email','Chat_Message','Chat_Message_Creation' ) # Don't remove the comma, that is required to make this a tuple as there is only 1 element
+        data_list = []
+        for row in all_rows:
+            data_list.append((row[0],row[1],row[2],row[3],row[4]))
+
+        report.write_artifact_data_table(data_headers, data_list, file_found)
+        report.end_artifact_report()
+        
+        tsvname = f'Words With Friends Chats'
+        tsv(report_folder, data_headers, data_list, tsvname)
+    else:
+        logfunc('No Words With Friends data available')
+    
+    db.close()
+    return

--- a/scripts/artifacts/WordsWithFriends.py
+++ b/scripts/artifacts/WordsWithFriends.py
@@ -15,8 +15,8 @@ def get_WordsWithFriends(files_found, report_folder, seeker):
 	users.name,
 	users.email_address,
 	messages.text,
-	messages.created_at
-	datetime(created_at/1000, 'unixepoch') as dates from messages
+	messages.created_at,
+	datetime(created_at/1000, 'unixepoch')
 	FROM
 	messages
 	INNER JOIN
@@ -24,7 +24,7 @@ def get_WordsWithFriends(files_found, report_folder, seeker):
 	ON
 	messages.user_zynga_id=users.zynga_account_id
 	ORDER BY
-	dates DESC
+	messages.created_at DESC
     ''')
 
     all_rows = cursor.fetchall()

--- a/scripts/artifacts/WordsWithFriends.py
+++ b/scripts/artifacts/WordsWithFriends.py
@@ -15,8 +15,7 @@ def get_WordsWithFriends(files_found, report_folder, seeker):
 	users.name,
 	users.email_address,
 	messages.text,
-	messages.created_at
-	datetime(messages.created_at / 1000000 + (strftime('%s', '1601-01-01')), "unixepoch")
+	messages(created_at / 1000000 + (strftime('%s', '1601-01-01')), "unixepoch")
 	FROM
 	messages
 	INNER JOIN

--- a/scripts/ilap_artifacts.py
+++ b/scripts/ilap_artifacts.py
@@ -48,7 +48,7 @@ from scripts.artifacts.wellbeing import get_wellbeing
 from scripts.artifacts.swellbeing import get_swellbeing
 from scripts.artifacts.wellbeingaccount import get_wellbeingaccount
 from scripts.artifacts.wifiProfiles import get_wifiProfiles
-from scripts.artifacts.zyngachessChats import get_zyngachessChats
+from scripts.artifacts.ChessWithFriendsChats import get_ChessWithFriendsChats
 
 from scripts.ilapfuncs import *
 
@@ -103,7 +103,7 @@ tosearch = {
     'smanagerLow':('App Interaction', '**/com.samsung.android.sm/databases/lowpowercontext-system-db'),
     'smanagerCrash':('App Interaction', '**/com.samsung.android.sm/databases/sm.db'),
     'scontextLog':('App Interaction', '**/com.samsung.android.providers.context/databases/ContextLog.db'),
-    'zyngachessChats':('Chats', '**/com.zynga.chess.googleplay/databases/wf_database.sqlite')
+    'ChessWithFriends':('Chats', '**/com.zynga.chess.googleplay/databases/wf_database.sqlite')
     }
 '''
 tosearch = {'journalStrings':('SQLite Journaling', '**/*-journal'),

--- a/scripts/ilap_artifacts.py
+++ b/scripts/ilap_artifacts.py
@@ -49,6 +49,7 @@ from scripts.artifacts.swellbeing import get_swellbeing
 from scripts.artifacts.wellbeingaccount import get_wellbeingaccount
 from scripts.artifacts.wifiProfiles import get_wifiProfiles
 from scripts.artifacts.ChessWithFriends import get_ChessWithFriends
+from scripts.artifacts.WordsWithFriends import get_WordsWithFriends
 
 from scripts.ilapfuncs import *
 
@@ -104,7 +105,8 @@ tosearch = {
     'smanagerCrash':('App Interaction', '**/com.samsung.android.sm/databases/sm.db'),
     'scontextLog':('App Interaction', '**/com.samsung.android.providers.context/databases/ContextLog.db'),
     'ChessWithFriends':('Chats', '**/com.zynga.chess.googleplay/databases/wf_database.sqlite'),
-    'ChessWithFriends':('Chats', '**/com.zynga.chess.googleplay/db/wf_database.sqlite')
+    'ChessWithFriends':('Chats', '**/com.zynga.chess.googleplay/db/wf_database.sqlite'),
+    'WordsWithFriends':('Chats', '**/com.zynga.words/db/wf_database.sqlite')
     }
 '''
 tosearch = {'journalStrings':('SQLite Journaling', '**/*-journal'),

--- a/scripts/ilap_artifacts.py
+++ b/scripts/ilap_artifacts.py
@@ -48,7 +48,7 @@ from scripts.artifacts.wellbeing import get_wellbeing
 from scripts.artifacts.swellbeing import get_swellbeing
 from scripts.artifacts.wellbeingaccount import get_wellbeingaccount
 from scripts.artifacts.wifiProfiles import get_wifiProfiles
-from scripts.artifacts.ChessWithFriendsChats import get_ChessWithFriendsChats
+from scripts.artifacts.ChessWithFriends import get_ChessWithFriends
 
 from scripts.ilapfuncs import *
 

--- a/scripts/ilap_artifacts.py
+++ b/scripts/ilap_artifacts.py
@@ -103,7 +103,8 @@ tosearch = {
     'smanagerLow':('App Interaction', '**/com.samsung.android.sm/databases/lowpowercontext-system-db'),
     'smanagerCrash':('App Interaction', '**/com.samsung.android.sm/databases/sm.db'),
     'scontextLog':('App Interaction', '**/com.samsung.android.providers.context/databases/ContextLog.db'),
-    'ChessWithFriends':('Chats', '**/com.zynga.chess.googleplay/databases/wf_database.sqlite')
+    'ChessWithFriends':('Chats', '**/com.zynga.chess.googleplay/databases/wf_database.sqlite'),
+    'ChessWithFriends':('Chats', '**/com.zynga.chess.googleplay/db/wf_database.sqlite')
     }
 '''
 tosearch = {'journalStrings':('SQLite Journaling', '**/*-journal'),


### PR DESCRIPTION
Renamed the Zynga Chess Chats to Chess with Friends.

After installing a current versions of Chess with Friends and Words with Friends on a current Android OS (Android 10) and obtaining an ADB backup, some of the folder structures/naming had changed, so modifications to GREP searching in ilap_artifacts.py for the databases were made.  

Words with Friends had changed some of the table names for their in-app chats as well as timestamps, so modifications were made to the SQL Query.  