### PR TITLE
sqlite open as readonly db

### DIFF
--- a/scripts/artifacts/ChessWithFriends.py
+++ b/scripts/artifacts/ChessWithFriends.py
@@ -2,12 +2,12 @@ import sqlite3
 import textwrap
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, open_sqlite_db_readonly
 
 def get_ChessWithFriends(files_found, report_folder, seeker):
     
     file_found = str(files_found[0])
-    db = sqlite3.connect(file_found)
+    db = open_sqlite_db_readonly(file_found)
     cursor = db.cursor()
     cursor.execute('''
     SELECT

--- a/scripts/artifacts/WordsWithFriends.py
+++ b/scripts/artifacts/WordsWithFriends.py
@@ -2,12 +2,12 @@ import sqlite3
 import textwrap
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
 def get_WordsWithFriends(files_found, report_folder, seeker):
     
     file_found = str(files_found[0])
-    db = sqlite3.connect(file_found)
+    db = open_sqlite_db_readonly(file_found)
     cursor = db.cursor()
     cursor.execute('''
     SELECT

--- a/scripts/artifacts/accounts_ce.py
+++ b/scripts/artifacts/accounts_ce.py
@@ -5,7 +5,7 @@ import shutil
 import sqlite3
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, open_sqlite_db_readonly
 
 def get_accounts_ce(files_found, report_folder, seeker):
 
@@ -28,7 +28,7 @@ def get_accounts_ce(files_found, report_folder, seeker):
 def process_accounts_ce(folder, uid, report_folder):
     
     #Query to create report
-    db = sqlite3.connect(folder)
+    db = open_sqlite_db_readonly(folder)
     cursor = db.cursor()
 
     #Query to create report

--- a/scripts/artifacts/accounts_ce_authtokens.py
+++ b/scripts/artifacts/accounts_ce_authtokens.py
@@ -5,7 +5,7 @@ import shutil
 import sqlite3
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, open_sqlite_db_readonly
 
 def get_accounts_ce_authtokens(files_found, report_folder, seeker):
 
@@ -28,7 +28,7 @@ def get_accounts_ce_authtokens(files_found, report_folder, seeker):
 def process_accounts_ce_authtokens(folder, uid, report_folder):
     
     #Query to create report
-    db = sqlite3.connect(folder)
+    db = open_sqlite_db_readonly(folder)
     cursor = db.cursor()
 
     #Query to create report

--- a/scripts/artifacts/accounts_de.py
+++ b/scripts/artifacts/accounts_de.py
@@ -5,7 +5,7 @@ import shutil
 import sqlite3
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
 def get_accounts_de(files_found, report_folder, seeker):
 
@@ -28,7 +28,7 @@ def get_accounts_de(files_found, report_folder, seeker):
 def process_accounts_de(folder, uid, report_folder):
     
     #Query to create report
-    db = sqlite3.connect(folder)
+    db = open_sqlite_db_readonly(folder)
     cursor = db.cursor()
 
     #Query to create report

--- a/scripts/artifacts/appicons.py
+++ b/scripts/artifacts/appicons.py
@@ -4,7 +4,7 @@ import os
 import sqlite3
 from html import escape
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
 is_windows = is_platform_windows()
 slash = '\\' if is_windows else '/' 
@@ -29,7 +29,7 @@ def get_appicons(files_found, report_folder, seeker):
             continue
         
         file_name = os.path.basename(file_found)
-        db = sqlite3.connect(file_found)
+        db = open_sqlite_db_readonly(file_found)
         db.row_factory = sqlite3.Row # For fetching columns by name
 
         cursor = db.cursor()

--- a/scripts/artifacts/calllog.py
+++ b/scripts/artifacts/calllog.py
@@ -1,12 +1,12 @@
 import sqlite3
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline 
+from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
 
 def get_calllog(files_found, report_folder, seeker):
     
     file_found = str(files_found[0])
-    db = sqlite3.connect(file_found)
+    db = open_sqlite_db_readonly(file_found)
     cursor = db.cursor()
     cursor.execute('''
     SELECT

--- a/scripts/artifacts/chrome.py
+++ b/scripts/artifacts/chrome.py
@@ -3,7 +3,7 @@ import sqlite3
 import textwrap
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, get_next_unused_name
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, get_next_unused_name, open_sqlite_db_readonly
 
 def get_chrome(files_found, report_folder, seeker):
     
@@ -17,7 +17,7 @@ def get_chrome(files_found, report_folder, seeker):
         if file_found.find('app_sbrowser') >= 0:
             browser_name = 'Browser'
 
-        db = sqlite3.connect(file_found)
+        db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
         select

--- a/scripts/artifacts/chromeCookies.py
+++ b/scripts/artifacts/chromeCookies.py
@@ -3,7 +3,7 @@ import sqlite3
 import textwrap
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, get_next_unused_name
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, get_next_unused_name, open_sqlite_db_readonly
 
 def get_chromeCookies(files_found, report_folder, seeker):
     
@@ -17,7 +17,7 @@ def get_chromeCookies(files_found, report_folder, seeker):
         elif file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
             continue # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data??
 
-        db = sqlite3.connect(file_found)
+        db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
         SELECT

--- a/scripts/artifacts/chromeDownloads.py
+++ b/scripts/artifacts/chromeDownloads.py
@@ -3,7 +3,7 @@ import sqlite3
 import textwrap
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, get_next_unused_name, does_column_exist_in_db
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, get_next_unused_name, does_column_exist_in_db, open_sqlite_db_readonly
 
 def get_chromeDownloads(files_found, report_folder, seeker):
     
@@ -17,7 +17,7 @@ def get_chromeDownloads(files_found, report_folder, seeker):
         elif file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
             continue # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data??
 
-        db = sqlite3.connect(file_found)
+        db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
 
         # check for last_access_time column, an older version of chrome db (32) does not have it

--- a/scripts/artifacts/chromeLoginData.py
+++ b/scripts/artifacts/chromeLoginData.py
@@ -6,7 +6,7 @@ import sqlite3
 from Crypto.Cipher import AES
 from Crypto.Protocol.KDF import PBKDF2
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, get_next_unused_name
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, get_next_unused_name, open_sqlite_db_readonly
 
 def decrypt(ciphertxt, key=b"peanuts"):
     if re.match(rb"^v1[01]",ciphertxt): 
@@ -53,7 +53,7 @@ def get_chromeLoginData(files_found, report_folder, seeker):
         elif file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
             continue # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data??
 
-        db = sqlite3.connect(file_found)
+        db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
         SELECT

--- a/scripts/artifacts/chromeOfflinePages.py
+++ b/scripts/artifacts/chromeOfflinePages.py
@@ -3,7 +3,7 @@ import sqlite3
 import textwrap
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, get_next_unused_name
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, get_next_unused_name, open_sqlite_db_readonly
 
 def get_chromeOfflinePages(files_found, report_folder, seeker):
     
@@ -17,7 +17,7 @@ def get_chromeOfflinePages(files_found, report_folder, seeker):
         elif file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
             continue # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data??
 
-        db = sqlite3.connect(file_found)
+        db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
         SELECT

--- a/scripts/artifacts/chromeSearchTerms.py
+++ b/scripts/artifacts/chromeSearchTerms.py
@@ -3,7 +3,7 @@ import sqlite3
 import textwrap
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, get_next_unused_name
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, get_next_unused_name, open_sqlite_db_readonly
 
 def get_chromeSearchTerms(files_found, report_folder, seeker):
     
@@ -17,7 +17,7 @@ def get_chromeSearchTerms(files_found, report_folder, seeker):
         elif file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
             continue # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data??
 
-        db = sqlite3.connect(file_found)
+        db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
         SELECT

--- a/scripts/artifacts/chromeTopSites.py
+++ b/scripts/artifacts/chromeTopSites.py
@@ -2,7 +2,7 @@ import os
 import sqlite3
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, get_next_unused_name
+from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, get_next_unused_name, open_sqlite_db_readonly
 
 def get_chromeTopSites(files_found, report_folder, seeker):
     
@@ -16,7 +16,7 @@ def get_chromeTopSites(files_found, report_folder, seeker):
         elif file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
             continue # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data??
 
-        db = sqlite3.connect(file_found)
+        db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
         select

--- a/scripts/artifacts/chromeWebsearch.py
+++ b/scripts/artifacts/chromeWebsearch.py
@@ -3,7 +3,7 @@ import sqlite3
 import textwrap
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, get_next_unused_name
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, get_next_unused_name, open_sqlite_db_readonly
 
 def get_chromeWebsearch(files_found, report_folder, seeker):
     
@@ -17,7 +17,7 @@ def get_chromeWebsearch(files_found, report_folder, seeker):
         elif file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
             continue # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data??
 
-        db = sqlite3.connect(file_found)
+        db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
         SELECT

--- a/scripts/artifacts/cmh.py
+++ b/scripts/artifacts/cmh.py
@@ -5,12 +5,12 @@ import shutil
 import sqlite3
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
 def get_cmh(files_found, report_folder, seeker):
 
     file_found = str(files_found[0])
-    db = sqlite3.connect(file_found)
+    db = open_sqlite_db_readonly(file_found)
     cursor = db.cursor()
     cursor.execute('''
     SELECT

--- a/scripts/artifacts/emulatedSmeta.py
+++ b/scripts/artifacts/emulatedSmeta.py
@@ -1,7 +1,7 @@
 import os
 import sqlite3
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
 def get_emulatedSmeta(files_found, report_folder, seeker):
 
@@ -10,7 +10,7 @@ def get_emulatedSmeta(files_found, report_folder, seeker):
         if not file_found.endswith('external.db'):
             continue # Skip all other files
         
-        db = sqlite3.connect(file_found)
+        db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
         SELECT

--- a/scripts/artifacts/googleNowPlaying.py
+++ b/scripts/artifacts/googleNowPlaying.py
@@ -5,7 +5,7 @@ import time
 
 from html import escape
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
 is_windows = is_platform_windows()
 slash = '\\' if is_windows else '/' 
@@ -53,7 +53,7 @@ def get_googleNowPlaying(files_found, report_folder, seeker):
         elif not file_found.endswith('history_db'):
             continue # Skip all other files (-wal)
 
-        db = sqlite3.connect(file_found)
+        db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
         Select

--- a/scripts/artifacts/googlePlaySearches.py
+++ b/scripts/artifacts/googlePlaySearches.py
@@ -2,12 +2,12 @@ import sqlite3
 import textwrap
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
 def get_googlePlaySearches(files_found, report_folder, seeker):
     
     file_found = str(files_found[0])
-    db = sqlite3.connect(file_found)
+    db = open_sqlite_db_readonly(file_found)
     cursor = db.cursor()
     cursor.execute('''
     SELECT

--- a/scripts/artifacts/googleQuickSearchboxRecent.py
+++ b/scripts/artifacts/googleQuickSearchboxRecent.py
@@ -92,7 +92,7 @@ def get_quicksearch_recent(files_found, report_folder, seeker):
                 screenshot_file_path = os.path.join(dir_path, f'{base_name}-{screenshot_id}.jpg')
                 if os.path.exists(screenshot_file_path):
                     shutil.copy2(screenshot_file_path, report_folder)
-                img_html = '<a href="{1}/{0}"><img src="{1}/{0}" class="img-fluid" style="max-height:600px" title="{0}"></a>'.format(f'{base_name}-{screenshot_id}.jpg', folder_name)
+                img_html = '<a href="{1}/{0}"><img src="{1}/{0}" class="img-fluid" style="max-height:600px; min-width:300px" title="{0}"></a>'.format(f'{base_name}-{screenshot_id}.jpg', folder_name)
                 recursive_convert_bytes_to_str(item) # convert all 'bytes' to str
                 data_list.append( (img_html, '<pre id="json" style="font-size: 110%">'+ escape(json.dumps(item, indent=4)).replace('\\n', '<br>') +'</pre>') )
 

--- a/scripts/artifacts/installedappsGass.py
+++ b/scripts/artifacts/installedappsGass.py
@@ -1,12 +1,12 @@
 import sqlite3
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv
+from scripts.ilapfuncs import logfunc, tsv, open_sqlite_db_readonly
 
 def get_installedappsGass(files_found, report_folder, seeker):
     
     file_found = str(files_found[0])
-    db = sqlite3.connect(file_found)
+    db = open_sqlite_db_readonly(file_found)
     cursor = db.cursor()
     cursor.execute('''
     SELECT 

--- a/scripts/artifacts/installedappsLibrary.py
+++ b/scripts/artifacts/installedappsLibrary.py
@@ -1,12 +1,12 @@
 import sqlite3
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline 
+from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
 
 def get_installedappsLibrary(files_found, report_folder, seeker):
     
     file_found = str(files_found[0])
-    db = sqlite3.connect(file_found)
+    db = open_sqlite_db_readonly(file_found)
     cursor = db.cursor()
     cursor.execute('''
     SELECT

--- a/scripts/artifacts/installedappsVending.py
+++ b/scripts/artifacts/installedappsVending.py
@@ -1,12 +1,12 @@
 import sqlite3
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline
+from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
 
 def get_installedappsVending(files_found, report_folder, seeker):
 
     file_found = str(files_found[0])
-    db = sqlite3.connect(file_found)
+    db = open_sqlite_db_readonly(file_found)
     cursor = db.cursor()
     cursor.execute('''
     SELECT

--- a/scripts/artifacts/pSettings.py
+++ b/scripts/artifacts/pSettings.py
@@ -2,12 +2,12 @@ import sqlite3
 import textwrap
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, open_sqlite_db_readonly
 
 def get_pSettings(files_found, report_folder, seeker):
     
     file_found = str(files_found[0])
-    db = sqlite3.connect(file_found)
+    db = open_sqlite_db_readonly(file_found)
     cursor = db.cursor()
     cursor.execute('''
     select 

--- a/scripts/artifacts/scontextLog.py
+++ b/scripts/artifacts/scontextLog.py
@@ -2,12 +2,12 @@ import sqlite3
 import textwrap
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
 def get_scontextLog(files_found, report_folder, seeker):
     
     file_found = str(files_found[0])
-    db = sqlite3.connect(file_found)
+    db = open_sqlite_db_readonly(file_found)
     cursor = db.cursor()
     cursor.execute('''
     SELECT

--- a/scripts/artifacts/siminfo.py
+++ b/scripts/artifacts/siminfo.py
@@ -5,7 +5,7 @@ import shutil
 import sqlite3
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, open_sqlite_db_readonly
 
 def get_siminfo(files_found, report_folder, seeker):
 
@@ -27,7 +27,7 @@ def get_siminfo(files_found, report_folder, seeker):
 def process_siminfo(folder, uid, report_folder):
     
     #Query to create report
-    db = sqlite3.connect(folder)
+    db = open_sqlite_db_readonly(folder)
     cursor = db.cursor()
 
     #Query to create report

--- a/scripts/artifacts/smanagerCrash.py
+++ b/scripts/artifacts/smanagerCrash.py
@@ -2,12 +2,12 @@ import sqlite3
 import textwrap
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
 def get_smanagerCrash(files_found, report_folder, seeker):
     
     file_found = str(files_found[0])
-    db = sqlite3.connect(file_found)
+    db = open_sqlite_db_readonly(file_found)
     cursor = db.cursor()
     cursor.execute('''
     SELECT

--- a/scripts/artifacts/smanagerLow.py
+++ b/scripts/artifacts/smanagerLow.py
@@ -2,12 +2,12 @@ import sqlite3
 import textwrap
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
 def get_smanagerLow(files_found, report_folder, seeker):
     
     file_found = str(files_found[0])
-    db = sqlite3.connect(file_found)
+    db = open_sqlite_db_readonly(file_found)
     cursor = db.cursor()
     cursor.execute('''
     SELECT 

--- a/scripts/artifacts/smembersAppInv.py
+++ b/scripts/artifacts/smembersAppInv.py
@@ -2,12 +2,12 @@ import sqlite3
 import textwrap
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
 def get_smembersAppInv(files_found, report_folder, seeker):
     
     file_found = str(files_found[0])
-    db = sqlite3.connect(file_found)
+    db = open_sqlite_db_readonly(file_found)
     cursor = db.cursor()
     cursor.execute('''
     select

--- a/scripts/artifacts/smembersEvents.py
+++ b/scripts/artifacts/smembersEvents.py
@@ -2,12 +2,12 @@ import sqlite3
 import textwrap
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
 def get_smembersEvents(files_found, report_folder, seeker):
     
     file_found = str(files_found[0])
-    db = sqlite3.connect(file_found)
+    db = open_sqlite_db_readonly(file_found)
     cursor = db.cursor()
     cursor.execute('''
     select 

--- a/scripts/artifacts/smsmms.py
+++ b/scripts/artifacts/smsmms.py
@@ -4,7 +4,7 @@ import sqlite3
 
 from html import escape
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
 # Reference for flag values for mms:
 # ---------------------------------- 
@@ -70,7 +70,7 @@ def get_sms_mms(files_found, report_folder, seeker):
         elif not file_found.endswith('mmssms.db'):
             continue # Skip all other files
         
-        db = sqlite3.connect(file_found)
+        db = open_sqlite_db_readonly(file_found)
         db.row_factory = sqlite3.Row # For fetching columns by name
 
         got_messages = read_sms_messages(db, report_folder, file_found)

--- a/scripts/artifacts/smyfilesRecents.py
+++ b/scripts/artifacts/smyfilesRecents.py
@@ -2,12 +2,12 @@ import sqlite3
 import textwrap
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
 def get_smyfilesRecents(files_found, report_folder, seeker):
     
     file_found = str(files_found[0])
-    db = sqlite3.connect(file_found)
+    db = open_sqlite_db_readonly(file_found)
     cursor = db.cursor()
     cursor.execute('''
     select

--- a/scripts/artifacts/smyfilesStored.py
+++ b/scripts/artifacts/smyfilesStored.py
@@ -2,12 +2,12 @@ import sqlite3
 import textwrap
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
 def get_smyfilesStored(files_found, report_folder, seeker):
     
     file_found = str(files_found[0])
-    db = sqlite3.connect(file_found)
+    db = open_sqlite_db_readonly(file_found)
     cursor = db.cursor()
     cursor.execute('''
     SELECT

--- a/scripts/artifacts/swellbeing.py
+++ b/scripts/artifacts/swellbeing.py
@@ -1,7 +1,7 @@
 import os
 import sqlite3
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
 def get_swellbeing(files_found, report_folder, seeker):
 
@@ -10,7 +10,7 @@ def get_swellbeing(files_found, report_folder, seeker):
         if not file_found.endswith('dwbCommon.db'):
             continue # Skip all other files
         
-        db = sqlite3.connect(file_found)
+        db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
         SELECT

--- a/scripts/artifacts/usageapps.py
+++ b/scripts/artifacts/usageapps.py
@@ -3,7 +3,7 @@ import json
 import sqlite3
 import time
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
 is_windows = is_platform_windows()
 slash = '\\' if is_windows else '/' 
@@ -43,7 +43,7 @@ def get_usageapps(files_found, report_folder, seeker):
         elif not file_found.endswith('reflection_gel_events.db'):
             continue # Skip all other files (-wal, -journal)
 
-        db = sqlite3.connect(file_found)
+        db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
         SELECT

--- a/scripts/artifacts/userDict.py
+++ b/scripts/artifacts/userDict.py
@@ -2,12 +2,12 @@ import sqlite3
 import textwrap
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, open_sqlite_db_readonly
 
 def get_userDict(files_found, report_folder, seeker):
     
     file_found = str(files_found[0])
-    db = sqlite3.connect(file_found)
+    db = open_sqlite_db_readonly(file_found)
     cursor = db.cursor()
     cursor.execute('''
     select 

--- a/scripts/artifacts/wellbeing.py
+++ b/scripts/artifacts/wellbeing.py
@@ -1,7 +1,7 @@
 import os
 import sqlite3
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
 def get_wellbeing(files_found, report_folder, seeker):
 
@@ -10,7 +10,7 @@ def get_wellbeing(files_found, report_folder, seeker):
         if not file_found.endswith('app_usage'):
             continue # Skip all other files
         
-        db = sqlite3.connect(file_found)
+        db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
         SELECT 

--- a/scripts/artifacts/wellbeingURLs.py
+++ b/scripts/artifacts/wellbeingURLs.py
@@ -1,7 +1,7 @@
 import os
 import sqlite3
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
 def get_wellbeingURLs(files_found, report_folder, seeker):
 
@@ -10,7 +10,7 @@ def get_wellbeingURLs(files_found, report_folder, seeker):
         if not file_found.endswith('app_usage'):
             continue # Skip all other files
         
-        db = sqlite3.connect(file_found)
+        db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
         SELECT 

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -61,6 +61,19 @@ def get_next_unused_name(path):
         num += 1
     return os.path.join(folder, new_name)
 
+def open_sqlite_db_readonly(path):
+    '''Opens an sqlite db in read-only mode, so original db (and -wal/journal are intact)'''
+    if is_platform_windows():
+        if path.startswith('\\\\?\\UNC\\'): # UNC long path
+            path = "%5C%5C%3F%5C" + path[4:]
+        elif path.startswith('\\\\?\\'):    # normal long path
+            path = "%5C%5C%3F%5C" + path[4:]
+        elif path.startswith('\\\\'):       # UNC path
+            path = "%5C%5C%3F%5C\\UNC" + path[1:]
+        else:                               # normal path
+            path = "%5C%5C%3F%5C" + path
+    return sqlite3.connect (f"file:{path}?mode=ro", uri=True)
+
 def does_column_exist_in_db(db, table_name, col_name):
     '''Checks if a specific col exists'''
     col_name = col_name.lower()

--- a/scripts/version_info.py
+++ b/scripts/version_info.py
@@ -1,4 +1,4 @@
-aleapp_version = '1.4.0'
+aleapp_version = '1.4.1'
 
 # Contributors List
 # Format = [ Name, Blog-url, Twitter-handle, Github-url]


### PR DESCRIPTION
Fixes #77 
All future modules should use `open_sqlite_db_readonly(path)` from ilapfuncs instead of `sqlite3.connect(path)`

I will be making the same edits to ileapp too tomorrow.