### PR TITLE
CSS fix for pre html tag in dark mode

### DIFF
--- a/scripts/dark-mode.css
+++ b/scripts/dark-mode.css
@@ -63,6 +63,10 @@
     color: #eee;
 }
 
+[data-theme="dark"] pre {
+    color: #bdbdbd;
+}
+
 /* Table hover */
 
 [data-theme="dark"] .table-hover tbody tr:hover {


### PR DESCRIPTION
BEFORE
![image](https://user-images.githubusercontent.com/13247440/104378388-e9bb0280-54f5-11eb-9e0c-94c57e4a2e9b.png)

NOW
![image](https://user-images.githubusercontent.com/13247440/104378460-05260d80-54f6-11eb-9a5d-29ba329266d3.png)
