### PR TITLE
Update roles.py

### DIFF
--- a/scripts/artifacts/roles.py
+++ b/scripts/artifacts/roles.py
@@ -21,8 +21,10 @@ def get_roles(files_found, report_folder, seeker, wrap_text):
             user = 'mirror'
         elif 'users' in parts:
             user = parts[-2]
+            ver = 'Android 10'
         elif 'misc_de' in parts:
             user = parts[-4]
+            ver = 'Android 11'
         
         if user == 'mirror':
             continue
@@ -47,7 +49,7 @@ def get_roles(files_found, report_folder, seeker, wrap_text):
                 
                 if len(data_list) > 0:
                     report = ArtifactHtmlReport('App Roles')
-                    report.start_artifact_report(report_folder, f'App Roles_{user}')
+                    report.start_artifact_report(report_folder, f'{ver} Roles_{user}')
                     report.add_script()
                     data_headers = ('Role', 'Holder')
                     report.write_artifact_data_table(data_headers, data_list, file_found)


### PR DESCRIPTION
If device upgrades from Android 10 to Android 11 the parser will be able to process and show the roles.xm content from both files. Content from the old one that remains and the new one that is generated after the upgrade.