### PR TITLE
Add Chrome Network Action Predictor

### DIFF
--- a/scripts/artifacts/chromeNetworkActionPredictor.py
+++ b/scripts/artifacts/chromeNetworkActionPredictor.py
@@ -1,0 +1,56 @@
+import os
+import sqlite3
+from scripts.artifact_report import ArtifactHtmlReport
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, get_next_unused_name, open_sqlite_db_readonly
+
+def get_chromeNetworkActionPredictor(files_found, report_folder, seeker, wrap_text):
+
+    for file_found in files_found:
+        file_found = str(file_found)
+        if not file_found.endswith('Network Action Predictor'):
+            continue # Skip all other files
+            
+        browser_name = 'Chrome'
+        if file_found.find('app_sbrowser') >= 0:
+            browser_name = 'Browser'
+        elif file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
+            continue # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data??
+        
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        cursor.execute('''
+        select
+        user_text,
+        url,
+        number_of_hits,
+        number_of_misses
+        from network_action_predictor
+        ''')
+
+        all_rows = cursor.fetchall()
+        usageentries = len(all_rows)
+        if usageentries > 0:
+            report = ArtifactHtmlReport(f'{browser_name} Network Action Predictor')
+            #check for existing and get next name for report file, so report from another file does not get overwritten
+            report_path = os.path.join(report_folder, f'{browser_name} Network Action Predictor.temphtml')
+            report_path = get_next_unused_name(report_path)[:-9] # remove .temphtml
+            report.start_artifact_report(report_folder, os.path.basename(report_path))
+            report.add_script()
+            data_headers = ('User Text','URL','Number of Hits','Number of Misses') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
+            data_list = []
+            for row in all_rows:
+                data_list.append((row[0],row[1],row[2],row[3]))
+
+            report.write_artifact_data_table(data_headers, data_list, file_found)
+            report.end_artifact_report()
+            
+            tsvname = f'{browser_name} Network Action Predictor'
+            tsv(report_folder, data_headers, data_list, tsvname)
+            
+            tlactivity = f'{browser_name} Network Action Predictor'
+            timeline(report_folder, tlactivity, data_list, data_headers)
+        else:
+            logfunc('No Browser Network Action Predictor data available')
+        
+        db.close()
+        return

--- a/scripts/ilap_artifacts.py
+++ b/scripts/ilap_artifacts.py
@@ -24,6 +24,7 @@ from scripts.artifacts.chromeCookies import get_chromeCookies
 from scripts.artifacts.chromeDownloads import get_chromeDownloads
 from scripts.artifacts.chromeLoginData import get_chromeLoginData
 from scripts.artifacts.chromeMediaHistory import get_chromeMediaHistory
+from scripts.artifacts.chromeNetworkActionPredictor import get_chromeNetworkActionPredictor
 from scripts.artifacts.chromeOfflinePages import get_chromeOfflinePages
 from scripts.artifacts.chromeSearchTerms import get_chromeSearchTerms
 from scripts.artifacts.chromeTopSites import get_chromeTopSites
@@ -101,6 +102,7 @@ tosearch = {
     'chromeDownloads':('Chrome', ('**/app_chrome/Default/History*', '**/app_sbrowser/Default/History*')),
     'chromeLoginData':('Chrome', ('**/app_chrome/Default/Login Data*', '**/app_sbrowser/Default/Login Data*')),
     'chromeMediaHistory':('Chrome', ('**/app_chrome/Default/Media History*','**/app_sbrowser/Default/Media History*')),
+    'chromeNetworkActionPredictor':('Chrome', ('**/app_Chrome/Default/Network Action Predictor*','**/app_sbrowser/Default/Network Action Predictor*')),
     'chromeOfflinePages':('Chrome', ('**/app_chrome/Default/Offline Pages/metadata/OfflinePages.db*', '**/app_sbrowser/Default/Offline Pages/metadata/OfflinePages.db*')),
     'chromeSearchTerms':('Chrome', ('**/app_chrome/Default/History*', '**/app_sbrowser/Default/History*')),
     'chromeTopSites':('Chrome', ('**/app_chrome/Default/Top Sites*', '**/app_sbrowser/Default/Top Sites*')),

--- a/scripts/report.py
+++ b/scripts/report.py
@@ -35,6 +35,7 @@ def get_icon_name(category, artifact):
         elif artifact.find('BOOKMARKS') >= 0:       icon = 'bookmark'
         elif artifact.find('LOGIN') >= 0:           icon = 'log-in'
         elif artifact.find('MEDIA HISTORY') >= 0:   icon = 'video'
+        elif artifact.find('NETWORK ACTION PREDICTOR') >=0:    icon = 'type'
         elif artifact.find('TOP SITES') >= 0:       icon = 'list'
         elif artifact.find('OFFLINE PAGES') >= 0:   icon = 'cloud-off'
         else:                                       icon = 'chrome'


### PR DESCRIPTION
Network Action Predictor is a preloading feature Chrome uses to attempt and guess what webpages someone will click on when searching