### PR TITLE
Add new artifact: Google Keep - Notes

### DIFF
--- a/scripts/artifacts/googleKeep.py
+++ b/scripts/artifacts/googleKeep.py
@@ -63,21 +63,16 @@ def get_googleKeep(files_found, report_folder, seeker, wrap_text):
             data_headers = ('Time Created','Time Last Updated', 'Account ID','Title', 'Text', 'Synced Text', 'List Parent ID' , 'Is deleted', 'Last Modifier Email')
             data_list = []
             for row in all_rows:
-                # print(row)
                 data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], 'True' if row[7]==1 else 'False', row[8]))
 
             report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
             report.end_artifact_report()
-            # print(all_rows)
 
             tsvname = "Google Keep - Notes"
             tsv(report_folder, data_headers, data_list, tsvname)
 
             tlactivity = "Google Keep - Notes"
             timeline(report_folder, tlactivity, data_list, data_headers)
-
-            # kmlactivity = "Google Keep"
-            # kmlgen(".", kmlactivity, data_list, data_headers)
         else:
             logfunc("No Google Keep - Notes data found")
 

--- a/scripts/ilap_artifacts.py
+++ b/scripts/ilap_artifacts.py
@@ -100,7 +100,7 @@ from scripts.artifacts.browserlocation import get_browserlocation
 from scripts.artifacts.googlemaplocation import get_googlemaplocation
 from scripts.artifacts.packageGplinks import get_packageGplinks
 from scripts.artifacts.teams import get_teams
-from scripts.artifacts.googleKeep import get_googleKeep
+from scripts.artifacts.googleKeepNotes import get_googleKeepNotes
 
 from scripts.ilapfuncs import *
 
@@ -207,7 +207,7 @@ tosearch = {
     'cachelocation': ('GEO Location', ('**/com.google.android.location/files/cache.cell/cache.cell', '**/com.google.android.location/files/cache.wifi/cache.wifi')),
     'browserlocation': ('GEO Location', ('**/com.android.browser/app_geolocation/CachedGeoposition.db')),
     'googlemaplocation': ('GEO Location', ('**/com.google.android.apps.maps/databases/da_destination_history*')),
-    'googleKeep':('Google Keep', "**/data/com.google.android.keep/databases/keep.db"),
+    'googleKeepNotes':('Google Keep', "**/data/com.google.android.keep/databases/keep.db"),
     }
 
 slash = '\\' if is_platform_windows() else '/'

--- a/scripts/ilap_artifacts.py
+++ b/scripts/ilap_artifacts.py
@@ -100,6 +100,7 @@ from scripts.artifacts.browserlocation import get_browserlocation
 from scripts.artifacts.googlemaplocation import get_googlemaplocation
 from scripts.artifacts.packageGplinks import get_packageGplinks
 from scripts.artifacts.teams import get_teams
+from scripts.artifacts.googleKeep import get_googleKeep
 
 from scripts.ilapfuncs import *
 
@@ -206,6 +207,7 @@ tosearch = {
     'cachelocation': ('GEO Location', ('**/com.google.android.location/files/cache.cell/cache.cell', '**/com.google.android.location/files/cache.wifi/cache.wifi')),
     'browserlocation': ('GEO Location', ('**/com.android.browser/app_geolocation/CachedGeoposition.db')),
     'googlemaplocation': ('GEO Location', ('**/com.google.android.apps.maps/databases/da_destination_history*')),
+    'googleKeep':('Google Keep', "**/data/com.google.android.keep/databases/keep.db"),
     }
 
 slash = '\\' if is_platform_windows() else '/'


### PR DESCRIPTION
Added Google Keep - Notes ability. It will retrieve the notes text, created, updated timestamp, last modifier email, and parent id of the notes. 

To-do Artifacts in Google Keep:

- [ ] Photos taken using the app (Present in `files/1/image/original`)
- [ ] alerts/reminders
- [x] Sharer email, timestamp.

Adding screenshots for reference:

![image](https://user-images.githubusercontent.com/44309333/118493089-5a8d5800-b73e-11eb-913b-debab6143cd2.png)
![image](https://user-images.githubusercontent.com/44309333/118493166-6f69eb80-b73e-11eb-8295-700dd946d14e.png)
![image](https://user-images.githubusercontent.com/44309333/118493212-7c86da80-b73e-11eb-9a80-f49c4e1d827a.png)
![image](https://user-images.githubusercontent.com/44309333/118493327-9d4f3000-b73e-11eb-9ec3-c73fbdc0f5e5.png)
