### PR TITLE
include wheel as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ packaging==20.1
 protobuf==3.10.0
 PyCryptodome
 PySimpleGUI==4.16.0
+wheel
 simplekml
 xmltodict


### PR DESCRIPTION
wheel package required for a fresh install on Windows 11.

Specifically, simplekml and blackboxprotobuf require wheel.

![image](https://user-images.githubusercontent.com/12966369/139536118-38cb1b44-019e-4911-b61d-a09eefe10ec6.png)
