### PR TITLE
Adds requirements for SGallery

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ wheel
 simplekml
 xmltodict
 bcrypt==3.2.0
+filetype==1.0.8
+mimetypes-magic==0.4.30
+python-magic-bin==0.4.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ simplekml
 xmltodict
 bcrypt==3.2.0
 filetype==1.0.8
-mimetypes-magic==0.4.30
 python-magic-bin==0.4.14


### PR DESCRIPTION
Relates to #178 

Hi Briggs, these requirements appear to be missing following the SGallery addition.

Still appears problematic though... 
- When I install the original `requirements.txt`, followed by the three additions, ALEAPP runs fine.
- When the three additions are inside `requirements.txt` and installed, ALEAPP still missing libraries...

Now I'm confused!