### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 bcrypt==3.2.0
 beautifulsoup4==4.8.2
 blackboxprotobuf
-filetype
 packaging==20.1
 protobuf==3.10.0
 PyCryptodome
@@ -10,5 +9,7 @@ simplekml
 wheel
 xmltodict
 filetype==1.0.8
-python-magic-bin==0.4.14
+python-magic==0.4.24; platform_system == "Linux"
+python-magic-bin==0.4.14; platform_system == "Windows"
+python-magic-bin==0.4.14; platform_system == "Darwin"
 pillow


### PR DESCRIPTION
Current requirements have a duplicate of filetype, so this removes the version-less filetype in favor of the versioned filetype (which was added more recently).
Additionally, the same issue as experienced with iLEAPP and python-magic is experienced in this one as well, so I've added the same platform identification to resolve the python-magic-bin issue identified in Issue #214 .