### PR TITLE
Amends Vaulty data headers

### DIFF
--- a/scripts/artifacts/vaulty_files.py
+++ b/scripts/artifacts/vaulty_files.py
@@ -12,18 +12,19 @@ def get_vaulty_files(files_found, report_folder, seeker, wrap_text):
     db_filepath = str(files_found[0])
     conn = sqlite3.connect(db_filepath)
     c = conn.cursor()
-    sql = """SELECT Media._id, datetime(Media.datetaken / 1000, 'unixepoch'), datetime(Media.date_added, 'unixepoch'), datetime(Media.date_modified / 1000, 'unixepoch'), Media.path, Media._data FROM Media"""
+    sql = """SELECT Media._id, datetime(Media.date_added, 'unixepoch'), datetime(Media.date_modified / 1000, 'unixepoch'), Media.path, Media._data FROM Media"""
     c.execute(sql)
     results = c.fetchall()
     conn.close()
 
     # Data results
-    data_headers = ('ID', 'Date Taken', 'Date Added', 'Date Modified', 'Original Path', 'Vault Path')
+    data_headers = ('ID', 'Date Created', 'Date Added', 'Original Path', 'Vault Path')
     data_list = results
     
     # Reporting
+    description = "Vaulty (com.theronrogers.vaultyfree) - Research at https://kibaffo33.data.blog/2022/03/05/decoding-vaulty/"
     report = ArtifactHtmlReport(title)
-    report.start_artifact_report(report_folder, title)
+    report.start_artifact_report(report_folder, title, description)
     report.add_script()
     report.write_artifact_data_table(data_headers, data_list, db_filepath, html_escape=False)
     report.end_artifact_report()


### PR DESCRIPTION
Amends headers to match research rather than DB.

As queried here https://twitter.com/kibaffo33/status/1501212458417102858

_<blockquote class="twitter-tweet"><p lang="en" dir="ltr"><a href="https://twitter.com/AlexisBrignoni?ref_src=twsrc%5Etfw">@AlexisBrignoni</a> ALEAPP etiquette question - when research shows a column header is inaccurate/better described another way (eg date modified is date added) - should the ALEAPP artefact reflect the DB or the research? <a href="https://twitter.com/hashtag/aleapp?src=hash&amp;ref_src=twsrc%5Etfw">#aleapp</a> <a href="https://twitter.com/hashtag/dfir?src=hash&amp;ref_src=twsrc%5Etfw">#dfir</a> <a href="https://t.co/Ird6vbousd">pic.twitter.com/Ird6vbousd</a></p>&mdash; Bob (@kibaffo33) <a href="https://twitter.com/kibaffo33/status/1501212458417102858?ref_src=twsrc%5Etfw">March 8, 2022</a></blockquote>_

_<blockquote class="twitter-tweet"><p lang="en" dir="ltr">I name the fields in a way that accurately reflects the proper interpretation of the data.<br><br>This is where having a blogpost for the research is key. You can put a link to it in the artifact report. See usage of the description variable below. <a href="https://t.co/KQBRB2NSAV">pic.twitter.com/KQBRB2NSAV</a></p>&mdash; Brigs 💬 (@AlexisBrignoni) <a href="https://twitter.com/AlexisBrignoni/status/1501215046923345930?ref_src=twsrc%5Etfw">March 8, 2022</a></blockquote>_

Thanks!