### PR TITLE
SnapChat My Eyes Only PIN Bruteforce

### DIFF
--- a/scripts/artifacts/snapchatMEO.py
+++ b/scripts/artifacts/snapchatMEO.py
@@ -1,0 +1,69 @@
+# snapchatMEO: Brute-force SnapChat My Eyes Only PIN Code
+# Author: David Mann {Twitter: @Sector7Reactor}
+# Date: 17/06/2022
+# Artifact version: 1.0.0
+# Android version tested: 12
+# Requirements: None
+
+import bcrypt
+import sqlite3
+import itertools
+import string
+
+from scripts.artifact_report import ArtifactHtmlReport
+from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html, open_sqlite_db_readonly
+
+
+def bruteforceMEO(encrypted_password):
+
+    for numbers in itertools.product(string.digits, repeat=4):
+
+        pin = ''.join(numbers)
+        check_hash_match = bcrypt.checkpw(pin.encode('utf-8'), encrypted_password.encode('utf-8'))
+
+        if check_hash_match == True:
+            logfunc(f'PIN code match found: {pin}')
+
+            return encrypted_password, pin
+    else:
+        return None
+
+def get_snapchatMEO(files_found, report_folder, seeker, wrap_text):
+
+    data_list = []
+
+    for file_found in files_found:
+        file_found = str(file_found)
+
+        connection = open_sqlite_db_readonly(file_found)
+
+        pointer = connection.cursor()
+        try:
+            pointer.execute("SELECT hashed_passcode FROM memories_meo_confidential")
+            encrypted_password = pointer.fetchone()[0]
+        except:
+            continue
+
+        if encrypted_password != '':
+            logfunc(f'Encrypted PIN Found: {encrypted_password}')
+
+            try:
+                data_list.append((bruteforceMEO(encrypted_password)))
+            except:
+                continue
+
+            if data_list != [None]:
+                report = ArtifactHtmlReport('SnapChat My Eyes Only PIN')
+                report.start_artifact_report(report_folder, 'SnapChat My Eyes Only PIN')
+                report.add_script()
+                data_headers = ('Encrypted PIN', 'Decrypted PIN')
+
+                report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Media'])
+                report.end_artifact_report()
+
+                tsvname = f'SnapChat My Eyes Only PIN'
+                tsv(report_folder, data_headers, data_list, tsvname)
+            else:
+                logfunc('No PIN code found.')
+        else:
+            logfunc('No encrypted PIN hash found in Database.')

--- a/scripts/ilap_artifacts.py
+++ b/scripts/ilap_artifacts.py
@@ -134,6 +134,7 @@ from scripts.artifacts.smyfilesRecents import get_smyfilesRecents
 from scripts.artifacts.smyFiles import get_smyFiles
 from scripts.artifacts.smyfilesStored import get_smyfilesStored
 from scripts.artifacts.snapchat import get_snapchat
+from scripts.artifacts.snapchatMEO import get_snapchatMEO
 from scripts.artifacts.settingsSecure import get_settingsSecure
 from scripts.artifacts.suggestions import get_suggestions
 from scripts.artifacts.swellbeing import get_swellbeing
@@ -308,6 +309,7 @@ tosearch = {
     'smyFiles':('Media Metadata', '**/com.sec.android.app.myfiles/databases/MyFiles*.db*'),
     'smyfilesStored':('Media Metadata', '**/com.sec.android.app.myfiles/databases/FileCache.db'),
     'snapchat': ('Snapchat', ('**/data/com.snapchat.android/databases/*.db', '**/data/com.snapchat.android/shared_prefs/*.xml')),
+    'snapchatMEO': ('Snapchat My Eyes Only PIN', '**/data/com.snapchat.android/databases/memories.db'),
     'suggestions': ('Wipe & Setup', '*/data/com.google.android.settings.intelligence/shared_prefs/suggestions.xml'),
     'swellbeing': ('Wellbeing', '**/com.samsung.android.forest/databases/dwbCommon.db*'),
     'sWipehist': ('Wipe & Setup', '*/efs/recovery/history'),


### PR DESCRIPTION
Script to brute-force SnapChat My Eyes Only PIN

Memories.db stores the PIN hash in the 'memories_meo_confidential' table - 'hashed_passcode' column as a bcrypt hash. 

Memories.db will only be available/contain a hashed passcode if the user has entered the MEO PIN code while connected to the internet. During my testing, when logging out of SnapChat, the memories.db database was deleted/no longer accessible.
Memories.db was re-created upon login, but the hashed_passcode column was empty until I entered the MEO PIN code
while connected to the internet.

It seems that once the PIN code is verified online initially, and a bcrypt hash is created and stored offline within Memories.db,
the user may then enter the PIN to access MEO folder offline (the hash will be cached for an undetermined period of time - this may be the same as the 60 day timeout reported on the Forensics Discord server for media).

memories.db/hash is persistent through power off/on states. Logout and x days is the only thing that appears to remove the hash. However, may still be handy if device is seized and examined early.

Example bcrypt hash [PIN - 1234]:  $2a$06$hJJsu8Yb5tlJtsQzMX3ZJu9u6JIiZaoq60U2AbBpx57CImBDrx15q

Iterations = 6
Salt = $2a$06$hJJsu8Yb5tlJtsQzMX3ZJu
Password hash = 9u6JIiZaoq60U2AbBpx57CImBDrx15q

I have some test memories.db so that you can test the script (one db which contains the hash, and one without for error checking via script).

My Discord is AeroDai#1361 and I'm on the Forensic Discord server.