### PR TITLE
A few optimizations

### DIFF
--- a/scripts/ccl_simplesnappy.py
+++ b/scripts/ccl_simplesnappy.py
@@ -170,8 +170,16 @@ def decompress(data: typing.BinaryIO) -> bytes:
 
             # have to read incrementally because you might have to read data that you've just written
             # this is probably a really slow way of doing this.
-            for i in range(length):
-                out.write(out.getbuffer()[actual_offset + i: actual_offset + i + 1].tobytes())
+            # for i in range(length):
+            #     out.write(out.getbuffer()[actual_offset + i: actual_offset + i + 1].tobytes())
+            # new method for doing the same:
+            buffer = out.getbuffer()[actual_offset: actual_offset + length].tobytes()
+            condition = (offset - length) <= 0
+            if condition:
+                buffer = (buffer * length)[:length]
+                # better safe than sorry, this way we're sure to extend it
+                # as much as needed without doing some extra calculations
+            out.write(buffer)
 
     result = out.getvalue()
     if uncompressed_length != len(result):

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -261,6 +261,9 @@ def media_to_html(media_path, files_found, report_folder):
     :rtype: str
     """
     
+    def media_path_filter(name):
+        return media_path in name
+    
     def relative_paths(source, splitter):
         splitted_a = source.split(splitter)
         for x in splitted_a:
@@ -278,42 +281,38 @@ def media_to_html(media_path, files_found, report_folder):
         splitter = '/'
         
     thumb = media_path
-    for match in files_found:
+    for match in filter(media_path_filter, files_found):
         filename = os.path.basename(match)
-        if filename.startswith('~'):
-            continue
-        if filename.startswith('._'):
+        if filename.startswith('~') or filename.startswith('._'):
             continue
         
-        if media_path in match:
+        dirs = os.path.dirname(report_folder)
+        dirs = os.path.dirname(dirs)
+        env_path = os.path.join(dirs, 'temp')
+        if env_path in match:
+            source = match
+            source = relative_paths(source, splitter)
+        else:
+            path = os.path.dirname(match)
+            dirname = os.path.basename(path)
+            filename = Path(match)
+            filename = filename.name
+            locationfiles = Path(report_folder).joinpath(dirname)
+            Path(f'{locationfiles}').mkdir(parents=True, exist_ok=True)
+            shutil.copy2(match, locationfiles)
+            source = Path(locationfiles, filename)
+            source = relative_paths(str(source), splitter)
             
-            dirs = os.path.dirname(report_folder)
-            dirs = os.path.dirname(dirs)
-            env_path = os.path.join(dirs, 'temp')
-            if env_path in match:
-                source = match
-                source = relative_paths(source, splitter)
-            else:
-                path = os.path.dirname(match)
-                dirname = os.path.basename(path)
-                filename = Path(match)
-                filename = filename.name
-                locationfiles = Path(report_folder).joinpath(dirname)
-                Path(f'{locationfiles}').mkdir(parents=True, exist_ok=True)
-                shutil.copy2(match, locationfiles)
-                source = Path(locationfiles, filename)
-                source = relative_paths(str(source), splitter)
-                
-            mimetype = magic.from_file(match, mime = True)
-            
-            if 'video' in mimetype:
-                thumb = f'<video width="320" height="240" controls="controls"><source src="{source}" type="video/mp4">Your browser does not support the video tag.</video>'
-            elif 'image' in mimetype:
-                thumb = f'<img src="{source}"width="300"></img>'
-            elif 'audio' in mimetype:
-                thumb = f'<audio controls><source src="{source}" type="audio/ogg"><source src="{source}" type="audio/mpeg">Your browser does not support the audio element.</audio>'
-            else:
-                thumb = f'<a href="{source}"> Link to {mimetype} </>'
+        mimetype = magic.from_file(match, mime = True)
+        
+        if 'video' in mimetype:
+            thumb = f'<video width="320" height="240" controls="controls"><source src="{source}" type="video/mp4">Your browser does not support the video tag.</video>'
+        elif 'image' in mimetype:
+            thumb = f'<img src="{source}"width="300"></img>'
+        elif 'audio' in mimetype:
+            thumb = f'<audio controls><source src="{source}" type="audio/ogg"><source src="{source}" type="audio/mpeg">Your browser does not support the audio element.</audio>'
+        else:
+            thumb = f'<a href="{source}"> Link to {mimetype} </>'
     return thumb
 
 def kmlgen(report_folder, kmlactivity, data_list, data_headers):

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -12,6 +12,9 @@ import shutil
 from pathlib import Path
 
 from bs4 import BeautifulSoup
+from functools import lru_cache
+
+os.path.basename = lru_cache(maxsize=None)(os.path.basename)
 
 class OutputParameters:
     '''Defines the parameters that are common for '''

--- a/scripts/search_files.py
+++ b/scripts/search_files.py
@@ -7,6 +7,9 @@ from pathlib import Path
 from scripts.ilapfuncs import *
 from zipfile import ZipFile
 
+from fnmatch import _compile_pattern
+from os.path import normcase
+
 class FileSeekerBase:
     # This is an abstract base class
     def search(self, filepattern_to_search, return_on_first_hit=False):
@@ -56,8 +59,10 @@ class FileSeekerTar(FileSeekerBase):
 
     def search(self, filepattern, return_on_first_hit=False):
         pathlist = []
+        pat = _compile_pattern( normcase(filepattern) )
+        root = normcase("root/")
         for member in self.tar_file.getmembers():
-            if fnmatch.fnmatch('root/' + member.name, filepattern):
+            if pat( root + normcase(member.name) ) is not None:
                 try:
                     clean_name = sanitize_file_path(member.name)
                     full_path = os.path.join(self.temp_folder, Path(clean_name))

--- a/scripts/search_files.py
+++ b/scripts/search_files.py
@@ -95,8 +95,10 @@ class FileSeekerZip(FileSeekerBase):
 
     def search(self, filepattern, return_on_first_hit=False):
         pathlist = []
+        pat = _compile_pattern( normcase(filepattern) )
+        root = normcase("root/")
         for member in self.name_list:
-            if fnmatch.fnmatch('root/' + member, filepattern):
+            if pat( root + normcase(member) ) is not None:
                 try:
                     extracted_path = self.zip_file.extract(member, path=self.temp_folder) # already replaces illegal chars with _ when exporting
                     f = self.zip_file.getinfo(member)

--- a/scripts/search_files.py
+++ b/scripts/search_files.py
@@ -8,7 +8,8 @@ from scripts.ilapfuncs import *
 from zipfile import ZipFile
 
 from fnmatch import _compile_pattern
-from os.path import normcase
+from functools import lru_cache
+normcase = lru_cache(maxsize=None)(os.path.normcase)
 
 class FileSeekerBase:
     # This is an abstract base class

--- a/scripts/search_files.py
+++ b/scripts/search_files.py
@@ -42,12 +42,18 @@ class FileSeekerDir(FileSeekerBase):
             logfunc(f'Error reading {directory} ' + str(ex))
 
     def search(self, filepattern, return_on_first_hit=False):
+        pat = _compile_pattern( normcase(filepattern) )
+        root = normcase("root/")
         if return_on_first_hit:
             for item in self._all_files:
-                if fnmatch.fnmatch(item, filepattern):
+                if pat( root + normcase(item) ) is not None:
                     return [item]
             return []
-        return fnmatch.filter(self._all_files, filepattern)
+        pathlist = []
+        for item in self._all_files:
+            if pat( root + normcase(item) ) is not None:
+                pathlist.append(item)
+        return pathlist
 
 class FileSeekerTar(FileSeekerBase):
     def __init__(self, tar_file_path, temp_folder):


### PR DESCRIPTION
I've been profiling and testing a few changes that have a major impact on the Windows performance of ALEAPP.

The reported time goes down by about 3x on my benchmarks. The changes don't affect behavior as far as I could test, the results are consistent between runs, it just goes faster.

Mainly this is achived by placing a few caches in place (functools.lru_cache with maxsize set to None), and avoiding duplicating work (fnmatch.fnmatch usage is changed by a "deconstructed" version of it). Tried to keep the code as simple and readable as it could be, while netting some nice speedups.

There's also a small bit that covers specifically snappy decompression, where I managed to improve the algorithm just a bit. Enough to get a 4-5% performance increase, without resorting to overly complicated code.

Methodology:

- Ran ALEAPP against [Josh Hickman's Android 12 test image](https://thebinaryhick.blog/public_images/).
- Checked reported run time.
- Profiled everything and analyzed the call graphs and functions (with cProfile, gprof2dot, and the amazing line_profiler).
- Got millions of files and hundreds of gigabytes of storage space used up on my disk.
- Found out a few spots where things could be improved.
- Rinse and repeat.