### PR TITLE
Update FacebookMessenger.py

### DIFF
--- a/scripts/artifacts/FacebookMessenger.py
+++ b/scripts/artifacts/FacebookMessenger.py
@@ -30,7 +30,7 @@ def get_FacebookMessenger(files_found, report_folder, seeker, wrap_text):
         else:
             typeof =''
         
-        if file_found.endswith('threads_db2-uid'):
+        if file_found.endswith('threads_db2-uid') or (file_found.startswith('ssus.') and file_found.endswith('threads_db2')):
             source_file = file_found.replace(seeker.directory, '')
             userid = ''
             data_list = []
@@ -209,6 +209,6 @@ def get_FacebookMessenger(files_found, report_folder, seeker, wrap_text):
 __artifacts__ = {
         "FacebookMessenger": (
                 "Facebook Messenger",
-                ('*/threads_db2*'),
+                ('*/*threads_db2*'),
                 get_FacebookMessenger)
 }


### PR DESCRIPTION
I noticed that from at least version 379.1.0.23.114 onwards the app changed the name of the db from threads_db2 to ssus.USER-ID.threads_db2. Hence the update. The parser seems to still work just fine. However further research may be needed though to verify if anything else changed.