### PR TITLE
Python Magic requirments diffrent arquitecture for macos

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,8 @@ xmltodict
 filetype==1.0.8
 python-magic==0.4.24; platform_system == "Linux"
 python-magic-bin==0.4.14; platform_system == "Windows"
-python-magic-bin; platform_system == "Darwin"
+python-magic-bin; platform_system == "Darwin" and platform_machine == "x86_64"
+python-magic; platform_system == "Darwin" and platform_machine == "arm64"
 pillow
 folium==0.14.0
 polyline==2.0.0


### PR DESCRIPTION
For MacBooks with M1 Python Magic bin causes pip to crash during the installation of the dependencies, however this does not seem to affect Intel MacBooks, my solution is to add an extra check to the requirements to differentiate between different arquitecturas in the case of MacOS. (It would be interesting to see if this bug affects arm64 linux such as Raspian).

This way Intel MacBooks install the latest version of [Magic Bin](https://pypi.org/project/python-magic-bin/).
And ARM MacBooks install the latest version of [Python Magic](https://pypi.org/project/python-magic/).