### PR TITLE
Fix database bug and polyline bug

### DIFF
--- a/scripts/artifacts/AdidasActivities.py
+++ b/scripts/artifacts/AdidasActivities.py
@@ -15,7 +15,7 @@ from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
 
 def get_adidas_activities(files_found, report_folder, seeker, wrap_text):
     logfunc("Processing data for Adidas Activities")
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    files_found = [x for x in files_found if not x.endswith('-journal')]
     file_found = str(files_found[0])
     db = open_sqlite_db_readonly(file_found)
 
@@ -67,7 +67,13 @@ def get_adidas_activities(files_found, report_folder, seeker, wrap_text):
                 humidity = 'N/A'
             poly = row[15]
             if poly:
-                coordinates = polyline.decode(poly)
+                # logfunc(f"Polyline: {poly}")
+                try:
+                    coordinates = polyline.decode(poly)
+                except:
+                    logfunc(f"Polyline: {poly} could not be decoded")
+                    poly = None
+                    break
                 place_lat = []
                 place_lon = []
                 for coordinate in coordinates:

--- a/scripts/artifacts/AdidasUser.py
+++ b/scripts/artifacts/AdidasUser.py
@@ -10,7 +10,8 @@ from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
 
 
 def get_adidas_user(files_found, report_folder, seeker, wrap_text):
-    logfunc("Processing data for Garmin Sync")
+    logfunc("Processing data for Adidas User")
+    files_found = [x for x in files_found if not x.endswith('-journal')]
     file_found = str(files_found[0])
     db = open_sqlite_db_readonly(file_found)
 
@@ -95,6 +96,6 @@ def get_adidas_user(files_found, report_folder, seeker, wrap_text):
 __artifacts__ = {
     "AdidasUser": (
         "Adidas-Running",
-        ('*com.runtastic.android/databases/user.db'),
+        ('*com.runtastic.android/databases/user.db*'),
         get_adidas_user)
 }

--- a/scripts/artifacts/AdidasUser.py
+++ b/scripts/artifacts/AdidasUser.py
@@ -95,6 +95,6 @@ def get_adidas_user(files_found, report_folder, seeker, wrap_text):
 __artifacts__ = {
     "AdidasUser": (
         "Adidas-Running",
-        ('*com.runtastic.android/databases/user.db*'),
+        ('*com.runtastic.android/databases/user.db'),
         get_adidas_user)
 }

--- a/scripts/artifacts/MMWActivities.py
+++ b/scripts/artifacts/MMWActivities.py
@@ -211,6 +211,6 @@ def get_map_activities(files_found, report_folder, seeker, wrap_text):
 __artifacts__ = {
     "MapWalkActivities": (
         "Map-My-Walk",
-        ('*com.mapmywalk.android2/databases/workout.db*'),
+        ('*com.mapmywalk.android2/databases/workout.db'),
         get_map_activities)
 }

--- a/scripts/artifacts/MMWActivities.py
+++ b/scripts/artifacts/MMWActivities.py
@@ -211,6 +211,6 @@ def get_map_activities(files_found, report_folder, seeker, wrap_text):
 __artifacts__ = {
     "MapWalkActivities": (
         "Map-My-Walk",
-        ('*com.mapmywalk.android2/databases/workout.db'),
+        ('*com.mapmywalk.android2/databases/workout.db*'),
         get_map_activities)
 }

--- a/scripts/artifacts/MMWUsers.py
+++ b/scripts/artifacts/MMWUsers.py
@@ -10,7 +10,7 @@ from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
 
 def get_map_users(files_found, report_folder, seeker, wrap_text):
     logfunc("Processing data for Map My Walk Users")
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    files_found = [x for x in files_found if not x.endswith('-journal') and not x.endswith('_gear') and not x.endswith('_gear-journal')]
     file_found = str(files_found[0])
     db = open_sqlite_db_readonly(file_found)
 

--- a/scripts/artifacts/NikeAMoments.py
+++ b/scripts/artifacts/NikeAMoments.py
@@ -26,8 +26,8 @@ def get_nike_activMoments(files_found, report_folder, seeker, wrap_text):
     usageentries = len(all_rows)
     if usageentries > 0:
         logfunc(f"Found {usageentries} Nike Activities")
-        report = ArtifactHtmlReport('Activity Moments')
-        report.start_artifact_report(report_folder, 'Activity Moments')
+        report = ArtifactHtmlReport('Nike - Activity Moments')
+        report.start_artifact_report(report_folder, 'Nike - Activity Moments')
         report.add_script()
         data_headers = ('Activity ID', 'Start Time UTC', 'End Time UTC', 'Duration', 'Timeline')
         data_list = []

--- a/scripts/artifacts/NikeActivities.py
+++ b/scripts/artifacts/NikeActivities.py
@@ -26,8 +26,8 @@ def get_nike_activities(files_found, report_folder, seeker, wrap_text):
     usageentries = len(all_rows)
     if usageentries > 0:
         logfunc(f"Found {usageentries} Nike Activities")
-        report = ArtifactHtmlReport('Activities')
-        report.start_artifact_report(report_folder, 'Activities')
+        report = ArtifactHtmlReport('Nike - Activities')
+        report.start_artifact_report(report_folder, 'Nike - Activities')
         report.add_script()
         data_headers = ('Activity ID', 'Name', 'Start Time UTC', 'End Time UTC', 'Location', 'Source', 'Version', 'Temperature', 'Weather', 'Duration', 'Calories', 'Max Speed', 'Mean Speed', 'Steps', 'Distance', 'Pace', 'Cadence')
         data_list = []

--- a/scripts/artifacts/NikeNotifications.py
+++ b/scripts/artifacts/NikeNotifications.py
@@ -10,6 +10,7 @@ from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
 
 def get_nike_notifications(files_found, report_folder, seeker, wrap_text):
     logfunc("Processing data for Nike Notifications")
+    files_found = [x for x in files_found if not x.endswith('-journal')]
     file_found = str(files_found[0])
     db = open_sqlite_db_readonly(file_found)
 
@@ -70,6 +71,6 @@ def get_nike_notifications(files_found, report_folder, seeker, wrap_text):
 __artifacts__ = {
     "NikeNotifications": (
         "Nike-Run",
-        ('*/com.nike.plusgps/databases/ns_inbox.db'),
+        ('*/com.nike.plusgps/databases/ns_inbox.db*'),
         get_nike_notifications)
 }

--- a/scripts/artifacts/NikeNotifications.py
+++ b/scripts/artifacts/NikeNotifications.py
@@ -9,7 +9,7 @@ from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
 
 
 def get_nike_notifications(files_found, report_folder, seeker, wrap_text):
-    logfunc("Processing data for Garmin Notifications")
+    logfunc("Processing data for Nike Notifications")
     file_found = str(files_found[0])
     db = open_sqlite_db_readonly(file_found)
 
@@ -70,6 +70,6 @@ def get_nike_notifications(files_found, report_folder, seeker, wrap_text):
 __artifacts__ = {
     "NikeNotifications": (
         "Nike-Run",
-        ('*/com.nike.plusgps/databases/ns_inbox.db*'),
+        ('*/com.nike.plusgps/databases/ns_inbox.db'),
         get_nike_notifications)
 }

--- a/scripts/artifacts/NikePolyline.py
+++ b/scripts/artifacts/NikePolyline.py
@@ -41,8 +41,8 @@ def get_nike_polyline(files_found, report_folder, seeker, wrap_text):
     usageentries = len(all_rows)
     if usageentries > 0:
         logfunc(f'Found {usageentries} activity_polyline entries')
-        report = ArtifactHtmlReport('Activity Route')
-        report.start_artifact_report(report_folder, 'Activity Route')
+        report = ArtifactHtmlReport('Nike - Activity Route')
+        report.start_artifact_report(report_folder, 'Nike - Activity Route')
         report.add_script()
         data_headers = ('Activity ID', 'Start Time UTC', 'End Time UTC', 'Duration', 'Coordinates File', 'Button')
         data_list = []

--- a/scripts/artifacts/RunkeeperActivities.py
+++ b/scripts/artifacts/RunkeeperActivities.py
@@ -187,6 +187,6 @@ def get_run_activities(files_found, report_folder, seeker, wrap_text):
 __artifacts__ = {
     "RunkeeperActivities": (
         "Runkeeper",
-        ('*com.fitnesskeeper.runkeeper.pro/databases/RunKeeper.sqlite*'),
+        ('*com.fitnesskeeper.runkeeper.pro/databases/RunKeeper.sqlite'),
         get_run_activities)
 }

--- a/scripts/artifacts/RunkeeperActivities.py
+++ b/scripts/artifacts/RunkeeperActivities.py
@@ -14,7 +14,7 @@ from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
 
 def get_run_activities(files_found, report_folder, seeker, wrap_text):
     logfunc("Processing data for Runkeeper Activities")
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    files_found = [x for x in files_found if not x.endswith('-journal')]
     file_found = str(files_found[0])
     db = open_sqlite_db_readonly(file_found)
 
@@ -187,6 +187,6 @@ def get_run_activities(files_found, report_folder, seeker, wrap_text):
 __artifacts__ = {
     "RunkeeperActivities": (
         "Runkeeper",
-        ('*com.fitnesskeeper.runkeeper.pro/databases/RunKeeper.sqlite'),
+        ('*com.fitnesskeeper.runkeeper.pro/databases/RunKeeper.sqlite*'),
         get_run_activities)
 }


### PR DESCRIPTION
Fixed a bug where there would be confusion in the files for some artifacts in macOS (example db and db-journal) thanks, @abrignoni, for the explanation, I changed the for loop to only get the files I wanted and not limit the grep as I was doing in the other pull request.

Additionally, I discovered that Adidas Run can store a corrupted polyline and would cause the artifact to crash, so I added a try/catch to the decoding process.