### PR TITLE
Add badoo modules

### DIFF
--- a/scripts/artifact_report.py
+++ b/scripts/artifact_report.py
@@ -339,3 +339,23 @@ class ArtifactHtmlReport:
             }});
             </script>
             """
+
+    # Function to add a chat window to the artifact
+    def add_chat(self):
+        self.report_file.write('<div class="container py-5">')
+        self.report_file.write('<div class="row d-flex justify-content-center">')
+        self.report_file.write('<div class="col-md-8 col-lg-6 col-xl-4">')
+        self.report_file.write('<div class="card" id="chat">')
+        self.report_file.write('<div class="card-header d-flex justify-content-center align-items-center p-3 bg-dark text-white border-bottom-0">')
+        self.report_file.write('<p class="mb-0 fw-bold" id="title">Chat</p>')
+        self.report_file.write('</div>')
+        self.report_file.write('<div class="card-body" id="text-area">')
+        self.report_file.write('</div>')
+        self.report_file.write('</div>')
+        self.report_file.write('</div>')
+        self.report_file.write('</div>')
+        self.report_file.write('</div>')
+
+    # Function to add a empty element with the data to be added later (roundabout way to add data to the chat)
+    def add_chat_invisble(self, id, text):
+        self.report_file.write(f'<div id="{id}" hidden>{text}</div>')

--- a/scripts/artifacts/BadooChat.py
+++ b/scripts/artifacts/BadooChat.py
@@ -1,0 +1,128 @@
+# Get Information related to the Chats of the user with other users from the Badoo app (com.badoo.mobile)
+# Author: Fabian Nunes {fabiannunes12@gmail.com}
+# Date: 2023-05-03
+# Version: 1.0
+# Requirements: Python 3.7 or higher, json
+import json
+
+from scripts.artifact_report import ArtifactHtmlReport
+from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+
+
+def get_badoo_chat(files_found, report_folder, seeker, wrap_text):
+    logfunc("Processing data for Badoo Conections")
+    files_found = [x for x in files_found if not x.endswith('-journal')]
+    file_found = str(files_found[0])
+    db = open_sqlite_db_readonly(file_found)
+
+
+    cursor = db.cursor()
+    cursor.execute('''
+        Select user_id, gender, user_name, user_image_url, age, user_photos, work, education, encrypted_user_id
+        from conversation_info
+    ''')
+
+    all_rows = cursor.fetchall()
+    usageentries = len(all_rows)
+    if usageentries > 0:
+        logfunc(f"Found {usageentries} entries in conversation_info")
+        report = ArtifactHtmlReport('Chat')
+        report.start_artifact_report(report_folder, 'Badoo Chat')
+        report.add_script()
+        data_headers = ('ID', 'Gender', 'User Name', 'User Image URL', 'Age', 'User Photos', 'Work', 'Education', 'Encrypted User ID', 'Button')
+        data_list = []
+
+        for row in all_rows:
+            id = row[0]
+            gender = row[1]
+            if (gender == 0):
+                gender_text = "Male"
+            elif (gender == 1):
+                gender_text = "Female"
+            else:
+                gender_text = "Other"
+            user_name = row[2]
+            user_image_url = row[3]
+            user_image = '<img src="' + user_image_url + '" width="100" height="100">'
+            age = row[4]
+            user_photos = row[5]
+            # convert string to array
+            user_photos = json.loads(user_photos)
+            photo_urls = ''
+            for i in range(len(user_photos)):
+                photo_url = user_photos[i]['url']
+                #photo_urls = photo_urls + '<img src="' + photo_url + '" width="100" height="100">'
+                photo_urls = photo_urls + '<a href="' + photo_url + '" target="_blank">Photo ' + str(i+1) + '</a><br>'
+
+            work = row[6]
+            education = row[7]
+            encrypted_user_id = row[8]
+            cursor.execute(f'''
+                                        Select sender_id, recipient_id, datetime("created_timestamp"/1000,'unixepoch'), payload, payload_type
+                                        from message
+                                        where sender_id = '{encrypted_user_id}' or recipient_id = '{encrypted_user_id}'
+                                    ''')
+            messages = cursor.fetchall()
+            usageentries_m = len(messages)
+            if usageentries_m > 0:
+                logfunc(f"Found {usageentries_m} entries in message")
+                message_list = []
+                for message in messages:
+                    text = message[3]
+                    text = json.loads(text)
+                    type = message[4]
+                    # Check if text exists
+                    if type == 'TEXT':
+                        message_text = text['text']
+                        typeM = 'text'
+                    elif type == 'QUESTION_GAME':
+                        message_text = text['text']
+                        if 'answer_own' in text:
+                            message_text = message_text + ';Own Answer:' + text['answer_own']
+                        if 'answer_other' in text:
+                            message_text = message_text + ';Other Answer:' + text['answer_other']
+                        typeM = 'question'
+                    elif type == 'INSTANT_VIDEO' or type == 'AUDIO' or type == 'IMAGE':
+                        message_text = text['url']
+                        typeM = 'url'
+
+                    message_dic = {
+                        'sender': message[0],
+                        'message': message_text,
+                        'time': message[2],
+                        'type': typeM
+                    }
+                    message_list.append(message_dic)
+                chat = {'name': user_name, 'messages': message_list}
+                chat = json.dumps(chat)
+                report.add_chat_invisble(encrypted_user_id, chat)
+                button = f'<button type="button" class="btn btn-primary" onclick="createChat(\'' + str(encrypted_user_id) + '\', \'' + str(user_image_url) + '\')">Open Chat</button>'
+            else:
+                button = '<button type="button" class="btn btn-primary" disabled>Open Chat</button>'
+            data_list.append((id, gender_text, user_name, user_image, age, photo_urls, work, education, encrypted_user_id, button))
+        # Filter by date
+        table_id = "BadooChat"
+        report.write_artifact_data_table(data_headers, data_list, file_found, table_id=table_id, html_escape=False)
+        # Add the map to the report
+        report.add_section_heading('Badoo Chat')
+        report.add_chat()
+        report.end_artifact_report()
+
+        tsvname = f'Badoo - Chat'
+        tsv(report_folder, data_headers, data_list, tsvname)
+
+        tlactivity = f'Badoo - Chat'
+        timeline(report_folder, tlactivity, data_list, data_headers)
+
+    else:
+        logfunc('No Badoo Chat data available')
+
+    db.close()
+
+
+__artifacts__ = {
+    "BadooChat": (
+        "Badoo",
+        ('*com.badoo.mobile/databases/ChatComDatabase*'),
+        get_badoo_chat)
+}

--- a/scripts/artifacts/BadooConnections.py
+++ b/scripts/artifacts/BadooConnections.py
@@ -1,0 +1,64 @@
+# Get Information related to possible connections (messages, views etc) of the user with other users from the Badoo app (com.badoo.mobile)
+# Author: Fabian Nunes {fabiannunes12@gmail.com}
+# Date: 2023-05-03
+# Version: 1.0
+# Requirements: Python 3.7 or higher
+
+from scripts.artifact_report import ArtifactHtmlReport
+from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+
+
+def get_badoo_conn(files_found, report_folder, seeker, wrap_text):
+    logfunc("Processing data for Badoo Conections")
+    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    file_found = str(files_found[0])
+    db = open_sqlite_db_readonly(file_found)
+
+    cursor = db.cursor()
+    cursor.execute('''
+        Select id, name, gender, origin, datetime("sort_timestamp"/1000,'unixepoch'), avatar_url, display_message
+        from connection
+    ''')
+
+    all_rows = cursor.fetchall()
+    usageentries = len(all_rows)
+    if usageentries > 0:
+        logfunc(f"Found {usageentries} entries in connection")
+        report = ArtifactHtmlReport('Chat')
+        report.start_artifact_report(report_folder, 'Badoo Connections')
+        report.add_script()
+        data_headers = ('ID', 'Name', 'Gender', 'Origin', 'Sort Timestamp', 'Avatar URL', 'Display Message')
+        data_list = []
+
+        for row in all_rows:
+            id = row[0]
+            name = row[1]
+            gender = row[2]
+            origin = row[3]
+            sort_timestamp = row[4]
+            avatar_url = '<img src="' + row[5] + '" width="100" height="100">'
+            display_message = row[6]
+            data_list.append((id, name, gender, origin, sort_timestamp, avatar_url, display_message))
+        # Filter by date
+        table_id = "BadooConnection"
+        report.write_artifact_data_table(data_headers, data_list, file_found, table_id=table_id, html_escape=False)
+        report.end_artifact_report()
+
+        tsvname = f'Badoo - Connections'
+        tsv(report_folder, data_headers, data_list, tsvname)
+
+        tlactivity = f'Badoo - Connections'
+        timeline(report_folder, tlactivity, data_list, data_headers)
+
+    else:
+        logfunc('No Badoo Connection data available')
+
+    db.close()
+
+
+__artifacts__ = {
+    "BadooConnections": (
+        "Badoo",
+        ('*com.badoo.mobile/databases/CombinedConnectionsDatabase*'),
+        get_badoo_conn)
+}

--- a/scripts/chat.css
+++ b/scripts/chat.css
@@ -1,0 +1,113 @@
+#chat .form-outline .form-control~.form-notch div {
+    pointer-events: none;
+    border: 1px solid;
+    border-color: #eee;
+    box-sizing: border-box;
+    background: transparent;
+}
+
+#chat .form-outline .form-control~.form-notch .form-notch-leading {
+    left: 0;
+    top: 0;
+    height: 100%;
+    border-right: none;
+    border-radius: .65rem 0 0 .65rem;
+}
+
+#chat .form-outline .form-control~.form-notch .form-notch-middle {
+    flex: 0 0 auto;
+    max-width: calc(100% - 1rem);
+    height: 100%;
+    border-right: none;
+    border-left: none;
+}
+
+#chat .form-outline .form-control~.form-notch .form-notch-trailing {
+    flex-grow: 1;
+    height: 100%;
+    border-left: none;
+    border-radius: 0 .65rem .65rem 0;
+}
+
+#chat .form-outline .form-control:focus~.form-notch .form-notch-leading {
+    border-top: 0.125rem solid #3c3c3c;
+    border-bottom: 0.125rem solid #3c3c3c;
+    border-left: 0.125rem solid #3c3c3c;
+}
+
+#chat .form-outline .form-control:focus~.form-notch .form-notch-leading,
+#chat .form-outline .form-control.active~.form-notch .form-notch-leading {
+    border-right: none;
+    transition: all 0.2s linear;
+}
+
+#chat .form-outline .form-control:focus~.form-notch .form-notch-middle {
+    border-bottom: 0.125rem solid;
+    border-color: #3c3c3c;
+}
+
+#chat .form-outline .form-control:focus~.form-notch .form-notch-middle,
+#chat .form-outline .form-control.active~.form-notch .form-notch-middle {
+    border-top: none;
+    border-right: none;
+    border-left: none;
+    transition: all 0.2s linear;
+}
+
+#chat .form-outline .form-control:focus~.form-notch .form-notch-trailing {
+    border-top: 0.125rem solid #3c3c3c;
+    border-bottom: 0.125rem solid #3c3c3c;
+    border-right: 0.125rem solid #3c3c3c;
+}
+
+#chat .form-outline .form-control:focus~.form-notch .form-notch-trailing,
+#chat .form-outline .form-control.active~.form-notch .form-notch-trailing {
+    border-left: none;
+    transition: all 0.2s linear;
+}
+
+#chat .form-outline .form-control:focus~.form-label {
+    color: #3c3c3c;
+}
+
+#chat .form-outline .form-control~.form-label {
+    color: #bfbfbf;
+}
+
+.hour {
+    margin: 0;
+    float: right;
+    font-size: 13px;
+    color: #a5a5a5
+}
+
+.card-body {
+    overflow-y: scroll;
+    height: 500px;
+}
+
+.avatar {
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+
+}
+
+.sender {
+    border-radius: 15px;
+    background-color: rgba(57, 192, 237,.2);
+}
+
+.receiver {
+    border-radius: 15px;
+    background-color: #fbfbfb;
+}
+
+#chat {
+    border-radius: 15px;
+}
+
+.card-header {
+    border-top-left-radius: 15px;
+    border-top-right-radius: 15px;
+}

--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -1,0 +1,72 @@
+function createMessage(message, time, type, messageType, url) {
+    let chat = document.getElementById("text-area");
+    let div = document.createElement("div");
+    chat.appendChild(div);
+
+    let div2 = document.createElement("div");
+    div.appendChild(div2);
+    if (messageType == "text") {
+        let p = document.createElement("p");
+        p.className = "small mb-0";
+        p.textContent = message;
+        div2.appendChild(p);
+    } else if (messageType == "url") {
+        let a = document.createElement("a");
+        a.className = "small mb-0";
+        a.href = message;
+        a.target = "_blank";
+        a.textContent = "Open link";
+        div2.appendChild(a);
+        let br = document.createElement("br");
+        div2.appendChild(br);
+    } else if (messageType == "question") {
+        let p = document.createElement("p");
+        p.className = "small mb-0";
+        let answer = message.split(";");
+        p.textContent = answer[0];
+        div2.appendChild(p);
+        let p2 = document.createElement("p");
+        p2.className = "small mb-0";
+        p2.textContent = answer[1];
+        div2.appendChild(p2);
+        let p3 = document.createElement("p");
+        p3.className = "small mb-0";
+        p3.textContent = answer[2];
+        div2.appendChild(p3);
+    }
+    let p2 = document.createElement("p");
+    p2.className = "hour";
+    p2.textContent = time;
+    div2.appendChild(p2);
+
+    if (type == "0") {
+        div.className = "d-flex flex-row justify-content-start mb-4";
+        div2.className = "p-3 ms-3 sender";
+    } else {
+        div.className = "d-flex flex-row justify-content-end mb-4";
+        div2.className = "p-3 me-3 border receiver";
+        let img = document.createElement("img");
+        img.className = "avatar";
+        img.src = url;
+        div.appendChild(img);
+    }
+}
+
+function createChat(sender, url) {
+    let content = document.getElementById(sender);
+    let myObJ = JSON.parse(content.textContent);
+    //destroy old chat
+    let chat = document.getElementById("text-area");
+    chat.innerHTML = "";
+    //create new chat
+    let title = document.getElementById("title");
+    title.textContent = myObJ.name;
+    for (let i = 0; i < myObJ.messages.length; i++) {
+        if (myObJ.messages[i].sender != sender) {
+            createMessage(myObJ.messages[i].message, myObJ.messages[i].time, "0", myObJ.messages[i].type, url);
+        } else {
+            createMessage(myObJ.messages[i].message, myObJ.messages[i].time, "1", myObJ.messages[i].type, url);
+        }
+        sender = myObJ.messages[i].sender;
+    }
+}

--- a/scripts/html_parts.py
+++ b/scripts/html_parts.py
@@ -29,6 +29,7 @@ page_header = \
         <script src="_elements/Tooltip.min.js"></script>
         <!-- Your custom styles (optional) -->
         <link rel="stylesheet" href="_elements/dashboard.css">
+        <link rel="stylesheet" href="_elements/chat.css">
         <!-- MDBootstrap Datatables  -->
         <link rel="stylesheet" href="_elements/MDB-Free_4.13.0/css/addons/datatables.min.css" rel="stylesheet">
         <link href="_elements/timeline/css/timeline.min.css" rel="stylesheet" />
@@ -286,6 +287,7 @@ body_end = \
     <script type="text/javascript" src="_elements/timeline/js/timeline.min.js"></script>
     <!-- Garmin Functions -->
     <script type="text/javascript" src="_elements/garmin-functions.js"></script>
+    <script type="text/javascript" src="_elements/chat.js"></script>
     <script>
         feather.replace()
     </script>

--- a/scripts/report.py
+++ b/scripts/report.py
@@ -35,6 +35,9 @@ def get_icon_name(category, artifact):
     elif category == 'APP INTERACTION': icon = 'bar-chart-2'
     elif category == 'APP ROLES':  icon = 'tool'
     elif category == 'BASH HISTORY':    icon = 'terminal'
+    elif category == 'BADOO':
+        if artifact.find('CHAT') >= 0:  icon = 'message-circle'
+        elif artifact.find('CONNECTIONS') >= 0:  icon = 'heart'
     elif category == 'BITTORRENT':    icon = 'share'
     elif category == 'BLUETOOTH CONNECTIONS':       icon = 'bluetooth'
     elif category == 'BUMBLE':
@@ -440,6 +443,8 @@ def generate_report(reportfolderbase, time_in_secs, time_HMS, extraction_type, i
     # Garmin Custom JS
     shutil.copy2(os.path.join(__location__, "garmin-functions.js"), elements_folder)
     shutil.copytree(os.path.join(__location__, "timeline"), os.path.join(elements_folder, 'timeline'))
+    shutil.copy2(os.path.join(__location__, "chat.css"), elements_folder)
+    shutil.copy2(os.path.join(__location__, "chat.js"), elements_folder)
 
 def get_file_content(path):
     f = open(path, 'r', encoding='utf8')


### PR DESCRIPTION
Create two modules for the dating app Badoo:

The **chat module** will extract all the conversations between users: (text, video, audio, images etc). The module also extracts connection information, such as name, gender, work, and all his photos.

<a href="https://ibb.co/Kh5Myq1"><img src="https://i.ibb.co/vqc7zPt/Captura-de-ecr-2023-05-03-s-20-53-17.png" alt="Captura-de-ecr-2023-05-03-s-20-53-17" border="0"></a>

To turn this into the most realistic possible, we added a new feature to ALEAPP. We present the chat window:

<img src="https://i.ibb.co/Cm0xNpc/Captura-de-ecr-2023-05-03-s-20-38-58.png" alt="Captura-de-ecr-2023-05-03-s-20-38-58" border="0">

By clicking on the button Open chat in the datable related to the connection, the report will open the conversation that happened in a chat window format for better understanding.

This feature is purely CSS and JS and can be adapted to other applications that store conversations.

Another module created is related to **notifications of the connections**, such as:
Persons that viewed your profile, messages sent without connection, etc.
This module gives the message, the user's name, and the profile picture.

There is room for improvement. Since I used fake accounts created with temp mail it was quite challenging to generate data since Badoo is one of the few apps that requires photo recognition to detect false accounts, I managed to bypass this, but I only had minutes for it.