### PR TITLE
Update aleapp.py

### DIFF
--- a/aleapp.py
+++ b/aleapp.py
@@ -92,7 +92,7 @@ def main():
         except NameError:
             casedata = {}
             
-        crunch_artifacts(list(loader.plugins), extracttype, input_path, out_params, 1, wrap_text, loader, casedata)
+        crunch_artifacts(list(loader.plugins), extracttype, input_path, out_params, 1, wrap_text, casedata)
         
 
 def crunch_artifacts(


### PR DESCRIPTION
Remove extra parameter that was causing the command line version of aLeapp to fail.

Will need to replace the current version 3.1.8 for aLeapp as it will not work.