### PR TITLE
Call logs from com.samsung.android.providers.contacts

### DIFF
--- a/scripts/artifacts/calllog.py
+++ b/scripts/artifacts/calllog.py
@@ -93,6 +93,6 @@ def get_calllog(files_found, report_folder, seeker, wrap_text, time_offset):
 __artifacts__ = {
         "Call logs ": (
                 "Call Logs",
-                ('*/com.android.providers.contacts/databases/calllog.db*','*/com.samsung.android.providers.contacts/databases/calllog.db'),
+                ('*/com.android.providers.contacts/databases/calllog.db*','*/com.samsung.android.providers.contacts/databases/calllog.db*'),
                 get_calllog)
 }

--- a/scripts/artifacts/calllog.py
+++ b/scripts/artifacts/calllog.py
@@ -93,6 +93,6 @@ def get_calllog(files_found, report_folder, seeker, wrap_text, time_offset):
 __artifacts__ = {
         "Call logs ": (
                 "Call Logs",
-                ('*/com.android.providers.contacts/databases/calllog.db*'),
+                ('*/com.android.providers.contacts/databases/calllog.db*','*/com.samsung.android.providers.contacts/databases/calllog.db'),
                 get_calllog)
 }


### PR DESCRIPTION
I found some phones where the calllog.db is on path pattern */com.samsung.android.providers.contacts/databases/calllog.db.