### PR TITLE
Contacts from com.samsung.android.providers

### DIFF
--- a/scripts/artifacts/contacts.py
+++ b/scripts/artifacts/contacts.py
@@ -78,6 +78,6 @@ def get_contacts(files_found, report_folder, seeker, wrap_text, time_offset):
 __artifacts__ = {
     "Contacts": (
         "Contacts",
-        ('*/com.android.providers.contacts/databases/contact*', '*/com.sec.android.provider.logsprovider/databases/logs.db*'),
+        ('*/com.android.providers.contacts/databases/contact*', '*/com.sec.android.provider.logsprovider/databases/logs.db*', '*/com.samsung.android.providers.contacts/databases/contact*'),
         get_contacts)
 }


### PR DESCRIPTION
In some cases the contacts database is found in the folder pattern */com.samsung.android.providers.contacts/databases