### PR TITLE
Filter content with valid JSON

### DIFF
--- a/scripts/artifacts/tikTok.py
+++ b/scripts/artifacts/tikTok.py
@@ -36,7 +36,7 @@ def get_tikTok(files_found, report_folder, seeker, wrap_text, time_offset):
             end
         local_info
         from db_im_xx.SIMPLE_USER, msg
-        where UID = sender order by created_time
+        where UID = sender and json_valid(content) = 1 order by created_time
         ''')
 
     all_rows = cursor.fetchall()


### PR DESCRIPTION
Found a database where many rows of the db were with the value of content field equals to 'placehoder'. No row was returned by the original SQL with a error message of invalid JSON. Filtering for only rows with valid json on content field returned some values.