### PR TITLE
Minor change/bug fix in kleinanzeigen.de.py

### DIFF
--- a/scripts/artifacts/kleinanzeigen.de.py
+++ b/scripts/artifacts/kleinanzeigen.de.py
@@ -280,7 +280,7 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "kleinanzeigen.de App",
         "notes": "",
-        "paths": ('*com.ebay.kleinanzeigen\databases\messageBoxDatabase.db*'),
+        "paths": ('*com.ebay.kleinanzeigen/databases/messageBoxDatabase.db*'),
         "function": "get_kleinanzeigenmessagebox"
     }
 }


### PR DESCRIPTION
- Changed value of field "paths" in get_kleinanzeigenmessagebox -> backslashes to slashes, so the database can be found and correctly parsed.
Tested on Android 14, App Version 100.1.0