### PR TITLE
fix error in calllog.py causing it to always fail

### DIFF
--- a/scripts/artifacts/calllog.py
+++ b/scripts/artifacts/calllog.py
@@ -8,7 +8,7 @@ def get_calllog(files_found, report_folder, seeker, wrap_text, time_offset):
     data_list = []
     
     for file_found in files_found:
-        file_found = str(files_found)
+        file_found = str(file_found)
         
         if file_found.endswith('calllog.db'):
             db = open_sqlite_db_readonly(file_found)


### PR DESCRIPTION
Small error in calllog.py causes the file_found variable to be a string representation of an array so the following check to see if it ends in 'calllog.db' always fails resulting in it skipping parse of this file.