### PR TITLE
Missing parameter from chromeCookies

### DIFF
--- a/scripts/artifacts/chromeCookies.py
+++ b/scripts/artifacts/chromeCookies.py
@@ -6,7 +6,7 @@ from scripts.artifact_report import ArtifactHtmlReport
 from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, get_next_unused_name, open_sqlite_db_readonly
 from scripts.artifacts.chrome import get_browser_name
 
-def get_chromeCookies(files_found, report_folder, seeker, wrap_text):
+def get_chromeCookies(files_found, report_folder, seeker, wrap_text, time_offset):
     
     for file_found in files_found:
         file_found = str(file_found)


### PR DESCRIPTION
Fixes missing parameter in the chromeCookies script preventing it from running successfully. 