### PR TITLE
Add missing hiddenimports to compile windows binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,6 @@ __pypackages__/
 *.pot
 *.mo
 *.manifest
-*.spec
 pip-wheel-metadata/
 share/python-wheels/
 wheels/

--- a/scripts/pyinstaller/aleapp-file_version_info.txt
+++ b/scripts/pyinstaller/aleapp-file_version_info.txt
@@ -25,4 +25,4 @@ VSVersionInfo(
       ]), 
     VarFileInfo([VarStruct('Translation', [1033, 1200])])
   ]
-)5
+)

--- a/scripts/pyinstaller/aleapp.spec
+++ b/scripts/pyinstaller/aleapp.spec
@@ -1,7 +1,6 @@
 # -*- mode: python ; coding: utf-8 -*-
 
 block_cipher = None
-
 a = Analysis(['..\\..\\aleapp.py'],
              pathex=['..\\scripts\\artifacts'],
              binaries=[],

--- a/scripts/pyinstaller/aleappGUI.spec
+++ b/scripts/pyinstaller/aleappGUI.spec
@@ -1,4 +1,5 @@
 # -*- mode: python ; coding: utf-8 -*-
+
 block_cipher = None
 a = Analysis(['..\\..\\aleappGUI.py'],
              pathex=['..\\scripts\\artifacts'],


### PR DESCRIPTION
Remove *.spec from .gitignore file
Add missing hiddenimports in .spec files to compile Windows executables.