### PR TITLE
Added Speedtest artifact extractor

### DIFF
--- a/scripts/artifacts/speedtest.py
+++ b/scripts/artifacts/speedtest.py
@@ -49,7 +49,7 @@ import json
 @artifact_processor
 def extract_speedtest_test_results(files_found, report_folder, seeker, wrap_text):
     file_path = files_found[0]
-    headers = [('Timestamp', 'datetime'), 'Connection type', 'SSID', 'User Latitude', 'User Longitude', 'External IP', 'Internal IP', 'Download speed (Kbps)', 'Upload speed (Kbps)']
+    headers = [('Timestamp', 'datetime'), 'Connection type', 'SSID', 'Latitude', 'Longitude', 'External IP', 'Internal IP', 'Download speed (Kbps)', 'Upload speed (Kbps)']
 
     db = open_sqlite_db_readonly(file_path)
     cur = db.cursor()

--- a/scripts/artifacts/speedtest.py
+++ b/scripts/artifacts/speedtest.py
@@ -115,6 +115,8 @@ def extract_speedtest_reports(files_found, report_folder, seeker, wrap_text):
     report.write_artifact_data_table(wifi_scan_headers, wifi_scan_results, file_path)
     report.end_artifact_report()
 
-    tsv(report_folder, headers, result, report_name, file_path)
+    tsv(report_folder, headers, reports, "Speedtest Extended Reports (Location Data)", file_path)
+    tsv(report_folder, wifi_scan_headers, wifi_scan_results, "Speedtest Extended Reports (Wi-Fi Data)", file_path)
 
-    timeline(report_folder, report_name, result, headers)
+    timeline(report_folder, "Speedtest Extended Reports (Location Data)", reports, headers)
+    timeline(report_folder, "Speedtest Extended Reports (Wi-Fi Data)", wifi_scan_results, wifi_scan_headers)

--- a/scripts/artifacts/speedtest.py
+++ b/scripts/artifacts/speedtest.py
@@ -1,0 +1,120 @@
+__artifacts_v2__ = {
+    "speedtest_tests": {
+        "name": "Speedtest Test Results",
+        "description": "Extracts Speedtest Test metadata and other interaction artifacts",
+        "author": "its5Q",
+        "version": "0.1",
+        "date": "2025-07-28",
+        "requirements": "none",
+        "category": "Speedtest",
+        "notes": "",
+        "paths": ('*/org.zwanoo.android.speedtest/databases/AmplifyDatastore.db',),
+        "function": "extract_speedtest_test_results"
+    },
+
+    "speedtest_reports": {
+        "name": "Speedtest Reports",
+        "description": "Extracts Speedtest logging reports which contain more information, like Wi-Fi scan data",
+        "author": "its5Q",
+        "version": "0.1",
+        "date": "2025-07-28",
+        "requirements": "none",
+        "category": "Speedtest",
+        "notes": "",
+        "paths": ('*/org.zwanoo.android.speedtest/databases/speedtest',),
+        "function": "extract_speedtest_reports"
+    },
+}
+
+from datetime import datetime, timezone, timedelta
+from scripts.artifact_report import ArtifactHtmlReport
+from scripts.ilapfuncs import open_sqlite_db_readonly, does_column_exist_in_db, tsv, timeline, logfunc
+import json
+
+def extract_speedtest_test_results(files_found, report_folder, seeker, wrap_text):
+    file_path = files_found[0]
+    headers = ['Timestamp', 'Connection type', 'SSID', 'User Latitude', 'User Longitude', 'External IP', 'Internal IP', 'Download speed (Kbps)', 'Upload speed (Kbps)']
+
+    db = open_sqlite_db_readonly(file_path)
+    cur = db.cursor()
+
+    try:
+        cur.execute('SELECT datetime(date, \'unixepoch\'), connectionType, ssid, userLatitude, userLongitude, externalIp, internalIp, downloadKbps, uploadKbps FROM UnivSpeedTestResult')
+        result = cur.fetchall()
+    except Exception as ex:
+        logfunc('Error retrieving Speedtest test results: ', ex)
+
+    if result:
+        report = ArtifactHtmlReport("Speedtest Test Results")
+        report_name = "Speedtest Test Results"
+        report.start_artifact_report(report_folder, report_name)
+        report.add_script()
+        report.write_artifact_data_table(headers, result, file_path)
+        report.end_artifact_report()
+
+        tsv(report_folder, headers, result, report_name, file_path)
+
+        timeline(report_folder, report_name, result, headers)
+
+
+def extract_speedtest_reports(files_found, report_folder, seeker, wrap_text):
+    file_path = files_found[0]
+    headers = ['Timestamp', 'Latitude', 'Longitude', 'Altitude', 'Accuracy (meters)']
+    wifi_scan_headers = ['Timestamp', 'BSSID', 'SSID', 'Signal Strength']
+
+    reports = []
+    wifi_scan_results = []
+
+    db = open_sqlite_db_readonly(file_path)
+    cur = db.cursor()
+
+    try:
+        cur.execute('SELECT DATA FROM REPORT')
+        result = cur.fetchall()
+    except Exception as ex:
+        logfunc('Error retrieving Speedtest reports: ', ex)
+
+    if result:
+        for row in result:
+            try:
+                j = json.loads(row[0])
+                location_data = j.get('start', {}).get('location', {})
+                wifi_scan_data = j.get('start', {}).get('extended', {}).get('wifi', {}).get('scanResults', [])
+                report_timestamp = datetime.fromisoformat(j.get('start', {}).get('timestamp', '1970-01-01T00:00:00Z'))
+                if location_data:
+                    latitude = location_data.get('latitude', None)
+                    longitude = location_data.get('longitude', None)
+                    altitude = location_data.get('altitude', None)
+                    accuracy = location_data.get('accuracy', None)
+
+                    reports.append((report_timestamp, latitude, longitude, altitude, accuracy))
+                
+                elapsedRealtimeNanos = j.get('start', {}).get('time', {}).get('elapsedRealtimeNanos', 0)
+                timestamp = j.get('start', {}).get('time', {}).get('timestamp', 0)
+                boot_time = datetime.fromisoformat(timestamp) - timedelta(microseconds=elapsedRealtimeNanos/1000) if timestamp and elapsedRealtimeNanos else None
+
+                for scan_result in wifi_scan_data:
+                    try:
+                        timestamp = boot_time + timedelta(microseconds=scan_result.get('timestamp', 0)) if boot_time else None
+                        bssid = scan_result.get('BSSID')
+                        ssid = scan_result.get('SSID')
+                        level = scan_result.get('level')
+                    except Exception as ex:
+                        logfunc('Error retrieving Speedtest Wi-Fi scan data: ', ex)
+
+                    wifi_scan_results.append((timestamp, bssid, ssid, level))
+
+            except Exception as ex:
+                logfunc('Error retrieving Speedtest reports: ', ex)
+
+    report = ArtifactHtmlReport("Speedtest Extended Reports")
+    report_name = "Speedtest Extended Reports"
+    report.start_artifact_report(report_folder, report_name)
+    report.add_script()
+    report.write_artifact_data_table(headers, reports, file_path)
+    report.write_artifact_data_table(wifi_scan_headers, wifi_scan_results, file_path)
+    report.end_artifact_report()
+
+    tsv(report_folder, headers, result, report_name, file_path)
+
+    timeline(report_folder, report_name, result, headers)

--- a/scripts/artifacts/usagestatsVersion.py
+++ b/scripts/artifacts/usagestatsVersion.py
@@ -28,7 +28,7 @@ def usagestatsVersion(files_found, report_folder, seeker, wrap_text):
 
     text_file = get_txt_file_content(source_path)
     for line in text_file:
-        splits = line.split(';')
+        splits = line.strip().split(';')
         totalvalues = len(splits)
         if totalvalues >= 3:
             device_info("Usagestats", "Android version", splits[0])


### PR DESCRIPTION
This PR implements a plugin to extract artifacts from the Speedtest app, which contain a lot of useful data such as location data and network names. Inspired by the recently finished Belkasoft CTF :)

Test data from the CTF image: [org.zwanoo.android.speedtest.zip](https://github.com/user-attachments/files/21455127/org.zwanoo.android.speedtest.zip)

Resulting report:
<img width="2560" height="1331" alt="chrome_cVDfOxhYH6" src="https://github.com/user-attachments/assets/5cfdad34-c192-477c-bb91-b51a2b869528" />
<img width="2560" height="1331" alt="image" src="https://github.com/user-attachments/assets/90db28dc-40e0-47d7-8ece-d871f17cafb0" />

