### PR TITLE
Update gmailIMAPEmails.py - Attachments/Accounts

### DIFF
--- a/scripts/artifacts/gmailIMAPEmails.py
+++ b/scripts/artifacts/gmailIMAPEmails.py
@@ -36,7 +36,7 @@ import urllib.parse
 from scripts.ilapfuncs import open_sqlite_db_readonly, artifact_processor, convert_unix_ts_to_utc, logfunc, media_to_html
 
 @artifact_processor
-def gmailIMAPEmails(files_found, report_folder, seeker, wrap_text):
+def gmailIMAPEmails(files_found, report_folder, _seeker, _wrap_text):
     emailProviderDB = ''    
     emailProviderDB_found = []
 
@@ -148,7 +148,7 @@ def gmailIMAPEmails(files_found, report_folder, seeker, wrap_text):
     return data_headers, data_list, 'See source file(s) below:'
     
 @artifact_processor
-def gmailIMAPAccounts(files_found, report_folder, seeker, wrap_text):
+def gmailIMAPAccounts(files_found, _report_folder, _seeker, _wrap_text):
     emailProviderDB = '' 
     emailProviderDB_found = []
 


### PR DESCRIPTION
Adding parsing of attachments, account details, and some more fields.

Building off of recent research on the attachments at https://ogmini.github.io/2025/10/06/Gmail-App-IMAP-Account-Attachments-Part-2.html. A few new columns have been added:

- Read Flag
- Attachment Flag
- List of Attachments which includes filename and the path
- Mailbox Folder (ie, Sent, Inbox, Trash)

![image](https://github.com/user-attachments/assets/43896c09-0494-49f0-8d54-8e8ccf4d11f3)

This also now pulls the account details for any IMAP mailboxes. This includes cleartext passwords.

![image](https://github.com/user-attachments/assets/4db79aaa-a7bf-468f-9b4d-5f1768bb5f23)

Welcome any suggestions, I was on the fence about the best way to handle displaying the attachments. 

