### PR TITLE
Fix: Improve Chrome Downloads History Compatibility (Pre-v65)

### DIFF
--- a/scripts/artifacts/chrome.py
+++ b/scripts/artifacts/chrome.py
@@ -204,6 +204,12 @@ def get_chrome(files_found, report_folder, seeker, wrap_text):
         else:
             last_access_time_query = "'' as last_access_query"
 
+        # check for tab_url column, the older versions (pre-v65) does not have it
+        if does_column_exist_in_db(file_found, 'downloads', 'tab_url') == True:
+            tab_url_column = "tab_url"
+        else:
+            tab_url_column = "'' as tab_url"
+
         cursor.execute(f'''
         SELECT 
         CASE start_time  
@@ -217,7 +223,7 @@ def get_chrome(files_found, report_folder, seeker, wrap_text):
             ELSE datetime(end_time / 1000000 + (strftime('%s', '1601-01-01')), "unixepoch")
         END AS "End Time", 
         {last_access_time_query},
-        tab_url, 
+        {tab_url_column}, 
         target_path, 
         CASE state
             WHEN "0" THEN "In Progress"

--- a/scripts/artifacts/chrome.py
+++ b/scripts/artifacts/chrome.py
@@ -1,10 +1,10 @@
 import os
-import sqlite3
 import textwrap
 import urllib.parse
+import re
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, get_next_unused_name, open_sqlite_db_readonly, does_column_exist_in_db
+from scripts.ilapfuncs import logfunc, tsv, timeline, get_next_unused_name, open_sqlite_db_readonly, does_column_exist_in_db
 
 def get_browser_name(file_name):
 
@@ -20,7 +20,7 @@ def get_browser_name(file_name):
         try:
             result = re.search('.*/(.*)/app_webview/Default.*', file_name)
             return result.group(1)
-        except:
+        except Exception:
             return 'Unknown'
     else:
         return 'Unknown'


### PR DESCRIPTION
### Summary
This patch addresses the `sqlite3.OperationalError: no such column: tab_url ` that occurs when processing the Chrome Downloads table from older Android images. This error prevents the entire Chrome artifact from being parsed successfully on devices running older Chrome versions.

This fix implements a column existence check before constructing the SQL query, ensuring the parser gracefully handles schemas from older Chrome installations.

### Motivation for the Change
When analyzing older Android images (e.g., Nexus 5 with Chrome v29 on Android 6.0.1), the `chrome.py` script frequently fails because it attempts to select the `tab_url` column from the downloads table.

The `tab_url` column was introduced much later (in Chromium v65.0.3300.0). By checking if the column exists before querying, we prevent the fatal SQL error and allow the extraction of all other critical download metadata (start/end time, target path, state, etc.), significantly improving the tool's compatibility with historical mobile images.

### Technical Details of the Fix
The following logic was added to the `get_chrome` function:
- A check is performed using `does_column_exist_in_db(file_found, 'downloads', 'tab_url')`.
- If the column exists (`True`), the query uses the actual column name: `tab_url`.
- If the column does not exist (`False`), the query uses a placeholder: `'' as tab_url`.

This dynamic query construction ensures ALEAPP remains robust across a wider range of Chrome versions.
