### PR TITLE
Fix `utcfromtimestamp()` TypeError in `offlinePages` artifact

### DIFF
--- a/scripts/artifacts/offlinePages.py
+++ b/scripts/artifacts/offlinePages.py
@@ -24,7 +24,7 @@ def get_offlinePages(files_found, report_folder, seeker, wrap_text):
         file_found = str(file_found)
         
         modified_time = os.path.getmtime(file_found)
-        utc_modified_date = datetime.utcfromtimestamp(modified_time, tz=timezone.utc)
+        utc_modified_date = datetime.fromtimestamp(modified_time, tz=timezone.utc)
         
         timestamp = convert_utc_int_to_timezone(utc_modified_date, 'UTC')
         


### PR DESCRIPTION
This pull request fixes a `TypeError` in the `offlinePages.py` artifact plugin. However, `utcfromtimestamp()` does not accept a `tz` keyword argument. 