### PR TITLE
Fix SQL syntax error in `bashHistory` artifact caused by reserved keyword `order`

### DIFF
--- a/scripts/artifacts/BashHistory.py
+++ b/scripts/artifacts/BashHistory.py
@@ -27,5 +27,5 @@ def bashHistory(files_found, report_folder, seeker, wrap_text):
             data_list.append((counter, row))
             counter += 1
 
-    data_headers = ('Order', 'Command')
+    data_headers = ('Entry Order', 'Command')
     return data_headers, data_list, file_found    


### PR DESCRIPTION
Fixes a `sqlite3.OperationalError` that occurs when generating the Bash History artifact report.
The issue is triggered because the artifact used a column header named `Order`, which is a reserved SQL keyword. when ALEAPP builds the SQLite table for the report, SQLite interprets `order` as part of an SQL statement instead of a column name.