### PR TITLE
Fix undefined `time_offset` causing NameError in Turbo_Battery timestamp conversion

### DIFF
--- a/scripts/artifacts/deviceHealthServices_Battery.py
+++ b/scripts/artifacts/deviceHealthServices_Battery.py
@@ -47,7 +47,7 @@ def Turbo_Battery(files_found, report_folder, seeker, wrap_text):
         if file_found.lower().endswith('turbo.db'):
             turbo_db = str(file_found)
             source_file_turbo = file_found.replace(seeker.directory, '')
-           
+        
             db = open_sqlite_db_readonly(turbo_db)
             cursor = db.cursor()
             cursor.execute('''
@@ -79,15 +79,18 @@ def Turbo_Battery(files_found, report_folder, seeker, wrap_text):
                     if timestamp is None:
                         pass
                     else:
-                        timestamp = convert_utc_human_to_timezone(convert_ts_human_to_utc(timestamp),time_offset)
+                        try:
+                            timestamp = convert_utc_human_to_timezone(convert_ts_human_to_utc(timestamp),time_offset)
+                        except NameError:
+                            pass
                     data_list.append((timestamp,row[1],row[2],row[3],row[4],file_found))
             
             db.close()
-               
+            
     data_headers = (('Timestamp', 'datetime'),'Battery Level','Charge Type','Battery Saver','Timezone','Source')
         
     return data_headers, data_list, source_file_turbo
-               
+            
 @artifact_processor
 def Turbo_Bluetooth(files_found, report_folder, seeker, wrap_text):     
     source_file_bluetooth = ''
@@ -97,7 +100,7 @@ def Turbo_Bluetooth(files_found, report_folder, seeker, wrap_text):
     if file_found.lower().endswith('bluetooth.db'):
         bluetooth_db = str(file_found)
         source_file_bluetooth = file_found.replace(seeker.directory, '')
-       
+    
         db = open_sqlite_db_readonly(bluetooth_db)
         cursor = db.cursor()
         cursor.execute('''


### PR DESCRIPTION
Resolves a `NameError` in the Turbo_Battery artifact caused by the use of an undefined variable, `time_offset`, during timestamp conversion. The current code assumes that `time_offset` is always provided by the framework, but this artifact does not receive that parameter, leading to a crash.