### PR TITLE
Fix: Handle directory copying in file copy operation

### DIFF
--- a/scripts/search_files.py
+++ b/scripts/search_files.py
@@ -5,7 +5,7 @@ import struct
 
 from pathlib import Path
 from scripts.ilapfuncs import *
-from shutil import copyfile
+from shutil import copyfile, copytree
 from zipfile import ZipFile
 
 from fnmatch import _compile_pattern
@@ -68,7 +68,12 @@ class FileSeekerDir(FileSeekerBase):
                 if item not in self.copied or force:
                     try:
                         os.makedirs(os.path.dirname(data_path), exist_ok=True)
-                        copyfile(item, data_path)
+                        if os.path.isdir(item):
+                            copytree(item, data_path, dirs_exist_ok=True)
+                        else:
+                            copyfile(item, data_path)
+
+                        # copyfile(item, data_path)
                         self.copied[item] = data_path
                         creation_date = Path(item).stat().st_ctime
                         modification_date = Path(item).stat().st_mtime


### PR DESCRIPTION
## Description
Fixes an error that occurred when attempting to copy directories using `copyfile()`, which only handles individual files. This issue affects both recent and older Android images.

## Problem
The script was failing with `[Errno 21] Is a directory` when encountering directories during artifact extraction. The `copyfile()` function cannot copy directories, only files.

**Examples of affected paths:**
- `/mnt/android/userdata/system/usagestats/0`
- `/mnt/android/userdata/data/com.google.android.apps.maps/app_tts-temp/tts-1486142641089`

This caused subsequent artifacts that depend on these copied files/directories to fail with `[Errno 2] No such file or directory`, breaking the analysis chain.

## Solution
- Added a check using `os.path.isdir()` to detect whether the item is a directory or file
- Use `shutil.copytree()` for directories (with `dirs_exist_ok=True` to handle existing destinations)
- Continue using `shutil.copyfile()` for individual files
- This ensures both files and directories are copied correctly, allowing dependent artifacts to process successfully

## Impact
- Resolves copy failures across various Android versions (including older images)
- Prevents cascading errors in artifacts that depend on the copied data
- Improves overall reliability of the extraction process

## Testing
- Tested with directory paths that previously failed:
  - `system/usagestats/0`
  - `data/com.google.android.apps.maps/app_tts-temp/tts-1486142641089`
- Verified file copying still works as expected
- Confirmed metadata (creation/modification dates) is still captured correctly
- Validated that dependent artifacts (e.g., GooglemapaudioT) now process successfully

## Related Issue
Resolves the "[Errno 21] Is a directory" error encountered during artifact extraction across multiple Android versions