### PR TITLE
Fix: Handle missing magic bytes in Chrome Browser Cache

### DIFF
--- a/scripts/artifacts/browserCachechrome.py
+++ b/scripts/artifacts/browserCachechrome.py
@@ -28,7 +28,11 @@ def get_browserCachechrome(files_found, report_folder, seeker, wrap_text):
                 data = file.read()
                 ab = BytesIO(data)
                 
-                eofloc = data.index(b'\xD8\x41\x0D\x97\x45\x6F\xFA\xF4')
+                try:
+                    eofloc = data.index(b'\xD8\x41\x0D\x97\x45\x6F\xFA\xF4')
+                except ValueError:
+                    logfunc(f'Skipping {file_found}: Expected byte pattern not found')
+                    continue
                 
                 header = ab.read(8)
                 version = ab.read(4)


### PR DESCRIPTION
## Fix crash in Chrome Browser Cache (subsection not found)

### Summary
This PR fixes a `ValueError: subsection not found` crash in the `browserCachechrome.py` module. The crash occurs when the parser attempts to index specific "magic bytes" (`\xD8\x41...`) in cache files that do not contain them (likely due to version differences or corruption).

The fix wraps the indexing operation in a `try-except` block, allowing the parser to gracefully skip incompatible cache files instead of terminating the entire artifact extraction.

### Motivation and Context
When analyzing Android images with older or varying versions of Chrome (e.g., the 2019-owl image), the binary cache format may differ from what the current parser expects.
* **Current Behavior:** If a single cache file does not contain the expected byte sequence, the script throws a `ValueError` and the entire module halts.
* **New Behavior:** The script logs the issue for that specific file, skips it, and continues processing the remaining cache files.

### Technical Details
* **File Modified:** `scripts/artifacts/browserCachechrome.py`
* **Change:** Added a `try-except ValueError` block around the `data.index()` call at line 31.
* **Error Handling:** If the subsection is not found, the `continue` statement is triggered to move to the next file in the loop.

### Testing
* **Verified against:** Android Image (Nexus 5 / Android 6.0.1) where the error previously occurred.
* **Result:** The module now completes execution without crashing, successfully generating reports for the valid cache files found in the image.