### PR TITLE
Handle Errors in wifiConfigstore2 and gboard

### DIFF
--- a/scripts/artifacts/wifiConfigstore2.py
+++ b/scripts/artifacts/wifiConfigstore2.py
@@ -31,6 +31,22 @@ def get_wifiConfigstore(files_found, report_folder, seeker, wrap_text):
                         #print(b.tag)
                         tagg = b.tag
                         
+                        # Initialize all variables before processing fields
+                        configcombined = ''
+                        ssidcombined = ''
+                        bssidcombined = ''
+                        PreSharedKeycombined = ''
+                        WEPKeyscombined = ''
+                        HiddenSSIDcombined = ''
+                        RandomizedMacAddresscombined = ''
+                        CreatorNamecombined = ''
+                        CreationTimecombined = ''
+                        ConnectChoicecombined = ''
+                        ConnectChoiceTimeStampcombined = ''
+                        HasEverConnectedcombined = ''
+                        IpAssignmentcombined = ''
+                        ProxySettingscombined = ''
+                        
                         for c in b:
                             combined = (c.attrib, c.text)
                             datafieldname = (c.attrib['name']) #field
@@ -109,7 +125,7 @@ def get_wifiConfigstore(files_found, report_folder, seeker, wrap_text):
                                 ProxySettingsvalue = f'{datafieldvalue}'
                                 ProxySettingscombined = f'{ProxySettings} - {ProxySettingsvalue}'
                                 
-                    data_list.append((configcombined,ssidcombined,bssidcombined,PreSharedKeycombined, WEPKeyscombined,HiddenSSIDcombined,RandomizedMacAddresscombined,CreatorNamecombined,CreationTimecombined,ConnectChoicecombined,ConnectChoiceTimeStampcombined,HasEverConnectedcombined,IpAssignmentcombined,ProxySettingscombined))                    
+                        data_list.append((configcombined,ssidcombined,bssidcombined,PreSharedKeycombined, WEPKeyscombined,HiddenSSIDcombined,RandomizedMacAddresscombined,CreatorNamecombined,CreationTimecombined,ConnectChoicecombined,ConnectChoiceTimeStampcombined,HasEverConnectedcombined,IpAssignmentcombined,ProxySettingscombined))                    
         
             if data_list:
                 report = ArtifactHtmlReport(f'Wifi Configuration Store Details.xml - {count}')


### PR DESCRIPTION
 ## Fix: Gracefully handle errors in wifiConfigstore2 and gboard parsers

### Summary
Improves robustness of artifact parsers by adding proper error handling for missing data and corrupted files.

### Changes

#### wifiConfigstore2.py
- Initialize all 14 data variables to empty strings before XML processing
- Prevents `UnboundLocalError` when XML fields are missing from the data structure
- Allows parser to complete successfully with incomplete WiFi configuration data

#### gboard.py
- Import `DecodeError` from `google.protobuf.message`
- Wrap protobuf decoding logic in try-except block to catch and skip malformed data
- Skip individual rows with corrupted protobuf messages instead of crashing entire artifact
- Log skipped rows for debugging and transparency

### Testing
Both parsers now complete successfully when encountering:
- Missing or incomplete data fields
- Corrupted protobuf messages
- Malformed file structures

Valid data is still extracted and reported, with errors logged appropriately.

### Related Issues
- Fixes crash on incomplete WiFi configuration files
- Fixes crash on Gboard files with corrupted keystroke data
 
 
 This is tested on Android Forensic Image Version 11 from https://thebinaryhick.blog/public_images/