### PR TITLE
Update chromeDIPS.py to support legacy and new DIPS bounce schemas

### DIFF
--- a/scripts/artifacts/chromeDIPS.py
+++ b/scripts/artifacts/chromeDIPS.py
@@ -6,12 +6,11 @@
 # Thanks to Ryan Benson for awareness https://github.com/obsidianforensics/hindsight/pull/146/commits/015ee189c97c0a4e48deb59568dfe4f536ace8aa
 
 import os
-import sqlite3
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, get_next_unused_name, open_sqlite_db_readonly
+from scripts.ilapfuncs import logfunc, tsv, timeline, get_next_unused_name, open_sqlite_db_readonly
 from scripts.artifacts.chrome import get_browser_name
 
-def get_chromeDIPS(files_found, report_folder, seeker, wrap_text):
+def get_chromeDIPS(files_found, report_folder):
 
     for file_found in files_found:
         file_found = str(file_found)


### PR DESCRIPTION
Handle legacy and new Chrome DIPS bounces schemas.

Reference (v9.sql schema and btm_database_migrator.cc): 
- https://github.com/chromium/chromium/blob/6413af3594e3b4580016b322d07ca430062f9e80/content/test/data/btm/v9.sql
- https://github.com/chromium/chromium/blob/436ef68acc38dec9116a94ad1c2afd8be32e0106/content/browser/btm/btm_database_migrator.cc#L327

Tested on image: https://dl.ctf.do/BelkaCTF_7_CASE250722_EXH250723-2.zip

Adding screenshot for reference:
<img width="2110" height="891" alt="image" src="https://github.com/user-attachments/assets/6df2180f-5d4d-4ea3-a53a-8051f43bd049" />
