### PR TITLE
Add Citymapper parser

### DIFF
--- a/scripts/artifacts/citymapper.py
+++ b/scripts/artifacts/citymapper.py
@@ -247,9 +247,6 @@ def get_citymapperSavedTrips(files_found, report_folder, _seeker, _wrap_text):
 
             db.close()
     
-    """if not saved_trip_data_list:
-        return ('No Data',), [], source"""
-    
     trip_headers = ('ID', 'Commute Type', 'Timestamp', 'Home Latitude', 'Home Longitude', 'Work Latitude', 'Work Longitude', 'Region Code')
     
     # Create KML
@@ -322,8 +319,6 @@ def get_citymapperSavedTrips(files_found, report_folder, _seeker, _wrap_text):
             
             # Summary section
             report.add_section_heading('Saved Trips Summary', 'h3')
-            home_count = sum(1 for row in saved_trip_data_list if row[3] and row[4])
-            work_count = sum(1 for row in saved_trip_data_list if row[5] and row[6])
             report.write_raw_html(f'''
                 <dl class="row">
                     <dt class="col-sm-3">Total Saved Trips</dt>


### PR DESCRIPTION
This PR introduces initial support for the transportation app Citymapper.

It generates custom HTML reports with interactive Folium maps for:

- Location history with chronological markers
- Saved trips (home/work markers and lines between locations)
- App/user preferences (device info, last location, session data)