### PR TITLE
Update alex_live_data with dumpsys parsers

### DIFF
--- a/scripts/artifacts/alex_live_data.py
+++ b/scripts/artifacts/alex_live_data.py
@@ -522,7 +522,6 @@ def alex_live_bt_bonded(files_found, _report_folder, _seeker, _wrap_text):
         data_list = []
         in_bonded = False
         for line in btm_dump.splitlines():
-            stripped = line.strip()
             if "Bonded devices:" in line:
                 in_bonded = True
                 continue


### PR DESCRIPTION
This commit updates the alex_live_data script to provide some dumpsys parsers.

<img width="1525" height="823" alt="Bildschirmfoto_2026-02-09_09-13-09" src="https://github.com/user-attachments/assets/0eb24fd1-af70-4caf-85d2-3ffb87192d13" />

A new split_dumpsys_log function divides the entire dumpsys output into globally provided dumpsys partial extracts that can be accessed by the respective parsers.

Another auxiliary function standardizes the timestamps, some of which are only relative. 

The following artifacts are currently being added:

- Dumpsys wifi - configured networks 
- Dumpsys usagestats (yearly)
- Dumpsys usagestats Event-Log
- Dumpsys bluetooth_manager - bonded devices (Only available if bluetooth was active during aquisition)
- Dumpsys companiondevice (Android 12 and up - shows the name, MAC and companionapp - mostly refers to a smartwatch)
- Dumpsys role (default apps)
- Dumpsys account (Shows which apps have accounts, some with usernames)

There is much more information that can be parsed from the Dumpsys log—contributions are very welcome.