### PR TITLE
security: pin Pillow to patched versions in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ fitdecode==0.10.0
 folium==0.14.0
 geopy==2.3.0
 packaging==20.1
-pillow
+pillow>=10.3.0,<12.0.0
 polyline==2.0.0
 protobuf==3.10.0
 PyCryptodome


### PR DESCRIPTION
## What this change does
This PR hardens ALEAPP against supply-chain and parser-level image risk by pinning Pillow in `requirements.txt` from:

- `pillow`

to:

- `pillow>=10.3.0,<12.0.0`

## Why this is important
ALEAPP processes attacker-controlled evidence files and uses Pillow decoding in multiple artifacts:

- `scripts/artifacts/chatgpt.py`
- `scripts/artifacts/SamsungHoneyboard.py`
- `scripts/artifacts/torThumbs.py`

Leaving Pillow unpinned can result in vulnerable versions being installed depending on environment state.

## Maintainer acknowledgement and decision requested
As of **March 3, 2026**, current advisories indicate **CVE-2026-25990** affects `pillow >=10.3.0, <12.1.1` (fixed in `12.1.1`).

So this PR's current range (`>=10.3.0,<12.0.0`) improves posture against older issues, but does **not** fully clear the newest disclosed Pillow vulnerability.

Could maintainers confirm preferred direction?

1. **Security-first:** move to `pillow>=12.1.1,<13.0.0` (fully patched for CVE-2026-25990; implies Python 3.10+ runtime baseline for Pillow 12).
2. **Compatibility-first:** keep Python 3.9-compatible dependency range and use compensating controls until baseline can be raised.

Once you choose, we can push the exact follow-up change immediately.

## Security references
- [CVE-2026-25990](https://nvd.nist.gov/vuln/detail/CVE-2026-25990)
- [GHSA-cfh3-3jmp-rvhc](https://github.com/advisories/GHSA-cfh3-3jmp-rvhc)
- [Pillow 12.1.1 release notes](https://pillow.readthedocs.io/en/stable/releasenotes/12.1.1.html)
- [Pillow Python support matrix](https://pillow.readthedocs.io/en/stable/installation/python-support.html)

Older relevant CVEs:
- [CVE-2023-50447](https://nvd.nist.gov/vuln/detail/CVE-2023-50447)
- [CVE-2022-22817](https://nvd.nist.gov/vuln/detail/CVE-2022-22817)
- [CVE-2024-28219](https://nvd.nist.gov/vuln/detail/CVE-2024-28219)
- [CVE-2023-5129](https://nvd.nist.gov/vuln/detail/CVE-2023-5129)

Additional references:
- [Snyk Pillow package advisories](https://security.snyk.io/package/pip/pillow)
- [Pillow release history](https://github.com/python-pillow/Pillow/releases)

## Validation performed
- Created a clean Python 3.11 virtual environment.
- Ran `python -m pip install -r requirements.txt`.
- Dependency resolution completed successfully for the pinned range in this branch.

## Scope
- One-file dependency hardening in:
  - `requirements.txt`
