### PR TITLE
Add Logcat Parser for the ALEX Backup

### DIFF
--- a/scripts/artifacts/alex_live_data.py
+++ b/scripts/artifacts/alex_live_data.py
@@ -215,7 +215,7 @@ def parse_timestamp(s, device_ts):
 # Helper to split the Dumpsys Output
 def split_dumpsys_log(dumpsys_file) -> dict:
     """Function to split the dumpsys txt file in service parts"""
-    global _PARSED_DUMPSYS, _DUMPSYS_DICT, _DEVICE_TIME
+    global _PARSED_DUMPSYS, _DUMPSYS_DICT, _DEVICE_TIME # pylint: disable=global-statement
     if _PARSED_DUMPSYS:
         return
     if not dumpsys_file:


### PR DESCRIPTION
This commit adds the Logcat Parser for logcat.txt contained in an ALEX backup. Currently, a searchable display is provided. An interpretation (as with the unified logs under iLEAPP) can be added later once the relevant investigations into individual entries have been carried out.

<img width="1598" height="1072" alt="Bildschirmfoto_2026-03-03_06-29-13" src="https://github.com/user-attachments/assets/8260a420-deb3-4c86-bd96-56c5a3dc05bf" />
