### PR TITLE
Fix GroupMe not showing all chat messages

### DIFF
--- a/scripts/artifacts/groupMe.py
+++ b/scripts/artifacts/groupMe.py
@@ -4,12 +4,8 @@
 # Version: 0.1
 # Requirements:  None
 
-import os
-import sqlite3
-import textwrap
-
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
 
 def get_groupMe(files_found, report_folder, seeker, wrap_text):
     

--- a/scripts/artifacts/groupMe.py
+++ b/scripts/artifacts/groupMe.py
@@ -93,7 +93,7 @@ def get_groupMe(files_found, report_folder, seeker, wrap_text):
         messages.location_name AS "Location Name"
         FROM
         messages
-        JOIN groups ON groups.group_id=messages.conversation_id
+        LEFT JOIN groups ON groups.group_id=messages.conversation_id
         ORDER BY "Message Time" ASC
         ''')
 


### PR DESCRIPTION
The GroupMe chat parser did not show all messages because it would ignore records that didn't have a `conversation_id` set (NULL value).

Changing the query to use a LEFT JOIN instead of a JOIN fixes this issue and shows all records in the table