### PR TITLE
Fix in artifact androidauto

### DIFF
--- a/scripts/artifacts/androidauto.py
+++ b/scripts/artifacts/androidauto.py
@@ -1,5 +1,5 @@
 __artifacts_v2__ = {
-    "androidauto": {
+    "extract_android_auto": {
         "name": "Android Auto Connected Cars",
         "description": "Android Auto connected cars",
         "author": "its5Q",
@@ -10,7 +10,6 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.google.android.projection.gearhead/databases/carservicedata.db'),
         "output_types": "standard",
-        "function": "extract_android_auto",
         "artifact_icon": "truck",
     }
 }


### PR DESCRIPTION
### Description
This PR fixes a `ValueError: Context not set` exception that occurs when running the `androidauto` artifact (specifically observed on an Android 13 image). 

The issue was caused by a mistake in the name on the `__artifacts_v2__` dictionary. Changing the key from `"androidauto"` to `"extract_android_auto"` resolves the context initialization error and allows the artifact to be processed successfully.

### Checklist
- [x] Verified the fix by running the `androidauto` artifact independently.
- [x] Confirmed that the artifact now parses correctly without throwing traceback errors.

---

*Note: This is one of my first contributions to open-source software! Please let me know if there is anything wrong*