### PR TITLE
Convert Firefox artifacts to LAVA (@artifact_processor)

### DIFF
--- a/scripts/artifacts/firefoxCookies.py
+++ b/scripts/artifacts/firefoxCookies.py
@@ -1,7 +1,7 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_firefoxCookies": {
-        "name": "FirefoxCookies",
+        "name": "Firefox - Cookies",
         "description": "",
         "author": "",
         "creation_date": "2022-01-12",
@@ -10,26 +10,26 @@ __artifacts_v2__ = {
         "category": "Firefox",
         "notes": "",
         "paths": ('*/org.mozilla.firefox/files/mozilla/*.default/cookies.sqlite*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "globe",
-        "function": "get_firefoxCookies",
     }
 }
 
 import os
-import sqlite3
-import textwrap
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_firefoxCookies(files_found, report_folder, seeker, wrap_text):
-    
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        if not os.path.basename(file_found) == 'cookies.sqlite': # skip -journal and other files
+        if not os.path.basename(file_found) == 'cookies.sqlite':  # skip -journal and other files
             continue
-        
+
+        source_path = file_found
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
@@ -46,26 +46,18 @@ def get_firefoxCookies(files_found, report_folder, seeker, wrap_text):
         ''')
 
         all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Firefox - Cookies')
-            report.start_artifact_report(report_folder, 'Firefox - Cookies')
-            report.add_script()
-            data_headers = ('Last Accessed Timestamp','Created Timestamp','Host','Name','Value','Expiration Timestamp','Path') 
-            data_list = []
-            for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
+        for row in all_rows:
+            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
 
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Firefox - Cookies'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Firefox - Cookies'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Firefox - Cookies data available')
-        
         db.close()
-    
+
+    data_headers = (
+        ('Last Accessed Timestamp', 'datetime'),
+        ('Created Timestamp', 'datetime'),
+        'Host',
+        'Name',
+        'Value',
+        ('Expiration Timestamp', 'datetime'),
+        'Path',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/firefoxDownloads.py
+++ b/scripts/artifacts/firefoxDownloads.py
@@ -1,7 +1,7 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_firefoxDownloads": {
-        "name": "FirefoxDownloads",
+        "name": "Firefox - Downloads",
         "description": "",
         "author": "",
         "creation_date": "2022-01-12",
@@ -10,26 +10,26 @@ __artifacts_v2__ = {
         "category": "Firefox",
         "notes": "",
         "paths": ('*/org.mozilla.firefox/databases/mozac_downloads_database*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "globe",
-        "function": "get_firefoxDownloads",
     }
 }
 
 import os
-import sqlite3
-import textwrap
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_firefoxDownloads(files_found, report_folder, seeker, wrap_text):
-    
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        if not os.path.basename(file_found) == 'mozac_downloads_database': # skip -journal and other files
+        if not os.path.basename(file_found) == 'mozac_downloads_database':  # skip -journal and other files
             continue
-        
+
+        source_path = file_found
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
@@ -50,26 +50,18 @@ def get_firefoxDownloads(files_found, report_folder, seeker, wrap_text):
         ''')
 
         all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Firefox - Downloads')
-            report.start_artifact_report(report_folder, 'Firefox - Downloads')
-            report.add_script()
-            data_headers = ('Created Timestamp','File Name','URL','MIME Type','File Size (Bytes)','Status','Destination Directory') 
-            data_list = []
-            for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
+        for row in all_rows:
+            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
 
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Firefox - Downloads'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Firefox - Downloads'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Firefox - Downloads data available')
-        
         db.close()
-    
+
+    data_headers = (
+        ('Created Timestamp', 'datetime'),
+        'File Name',
+        'URL',
+        'MIME Type',
+        'File Size (Bytes)',
+        'Status',
+        'Destination Directory',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/firefoxFormHistory.py
+++ b/scripts/artifacts/firefoxFormHistory.py
@@ -1,7 +1,7 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_firefoxFormHistory": {
-        "name": "FirefoxFormHistory",
+        "name": "Firefox - Form History",
         "description": "",
         "author": "",
         "creation_date": "2022-01-12",
@@ -10,26 +10,26 @@ __artifacts_v2__ = {
         "category": "Firefox",
         "notes": "",
         "paths": ('*/org.mozilla.firefox/files/mozilla/*.default/formhistory.sqlite*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "globe",
-        "function": "get_firefoxFormHistory",
     }
 }
 
 import os
-import sqlite3
-import textwrap
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_firefoxFormHistory(files_found, report_folder, seeker, wrap_text):
-    
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        if not os.path.basename(file_found) == 'formhistory.sqlite': # skip -journal and other files
+        if not os.path.basename(file_found) == 'formhistory.sqlite':  # skip -journal and other files
             continue
-        
+
+        source_path = file_found
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
@@ -45,26 +45,17 @@ def get_firefoxFormHistory(files_found, report_folder, seeker, wrap_text):
         ''')
 
         all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Firefox - Form History')
-            report.start_artifact_report(report_folder, 'Firefox - Form History')
-            report.add_script()
-            data_headers = ('First Used Timestamp','Last Used Timestamp','Field Name','Value','Times Used','ID')
-            data_list = []
-            for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3],row[4],row[5]))
+        for row in all_rows:
+            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5]))
 
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Firefox - Form History'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Firefox - Form History'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Firefox - Form History data available')
-        
         db.close()
-    
+
+    data_headers = (
+        ('First Used Timestamp', 'datetime'),
+        ('Last Used Timestamp', 'datetime'),
+        'Field Name',
+        'Value',
+        'Times Used',
+        'ID',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/firefoxPermissions.py
+++ b/scripts/artifacts/firefoxPermissions.py
@@ -1,7 +1,7 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_firefoxPermissions": {
-        "name": "FirefoxPermissions",
+        "name": "Firefox - Permissions",
         "description": "",
         "author": "",
         "creation_date": "2022-01-12",
@@ -10,26 +10,26 @@ __artifacts_v2__ = {
         "category": "Firefox",
         "notes": "",
         "paths": ('*/org.mozilla.firefox/files/mozilla/*.default/permissions.sqlite*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "globe",
-        "function": "get_firefoxPermissions",
     }
 }
 
 import os
-import sqlite3
-import textwrap
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_firefoxPermissions(files_found, report_folder, seeker, wrap_text):
-    
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        if not os.path.basename(file_found) == 'permissions.sqlite': # skip -journal and other files
+        if not os.path.basename(file_found) == 'permissions.sqlite':  # skip -journal and other files
             continue
-        
+
+        source_path = file_found
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
@@ -50,26 +50,16 @@ def get_firefoxPermissions(files_found, report_folder, seeker, wrap_text):
         ''')
 
         all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Firefox - Permissions')
-            report.start_artifact_report(report_folder, 'Firefox - Permissions')
-            report.add_script()
-            data_headers = ('Modification Timestamp','Origin Site','Permission Type','Status','Expiration Timestamp') 
-            data_list = []
-            for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3],row[4]))
+        for row in all_rows:
+            data_list.append((row[0],row[1],row[2],row[3],row[4]))
 
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Firefox - Permissions'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Firefox - Permissions'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Firefox - Permissions data available')
-        
         db.close()
-    
+
+    data_headers = (
+        ('Modification Timestamp', 'datetime'),
+        'Origin Site',
+        'Permission Type',
+        'Status',
+        ('Expiration Timestamp', 'datetime'),
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/firefoxRecentlyClosedTabs.py
+++ b/scripts/artifacts/firefoxRecentlyClosedTabs.py
@@ -1,7 +1,7 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_firefoxRecentlyClosedTabs": {
-        "name": "FirefoxRecentlyClosedTabs",
+        "name": "Firefox - Recently Closed Tabs",
         "description": "",
         "author": "",
         "creation_date": "2022-01-12",
@@ -10,26 +10,26 @@ __artifacts_v2__ = {
         "category": "Firefox",
         "notes": "",
         "paths": ('*/org.mozilla.firefox/databases/recently_closed_tabs*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "globe",
-        "function": "get_firefoxRecentlyClosedTabs",
     }
 }
 
 import os
-import sqlite3
-import textwrap
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_firefoxRecentlyClosedTabs(files_found, report_folder, seeker, wrap_text):
-    
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        if not os.path.basename(file_found) == 'recently_closed_tabs': # skip -journal and other files
+        if not os.path.basename(file_found) == 'recently_closed_tabs':  # skip -journal and other files
             continue
-        
+
+        source_path = file_found
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
@@ -41,25 +41,14 @@ def get_firefoxRecentlyClosedTabs(files_found, report_folder, seeker, wrap_text)
         ''')
 
         all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Firefox - Recently Closed Tabs')
-            report.start_artifact_report(report_folder, 'Firefox - Recently Closed Tabs')
-            report.add_script()
-            data_headers = ('Timestamp','Title','URL')
-            data_list = []
-            for row in all_rows:
-                data_list.append((row[0],row[1],row[2]))
+        for row in all_rows:
+            data_list.append((row[0],row[1],row[2]))
 
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Firefox - Recently Closed Tabs'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Firefox - Recently Closed Tabs'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Firefox - Recently Closed Tabs data available')
-        
         db.close()
+
+    data_headers = (
+        ('Timestamp', 'datetime'),
+        'Title',
+        'URL',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/firefoxTopSites.py
+++ b/scripts/artifacts/firefoxTopSites.py
@@ -1,7 +1,7 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_firefoxTopSites": {
-        "name": "FirefoxTopSites",
+        "name": "Firefox - Top Sites",
         "description": "",
         "author": "",
         "creation_date": "2022-01-12",
@@ -10,26 +10,26 @@ __artifacts_v2__ = {
         "category": "Firefox",
         "notes": "",
         "paths": ('*/org.mozilla.firefox/databases/top_sites*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "globe",
-        "function": "get_firefoxTopSites",
     }
 }
 
 import os
-import sqlite3
-import textwrap
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_firefoxTopSites(files_found, report_folder, seeker, wrap_text):
-    
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        if not os.path.basename(file_found) == 'top_sites': # skip -journal and other files
+        if not os.path.basename(file_found) == 'top_sites':  # skip -journal and other files
             continue
-        
+
+        source_path = file_found
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
@@ -45,26 +45,15 @@ def get_firefoxTopSites(files_found, report_folder, seeker, wrap_text):
         ''')
 
         all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Firefox - Top Sites')
-            report.start_artifact_report(report_folder, 'Firefox - Top Sites')
-            report.add_script()
-            data_headers = ('Created Timestamp','Title','URL','Is Default') 
-            data_list = []
-            for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3]))
+        for row in all_rows:
+            data_list.append((row[0],row[1],row[2],row[3]))
 
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Firefox - Top Sites'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Firefox - Top Sites'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Firefox - Top Sites data available')
-        
         db.close()
-    
+
+    data_headers = (
+        ('Created Timestamp', 'datetime'),
+        'Title',
+        'URL',
+        'Is Default',
+    )
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts six single-report Firefox artifacts to the LAVA output pipeline:

- firefoxCookies
- firefoxDownloads
- firefoxFormHistory
- firefoxPermissions
- firefoxRecentlyClosedTabs
- firefoxTopSites

Each now uses `@artifact_processor` and returns `(data_headers, data_list, source_path)`, adding LAVA output alongside the existing HTML/TSV/timeline. The SQL queries and row extraction are unchanged from the previous versions (verified structurally against `main`); datetime columns are marked with the `'datetime'` type and `output_types` is `"standard"`. The redundant `"function"` key is dropped since decorated functions resolve by name.

Deferred to a later PR: `firefox` (multi-report — 4 tables).

Verified: all six parse, are lint-clean, the plugin loader resolves them with no warnings, and their SQL queries / data rows match the pre-conversion versions.