### PR TITLE
Convert BitTorrent artifacts to LAVA (@artifact_processor)

### DIFF
--- a/scripts/artifacts/bittorrentClientpref.py
+++ b/scripts/artifacts/bittorrentClientpref.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0631,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_bittorrentClientpref": {
         "name": "BitTorrent Prefs",
@@ -10,37 +10,39 @@ __artifacts_v2__ = {
         "category": "BitTorrent",
         "notes": "",
         "paths": ('*/com.bittorrent.client/shared_prefs/com.bittorrent.client_preferences.xml',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "download",
-        "function": "get_bittorrentClientpref",
     }
 }
 
-import os
 import datetime
 import xml.etree.ElementTree as ET
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, abxread, checkabx, logdevinfo
-    
+
+from scripts.ilapfuncs import artifact_processor, abxread, checkabx
+
+
 def timestampcalc(timevalue):
     timestamp = (datetime.datetime.utcfromtimestamp(int(timevalue)/1000).strftime('%Y-%m-%d %H:%M:%S'))
     return timestamp
 
+
+@artifact_processor
 def get_bittorrentClientpref(files_found, report_folder, seeker, wrap_text):
     data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
-            
-        #check if file is abx
+        source_path = file_found
+
+        # check if file is abx
         if (checkabx(file_found)):
             multi_root = False
             tree = abxread(file_found, multi_root)
         else:
             tree = ET.parse(file_found)
-        
+
         root = tree.getroot()
-    
+
         for elem in root:
             key = elem.attrib['name']
             value = elem.attrib.get('value')
@@ -48,18 +50,6 @@ def get_bittorrentClientpref(files_found, report_folder, seeker, wrap_text):
             if key == 'BornOn':
                 value = timestampcalc(value)
             data_list.append((key, value, text))
-                    
-    if data_list:
-        report = ArtifactHtmlReport('Bittorent Client Preferences')
-        report.start_artifact_report(report_folder, 'Bittorent Client Preferences')
-        report.add_script()
-        data_headers = ('Key', 'Value', 'Text')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Bittorent Client Preferences'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-    else:
-        logfunc('No Bittorent Client Preferences data available')
-        
+
+    data_headers = ('Key', 'Value', 'Text')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/bittorrentDlhist.py
+++ b/scripts/artifacts/bittorrentDlhist.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0631
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_bittorrentDlhist": {
         "name": "bittorrentDlhist",
@@ -10,49 +10,47 @@ __artifacts_v2__ = {
         "category": "BitTorrent",
         "notes": "",
         "paths": ('*/dlhistory*.config.bak', '*/dlhistory*.config'),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "download",
-        "function": "get_bittorrentDlhist",
     }
 }
 
 import bencoding
-import hashlib
 import datetime
 import textwrap
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows 
+from scripts.ilapfuncs import artifact_processor
+
 
 def timestampcalc(timevalue):
     timestamp = (datetime.datetime.utcfromtimestamp(int(timevalue)/1000).strftime('%Y-%m-%d %H:%M:%S'))
     return timestamp
 
+
+@artifact_processor
 def get_bittorrentDlhist(files_found, report_folder, seeker, wrap_text):
 
     data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
+        source_path = file_found
 
         with open(file_found, 'rb') as f:
             decodedDict = bencoding.bdecode(f.read())
-        
+
         for key, value in decodedDict.items():
             if key.decode() == 'records':
                 for x in value:
                     time = timestampcalc(x[b'a'])
                     filename = x[b'n'].decode()
                     filepath = x[b's'].decode()
-                    print(filepath)
                 data_list.append((time,filename,filepath,textwrap.fill(file_found.strip(), width=25)))
 
-    # Reporting
-    title = "BitTorrent Download Info"
-    report = ArtifactHtmlReport(title)
-    report.start_artifact_report(report_folder, title)
-    report.add_script()
-    data_headers = ('Record Timestamp', 'Filename', 'Download File Path', 'Source File')
-    report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Data'])
-    report.end_artifact_report()
-    
-    tsv(report_folder, data_headers, data_list, title)
+    data_headers = (
+        ('Record Timestamp', 'datetime'),
+        'Filename',
+        'Download File Path',
+        'Source File',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/torrentResumeinfo.py
+++ b/scripts/artifacts/torrentResumeinfo.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0631,W0702
+# pylint: disable=W0613,W0702
 __artifacts_v2__ = {
     "get_torrentResumeinfo": {
         "name": "torrentResumeinfo",
@@ -10,9 +10,9 @@ __artifacts_v2__ = {
         "category": "BitTorrent",
         "notes": "",
         "paths": ('*/*.resume',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "download",
-        "function": "get_torrentResumeinfo",
+        "html_columns": ['Data'],
     }
 }
 
@@ -21,29 +21,33 @@ import hashlib
 import datetime
 import textwrap
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows 
+from scripts.ilapfuncs import artifact_processor
+
 
 def timestampcalc(timevalue):
     timestamp = (datetime.datetime.utcfromtimestamp(int(timevalue)).strftime('%Y-%m-%d %H:%M:%S'))
     return timestamp
 
+
+@artifact_processor
 def get_torrentResumeinfo(files_found, report_folder, seeker, wrap_text):
 
     data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
+        source_path = file_found
 
         with open(file_found, 'rb') as f:
             decodedDict = bencoding.bdecode(f.read())
-        
+
         aggregate = ''
         try:
             infoh= hashlib.sha1(bencoding.bencode(decodedDict[b"info"])).hexdigest()
             infohash = infoh
         except:
             infohash = ''
-            
+
         for key, value in decodedDict.items():
             if key.decode() == 'info':
                 for x, y in value.items():
@@ -57,16 +61,8 @@ def get_torrentResumeinfo(files_found, report_folder, seeker, wrap_text):
                 aggregate = aggregate + f'{key.decode()}: {timestampcalc(value)} <br>'
             else:
                 aggregate = aggregate + f'{key.decode()}: {value} <br>' #add if value is binary decode
-        
+
         data_list.append((textwrap.fill(file_found, width=25),infohash,aggregate.strip()))
 
-    # Reporting
-    title = "Torrent Resume Info"
-    report = ArtifactHtmlReport(title)
-    report.start_artifact_report(report_folder, title)
-    report.add_script()
     data_headers = ('File', 'InfoHash', 'Data')
-    report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Data'])
-    report.end_artifact_report()
-    
-    tsv(report_folder, data_headers, data_list, title)
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/torrentinfo.py
+++ b/scripts/artifacts/torrentinfo.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0631,W0702,W0718
+# pylint: disable=W0613,W0702,W0718
 __artifacts_v2__ = {
     "get_torrentinfo": {
         "name": "torrentinfo",
@@ -10,9 +10,9 @@ __artifacts_v2__ = {
         "category": "BitTorrent",
         "notes": "",
         "paths": ('*/*.torrent',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "download",
-        "function": "get_torrentinfo",
+        "html_columns": ['Data'],
     }
 }
 
@@ -21,30 +21,34 @@ import hashlib
 import datetime
 import textwrap
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows 
+from scripts.ilapfuncs import artifact_processor, logfunc
+
 
 def timestampcalc(timevalue):
     timestamp = (datetime.datetime.utcfromtimestamp(int(timevalue)).strftime('%Y-%m-%d %H:%M:%S'))
     return timestamp
 
+
+@artifact_processor
 def get_torrentinfo(files_found, report_folder, seeker, wrap_text):
 
     data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
+        source_path = file_found
 
         try:
             with open(file_found, 'rb') as f:
                 decodedDict = bencoding.bdecode(f.read())
-            
+
             aggregate = ''
             try:
                 infoh= hashlib.sha1(bencoding.bencode(decodedDict[b"info"])).hexdigest()
                 infohash = infoh
             except:
                 infohash = ''
-                
+
             for key, value in decodedDict.items():
                 if key.decode() == 'info':
                     for x, y in value.items():
@@ -59,24 +63,16 @@ def get_torrentinfo(files_found, report_folder, seeker, wrap_text):
                                             aggregate = aggregate + f'Files: {file} <br>'
                         else:
                             aggregate = aggregate + f'{x.decode()}: {y.decode()} <br>'
-                
+
                 elif key.decode() == 'pieces':
                     pass
                 elif key.decode() == 'creation date':
                     aggregate = aggregate + f'{key.decode()}: {timestampcalc(value)} <br>'
                 else:
                     aggregate = aggregate + f'{key.decode()}: {value.decode()} <br>' #add if value is binary decode
-        
+
             data_list.append((textwrap.fill(file_found.strip(), width=25),infohash,aggregate))
         except Exception as e: logfunc(str(e))
 
-    # Reporting
-    title = "Torrent Info"
-    report = ArtifactHtmlReport(title)
-    report.start_artifact_report(report_folder, title)
-    report.add_script()
     data_headers = ('File', 'InfoHash', 'Data')
-    report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Data'])
-    report.end_artifact_report()
-    
-    tsv(report_folder, data_headers, data_list, title)
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts four single-report BitTorrent artifacts to the LAVA output pipeline:

- torrentinfo
- torrentResumeinfo
- bittorrentDlhist
- bittorrentClientpref

Each now uses `@artifact_processor` and returns `(data_headers, data_list, source_path)`, adding LAVA output alongside the existing HTML/TSV. Parsing logic and the `data_list` rows are unchanged (verified structurally against `main`).

Notes:
- `torrentinfo` / `torrentResumeinfo`: the HTML `Data` column is preserved via `"html_columns": ['Data']` (replacing the old `html_no_escape` report flag).
- `bittorrentDlhist`: marks the `Record Timestamp` column as `'datetime'`, drops a stray `html_no_escape` that referenced a non-existent column, and removes a leftover debug `print()`.
- `bittorrentClientpref`: ABX/XML preferences preserved as a Key/Value/Text table.

The `"function"` key is dropped since decorated functions resolve by name.

Verified: all four parse, are lint-clean, the plugin loader resolves them with no warnings, and their parsed `data_list` rows match the pre-conversion versions. (No test data for these apps in available extractions; this is a structural-gate conversion.)

Deferred to later PRs: `torrentData`, `libretorrent` (kml/media handling).