### PR TITLE
Convert vault/locker and Cash App artifacts to LAVA (@artifact_processor)

### DIFF
--- a/scripts/artifacts/appLockerfishingnetdb.py
+++ b/scripts/artifacts/appLockerfishingnetdb.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_appLockerfishingnetdb": {
         "name": "App Locker DB",
@@ -10,40 +10,28 @@ __artifacts_v2__ = {
         "category": "Encrypting Media Apps",
         "notes": "",
         "paths": ('*/.privacy_safe/db/privacy_safe.db',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "image",
-        "function": "get_appLockerfishingnetdb",
     }
 }
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import artifact_processor
 
+
+@artifact_processor
 def get_appLockerfishingnetdb(files_found, report_folder, seeker, wrap_text):
-    
+
     data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
+        source_path = file_found
+
         message = 'The located database is encrypted. It contains information regarding the source directory of the encrypted files, timestamp metadata, and original filenames.'
         decryptioninst = 'To decrypt follow the instructions at the following URL: https://theincidentalchewtoy.wordpress.com/2021/12/07/decrypting-the-calculator-apps/'
-        keytodecrypt = 'Rny48Ni8aPjYCnUI'    
-                       
+        keytodecrypt = 'Rny48Ni8aPjYCnUI'
+
         data_list.append((message, decryptioninst, keytodecrypt))
-                            
-                        
-        if data_list:
-            report = ArtifactHtmlReport('Calculator Locker Database')
-            report.start_artifact_report(report_folder, 'Calculator Locker Database')
-            report.add_script()
-            data_headers = ('Encrypted Pattern', 'Decrypted Pattern', 'Key To Decrypt')
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Media'])
-            report.end_artifact_report()
-            
-            tsvname = f'Calculator Locker Database data'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            
-        else:
-            logfunc('No Calculator Locker Database data available')
-            
+
+    data_headers = ('Encrypted Pattern', 'Decrypted Pattern', 'Key To Decrypt')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/appLockerfishingnetpat.py
+++ b/scripts/artifacts/appLockerfishingnetpat.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_appLockerfishingnetpat": {
         "name": "App Locker Pat",
@@ -10,50 +10,37 @@ __artifacts_v2__ = {
         "category": "Encrypting Media Apps",
         "notes": "",
         "paths": ('*/com.hld.anzenbokusufake/shared_prefs/share_privacy_safe.xml',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "image",
-        "function": "get_appLockerfishingnetpat",
     }
 }
 
-import sys
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import unpad
 import xml.etree.ElementTree as ET
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
 
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
 def get_appLockerfishingnetpat(files_found, report_folder, seeker, wrap_text):
-    
+
     standardKey = '526e7934384e693861506a59436e5549'
     standardIV = '526e7934384e693861506a59436e5549'
     data_list = []
-    
+    source_path = ''
+
     for file_found in files_found:
         file_found = str(file_found)
-        
+        source_path = file_found
+
         tree = ET.parse(file_found)
         root = tree.getroot()
         encryptedPattern = root.findall('./string[@name="85B064D26810275C89F1F2CC15E20B442E98874398F16F6717BBD5D34920E3F8"]')[0].text
         cipher = AES.new(bytes.fromhex(standardKey), AES.MODE_CBC, bytes.fromhex(standardIV))
         decryptedPattern = unpad(cipher.decrypt(bytes.fromhex(encryptedPattern)), AES.block_size)
-            
-                       
+
         data_list.append((encryptedPattern, decryptedPattern))
-                            
-                        
-        if data_list:
-            report = ArtifactHtmlReport('Calculator Locker Pattern')
-            report.start_artifact_report(report_folder, 'Calculator Locker Pattern')
-            report.add_script()
-            data_headers = ('Encrypted Pattern', 'Decrypted Pattern')
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Media'])
-            report.end_artifact_report()
-            
-            tsvname = f'Calculator Locker Pattern data'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            
-        else:
-            logfunc('No Calculator Locker Pattern data available')
-            
+
+    data_headers = ('Encrypted Pattern', 'Decrypted Pattern')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/cashApp.py
+++ b/scripts/artifacts/cashApp.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0631,W1309
+# pylint: disable=W0613,W0631
 __artifacts_v2__ = {
     "get_cashApp": {
         "name": "Cash App",
@@ -10,26 +10,26 @@ __artifacts_v2__ = {
         "category": "Cash App",
         "notes": "",
         "paths": ('*/com.squareup.cash/databases/cash_money.db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "package",
-        "function": "get_cashApp",
     }
 }
 
-import sqlite3
-import textwrap
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
+@artifact_processor
 def get_cashApp(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
+
         if file_found.endswith('.db'):
+            source_path = file_found
             db = open_sqlite_db_readonly(file_found)
             cursor = db.cursor()
-            cursor.execute('''Select 
+            cursor.execute('''Select
         payment.role,
         payment.sender_id,
         CASE WHEN customer.cashtag IS NULL THEN '***NO CASH TAG PRESENT***' ELSE customer.cashtag END,
@@ -44,30 +44,26 @@ def get_cashApp(files_found, report_folder, seeker, wrap_text):
     From payment
         Inner Join customer On customer.customer_id = payment.sender_id
         Inner Join customer customer1 On payment.recipient_id = customer1.customer_id
-    
+
     ORDER BY payment.display_date DESC
     ''')
 
     all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Transactions')
-        report.start_artifact_report(report_folder, 'Transactions')
-        report.add_script()
-        data_headers = ('Transaction Date', 'User Account Role','Sender Display Name','Sender Unique ID', 'Sender Cashtag','Recipient Display Name', 'Recipient Unique ID', 'Recipient Cashtag','Transaction Amount','Transaction Status','Note') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = []
-        for row in all_rows:
-            data_list.append((row[8],row[0],row[3],row[1],row[2],row[6],row[4],row[5],row[10],row[7],row[9]))
-
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Cash App Transactions'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Cash App Transactions'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Cash App Transactions data available')
-    
+    for row in all_rows:
+        data_list.append((row[8],row[0],row[3],row[1],row[2],row[6],row[4],row[5],row[10],row[7],row[9]))
     db.close()
+
+    data_headers = (
+        ('Transaction Date', 'datetime'),
+        'User Account Role',
+        'Sender Display Name',
+        'Sender Unique ID',
+        'Sender Cashtag',
+        'Recipient Display Name',
+        'Recipient Unique ID',
+        'Recipient Cashtag',
+        'Transaction Amount',
+        'Transaction Status',
+        'Note',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/vaulty_files.py
+++ b/scripts/artifacts/vaulty_files.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0611,W0613
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_vaulty_files": {
         "name": "vaulty_files",
-        "description": "Media database",
+        "description": "Vaulty (com.theronrogers.vaultyfree) media database. Research at https://kibaffo33.data.blog/2022/03/05/decoding-vaulty/",
         "author": "",
         "creation_date": "2022-02-23",
         "last_update_date": "2022-02-23",
@@ -10,21 +10,18 @@ __artifacts_v2__ = {
         "category": "Vaulty",
         "notes": "",
         "paths": ('*/com.theronrogers.vaultyfree/databases/media.db',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "lock",
-        "function": "get_vaulty_files",
     }
 }
 
 import sqlite3
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows 
-from scripts.parse3 import ParseProto
+from scripts.ilapfuncs import artifact_processor
 
+
+@artifact_processor
 def get_vaulty_files(files_found, report_folder, seeker, wrap_text):
-
-    title = "Vaulty - Files"
 
     # Media database
     db_filepath = str(files_found[0])
@@ -36,15 +33,13 @@ def get_vaulty_files(files_found, report_folder, seeker, wrap_text):
     conn.close()
 
     # Data results
-    data_headers = ('ID', 'Date Created', 'Date Added', 'Original Path', 'Vault Path')
+    data_headers = (
+        'ID',
+        ('Date Created', 'datetime'),
+        ('Date Added', 'datetime'),
+        'Original Path',
+        'Vault Path',
+    )
     data_list = results
-    
-    # Reporting
-    description = "Vaulty (com.theronrogers.vaultyfree) - Research at https://kibaffo33.data.blog/2022/03/05/decoding-vaulty/"
-    report = ArtifactHtmlReport(title)
-    report.start_artifact_report(report_folder, title, description)
-    report.add_script()
-    report.write_artifact_data_table(data_headers, data_list, db_filepath, html_escape=False)
-    report.end_artifact_report()
-    
-    tsv(report_folder, data_headers, data_list, title)
+
+    return data_headers, data_list, db_filepath


### PR DESCRIPTION
Converts four single-report artifacts to the LAVA output pipeline:

- vaulty_files
- appLockerfishingnetdb
- appLockerfishingnetpat
- cashApp

Each now uses `@artifact_processor` and returns `(data_headers, data_list, source_path)`, adding LAVA output alongside the existing HTML/TSV (and timeline for `cashApp`, which has a datetime column). Queries and row extraction are unchanged (verified structurally against `main`).

Notes:
- `vaulty_files`: datetime columns marked; the research-URL note moved into the header `description`.
- `appLockerfishingnetdb` / `appLockerfishingnetpat`: dropped the old `html_no_escape=['Media']` flag, which referenced a non-existent column.
- `cashApp`: marks `Transaction Date` as `'datetime'`; the pre-existing process-last-`.db`-file structure is preserved.

**Deferred:** `vaulty_info` (same Vaulty app) has a pre-existing Python 3.9+ crash — `base64.decodestring` was removed from the stdlib — so it should be fixed as a bug before being converted.

Verified: all four parse, are lint-clean, the plugin loader resolves them with no warnings, and their queries / `data_list` rows match the pre-conversion versions. (No test data for these apps in available extractions; structural-gate conversion.)