### PR TITLE
Fix pre-existing crashes in three artifacts

### DIFF
--- a/scripts/artifacts/deviceHealthServices_Battery.py
+++ b/scripts/artifacts/deviceHealthServices_Battery.py
@@ -1,4 +1,4 @@
-# pylint: disable=E0602,W0611,W0612,W0613
+# pylint: disable=W0611,W0612,W0613,W0718
 __artifacts_v2__ = {
     "Turbo_Battery": {
         "name": "Turbo - Phone Battery",
@@ -76,10 +76,11 @@ def Turbo_Battery(files_found, report_folder, seeker, wrap_text):
             if usageentries > 0:
                 for row in all_rows:
                     timestamp = row[0]
-                    if timestamp is None:
-                        pass
-                    else:
-                        timestamp = convert_utc_human_to_timezone(convert_ts_human_to_utc(timestamp),time_offset)
+                    if timestamp is not None and row[4]:
+                        try:
+                            timestamp = convert_utc_human_to_timezone(convert_ts_human_to_utc(timestamp), row[4])
+                        except Exception:
+                            pass
                     data_list.append((timestamp,row[1],row[2],row[3],row[4],file_found))
             
             db.close()
@@ -89,41 +90,43 @@ def Turbo_Battery(files_found, report_folder, seeker, wrap_text):
     return data_headers, data_list, source_file_turbo
             
 @artifact_processor
-def Turbo_Bluetooth(files_found, report_folder, seeker, wrap_text):     
+def Turbo_Bluetooth(files_found, report_folder, seeker, wrap_text):
     source_file_bluetooth = ''
-    turbo_db = ''
     data_list = []
 
-    if file_found.lower().endswith('bluetooth.db'):
-        bluetooth_db = str(file_found)
-        source_file_bluetooth = file_found.replace(seeker.directory, '')
-    
-        db = open_sqlite_db_readonly(bluetooth_db)
-        cursor = db.cursor()
-        cursor.execute('''
-        select
-        datetime(timestamp_millis/1000,'unixepoch'),
-        bd_addr,
-        device_identifier,
-        battery_level,
-        volume_level,
-        time_zone
-        from battery_event
-        join device_address on battery_event.device_idx = device_address.device_idx
-        ''')
+    for file_found in files_found:
+        file_found = str(file_found)
+        if file_found.lower().endswith('bluetooth.db'):
+            bluetooth_db = str(file_found)
+            source_file_bluetooth = os.path.basename(file_found)
 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            for row in all_rows:
-                timestamp = row[0]
-                if timestamp is None:
-                    pass
-                else:
-                    timestamp = convert_utc_human_to_timezone(convert_ts_human_to_utc(timestamp),time_offset)
-                data_list.append((timestamp,row[1],row[2],row[3],row[4],row[5],file_found))
-        db.close()
-        
+            db = open_sqlite_db_readonly(bluetooth_db)
+            cursor = db.cursor()
+            cursor.execute('''
+            select
+            datetime(timestamp_millis/1000,'unixepoch'),
+            bd_addr,
+            device_identifier,
+            battery_level,
+            volume_level,
+            time_zone
+            from battery_event
+            join device_address on battery_event.device_idx = device_address.device_idx
+            ''')
+
+            all_rows = cursor.fetchall()
+            usageentries = len(all_rows)
+            if usageentries > 0:
+                for row in all_rows:
+                    timestamp = row[0]
+                    if timestamp is not None and row[5]:
+                        try:
+                            timestamp = convert_utc_human_to_timezone(convert_ts_human_to_utc(timestamp), row[5])
+                        except Exception:
+                            pass
+                    data_list.append((timestamp,row[1],row[2],row[3],row[4],row[5],file_found))
+            db.close()
+
     data_headers = (('Timestamp','datetime'),'BT Device MAC Address','BT Device ID','Battery Level','Volume Level','Timezone','Source')
 
     return data_headers, data_list, source_file_bluetooth

--- a/scripts/artifacts/vaulty_info.py
+++ b/scripts/artifacts/vaulty_info.py
@@ -46,7 +46,7 @@ def get_vaulty_info(files_found, report_folder, seeker, wrap_text):
             password_hash = item.get("#text", None)
 
     if password_hash:
-        md5_hash_binary = base64.decodestring(password_hash.encode())
+        md5_hash_binary = base64.decodebytes(password_hash.encode())
         md5_hash = binascii.hexlify(md5_hash_binary).decode()
 
         data_list.append(["Password MD5", md5_hash])
@@ -77,7 +77,7 @@ def get_vaulty_info(files_found, report_folder, seeker, wrap_text):
     for item in prefs["map"]["string"]:
         if item.get("@name", None) == "security_answer_hash":
             answer = item.get("#text", None)
-            answer = base64.decodestring(answer.encode())
+            answer = base64.decodebytes(answer.encode())
             answer = binascii.hexlify(answer).decode()
             data_list.append(["Security Answer MD5", answer])
 

--- a/scripts/artifacts/wifiConfigstore2.py
+++ b/scripts/artifacts/wifiConfigstore2.py
@@ -48,7 +48,24 @@ def get_wifiConfigstore(files_found, report_folder, seeker, wrap_text):
                     for b in a:
                         #print(b.tag)
                         tagg = b.tag
-                        
+
+                        # Default every field so a config missing one doesn't raise
+                        # UnboundLocalError or leak the previous config's value
+                        configcombined = ''
+                        ssidcombined = ''
+                        bssidcombined = ''
+                        PreSharedKeycombined = ''
+                        WEPKeyscombined = ''
+                        HiddenSSIDcombined = ''
+                        RandomizedMacAddresscombined = ''
+                        CreatorNamecombined = ''
+                        CreationTimecombined = ''
+                        ConnectChoicecombined = ''
+                        ConnectChoiceTimeStampcombined = ''
+                        HasEverConnectedcombined = ''
+                        IpAssignmentcombined = ''
+                        ProxySettingscombined = ''
+
                         for c in b:
                             combined = (c.attrib, c.text)
                             datafieldname = (c.attrib['name']) #field


### PR DESCRIPTION
Fixes three pre-existing runtime crashes (independent of the LAVA conversion work). Each artifact errored out when its data was present.

### vaulty_info
`base64.decodestring` was removed from the standard library in Python 3.9, so the artifact crashed with `AttributeError`. Switched to `base64.decodebytes` (identical behavior).

### deviceHealthServices_Battery (Turbo_Battery / Turbo_Bluetooth)
- Both functions referenced an undefined `time_offset` in their timezone conversion (`NameError`). They now use the row's own timezone column and guard `pytz` against unknown/empty values, falling back to the UTC timestamp.
- `Turbo_Bluetooth` was also missing its `for file_found in files_found:` loop entirely (`NameError: name 'file_found' is not defined`); added it, and switched its source-path handling to `os.path.basename` for parity with `Turbo_Battery`.

### wifiConfigstore2
The per-field `*combined` variables were only assigned inside conditional `if datafieldname == ...:` blocks, so a wifi config missing any field raised `UnboundLocalError` (and otherwise leaked the previous config's value). All 14 are now initialized per config.

Verified: all three parse, are lint-clean, and the plugin loader resolves them with no warnings.

Remaining known crashes (deferred — these are data-shape issues that need test data or careful defensive handling): `mastodon`, `googleInitiatedNav`, `googleVoice` (messages), `gmailEmails`.