### PR TITLE
Convert chat artifacts to LAVA (@artifact_processor)

### DIFF
--- a/scripts/artifacts/discordChats.py
+++ b/scripts/artifacts/discordChats.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0611,W0612,W0613,W0631,W1309
+# pylint: disable=W0612,W0613,W0631
 __artifacts_v2__ = {
     "get_discordChats": {
         "name": "discordChats",
-        "description": "build a table mapping all non-printable characters to None",
+        "description": "Parses Discord chat messages from the kv-storage key-value store",
         "author": "",
         "creation_date": "2023-09-18",
         "last_update_date": "2023-09-18",
@@ -10,96 +10,89 @@ __artifacts_v2__ = {
         "category": "Discord Chats",
         "notes": "",
         "paths": ('*/data/com.discord/files/kv-storage/*/a*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "message-square",
-        "function": "get_discordChats",
     }
 }
 
-import sqlite3
-import textwrap
 import sys
 import json
-from datetime import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, kmlgen
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_discordChats(files_found, report_folder, seeker, wrap_text):
-    
+
     # build a table mapping all non-printable characters to None
     NOPRINT_TRANS_TABLE = {
         i: None for i in range(0, sys.maxunicode + 1) if not chr(i).isprintable()
     }
-    
+
     def make_printable(s):
         """Replace non-printable characters in a string."""
-        
+
         # the translate method on str removes characters
         # that map to None from the string
         return s.translate(NOPRINT_TRANS_TABLE)
-    
+
     for file_found in files_found:
         file_name = str(file_found)
         if file_found.endswith('a'):
             break # Skip all other files
-    
+
+    source_path = str(file_found)
     db = open_sqlite_db_readonly(file_found)
     cursor = db.cursor()
     cursor.execute('''
         SELECT
-        * 
+        *
         from messages0
     ''')
-    
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Discord Chats')
-        report.start_artifact_report(report_folder, 'Discord Chats')
-        report.add_script()
-        data_headers = ('Timestamp','Channel ID','ID','Username','Content','Attachment Filename','Attachment URL','Attachment Proxy URL','Mentions','Mention Roles','Pinned','Avatar','Edited Timestamp')
-        data_list = []
 
-        for row in all_rows:
-            data = (row[6].decode())
-            
-            jsontext = make_printable(data)	
-            
-            data = json.loads(jsontext)
-            #print(data)
-            datatimestamp = (data['message']['timestamp'])
-            channelid = (data['channelId'])
-            dataid = (data['id'])
-            #print(data['message'])
-            username = (data['message']['author']['username'])
-            content = (data['message']['content'])
-            attachments = (data['message']['attachments'])
-            if len(attachments) > 0:
-                attachementfilename = (attachments[0]['filename'])
-                attachementurl = (attachments[0]['url'])
-                attachmentproxyurl = (attachments[0]['proxy_url'])
-            else:
-                attachementfilename = attachementurl = attachmentproxyurl = ''
-            mentions = (data['message']['mentions'])
-            mentionroles = (data['message']['mention_roles'])
-            pinned = (data['message']['pinned'])
-            avatar = (data['message']['author']['avatar'])
-            editedtimestamp = (data['message']['edited_timestamp'])
-            
-            data_list.append((datatimestamp,channelid,dataid,username,content,attachementfilename,attachementurl,attachmentproxyurl,mentions,mentionroles,pinned,avatar,editedtimestamp))
-            
-            
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Discord Chats'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Discord Chats'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-    else:
-        logfunc('No Discord Chats data available')
-        
+    all_rows = cursor.fetchall()
+    data_list = []
+    for row in all_rows:
+        data = (row[6].decode())
+
+        jsontext = make_printable(data)
+
+        data = json.loads(jsontext)
+        datatimestamp = (data['message']['timestamp'])
+        channelid = (data['channelId'])
+        dataid = (data['id'])
+        username = (data['message']['author']['username'])
+        content = (data['message']['content'])
+        attachments = (data['message']['attachments'])
+        if len(attachments) > 0:
+            attachementfilename = (attachments[0]['filename'])
+            attachementurl = (attachments[0]['url'])
+            attachmentproxyurl = (attachments[0]['proxy_url'])
+        else:
+            attachementfilename = attachementurl = attachmentproxyurl = ''
+        mentions = (data['message']['mentions'])
+        mentionroles = (data['message']['mention_roles'])
+        pinned = (data['message']['pinned'])
+        avatar = (data['message']['author']['avatar'])
+        editedtimestamp = (data['message']['edited_timestamp'])
+
+        data_list.append((datatimestamp,channelid,dataid,username,content,attachementfilename,attachementurl,attachmentproxyurl,mentions,mentionroles,pinned,avatar,editedtimestamp))
+
     db.close()
+
+    data_headers = (
+        ('Timestamp', 'datetime'),
+        'Channel ID',
+        'ID',
+        'Username',
+        'Content',
+        'Attachment Filename',
+        'Attachment URL',
+        'Attachment Proxy URL',
+        'Mentions',
+        'Mention Roles',
+        'Pinned',
+        'Avatar',
+        ('Edited Timestamp', 'datetime'),
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/meetme.py
+++ b/scripts/artifacts/meetme.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0631
+# pylint: disable=W0613,W0631
 __artifacts_v2__ = {
     "get_meetmechats": {
         "name": "MeetMe Chats",
@@ -10,30 +10,29 @@ __artifacts_v2__ = {
         "category": "Chats",
         "notes": "",
         "paths": ('*/data/com.myyearbook.m/databases/chats.db*'),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "users",
-        "function": "get_meetmechats",
     }
 }
 
-#Update line 3-13
-import sqlite3
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, timeline, tsv, is_platform_windows, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone
 
+@artifact_processor
 def get_meetmechats(files_found, report_folder, seeker, wrap_text):
-    
+
     data_list = []
-    
+    source_path = ''
+
     for file_found in files_found:
         file_found = str(file_found)
-        
+
         if file_found.endswith('chats.db'):
+            source_path = file_found
             db = open_sqlite_db_readonly(file_found)
             cursor = db.cursor()
             cursor.execute('''
-            SELECT 
+            SELECT
             messages.sent_at,
             messages.thread_id,
             members.first_name,
@@ -42,14 +41,14 @@ def get_meetmechats(files_found, report_folder, seeker, wrap_text):
             messages.body,
             messages.type,
             messages.local_path
-            FROM 
+            FROM
             messages
-            LEFT JOIN 
+            LEFT JOIN
             members
-            ON 
+            ON
             members.member_id = messages.sent_by
-            ORDER BY 
-            messages.thread_id, 
+            ORDER BY
+            messages.thread_id,
             messages.sent_at;
             ''')
 
@@ -57,32 +56,20 @@ def get_meetmechats(files_found, report_folder, seeker, wrap_text):
             usageentries = len(all_rows)
             if usageentries > 0:
                 for row in all_rows:
-                #    last_mod_date = row[0]
-                #   if last_mod_date is None:
-                #       pass
-                #   else:
-                #       last_mod_date = convert_utc_human_to_timezone(convert_ts_human_to_utc(last_mod_date),time_offset)
-                
                     data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7]))
             db.close()
-                    
+
         else:
             continue
-        
-    if data_list:
-        description = 'MeetMe Chats' 
-        report = ArtifactHtmlReport('MeetMe Chats')
-        report.start_artifact_report(report_folder, 'MeetMe Chats', description)
-        report.add_script()
-        data_headers = ('Timestamp','Thread ID','First Name','Last Name','Sent By','Message Text','Type','Attachment Path') 
-        report.write_artifact_data_table(data_headers, data_list, file_found,html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = 'MeetMe Chats'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = 'MeetMe Chats'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    
-    else:
-        logfunc('No MeetMe data available')
+
+    data_headers = (
+        ('Timestamp', 'datetime'),
+        'Thread ID',
+        'First Name',
+        'Last Name',
+        'Sent By',
+        'Message Text',
+        'Type',
+        'Attachment Path',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/sChats.py
+++ b/scripts/artifacts/sChats.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0631
+# pylint: disable=W0613,W0631
 __artifacts_v2__ = {
     "get_schats": {
         "name": "Sideline Chats and Calls",
@@ -10,27 +10,26 @@ __artifacts_v2__ = {
         "category": "Chats",
         "notes": "",
         "paths": ('*/data/com.sideline.phone.number/databases/textfree*'),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "message-square",
-        "function": "get_schats",
     }
 }
 
-import sqlite3
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, timeline, tsv, is_platform_windows, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone
 
+@artifact_processor
 def get_schats(files_found, report_folder, seeker, wrap_text):
-    
+
     data_list = []
-    
+    source_path = ''
+
     for file_found in files_found:
         file_found = str(file_found)
-        
+
         if file_found.endswith('textfree'):
+            source_path = file_found
             db = open_sqlite_db_readonly(file_found)
-            #SQL QUERY TIME!
             cursor = db.cursor()
             cursor.execute('''
             SELECT
@@ -58,32 +57,19 @@ def get_schats(files_found, report_folder, seeker, wrap_text):
             usageentries = len(all_rows)
             if usageentries > 0:
                 for row in all_rows:
-                #    last_mod_date = row[0]
-                #   if last_mod_date is None:
-                #       pass
-                #   else:
-                #       last_mod_date = convert_utc_human_to_timezone(convert_ts_human_to_utc(last_mod_date),time_offset)
-                
                     data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
             db.close()
-                    
+
         else:
             continue
-        
-    if data_list:
-        description = 'Sideline Chats and Calls'
-        report = ArtifactHtmlReport('Sideline Chats')
-        report.start_artifact_report(report_folder, 'Sideline Chats', description)
-        report.add_script()
-        data_headers = ('Timestamp','First Name','Last Name','Method','Message Text','Duration','Phone Number')
-        report.write_artifact_data_table(data_headers, data_list, file_found,html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = 'Sideline Chats'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = 'Sideline Chats'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    
-    else:
-        logfunc('No Sideline data available')
+
+    data_headers = (
+        ('Timestamp', 'datetime'),
+        'First Name',
+        'Last Name',
+        'Method',
+        'Message Text',
+        'Duration',
+        ('Phone Number', 'phonenumber'),
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/tangomessage.py
+++ b/scripts/artifacts/tangomessage.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0107,W0611,W0613,W0631,W0702,W0718,W1309
+# pylint: disable=W0613,W0631,W0702,W0718
 __artifacts_v2__ = {
     "get_tangomessage": {
         "name": "tangomessage",
@@ -10,18 +10,16 @@ __artifacts_v2__ = {
         "category": "Tango",
         "notes": "",
         "paths": ('*/com.sgiggle.production/files/tc.db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "message-square",
-        "function": "get_tangomessage",
     }
 }
 
-import sqlite3
 import base64
 import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+
 
 def _decodeMessage(wrapper, message):
     result = ""
@@ -31,26 +29,26 @@ def _decodeMessage(wrapper, message):
         result = Z.split(wrapper)[1]
     except Exception as ex:
         print ("Error decoding a Tango message. " + str(ex))
-        pass
     return result
 
 
+@artifact_processor
 def get_tangomessage(files_found, report_folder, seeker, wrap_text):
-    
+
     for file_found in files_found:
         file_found = str(file_found)
-        
+
         if file_found.endswith('tc.db'):
             break
 
-    source_file = file_found.replace(seeker.data_folder, '')
+    source_path = file_found
 
     db = open_sqlite_db_readonly(file_found)
     cursor = db.cursor()
     try:
         cursor.execute('''
-        SELECT conv_id, payload, create_time/1000 as create_time, 
-               case direction when 1 then "Incoming" else "Outgoing" end direction 
+        SELECT conv_id, payload, create_time/1000 as create_time,
+               case direction when 1 then "Incoming" else "Outgoing" end direction
           FROM messages ORDER BY create_time DESC
         ''')
 
@@ -58,28 +56,16 @@ def get_tangomessage(files_found, report_folder, seeker, wrap_text):
         usageentries = len(all_rows)
     except:
         usageentries = 0
-        
+
+    data_list = []
     if usageentries > 0:
-        report = ArtifactHtmlReport('Tango - Messages')
-        report.start_artifact_report(report_folder, 'Tango - Messages')
-        report.add_script()
-        data_headers = ('Create Time', 'Direction','Message') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = []
         for row in all_rows:
-            message = _decodeMessage(row[0], row[1]) 
+            message = _decodeMessage(row[0], row[1])
             timestamp = datetime.datetime.utcfromtimestamp(int(row[2])).strftime('%Y-%m-%d %H:%M:%S')
 
             data_list.append((timestamp, row[3], message))
 
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Tango Messages'
-        tsv(report_folder, data_headers, data_list, tsvname, source_file)
-                
-        tlactivity = f'Tango Messages'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Tango Messages data available')
-
     db.close()
+
+    data_headers = (('Create Time', 'datetime'), 'Direction', 'Message')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts four single-report chat artifacts to the LAVA output pipeline:

- tangomessage
- sChats (Sideline Chats and Calls)
- meetme (MeetMe Chats)
- discordChats

Each now uses `@artifact_processor` and returns `(data_headers, data_list, source_path)`, adding LAVA output alongside the existing HTML/TSV/timeline. Queries, JSON/base64 decoding, and row extraction are unchanged (verified structurally against `main`).

Notes:
- Timestamp / Edited Timestamp columns marked as `'datetime'`.
- `sChats`: Phone Number column marked as `'phonenumber'`.
- `discordChats`: replaced the `description` field (it was a stray code comment) with a real one.

These are converted as flat tables; a threaded `data_views` conversation view could be added later as an enhancement.

Verified: all four parse, are lint-clean, the plugin loader resolves them with no warnings, and their queries / `data_list` rows match the pre-conversion versions. (No test data for these apps in available extractions; structural-gate conversion.)