### PR TITLE
Convert ProtonVPN/ProtonMail to LAVA (multi-report split)

### DIFF
--- a/scripts/artifacts/protonVPN.py
+++ b/scripts/artifacts/protonVPN.py
@@ -1,7 +1,7 @@
-# pylint: disable=W0311,W0611,W0613,W0702,W1309,W1514
+# pylint: disable=W0613,W0702
 __artifacts_v2__ = {
-    "get_protonVPN": {
-        "name": "protonVPN User",
+    "get_protonvpn_device_info": {
+        "name": "ProtonVPN - Device Info",
         "description": "",
         "author": "",
         "creation_date": "2022-09-04",
@@ -9,148 +9,142 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "ProtonVPN",
         "notes": "",
-        "paths": ('*/ch.protonvpn.android/databases/db', '*/ch.protonvpn.android/shared_prefs/ServerListUpdater.xml', '*/ch.protonvpn.android/log/Data.log'),
-        "output_types": None,
+        "paths": ('*/ch.protonvpn.android/shared_prefs/ServerListUpdater.xml',),
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "user",
-        "function": "get_protonVPN",
+    },
+    "get_protonvpn_connection_history": {
+        "name": "ProtonVPN - Connection History",
+        "description": "",
+        "author": "",
+        "creation_date": "2022-09-04",
+        "last_update_date": "2022-09-04",
+        "requirements": "none",
+        "category": "ProtonVPN",
+        "notes": "",
+        "paths": ('*/ch.protonvpn.android/log/Data.log',),
+        "output_types": "standard",
+        "artifact_icon": "user",
+    },
+    "get_protonvpn_user_info": {
+        "name": "ProtonVPN - User Info",
+        "description": "",
+        "author": "",
+        "creation_date": "2022-09-04",
+        "last_update_date": "2022-09-04",
+        "requirements": "none",
+        "category": "ProtonVPN",
+        "notes": "",
+        "paths": ('*/ch.protonvpn.android/databases/db',),
+        "output_types": ['html', 'tsv', 'lava'],
+        "artifact_icon": "user",
     }
 }
 
-import os
 import re
 import socket
-import sqlite3
-import textwrap
 import datetime
 import xml.etree.ElementTree as ET
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import timeline, tsv, is_platform_windows, open_sqlite_db_readonly, logfunc, logdevinfo, checkabx, abxread
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, device_info, checkabx, abxread
 
-def get_protonVPN(files_found, report_folder, seeker, wrap_text):
 
-	for file_found in files_found:
-		file_found = str(file_found)
-		if file_found.endswith('ServerListUpdater.xml'):
+@artifact_processor
+def get_protonvpn_device_info(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if file_found.endswith('ServerListUpdater.xml'):
+            source_path = file_found
 
-			data_list = []
-			
-			if (checkabx(file_found)):
-				multi_root = False
-				tree = abxread(file_found, multi_root)
-			else:
-				tree = ET.parse(file_found)
+            if (checkabx(file_found)):
+                multi_root = False
+                tree = abxread(file_found, multi_root)
+            else:
+                tree = ET.parse(file_found)
 
-			root = tree.getroot()
+            root = tree.getroot()
 
-			for elem in root.iter():
-				if elem.attrib.get('name') is not None:
-					if elem.text is not None:
-						data_list.append((elem.attrib.get('name'), elem.text))
-					elif elem.attrib.get('value') is not None:
-						data_list.append((elem.attrib.get('name'), elem.attrib.get('value')))
+            for elem in root.iter():
+                if elem.attrib.get('name') is not None:
+                    if elem.text is not None:
+                        data_list.append((elem.attrib.get('name'), elem.text))
+                    elif elem.attrib.get('value') is not None:
+                        data_list.append((elem.attrib.get('name'), elem.attrib.get('value')))
 
-					if (elem.attrib.get('name')) == 'ipAddress':
-						logdevinfo(f'<b>IP Address: </b>{elem.text}')
+                    if (elem.attrib.get('name')) == 'ipAddress':
+                        device_info("ProtonVPN", "IP Address", elem.text, source_path)
 
-					if (elem.attrib.get('name')) == 'lastKnownIsp':
-						logdevinfo(f'<b>ISP: </b>{elem.text}')
+                    if (elem.attrib.get('name')) == 'lastKnownIsp':
+                        device_info("ProtonVPN", "ISP", elem.text, source_path)
 
-					if (elem.attrib.get('name')) == 'lastKnownCountry':
-						logdevinfo(f'<b>Country: </b>{elem.text}')
+                    if (elem.attrib.get('name')) == 'lastKnownCountry':
+                        device_info("ProtonVPN", "Country", elem.text, source_path)
 
-					if (elem.attrib.get('name')) == 'ipAddressCheckTimestamp':
-						timestamp =  datetime.datetime.utcfromtimestamp(int(elem.attrib.get("value"))/1000).strftime('%Y-%m-%d %H:%M:%S.%f')
-						logdevinfo(f'<b>Last IP Check Time: </b>{timestamp}')
-		
-			if data_list:
-				report = ArtifactHtmlReport('ProtonVPN Device Info.xml')
-				report.start_artifact_report(report_folder, 'ProtonVPN - Device Info')
-				report.add_script()
-				data_headers = ('Key', 'Value')
-				report.write_artifact_data_table(data_headers, data_list, file_found)
-				report.end_artifact_report()
+                    if (elem.attrib.get('name')) == 'ipAddressCheckTimestamp':
+                        timestamp = datetime.datetime.utcfromtimestamp(int(elem.attrib.get("value"))/1000).strftime('%Y-%m-%d %H:%M:%S.%f')
+                        device_info("ProtonVPN", "Last IP Check Time", timestamp, source_path)
 
-				tsvname = f'ProtonVPN - Device Info'
-				tsv(report_folder, data_headers, data_list, tsvname)
+    data_headers = ('Key', 'Value')
+    return data_headers, data_list, source_path
 
-				tlactivity = f'ProtonVPN - Device Info'
-				timeline(report_folder, tlactivity, data_list, data_headers)
-			else:
-				logfunc('No ProtonVPN - Device Info available')
 
-		elif file_found.endswith('Data.log'):
+@artifact_processor
+def get_protonvpn_connection_history(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if file_found.endswith('Data.log'):
+            source_path = file_found
 
-			data_list = []
+            with open(file_found, 'r', encoding='utf-8') as protonvpn_log:
+                log_entries = protonvpn_log.readlines()
 
-			protonvpn_log = open(file_found, 'r')
-			log_entries = protonvpn_log.readlines()
-			protonvpn_log.close()
-			
-			regex = re.compile(r"node.+\.protonvpn\.net")
-			for entry in log_entries: 
-				initial_connect = entry.find('to:')
-				if initial_connect != -1:
-					timestamp = entry[:entry.find('|')-1].split('.')[0].replace('T', ' ')
-					try:
-						server_hostname = regex.search(entry)[0]
-						server_ip = socket.gethostbyname(server_hostname)
-						data_list.append((server_hostname + f"  -  [ {server_ip} ]", timestamp))
-					except socket.error:
-						server_hostname = regex.search(entry)[0]
-						data_list.append((server_hostname, timestamp))
-					except:
-						pass
+            regex = re.compile(r"node.+\.protonvpn\.net")
+            for entry in log_entries:
+                initial_connect = entry.find('to:')
+                if initial_connect != -1:
+                    timestamp = entry[:entry.find('|')-1].split('.')[0].replace('T', ' ')
+                    try:
+                        server_hostname = regex.search(entry)[0]
+                        server_ip = socket.gethostbyname(server_hostname)
+                        data_list.append((server_hostname + f"  -  [ {server_ip} ]", timestamp))
+                    except socket.error:
+                        server_hostname = regex.search(entry)[0]
+                        data_list.append((server_hostname, timestamp))
+                    except:
+                        pass
 
-			if data_list:
-				report = ArtifactHtmlReport('ProtonVPN Connection History')
-				report.start_artifact_report(report_folder, 'ProtonVPN - Connection History')
-				report.add_script()
-				data_headers = ('Server Address', 'Timestamp')
-				report.write_artifact_data_table(data_headers, data_list, file_found)
-				report.end_artifact_report()
+    data_headers = ('Server Address', ('Timestamp', 'datetime'))
+    return data_headers, data_list, source_path
 
-				tsvname = f'ProtonVPN - Conncetion History'
-				tsv(report_folder, data_headers, data_list, tsvname)
 
-				tlactivity = f'ProtonVPN - Connection History'
-				timeline(report_folder, tlactivity, data_list, data_headers)
-			else:
-				logfunc('No ProtonVPN - Connection History available')
+@artifact_processor
+def get_protonvpn_user_info(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if file_found.endswith('db'):
+            source_path = file_found
+            db = open_sqlite_db_readonly(file_found)
 
-		elif file_found.endswith('db'):
-			db = open_sqlite_db_readonly(file_found)
+            # Cursor for User Data
+            cursor = db.cursor()
+            cursor.execute('SELECT * FROM main.UserEntity')
+            user_data_rows = cursor.fetchall()
 
-			# Cursor for User Data
-			cursor = db.cursor()
-			cursor.execute('SELECT * FROM main.UserEntity')
-			user_data_rows = cursor.fetchall()
-			
-			# Cursor for Account Data
-			cursor = db.cursor()
-			cursor.execute('SELECT * FROM main.AccountEntity')
-			account_data_rows = cursor.fetchall()
+            # Cursor for Account Data
+            cursor = db.cursor()
+            cursor.execute('SELECT * FROM main.AccountEntity')
+            account_data_rows = cursor.fetchall()
 
-			userentries = len(user_data_rows)
-			accountentries = len(account_data_rows)
-			if userentries > 0 and accountentries > 0:
-				report = ArtifactHtmlReport('ProtonVPN - User Info')
-				report.start_artifact_report(report_folder, 'ProtonVPN - User data')
-				report.add_script()
-				data_headers = ('Email', 'Name', 'Username', 'Display Name', 'Account State')
-				data_list = []
-				for user_row, account_row in zip(user_data_rows, account_data_rows):
-					data_list.append((user_row[1], user_row[2], account_row[1], user_row[3], account_row[5]))
+            for user_row, account_row in zip(user_data_rows, account_data_rows):
+                data_list.append((user_row[1], user_row[2], account_row[1], user_row[3], account_row[5]))
 
-				report.write_artifact_data_table(data_headers, data_list, file_found)
-				report.end_artifact_report()
+            db.close()
 
-				tsvname = f'ProtonVPN - User Info'
-				tsv(report_folder, data_headers, data_list, tsvname)
-
-				tlactivity = f'ProtonVPN - User Info'
-				timeline(report_folder, tlactivity, data_list, data_headers)
-			else:
-				logfunc('No ProtonVPN - User Info available')
-
-			db.close()
+    data_headers = ('Email', 'Name', 'Username', 'Display Name', 'Account State')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/protonmail.py
+++ b/scripts/artifacts/protonmail.py
@@ -1,7 +1,7 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
-    "get_protonmail": {
-        "name": "protonmail",
+    "get_protonmail_messages": {
+        "name": "ProtonMail - Messages",
         "description": "",
         "author": "",
         "creation_date": "2023-04-26",
@@ -9,29 +9,40 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "ProtonMail",
         "notes": "",
-        "paths": ('*/ch.protonmail.android/databases/*-MessagesDatabase.db*', '*/ch.protonmail.android/databases/*-ContactsDatabase.db*'),
-        "output_types": None,
+        "paths": ('*/ch.protonmail.android/databases/*-MessagesDatabase.db*',),
+        "output_types": "standard",
         "artifact_icon": "mail",
-        "function": "get_protonmail",
+    },
+    "get_protonmail_contacts": {
+        "name": "ProtonMail - Contacts",
+        "description": "",
+        "author": "",
+        "creation_date": "2023-04-26",
+        "last_update_date": "2023-04-26",
+        "requirements": "none",
+        "category": "ProtonMail",
+        "notes": "",
+        "paths": ('*/ch.protonmail.android/databases/*-ContactsDatabase.db*',),
+        "output_types": "standard",
+        "artifact_icon": "mail",
     }
 }
 
-import os
-import sqlite3
-import textwrap
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
-def get_protonmail(files_found, report_folder, seeker, wrap_text):
-    
+@artifact_processor
+def get_protonmail_messages(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_name = str(file_found)
-        
+
         if file_name.lower().endswith(('-shm','-wal','-journal')):
             continue
-            
+
         if file_name.endswith('-MessagesDatabase.db'):
+            source_path = file_name
             db = open_sqlite_db_readonly(file_found)
             cursor = db.cursor()
             cursor.execute('''
@@ -79,30 +90,45 @@ def get_protonmail(files_found, report_folder, seeker, wrap_text):
             ''')
 
             all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                report = ArtifactHtmlReport('ProtonMail - Messages')
-                report.start_artifact_report(report_folder, 'ProtonMail - Messages')
-                report.add_script()
-                data_headers = ('Message Timestamp','Subject','Sender','Message Direction','Status','Message Size','Accessed Timestamp','Folder','Starred','Number of Attachments','Attachment Name','Attachment Size','To List','Reply To','CC List','BCC List','Message Header') 
-                data_list = []
-                for row in all_rows:
-                    data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11],row[12],row[13],row[14],row[15],row[16]))
+            for row in all_rows:
+                data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11],row[12],row[13],row[14],row[15],row[16]))
 
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'ProtonMail - Messages'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-                tlactivity = f'ProtonMail - Messages'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No ProtonMail - Messages data available')
-            
             db.close()
-            
+
+    data_headers = (
+        ('Message Timestamp', 'datetime'),
+        'Subject',
+        'Sender',
+        'Message Direction',
+        'Status',
+        'Message Size',
+        ('Accessed Timestamp', 'datetime'),
+        'Folder',
+        'Starred',
+        'Number of Attachments',
+        'Attachment Name',
+        'Attachment Size',
+        'To List',
+        'Reply To',
+        'CC List',
+        'BCC List',
+        'Message Header',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_protonmail_contacts(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for file_found in files_found:
+        file_name = str(file_found)
+
+        if file_name.lower().endswith(('-shm','-wal','-journal')):
+            continue
+
         if file_name.endswith('-ContactsDatabase.db'):
+            source_path = file_name
             db = open_sqlite_db_readonly(file_found)
             cursor = db.cursor()
             cursor.execute('''
@@ -116,29 +142,15 @@ def get_protonmail(files_found, report_folder, seeker, wrap_text):
             ''')
 
             all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                report = ArtifactHtmlReport('ProtonMail - Contacts')
-                report.start_artifact_report(report_folder, 'ProtonMail - Contacts')
-                report.add_script()
-                data_headers = ('Creation Timestamp','Modified Timestamp','Name','Email') 
-                data_list = []
-                for row in all_rows:
-                    data_list.append((row[0],row[1],row[2],row[3]))
+            for row in all_rows:
+                data_list.append((row[0],row[1],row[2],row[3]))
 
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'ProtonMail - Contacts'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-                tlactivity = f'ProtonMail - Contacts'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No ProtonMail - Contacts data available')
-            
             db.close()
-            
-        else:
-            continue
-        
+
+    data_headers = (
+        ('Creation Timestamp', 'datetime'),
+        ('Modified Timestamp', 'datetime'),
+        'Name',
+        'Email',
+    )
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Establishes the **multi-report** conversion pattern: an old artifact whose single function produced several distinct tables is split into one `@artifact_processor` function per table, each with its own `__artifacts_v2__` entry and its own `paths`. (This mirrors how existing converted artifacts like DuckDuckGo/googleVoice already register multiple entries.)

### protonVPN (1 function → 3)
- `get_protonvpn_device_info` — `ServerListUpdater.xml` (Key/Value)
- `get_protonvpn_connection_history` — `Data.log` (Server Address / Timestamp; Timestamp marked `'datetime'`)
- `get_protonvpn_user_info` — `db` (User Info)
- The deprecated `logdevinfo()` calls were migrated to `device_info()`.

### protonmail (1 function → 2)
- `get_protonmail_messages` — `*-MessagesDatabase.db`
- `get_protonmail_contacts` — `*-ContactsDatabase.db`
- datetime columns marked.

Queries and row extraction are unchanged (verified structurally against `main`). Each split function returns `(data_headers, data_list, source_path)`. The old `"function"` keys are dropped since decorated functions resolve by name.

Verified: both files parse, are lint-clean, the plugin loader resolves all five functions with no warnings, and the union of SQL queries / `data_list` rows matches the pre-conversion versions. (No test data for these apps in available extractions; structural-gate conversion.)