### PR TITLE
Convert TextNow/Skout to LAVA (multi-report split)

### DIFF
--- a/scripts/artifacts/skout.py
+++ b/scripts/artifacts/skout.py
@@ -1,7 +1,7 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
-    "get_skout": {
-        "name": "skout",
+    "get_skout_messages": {
+        "name": "Skout Messages",
         "description": "",
         "author": "",
         "creation_date": "2021-05-10",
@@ -10,73 +10,86 @@ __artifacts_v2__ = {
         "category": "Skout",
         "notes": "",
         "paths": ('*/com.skout.android/databases/skoutDatabase*',),
-        "output_types": None,
+        "output_types": "standard",
+        "artifact_icon": "message-square",
+    },
+    "get_skout_users": {
+        "name": "Skout Users",
+        "description": "",
+        "author": "",
+        "creation_date": "2021-05-10",
+        "last_update_date": "2021-05-10",
+        "requirements": "none",
+        "category": "Skout",
+        "notes": "",
+        "paths": ('*/com.skout.android/databases/skoutDatabase*',),
+        "output_types": "standard",
         "artifact_icon": "users",
-        "function": "get_skout",
     }
 }
 
-import sqlite3
-import textwrap
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
-def get_skout(files_found, report_folder, seeker, wrap_text):
-    
+@artifact_processor
+def get_skout_messages(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
         if file_found.endswith('skoutDatabase'):
-            
+            source_path = file_found
             db = open_sqlite_db_readonly(file_found)
             cursor = db.cursor()
             cursor.execute('''
-            SELECT 
+            SELECT
             strftime('%Y-%m-%d %H:%M:%S.', "timestamp"/1000, 'unixepoch') || ("timestamp"%1000) AS MessageTime,
-            
+
             ifnull(skoutUsersTable.userName,'(local user)') AS SkoutUser,
-            
+
             skoutMessagesTable.message,
             skoutMessagesTable.type,
             skoutMessagesTable.pictureUrl,
             skoutMessagesTable.giftUrl,
             skoutMessagesTable.chatId AS ThreadID
-            
+
             FROM skoutMessagesTable
                 LEFT JOIN skoutUsersTable ON skoutMessagesTable.fromUserID = skoutUsersTable.userId
-                
+
                 ORDER BY skoutMessagesTable.chatId,
                 skoutMessagesTable.timestamp
             ''')
-            
-            
+
             all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                report = ArtifactHtmlReport('Skout Messages')
-                report.start_artifact_report(report_folder, 'Skout Messages')
-                report.add_script()
-                data_headers = ('Timestamp','User','Message','Type','Picture URL','Gift URL','Thread ID' ) # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-                data_list = []
-                for row in all_rows:
-                    data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
-            
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Skout Messages'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-                tlactivity = f'Skout Messages'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No Skout Messages data available')
-        
-        
+            for row in all_rows:
+                data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
+
+            db.close()
+
+    data_headers = (
+        ('Timestamp', 'datetime'),
+        'User',
+        'Message',
+        'Type',
+        'Picture URL',
+        'Gift URL',
+        'Thread ID',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_skout_users(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if file_found.endswith('skoutDatabase'):
+            source_path = file_found
             db = open_sqlite_db_readonly(file_found)
             cursor = db.cursor()
             cursor.execute('''
-            SELECT 
+            SELECT
             strftime('%Y-%m-%d %H:%M:%S.', "lastMessageTimestamp"/1000, 'unixepoch') || ("lastMessageTimestamp"%1000) AS LastMessageTime,
             skoutUsersTable.userName,
             skoutUsersTable.picUrl,
@@ -84,29 +97,17 @@ def get_skout(files_found, report_folder, seeker, wrap_text):
             FROM skoutUsersTable
             ORDER BY skoutUsersTable.lastMessageTimestamp
             ''')
-            
-            
+
             all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                report = ArtifactHtmlReport('Skout Users')
-                report.start_artifact_report(report_folder, 'Skout Users')
-                report.add_script()
-                data_headers = ('Last Message Timestamp','User','Picture URL','User ID' ) # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-                data_list = []
-                for row in all_rows:
-                    data_list.append((row[0],row[1],row[2],row[3]))
-                    
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Skout Users'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-                tlactivity = f'Skout Users'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No Skout Users data available')
-                
-        
-    db.close()
+            for row in all_rows:
+                data_list.append((row[0],row[1],row[2],row[3]))
+
+            db.close()
+
+    data_headers = (
+        ('Last Message Timestamp', 'datetime'),
+        'User',
+        'Picture URL',
+        'User ID',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/textnow.py
+++ b/scripts/artifacts/textnow.py
@@ -1,7 +1,7 @@
-# pylint: disable=E0606,W0104,W0311,W0611,W0613,W0631,W0702,W1309
+# pylint: disable=W0613,W0702
 __artifacts_v2__ = {
-    "get_textnow": {
-        "name": "textnow",
+    "get_textnow_call_logs": {
+        "name": "Text Now - Call Logs",
         "description": "",
         "author": "",
         "creation_date": "2021-03-15",
@@ -10,176 +10,187 @@ __artifacts_v2__ = {
         "category": "Text Now",
         "notes": "",
         "paths": ('*/com.enflick.android.TextNow/databases/textnow_data.db*',),
-        "output_types": None,
+        "output_types": "standard",
+        "artifact_icon": "phone-call",
+    },
+    "get_textnow_messages": {
+        "name": "Text Now - Messages",
+        "description": "",
+        "author": "",
+        "creation_date": "2021-03-15",
+        "last_update_date": "2021-03-15",
+        "requirements": "none",
+        "category": "Text Now",
+        "notes": "",
+        "paths": ('*/com.enflick.android.TextNow/databases/textnow_data.db*',),
+        "output_types": "standard",
         "artifact_icon": "message-square",
-        "function": "get_textnow",
+    },
+    "get_textnow_contacts": {
+        "name": "Text Now - Contacts",
+        "description": "",
+        "author": "",
+        "creation_date": "2021-03-15",
+        "last_update_date": "2021-03-15",
+        "requirements": "none",
+        "category": "Text Now",
+        "notes": "",
+        "paths": ('*/com.enflick.android.TextNow/databases/textnow_data.db*',),
+        "output_types": ['html', 'tsv', 'lava'],
+        "artifact_icon": "user",
     }
 }
 
-import sqlite3
 import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-def get_textnow(files_found, report_folder, seeker, wrap_text):
 
-    source_file_msg = ''
-
+@artifact_processor
+def get_textnow_call_logs(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
     for file_found in files_found:
-        
         file_name = str(file_found)
         if file_name.endswith('textnow_data.db'):
-           textnow_db = str(file_found)
-           source_file_msg = file_found.replace(seeker.data_folder, '')
-
-    db = open_sqlite_db_readonly(textnow_db)
-    cursor = db.cursor()
-    try:
-        cursor.execute('''
-                    SELECT contact_value     AS num, 
-                           case message_direction when 2 then "Outgoing" else "Incoming" end AS direction, 
-                            date/1000 + message_text      AS duration, 
-                            date/1000              AS datetime 
-                      FROM  messages AS M 
+            source_path = file_name
+            db = open_sqlite_db_readonly(file_found)
+            cursor = db.cursor()
+            try:
+                cursor.execute('''
+                    SELECT contact_value     AS num,
+                           case message_direction when 2 then "Outgoing" else "Incoming" end AS direction,
+                            date/1000 + message_text      AS duration,
+                            date/1000              AS datetime
+                      FROM  messages AS M
                      WHERE  message_type IN ( 100, 102 )
-        ''')
+                ''')
+                all_rows = cursor.fetchall()
+            except:
+                all_rows = []
 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-    except:
-        usageentries = 0
-        
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Text Now - Call Logs')
-        report.start_artifact_report(report_folder, 'Text Now - Call Logs')
-        report.add_script()
-        data_headers = ('Start Time', 'End Time', 'From ID', 'To ID', 'Call Direction') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = []
-        for row in all_rows:
-            phone_number_from = None
-            phone_number_to = None
-            if row[1] == "Outgoing":
-                phone_number_to = row[0]
-            else:
-                phone_number_from = row[0]
-            starttime = datetime.datetime.utcfromtimestamp(int(row[3])).strftime('%Y-%m-%d %H:%M:%S')
-            endtime = datetime.datetime.utcfromtimestamp(int(row[2])).strftime('%Y-%m-%d %H:%M:%S')
-            data_list.append((starttime, endtime, phone_number_from, phone_number_to, row[1]))
+            for row in all_rows:
+                phone_number_from = None
+                phone_number_to = None
+                if row[1] == "Outgoing":
+                    phone_number_to = row[0]
+                else:
+                    phone_number_from = row[0]
+                starttime = datetime.datetime.utcfromtimestamp(int(row[3])).strftime('%Y-%m-%d %H:%M:%S')
+                endtime = datetime.datetime.utcfromtimestamp(int(row[2])).strftime('%Y-%m-%d %H:%M:%S')
+                data_list.append((starttime, endtime, phone_number_from, phone_number_to, row[1]))
 
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Text Now - Call Logs'
-        tsv(report_folder, data_headers, data_list, tsvname, source_file_msg)
+            db.close()
 
-        tlactivity = f'Text Now - Call Logs'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-    else:
-        logfunc('No Text Now Call Logs found')
-        
-    
-    try:
-        cursor.execute('''
-                    SELECT CASE 
-                             WHEN messages.message_direction == 2 THEN NULL 
-                             WHEN contact_book_w_groups.to_addresses IS NULL THEN 
-                             messages.contact_value 
-                           END from_address, 
-                           CASE 
-                             WHEN messages.message_direction == 1 THEN NULL 
-                             WHEN contact_book_w_groups.to_addresses IS NULL THEN 
-                             messages.contact_value 
-                             ELSE contact_book_w_groups.to_addresses 
-                           END to_address, 
+    data_headers = (
+        ('Start Time', 'datetime'),
+        ('End Time', 'datetime'),
+        ('From ID', 'phonenumber'),
+        ('To ID', 'phonenumber'),
+        'Call Direction',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_textnow_messages(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for file_found in files_found:
+        file_name = str(file_found)
+        if file_name.endswith('textnow_data.db'):
+            source_path = file_name
+            db = open_sqlite_db_readonly(file_found)
+            cursor = db.cursor()
+            try:
+                cursor.execute('''
+                    SELECT CASE
+                             WHEN messages.message_direction == 2 THEN NULL
+                             WHEN contact_book_w_groups.to_addresses IS NULL THEN
+                             messages.contact_value
+                           END from_address,
+                           CASE
+                             WHEN messages.message_direction == 1 THEN NULL
+                             WHEN contact_book_w_groups.to_addresses IS NULL THEN
+                             messages.contact_value
+                             ELSE contact_book_w_groups.to_addresses
+                           END to_address,
                            CASE messages.message_direction
                              WHEN 1 THEN "Incoming"
-                             ELSE "Outgoing" 
-                           END message_direction, 
-                           messages.message_text, 
-                           messages.READ, 
-                           messages.DATE/1000, 
-                           messages.attach, 
-                           thread_id 
-                    FROM   (SELECT GM.contact_value, 
-                                   Group_concat(GM.member_contact_value) AS to_addresses, 
-                                   G.contact_value                       AS thread_id 
-                            FROM   group_members AS GM 
-                                   join GROUPS AS G 
-                                     ON G.contact_value = GM.contact_value 
-                            GROUP  BY GM.contact_value 
-                            UNION 
-                            SELECT contact_value, 
-                                   NULL, 
-                                   NULL 
-                            FROM   contacts) AS contact_book_w_groups 
-                           join messages 
-                             ON messages.contact_value = contact_book_w_groups.contact_value 
-                    WHERE  message_type NOT IN ( 102, 100 ) 
-        ''')
-        
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-    except:
-        usageentries = 0
-        
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Text Now - Messages')
-        report.start_artifact_report(report_folder, 'Text Now - Messages')
-        report.add_script()
-        data_headers = ('Send Timestamp','Message ID','From ID', 'To ID', 'Direction', 'Message', 'Read',  'Attachment') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = []
-        for row in all_rows:
-            sendtime = datetime.datetime.utcfromtimestamp(int(row[5])).strftime('%Y-%m-%d %H:%M:%S')
+                             ELSE "Outgoing"
+                           END message_direction,
+                           messages.message_text,
+                           messages.READ,
+                           messages.DATE/1000,
+                           messages.attach,
+                           thread_id
+                    FROM   (SELECT GM.contact_value,
+                                   Group_concat(GM.member_contact_value) AS to_addresses,
+                                   G.contact_value                       AS thread_id
+                            FROM   group_members AS GM
+                                   join GROUPS AS G
+                                     ON G.contact_value = GM.contact_value
+                            GROUP  BY GM.contact_value
+                            UNION
+                            SELECT contact_value,
+                                   NULL,
+                                   NULL
+                            FROM   contacts) AS contact_book_w_groups
+                           join messages
+                             ON messages.contact_value = contact_book_w_groups.contact_value
+                    WHERE  message_type NOT IN ( 102, 100 )
+                ''')
+                all_rows = cursor.fetchall()
+            except:
+                all_rows = []
 
-            data_list.append((sendtime, row[7], row[0], row[1], row[2], row[3], row[4],  row[6]))
-            
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Text Now - Messages'
-        tsv(report_folder, data_headers, data_list, tsvname, source_file_msg)
-        
-        tlactivity = f'Text Now - Messages'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-    else:
-        logfunc('No Text Now messages data available')
+            for row in all_rows:
+                sendtime = datetime.datetime.utcfromtimestamp(int(row[5])).strftime('%Y-%m-%d %H:%M:%S')
 
-    cursor = db.cursor()
-    try:
-        cursor.execute('''
-                     SELECT C.contact_value AS number,  
-                            CASE 
-                              WHEN contact_name IS NULL THEN contact_value 
-                              WHEN contact_name == "" THEN contact_value 
-                              ELSE contact_name 
-                            END             name 
+                data_list.append((sendtime, row[7], row[0], row[1], row[2], row[3], row[4],  row[6]))
+
+            db.close()
+
+    data_headers = (
+        ('Send Timestamp', 'datetime'),
+        'Message ID',
+        'From ID',
+        'To ID',
+        'Direction',
+        'Message',
+        'Read',
+        'Attachment',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_textnow_contacts(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for file_found in files_found:
+        file_name = str(file_found)
+        if file_name.endswith('textnow_data.db'):
+            source_path = file_name
+            db = open_sqlite_db_readonly(file_found)
+            cursor = db.cursor()
+            try:
+                cursor.execute('''
+                     SELECT C.contact_value AS number,
+                            CASE
+                              WHEN contact_name IS NULL THEN contact_value
+                              WHEN contact_name == "" THEN contact_value
+                              ELSE contact_name
+                            END             name
                      FROM   contacts AS C        ''')
+                all_rows = cursor.fetchall()
+            except:
+                all_rows = []
 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-    except:
-        usageentries = 0
-        
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Text Now - Contacts')
-        report.start_artifact_report(report_folder, 'Text Now - Contacts')
-        report.add_script()
-        data_headers = ('number','name') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = []
-        for row in all_rows:
-            data_list.append((row[0], row[1]))
+            for row in all_rows:
+                data_list.append((row[0], row[1]))
 
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Text Now - Contacts'
-        tsv(report_folder, data_headers, data_list, tsvname, source_file_msg    )
+            db.close()
 
-    else:
-        logfunc('No Text Now Contacts found')
-
-    db.close
-    
+    data_headers = (('number', 'phonenumber'), 'name')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Continues the multi-report conversion pattern (one `@artifact_processor` function per table).

### textnow (1 function → 3)
All three read the same `textnow_data.db`; each runs its own query:
- `get_textnow_call_logs` — Start/End Time marked `'datetime'`, ID columns `'phonenumber'`
- `get_textnow_messages` — Send Timestamp `'datetime'`
- `get_textnow_contacts` — number marked `'phonenumber'`

### skout (1 function → 2)
Both read `skoutDatabase`:
- `get_skout_messages`
- `get_skout_users`

Queries and row extraction are unchanged (verified structurally against `main`). Each function now runs its query inside the file loop, removing the original undefined-variable patterns, and returns `(data_headers, data_list, source_path)`. The old `"function"` keys are dropped since decorated functions resolve by name.

Verified: both files parse, are lint-clean, the plugin loader resolves all five functions with no warnings, and the union of SQL queries / `data_list` rows matches the pre-conversion versions. (No test data for these apps in available extractions; structural-gate conversion.)