### PR TITLE
Convert chromeBookmarks to LAVA with per-browser tables (iLEAPP pattern)

### DIFF
--- a/scripts/artifacts/chromeBookmarks.py
+++ b/scripts/artifacts/chromeBookmarks.py
@@ -1,8 +1,8 @@
-# pylint: disable=E0601,W0611,W0612,W0613,W1514
+# pylint: disable=W0612,W0613
 __artifacts_v2__ = {
     "get_chromeBookmarks": {
-        "name": "ChromeBookmarks",
-        "description": "",
+        "name": "Bookmarks",
+        "description": "Parses Bookmarks from Chromium Based Browsers",
         "author": "",
         "creation_date": "2020-03-20",
         "last_update_date": "2020-03-20",
@@ -10,9 +10,8 @@ __artifacts_v2__ = {
         "category": "Chromium",
         "notes": "",
         "paths": ('*/app_chrome/Default/Bookmarks*', '*/app_sbrowser/Default/Bookmarks*', '*/app_opera/Bookmarks*', '*/app_webview/Default/Bookmarks*'),
-        "output_types": None,
-        "artifact_icon": "globe",
-        "function": "get_chromeBookmarks",
+        "output_types": "standard",
+        "artifact_icon": "bookmark",
     }
 }
 
@@ -21,59 +20,83 @@ import json
 import os
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, get_next_unused_name
-
+from scripts.ilapfuncs import logfunc, get_next_unused_name, lava_process_artifact, lava_insert_sqlite_data, artifact_processor
 from scripts.artifacts.chrome import get_browser_name
 
+
+@artifact_processor
 def get_chromeBookmarks(files_found, report_folder, seeker, wrap_text):
-    
+    # all_data is a consolidated list of all browsers with an extra column to discriminate the browser
+    all_data = []
+
+    data_headers = ['Added Date', 'URL', 'Name', 'Parent', 'Type']
+
+    lava_data_headers = data_headers.copy()
+    lava_data_headers[0] = (lava_data_headers[0], 'datetime')
+
+    all_data_headers = lava_data_headers + ['Browser Name']
+
+    report_file = 'Unknown'
+
     for file_found in files_found:
         file_found = str(file_found)
-        if not os.path.basename(file_found) == 'Bookmarks': # skip -journal and other files
+        if not os.path.basename(file_found) == 'Bookmarks':  # skip -journal and other files
             continue
-        elif file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
-            continue # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data??
+        if file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
+            continue  # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data
+
+        report_file = file_found if report_file == 'Unknown' else report_file + ', ' + file_found
+
         browser_name = get_browser_name(file_found)
         if file_found.find('app_sbrowser') >= 0:
             browser_name = 'Browser'
 
-        with open(file_found, "r") as f:
+        with open(file_found, "r", encoding='utf-8') as f:
             dataa = json.load(f)
         data_list = []
         for x, y in dataa.items():
-            flag = 0
-            if isinstance(y,dict):
+            children_items = list()
+            if isinstance(y, dict):
                 for key, value in y.items():
-                    if isinstance(value,dict):
+                    if isinstance(value, dict):
                         for keyb, valueb in value.items():
                             if keyb == 'children':
                                 if len(valueb) > 0:
-                                    url = valueb[0].get('url','')
-                                    dateadd = valueb[0].get('date_added','')
-                                    dateaddconv = datetime.datetime(1601, 1, 1) + datetime.timedelta(microseconds=int(dateadd))
-                                    name = valueb[0].get('name','')
-                                    typed = valueb[0].get('type','')
-                                    flag = 1
-                            if keyb == 'name' and flag == 1:
-                                flag = 0
+                                    for index in range(len(valueb)):
+                                        url = valueb[index].get('url', '')
+                                        dateadd = valueb[index].get('date_added', '')
+                                        dateaddconv = datetime.datetime(1601, 1, 1) + datetime.timedelta(microseconds=int(dateadd))
+                                        name = valueb[index].get('name', '')
+                                        typed = valueb[index].get('type', '')
+                                        children_items.append((url, dateaddconv, name, typed))
+                            if keyb == 'name' and len(children_items) > 0:
                                 parent = valueb
-                                data_list.append((dateaddconv, url, name, parent, typed))
-        num_entries = len(data_list)
-        if num_entries > 0:
-            report = ArtifactHtmlReport(f'{browser_name} - Bookmarks')
-            #check for existing and get next name for report file, so report from another file does not get overwritten
-            report_path = os.path.join(report_folder, f'{browser_name} - Bookmarks.temphtml')
-            report_path = get_next_unused_name(report_path)[:-9] # remove .temphtml
+                                for (url, dateaddconv, name, typed) in children_items:
+                                    data_list.append((dateaddconv, url, name, parent, typed))
+                                children_items = list()
+
+        if len(data_list) > 0:
+            report_name = f'{browser_name} - Bookmarks'
+            report = ArtifactHtmlReport(report_name)
+            # check for existing and get next name for report file, so report from another file does not get overwritten
+            report_path = os.path.join(report_folder, f'{report_name}.temphtml')
+            report_path = get_next_unused_name(report_path)[:-9]  # remove .temphtml
             report.start_artifact_report(report_folder, os.path.basename(report_path))
             report.add_script()
-            data_headers = ('Added Date', 'URL', 'Name', 'Parent', 'Type') 
             report.write_artifact_data_table(data_headers, data_list, file_found)
             report.end_artifact_report()
-            
-            tsvname = f'{browser_name} - Bookmarks'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'{browser_name} - Bookmarks'
-            timeline(report_folder, tlactivity, data_list, data_headers)
+
+            # Per-browser LAVA table
+            category = "Chromium"
+            module_name = "get_chromeBookmarks"
+            table_name, object_columns, column_map = lava_process_artifact(
+                category, module_name, report_name, lava_data_headers, len(data_list))
+            lava_insert_sqlite_data(table_name, data_list, object_columns, lava_data_headers, column_map)
+
+            # Add the browser name column and accumulate for the combined output
+            data_list = [row + (browser_name,) for row in data_list]
+            all_data.extend(data_list)
         else:
             logfunc(f'No {browser_name} - Bookmarks data available')
+
+    return all_data_headers, all_data, report_file


### PR DESCRIPTION
Establishes the **multi-browser** conversion pattern, emulating iLEAPP's `chrome.py`. This is the pilot for the Chrome/Chromium family.

### The pattern
One artifact per type (`chromeBookmarks`) that still produces **per-browser tables**:
- `get_browser_name()` identifies the browser at runtime from the path (Chrome / Brave / Edge / Opera / Samsung / embedded WebView).
- For each browser file found, a **per-browser HTML report** and a **per-browser LAVA table** (`"<Browser> - Bookmarks"`) are generated manually in the loop.
- Rows are accumulated into a combined dataset with a trailing **`Browser Name`** column, which `@artifact_processor` turns into the combined TSV / timeline / LAVA outputs.

### Why this instead of separate per-browser scripts
- **Full coverage** — any Chromium browser or embedded WebView is detected at runtime; no need to enumerate packages, and dynamic WebView apps are still captured (which a static per-browser split can't do).
- **Per-browser tables** — exactly the forensic separation we want, in one maintainable file instead of ~5 near-duplicate scripts.

### Also fixes a parser bug
The original only read the **first child** per folder and took every bookmark's name/type from that first child. It now reads **all** children with their own name/type. (Verified on synthetic Chromium Bookmarks data: 3 distinct bookmarks extracted with correct names/types/parents.)

Notes:
- Signature kept at ALEAPP's 4 args (iLEAPP passes a 5th `timezone_offset`; ALEAPP doesn't). Timestamps remain UTC as before.
- Verified: parses, lint-clean, loader resolves with no warnings, and the parse logic was functionally tested on synthetic data.

If the pattern looks good, I'll apply it across the rest of the Chrome family (Cookies, TopSites, LoginData, OfflinePages, NetworkActionPredictor, MediaHistory).