### PR TITLE
Convert chromeOfflinePages/chromeTopSites to LAVA (per-browser tables)

### DIFF
--- a/scripts/artifacts/chromeOfflinePages.py
+++ b/scripts/artifacts/chromeOfflinePages.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0611,W0613
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_chromeOfflinePages": {
-        "name": "ChromeOfflinePages",
-        "description": "",
+        "name": "Offline Pages",
+        "description": "Parses Offline Pages from Chromium Based Browsers",
         "author": "",
         "creation_date": "2020-04-02",
         "last_update_date": "2020-04-02",
@@ -10,31 +10,42 @@ __artifacts_v2__ = {
         "category": "Chromium",
         "notes": "",
         "paths": ('*/app_chrome/Default/Offline Pages/metadata/OfflinePages.db*', '*/app_sbrowser/Default/Offline Pages/metadata/OfflinePages.db*', '*/app_webview/Default/Offline Pages/metadata/OfflinePages.db*'),
-        "output_types": None,
-        "artifact_icon": "message-square",
-        "function": "get_chromeOfflinePages",
+        "output_types": "standard",
+        "artifact_icon": "download-cloud",
     }
 }
 
 import os
-import sqlite3
 import textwrap
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, get_next_unused_name, open_sqlite_db_readonly
+from scripts.ilapfuncs import logfunc, get_next_unused_name, open_sqlite_db_readonly, lava_process_artifact, lava_insert_sqlite_data, artifact_processor
 from scripts.artifacts.chrome import get_browser_name
 
+
+@artifact_processor
 def get_chromeOfflinePages(files_found, report_folder, seeker, wrap_text):
-    
+    all_data = []
+
+    data_headers = ['Creation Time', 'Last Access Time', 'Online URL', 'File Path', 'Title', 'Access Count', 'File Size']
+    lava_data_headers = data_headers.copy()
+    lava_data_headers[0] = (lava_data_headers[0], 'datetime')
+    lava_data_headers[1] = (lava_data_headers[1], 'datetime')
+    all_data_headers = lava_data_headers + ['Browser Name']
+
+    report_file = 'Unknown'
+
     for file_found in files_found:
         file_found = str(file_found)
-        if not os.path.basename(file_found) == 'OfflinePages.db': # skip -journal and other files
+        if not os.path.basename(file_found) == 'OfflinePages.db':  # skip -journal and other files
             continue
         browser_name = get_browser_name(file_found)
         if file_found.find('app_sbrowser') >= 0:
             browser_name = 'Browser'
         elif file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
-            continue # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data??
+            continue  # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data
+
+        report_file = file_found if report_file == 'Unknown' else report_file + ', ' + file_found
 
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
@@ -51,30 +62,34 @@ def get_chromeOfflinePages(files_found, report_folder, seeker, wrap_text):
         ''')
 
         all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport(f'{browser_name} - Offline Pages')
-            #check for existing and get next name for report file, so report from another file does not get overwritten
-            report_path = os.path.join(report_folder, f'{browser_name} - Offline Pages.temphtml')
-            report_path = get_next_unused_name(report_path)[:-9] # remove .temphtml
-            report.start_artifact_report(report_folder, os.path.basename(report_path))
-            report.add_script()
-            data_headers = ('Creation Time','Last Access Time', 'Online URL', 'File Path', 'Title', 'Access Count', 'File Size' ) # Don't remove the comma, that is required to make this a tuple as there is only 1 element
+        if len(all_rows) > 0:
             data_list = []
             for row in all_rows:
                 if wrap_text:
                     data_list.append((row[0],row[1],(textwrap.fill(row[2], width=75)),row[3],row[4],row[5],row[6]))
                 else:
                     data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
+
+            report_name = f'{browser_name} - Offline Pages'
+            report = ArtifactHtmlReport(report_name)
+            report_path = os.path.join(report_folder, f'{report_name}.temphtml')
+            report_path = get_next_unused_name(report_path)[:-9]  # remove .temphtml
+            report.start_artifact_report(report_folder, os.path.basename(report_path))
+            report.add_script()
             report.write_artifact_data_table(data_headers, data_list, file_found)
             report.end_artifact_report()
-            
-            tsvname = f'{browser_name} - Offline Pages'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'{browser_name} - Offline Pages'
-            timeline(report_folder, tlactivity, data_list, data_headers)
+
+            category = "Chromium"
+            module_name = "get_chromeOfflinePages"
+            table_name, object_columns, column_map = lava_process_artifact(
+                category, module_name, report_name, lava_data_headers, len(data_list))
+            lava_insert_sqlite_data(table_name, data_list, object_columns, lava_data_headers, column_map)
+
+            data_list = [row + (browser_name,) for row in data_list]
+            all_data.extend(data_list)
         else:
             logfunc(f'No {browser_name} - Offline Pages data available')
-        
+
         db.close()
+
+    return all_data_headers, all_data, report_file

--- a/scripts/artifacts/chromeTopSites.py
+++ b/scripts/artifacts/chromeTopSites.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0611,W0613,W0702
+# pylint: disable=W0613,W0702
 __artifacts_v2__ = {
     "get_chromeTopSites": {
-        "name": "ChromeTopSites",
-        "description": "",
+        "name": "Top Sites",
+        "description": "Parses Top Sites from Chromium Based Browsers",
         "author": "",
         "creation_date": "2020-03-21",
         "last_update_date": "2020-03-21",
@@ -10,30 +10,37 @@ __artifacts_v2__ = {
         "category": "Chromium",
         "notes": "",
         "paths": ('*/app_chrome/Default/Top Sites*', '*/app_sbrowser/Default/Top Sites*', '*/app_opera/Top Sites*', '*/app_webview/Default/Top Sites*'),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "globe",
-        "function": "get_chromeTopSites",
     }
 }
 
 import os
-import sqlite3
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, get_next_unused_name, open_sqlite_db_readonly
+from scripts.ilapfuncs import logfunc, get_next_unused_name, open_sqlite_db_readonly, lava_process_artifact, lava_insert_sqlite_data, artifact_processor
 from scripts.artifacts.chrome import get_browser_name
 
+
+@artifact_processor
 def get_chromeTopSites(files_found, report_folder, seeker, wrap_text):
-    
+    all_data = []
+
+    data_headers = ['URL', 'Rank', 'Title', 'Redirects']
+    lava_data_headers = data_headers.copy()
+    all_data_headers = lava_data_headers + ['Browser Name']
+
+    report_file = 'Unknown'
+
     for file_found in files_found:
         file_found = str(file_found)
-        if not os.path.basename(file_found) == 'Top Sites': # skip -journal and other files
+        if not os.path.basename(file_found) == 'Top Sites':  # skip -journal and other files
             continue
         browser_name = get_browser_name(file_found)
         if file_found.find('app_sbrowser') >= 0:
             browser_name = 'Browser'
         elif file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
-            continue # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data??
+            continue  # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data
 
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
@@ -47,31 +54,37 @@ def get_chromeTopSites(files_found, report_folder, seeker, wrap_text):
             FROM
             top_sites ORDER by url_rank asc
             ''')
-
             all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
         except:
-            usageentries = 0
-            
-        if usageentries > 0:
-            report = ArtifactHtmlReport(f'{browser_name} - Top Sites')
-            #check for existing and get next name for report file, so report from another file does not get overwritten
-            report_path = os.path.join(report_folder, f'{browser_name} - Top Sites.temphtml')
-            report_path = get_next_unused_name(report_path)[:-9] # remove .temphtml
-            report.start_artifact_report(report_folder, os.path.basename(report_path))
-            report.add_script()
-            data_headers = ('URL','Rank','Title','Redirects')
+            all_rows = []
+
+        if len(all_rows) > 0:
+            report_file = file_found if report_file == 'Unknown' else report_file + ', ' + file_found
+
             data_list = []
             for row in all_rows:
                 data_list.append((row[0],row[1],row[2],row[3]))
 
+            report_name = f'{browser_name} - Top Sites'
+            report = ArtifactHtmlReport(report_name)
+            report_path = os.path.join(report_folder, f'{report_name}.temphtml')
+            report_path = get_next_unused_name(report_path)[:-9]  # remove .temphtml
+            report.start_artifact_report(report_folder, os.path.basename(report_path))
+            report.add_script()
             report.write_artifact_data_table(data_headers, data_list, file_found)
             report.end_artifact_report()
-            
-            tsvname = f'{browser_name} - Top Sites'
-            tsv(report_folder, data_headers, data_list, tsvname)
+
+            category = "Chromium"
+            module_name = "get_chromeTopSites"
+            table_name, object_columns, column_map = lava_process_artifact(
+                category, module_name, report_name, lava_data_headers, len(data_list))
+            lava_insert_sqlite_data(table_name, data_list, object_columns, lava_data_headers, column_map)
+
+            data_list = [row + (browser_name,) for row in data_list]
+            all_data.extend(data_list)
         else:
             logfunc(f'No {browser_name} - Top Sites data available')
-        
+
         db.close()
-        
+
+    return all_data_headers, all_data, report_file


### PR DESCRIPTION
Continues the Chrome-family conversion using the per-browser pattern established in #729 (chromeBookmarks).

For each browser found, generates a per-browser HTML report and a per-browser LAVA table (`<Browser> - Offline Pages`, `<Browser> - Top Sites`), then returns a combined dataset with a trailing `Browser Name` column that `@artifact_processor` turns into the combined TSV/timeline/LAVA outputs. Browser is identified at runtime via `get_browser_name`, so coverage (including WebView) is preserved.

- **chromeOfflinePages** — two datetime columns marked; output `standard`.
- **chromeTopSites** — no datetime column; output `['html','tsv','lava']`.

Each artifact's **existing query and `data_list` rows are unchanged** — verified structurally against `main` (queries + rows match), so these clear the structural gate in addition to the per-browser restructuring.

Verified: both parse, are lint-clean, and the plugin loader resolves them with no warnings.