### PR TITLE
Convert chromeCookies/chromeNetworkActionPredictor to LAVA (per-browser tables)

### DIFF
--- a/scripts/artifacts/chromeCookies.py
+++ b/scripts/artifacts/chromeCookies.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0611,W0613
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_chromeCookies": {
-        "name": "ChromeCookies",
-        "description": "",
+        "name": "Cookies",
+        "description": "Parses Cookies from Chromium Based Browsers",
         "author": "",
         "creation_date": "2020-03-21",
         "last_update_date": "2020-03-21",
@@ -10,81 +10,85 @@ __artifacts_v2__ = {
         "category": "Chromium",
         "notes": "",
         "paths": ('*/app_chrome/Default/Cookies*', '*/app_sbrowser/Default/Cookies*', '*/app_opera/Cookies*', '*/app_webview/Default/Cookies*'),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "globe",
-        "function": "get_chromeCookies",
     }
 }
 
 import os
-import sqlite3
 import textwrap
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, get_next_unused_name, open_sqlite_db_readonly
+from scripts.ilapfuncs import logfunc, get_next_unused_name, open_sqlite_db_readonly, lava_process_artifact, lava_insert_sqlite_data, artifact_processor
 from scripts.artifacts.chrome import get_browser_name
 
+
+@artifact_processor
 def get_chromeCookies(files_found, report_folder, seeker, wrap_text):
-    
+    all_data = []
+
+    data_headers = ['Last Access Date', 'Host', 'Name', 'Value', 'Created Date', 'Expiration Date', 'Path']
+    lava_data_headers = data_headers.copy()
+    lava_data_headers[0] = (lava_data_headers[0], 'datetime')
+    lava_data_headers[4] = (lava_data_headers[4], 'datetime')
+    lava_data_headers[5] = (lava_data_headers[5], 'datetime')
+    all_data_headers = lava_data_headers + ['Browser Name']
+
+    report_file = 'Unknown'
+
     for file_found in files_found:
         file_found = str(file_found)
-        if not os.path.basename(file_found) == 'Cookies': # skip -journal and other files
+        if not os.path.basename(file_found) == 'Cookies':  # skip -journal and other files
             continue
         browser_name = get_browser_name(file_found)
         if file_found.find('app_sbrowser') >= 0:
             browser_name = 'Browser'
         elif file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
-            continue # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data??
+            continue  # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data
 
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
         SELECT
         CASE
-            last_access_utc 
+            last_access_utc
             WHEN
-                "0" 
+                "0"
             THEN
-                "" 
+                ""
             ELSE
                 datetime(last_access_utc / 1000000 + (strftime('%s', '1601-01-01')), "unixepoch")
-        END AS "last_access_utc", 
+        END AS "last_access_utc",
         host_key,
         name,
         value,
         CASE
-            creation_utc 
+            creation_utc
             WHEN
-                "0" 
+                "0"
             THEN
-                "" 
+                ""
             ELSE
                 datetime(creation_utc / 1000000 + (strftime('%s', '1601-01-01')), "unixepoch")
-        END AS "creation_utc", 
+        END AS "creation_utc",
         CASE
-            expires_utc 
+            expires_utc
             WHEN
-                "0" 
+                "0"
             THEN
-                "" 
+                ""
             ELSE
                 datetime(expires_utc / 1000000 + (strftime('%s', '1601-01-01')), "unixepoch")
-        END AS "expires_utc", 
+        END AS "expires_utc",
         path
         FROM
         cookies
         ''')
 
         all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport(f'{browser_name} - Cookies')
-            #check for existing and get next name for report file, so report from another file does not get overwritten
-            report_path = os.path.join(report_folder, f'{browser_name} - Cookies.temphtml')
-            report_path = get_next_unused_name(report_path)[:-9] # remove .temphtml
-            report.start_artifact_report(report_folder, os.path.basename(report_path))
-            report.add_script()
-            data_headers = ('Last Access Date','Host','Name','Value','Created Date','Expiration Date','Path')
+        if len(all_rows) > 0:
+            report_file = file_found if report_file == 'Unknown' else report_file + ', ' + file_found
+
             data_list = []
             for row in all_rows:
                 if wrap_text:
@@ -92,15 +96,26 @@ def get_chromeCookies(files_found, report_folder, seeker, wrap_text):
                 else:
                     data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
 
+            report_name = f'{browser_name} - Cookies'
+            report = ArtifactHtmlReport(report_name)
+            report_path = os.path.join(report_folder, f'{report_name}.temphtml')
+            report_path = get_next_unused_name(report_path)[:-9]  # remove .temphtml
+            report.start_artifact_report(report_folder, os.path.basename(report_path))
+            report.add_script()
             report.write_artifact_data_table(data_headers, data_list, file_found)
             report.end_artifact_report()
-            
-            tsvname = f'{browser_name} - Cookies'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'{browser_name} - Cookies'
-            timeline(report_folder, tlactivity, data_list, data_headers)
+
+            category = "Chromium"
+            module_name = "get_chromeCookies"
+            table_name, object_columns, column_map = lava_process_artifact(
+                category, module_name, report_name, lava_data_headers, len(data_list))
+            lava_insert_sqlite_data(table_name, data_list, object_columns, lava_data_headers, column_map)
+
+            data_list = [row + (browser_name,) for row in data_list]
+            all_data.extend(data_list)
         else:
             logfunc(f'No {browser_name} - Cookies data available')
-        
+
         db.close()
+
+    return all_data_headers, all_data, report_file

--- a/scripts/artifacts/chromeNetworkActionPredictor.py
+++ b/scripts/artifacts/chromeNetworkActionPredictor.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0611,W0613
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_chromeNetworkActionPredictor": {
-        "name": "ChromeNetworkActionPredictor",
-        "description": "",
+        "name": "Network Action Predictor",
+        "description": "Parses the Network Action Predictor from Chromium Based Browsers",
         "author": "",
         "creation_date": "2020-03-19",
         "last_update_date": "2020-03-19",
@@ -10,31 +10,39 @@ __artifacts_v2__ = {
         "category": "Chromium",
         "notes": "",
         "paths": ('*/app_Chrome/Default/Network Action Predictor*', '*/app_sbrowser/Default/Network Action Predictor*', '*/app_opera/Network Action Predicator*', '*/app_webview/Default/Network Action Predictor*'),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "wifi",
-        "function": "get_chromeNetworkActionPredictor",
     }
 }
 
 import os
-import sqlite3
+
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, get_next_unused_name, open_sqlite_db_readonly
+from scripts.ilapfuncs import logfunc, get_next_unused_name, open_sqlite_db_readonly, lava_process_artifact, lava_insert_sqlite_data, artifact_processor
 from scripts.artifacts.chrome import get_browser_name
 
+
+@artifact_processor
 def get_chromeNetworkActionPredictor(files_found, report_folder, seeker, wrap_text):
+    all_data = []
+
+    data_headers = ['User Text', 'URL', 'Number of Hits', 'Number of Misses']
+    lava_data_headers = data_headers.copy()
+    all_data_headers = lava_data_headers + ['Browser Name']
+
+    report_file = 'Unknown'
 
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('Network Action Predictor'):
-            continue # Skip all other files
-            
+            continue  # Skip all other files
+
         browser_name = get_browser_name(file_found)
         if file_found.find('app_sbrowser') >= 0:
             browser_name = 'Browser'
         elif file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
-            continue # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data??
-        
+            continue  # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data
+
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
@@ -47,26 +55,33 @@ def get_chromeNetworkActionPredictor(files_found, report_folder, seeker, wrap_te
         ''')
 
         all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport(f'{browser_name} - Network Action Predictor')
-            #check for existing and get next name for report file, so report from another file does not get overwritten
-            report_path = os.path.join(report_folder, f'{browser_name} - Network Action Predictor.temphtml')
-            report_path = get_next_unused_name(report_path)[:-9] # remove .temphtml
-            report.start_artifact_report(report_folder, os.path.basename(report_path))
-            report.add_script()
-            data_headers = ('User Text','URL','Number of Hits','Number of Misses') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
+        if len(all_rows) > 0:
+            report_file = file_found if report_file == 'Unknown' else report_file + ', ' + file_found
+
             data_list = []
             for row in all_rows:
                 data_list.append((row[0],row[1],row[2],row[3]))
 
+            report_name = f'{browser_name} - Network Action Predictor'
+            report = ArtifactHtmlReport(report_name)
+            report_path = os.path.join(report_folder, f'{report_name}.temphtml')
+            report_path = get_next_unused_name(report_path)[:-9]  # remove .temphtml
+            report.start_artifact_report(report_folder, os.path.basename(report_path))
+            report.add_script()
             report.write_artifact_data_table(data_headers, data_list, file_found)
             report.end_artifact_report()
-            
-            tsvname = f'{browser_name} - Network Action Predictor'
-            tsv(report_folder, data_headers, data_list, tsvname)
 
+            category = "Chromium"
+            module_name = "get_chromeNetworkActionPredictor"
+            table_name, object_columns, column_map = lava_process_artifact(
+                category, module_name, report_name, lava_data_headers, len(data_list))
+            lava_insert_sqlite_data(table_name, data_list, object_columns, lava_data_headers, column_map)
+
+            data_list = [row + (browser_name,) for row in data_list]
+            all_data.extend(data_list)
         else:
             logfunc(f'No {browser_name} - Network Action Predictor data available')
-        
+
         db.close()
+
+    return all_data_headers, all_data, report_file


### PR DESCRIPTION
Continues the Chrome-family conversion with the per-browser pattern (#729, #730).

For each browser found, generates a per-browser HTML report and a per-browser LAVA table (`<Browser> - Cookies`, `<Browser> - Network Action Predictor`), then returns a combined dataset with a trailing `Browser Name` column for the combined TSV/timeline/LAVA outputs. Browser identified at runtime via `get_browser_name`.

- **chromeCookies** — three datetime columns marked; output `standard`.
- **chromeNetworkActionPredictor** — no datetime column; output `['html','tsv','lava']`.

Each artifact's existing query and `data_list` rows are unchanged — verified structurally against `main`, so these clear the structural gate in addition to the per-browser restructuring.

Verified: both parse, are lint-clean, and the plugin loader resolves them with no warnings. (No test data for these two in available extractions; the per-browser pattern itself was behaviorally confirmed in #729/#730 on a Samsung extraction.)