### PR TITLE
Convert chromeLoginData to LAVA (per-browser tables)

### DIFF
--- a/scripts/artifacts/chromeLoginData.py
+++ b/scripts/artifacts/chromeLoginData.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0611,W0613
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_chromeLoginData": {
-        "name": "ChromeLoginData",
-        "description": "",
+        "name": "Login Data",
+        "description": "Parses saved Login Data from Chromium Based Browsers",
         "author": "",
         "creation_date": "2020-03-20",
         "last_update_date": "2020-03-20",
@@ -10,25 +10,24 @@ __artifacts_v2__ = {
         "category": "Chromium",
         "notes": "",
         "paths": ('*/app_chrome/Default/Login Data*', '*/app_sbrowser/Default/Login Data*', '*/app_opera/Login Data*', '*/app_webview/Default/Login Data*'),
-        "output_types": None,
-        "artifact_icon": "globe",
-        "function": "get_chromeLoginData",
+        "output_types": "standard",
+        "artifact_icon": "key",
     }
 }
 
 import datetime
 import os
 import re
-import sqlite3
 
 from Crypto.Cipher import AES
 from Crypto.Protocol.KDF import PBKDF2
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, get_next_unused_name, open_sqlite_db_readonly
+from scripts.ilapfuncs import logfunc, get_next_unused_name, open_sqlite_db_readonly, lava_process_artifact, lava_insert_sqlite_data, artifact_processor
 from scripts.artifacts.chrome import get_browser_name
 
+
 def decrypt(ciphertxt, key=b"peanuts"):
-    if re.match(rb"^v1[01]",ciphertxt): 
+    if re.match(rb"^v1[01]",ciphertxt):
         ciphertxt = ciphertxt[3:]
     salt = b"saltysalt"
     derived_key = PBKDF2(key, salt, 0x10, 1)
@@ -41,6 +40,7 @@ def decrypt(ciphertxt, key=b"peanuts"):
         logfunc('Exception while decrypting data: ' + str(ex))
         plaintxt = b''
     return plaintxt
+
 
 def get_valid_date(d1, d2):
     '''Returns a valid date based on closest year to now'''
@@ -60,17 +60,27 @@ def get_valid_date(d1, d2):
     else:
         return d2
 
+
+@artifact_processor
 def get_chromeLoginData(files_found, report_folder, seeker, wrap_text):
-    
+    all_data = []
+
+    data_headers = ['Created Time', 'Username', 'Password', 'Origin URL', 'Blacklisted by User']
+    lava_data_headers = data_headers.copy()
+    lava_data_headers[0] = (lava_data_headers[0], 'datetime')
+    all_data_headers = lava_data_headers + ['Browser Name']
+
+    report_file = 'Unknown'
+
     for file_found in files_found:
         file_found = str(file_found)
-        if not os.path.basename(file_found) == 'Login Data': # skip -journal and other files
+        if not os.path.basename(file_found) == 'Login Data':  # skip -journal and other files
             continue
         browser_name = get_browser_name(file_found)
         if file_found.find('app_sbrowser') >= 0:
             browser_name = 'Browser'
         elif file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
-            continue # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data??
+            continue  # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data
 
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
@@ -78,11 +88,11 @@ def get_chromeLoginData(files_found, report_folder, seeker, wrap_text):
         SELECT
         username_value,
         password_value,
-        CASE date_created 
-            WHEN "0" THEN "" 
+        CASE date_created
+            WHEN "0" THEN ""
             ELSE datetime(date_created / 1000000 + (strftime('%s', '1601-01-01')), "unixepoch")
-            END AS "date_created_win_epoch", 
-        CASE date_created WHEN "0" THEN "" 
+            END AS "date_created_win_epoch",
+        CASE date_created WHEN "0" THEN ""
             ELSE datetime(date_created / 1000000 + (strftime('%s', '1970-01-01')), "unixepoch")
             END AS "date_created_unix_epoch",
         origin_url,
@@ -91,15 +101,9 @@ def get_chromeLoginData(files_found, report_folder, seeker, wrap_text):
         ''')
 
         all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport(f'{browser_name} - Login Data')
-            #check for existing and get next name for report file, so report from another file does not get overwritten
-            report_path = os.path.join(report_folder, f'{browser_name} - Login Data.temphtml')
-            report_path = get_next_unused_name(report_path)[:-9] # remove .temphtml
-            report.start_artifact_report(report_folder, os.path.basename(report_path))
-            report.add_script()
-            data_headers = ('Created Time','Username','Password','Origin URL','Blacklisted by User', 'Browser Name') 
+        if len(all_rows) > 0:
+            report_file = file_found if report_file == 'Unknown' else report_file + ', ' + file_found
+
             data_list = []
             for row in all_rows:
                 password = ''
@@ -107,18 +111,28 @@ def get_chromeLoginData(files_found, report_folder, seeker, wrap_text):
                 if password_enc:
                     password = decrypt(password_enc).decode("utf-8", 'replace')
                 valid_date = get_valid_date(row[2], row[3])
-                data_list.append( (valid_date, row[0], password, row[4], row[5], browser_name) )
+                data_list.append((valid_date, row[0], password, row[4], row[5]))
 
+            report_name = f'{browser_name} - Login Data'
+            report = ArtifactHtmlReport(report_name)
+            report_path = os.path.join(report_folder, f'{report_name}.temphtml')
+            report_path = get_next_unused_name(report_path)[:-9]  # remove .temphtml
+            report.start_artifact_report(report_folder, os.path.basename(report_path))
+            report.add_script()
             report.write_artifact_data_table(data_headers, data_list, file_found)
             report.end_artifact_report()
-            
-            tsvname = f'{browser_name} - Login Data'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'{browser_name} - Login Data'
-            timeline(report_folder, tlactivity, data_list, data_headers)
+
+            category = "Chromium"
+            module_name = "get_chromeLoginData"
+            table_name, object_columns, column_map = lava_process_artifact(
+                category, module_name, report_name, lava_data_headers, len(data_list))
+            lava_insert_sqlite_data(table_name, data_list, object_columns, lava_data_headers, column_map)
+
+            data_list = [row + (browser_name,) for row in data_list]
+            all_data.extend(data_list)
         else:
             logfunc(f'No {browser_name} - Login Data available')
-        
+
         db.close()
-    
+
+    return all_data_headers, all_data, report_file


### PR DESCRIPTION
Continues the Chrome-family conversion with the per-browser pattern (#729–#731).

For each browser found, generates a per-browser HTML report and a per-browser LAVA table (`<Browser> - Login Data`), then returns a combined dataset with a trailing `Browser Name` column.

- The SQL query and the PBKDF2/AES password decryption are unchanged.
- The original baked `browser_name` into every row; it's now added at the combine step, so each per-browser table doesn't carry a redundant Browser column (consistent with the other Chrome conversions).
- `Created Time` marked as `datetime`; output `standard`.

Verified: parses, lint-clean, plugin loader resolves with no warnings. (No login-data test rows in available extractions; the per-browser pattern itself was behaviorally confirmed on a Samsung extraction in #729/#730.)