### PR TITLE
Convert HideX, samsungSmartThings, mega, smyfilesStored, PodcastAddict to LAVA

### DIFF
--- a/scripts/artifacts/HideX.py
+++ b/scripts/artifacts/HideX.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0631,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_HideX": {
         "name": "HideX",
@@ -10,23 +10,23 @@ __artifacts_v2__ = {
         "category": "GroupMe",
         "notes": "",
         "paths": ('*/com.flatfish.cal.privacy/databases/hidex.db*',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "message-square",
-        "function": "get_HideX",
     }
 }
 
-import sqlite3
-import textwrap
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, open_sqlite_db_readonly
 
+@artifact_processor
 def get_HideX(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
+
         if file_found.endswith('hidex.db'):
+            source_path = file_found
             db = open_sqlite_db_readonly(file_found)
             cursor = db.cursor()
             cursor.execute('''
@@ -40,24 +40,10 @@ def get_HideX(files_found, report_folder, seeker, wrap_text):
             FROM p_lock_app
             ''')
 
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        report = ArtifactHtmlReport('HideX - Locked Apps')
-        report.start_artifact_report(report_folder, 'HideX - Locked Apps')
-        report.add_script()
-        data_headers = ('ID','Package Name','Is Active') 
-        data_list = []
-        for row in all_rows:
-            data_list.append((row[0],row[1],row[2]))
+            all_rows = cursor.fetchall()
+            for row in all_rows:
+                data_list.append((row[0],row[1],row[2]))
+            db.close()
 
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'HideX'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-    else:
-        logfunc('No HideX data available')
-    
-    db.close()
+    data_headers = ('ID', 'Package Name', 'Is Active')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/PodcastAddict.py
+++ b/scripts/artifacts/PodcastAddict.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0611,W0613,W0718,W1309
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_podcasts": {
         "name": "Podcast Addict",
-        "description": "Module Description: Parses Podcast Addict Episode Database",
+        "description": "Parses Podcast Addict Episode Database",
         "author": "John Hyla",
         "creation_date": "2023-07-07",
         "last_update_date": "2023-07-07",
@@ -10,73 +10,56 @@ __artifacts_v2__ = {
         "category": "Podcast Addict",
         "notes": "",
         "paths": ('*/com.bambuna.podcastaddict/databases/podcastAddict.db',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "headphones",
-        "function": "get_podcasts",
     }
 }
 
-# Module Description: Parses Podcast Addict Episode Database
-# Author: John Hyla
-# Date: 2023-07-07
-# Artifact version: 0.0.1
-# Requirements: none
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-import os
-import sqlite3
-import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
-
+@artifact_processor
 def get_podcasts(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
 
-    source_file = ''
     for file_found in files_found:
         file_name = str(file_found)
+        source_path = file_name
 
         db = open_sqlite_db_readonly(file_name)
         cursor = db.cursor()
         try:
-
             cursor.execute('''
-                SELECT datetime(publication_date/1000, "UNIXEPOCH") as publication_date, 
+                SELECT datetime(publication_date/1000, "UNIXEPOCH") as publication_date,
                 datetime(playbackDate/1000, "UNIXEPOCH") as playbackDate,
-                name, 
-                duration, 
-                size, 
+                name,
+                duration,
+                size,
                 datetime(downloaded_date/1000, "UNIXEPOCH") as downloaded_date,
-                playing_status, 
+                playing_status,
                 position_to_resume,
                 download_url
                   FROM episodes
                   ''')
-
             all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-        except Exception as e:
-            print (e)
-            usageentries = 0
-            
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Podcast Addict')
-            report.start_artifact_report(report_folder, 'Podcast Addict')
-            report.add_script()
-            data_headers = ('publication_date', 'playback_date', 'name', 'duration', 'size', 'downloaded_date', 'playing_status', 'position_to_resume', 'download_url') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-            data_list = []
-            for row in all_rows:
-                data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8]))
+        except Exception:
+            all_rows = []
 
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Podcast Addict'
-            tsv(report_folder, data_headers, data_list, tsvname, source_file)
-            
-        else:
-            logfunc('No Podcast Episodes found')
-            
+        for row in all_rows:
+            data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8]))
 
         db.close()
-    
-    return
+
+    data_headers = (
+        ('publication_date', 'datetime'),
+        ('playback_date', 'datetime'),
+        'name',
+        'duration',
+        'size',
+        ('downloaded_date', 'datetime'),
+        'playing_status',
+        'position_to_resume',
+        'download_url',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/mega.py
+++ b/scripts/artifacts/mega.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0311,W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_mega": {
         "name": "mega",
@@ -10,9 +10,8 @@ __artifacts_v2__ = {
         "category": "Mega",
         "notes": "",
         "paths": ('*/mega.privacy.android.app/karere-*.db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "download",
-        "function": "get_mega",
     }
 }
 
@@ -24,20 +23,21 @@ __artifacts_v2__ = {
 # Requirements:  None
 
 import json
-import os
-import sqlite3
-import textwrap
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_mega(files_found, report_folder, seeker, wrap_text):
-    
+    data_list = []
+    source_path = ''
+
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('.db'):
-            continue # Skip all other files
-        
+            continue  # Skip all other files
+
+        source_path = file_found
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
@@ -58,45 +58,36 @@ def get_mega(files_found, report_folder, seeker, wrap_text):
         ''')
 
         all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport('MEGA - Chat')
-            report.start_artifact_report(report_folder, 'MEGA - Chat')
-            report.add_script()
-            data_headers = ('Message Timestamp','Sender','Message Type','Chat Message','Attachment Name') 
-            data_list = []
-            for row in all_rows:
-                attachment_name = ''
-                chat_message = ''
-                if row[2] == 'Chat Message':
-                   chat_contents = row[3]
-                   chat_message = chat_contents[0:]
-                   chat_message = (str(chat_message)[2:-1])
-                   
-                   data_list.append((row[0],row[1],row[2],chat_message,attachment_name))
-                
-                elif row[2] == 'Attachment':
-                    json_contents = row[3]
-                    json_string = json_contents[2:]
-                    json_string = (str(json_string)[2:-1])
-                    
-                    json_export = json.loads(json_string)
-                    
-                    attachment_name = json_export[0]['name']
-                    
-                    data_list.append((row[0],row[1],row[2],chat_message,attachment_name))
-                else:
-                    data_list.append((row[0],row[1],row[2],chat_message,attachment_name))
+        for row in all_rows:
+            attachment_name = ''
+            chat_message = ''
+            if row[2] == 'Chat Message':
+                chat_contents = row[3]
+                chat_message = chat_contents[0:]
+                chat_message = (str(chat_message)[2:-1])
 
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'MEGA - Chat'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'MEGA - Chat'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No MEGA - Chat data available')
-        
+                data_list.append((row[0],row[1],row[2],chat_message,attachment_name))
+
+            elif row[2] == 'Attachment':
+                json_contents = row[3]
+                json_string = json_contents[2:]
+                json_string = (str(json_string)[2:-1])
+
+                json_export = json.loads(json_string)
+
+                attachment_name = json_export[0]['name']
+
+                data_list.append((row[0],row[1],row[2],chat_message,attachment_name))
+            else:
+                data_list.append((row[0],row[1],row[2],chat_message,attachment_name))
+
         db.close()
+
+    data_headers = (
+        ('Message Timestamp', 'datetime'),
+        'Sender',
+        'Message Type',
+        'Chat Message',
+        'Attachment Name',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/samsungSmartThings.py
+++ b/scripts/artifacts/samsungSmartThings.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_samsungSmartThings": {
         "name": "samsungSmartThings",
@@ -10,9 +10,8 @@ __artifacts_v2__ = {
         "category": "Samsung SmartThings",
         "notes": "",
         "paths": ('*/com.samsung.android.oneconnect/databases/QcDB.db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "file",
-        "function": "get_samsungSmartThings",
     }
 }
 
@@ -22,20 +21,20 @@ __artifacts_v2__ = {
 # Artifact version: 0.0.1
 # Requirements: none
 
-import sqlite3
-import textwrap
-import scripts.artifacts.artGlobals
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
+@artifact_processor
 def get_samsungSmartThings(files_found, report_folder, seeker, wrap_text):
-    
+    data_list = []
+    source_path = ''
+
     for file_found in files_found:
         file_found = str(file_found)
-        if not file_found.endswith('QcDb.db'):
-            continue # Skip all other files
-    
+        if not file_found.endswith('QcDB.db'):
+            continue  # Skip all other files
+
+        source_path = file_found
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
@@ -51,26 +50,17 @@ def get_samsungSmartThings(files_found, report_folder, seeker, wrap_text):
         ''')
 
         all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Samsung SmartThings - Quick Connect')
-            report.start_artifact_report(report_folder, 'Samsung SmartThings - Quick Connect')
-            report.add_script()
-            data_headers = ('Connection Timestamp','Device Name','Device Type','Net Type','Wifi P2P MAC','Bluetooth MAC','Bluetooth (LE) MAC') 
-            data_list = []
-            for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
-
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Samsung SmartThings - Quick Connect'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Samsung SmartThings - Quick Connect'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Samsung SmartThings - Quick Connect data available')
-        
+        for row in all_rows:
+            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
         db.close()
-        
+
+    data_headers = (
+        ('Connection Timestamp', 'datetime'),
+        'Device Name',
+        'Device Type',
+        'Net Type',
+        'Wifi P2P MAC',
+        'Bluetooth MAC',
+        'Bluetooth (LE) MAC',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/smyfilesStored.py
+++ b/scripts/artifacts/smyfilesStored.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0702,W1309
+# pylint: disable=W0613,W0702
 __artifacts_v2__ = {
     "get_smyfilesStored": {
         "name": "smyfilesStored",
@@ -10,23 +10,21 @@ __artifacts_v2__ = {
         "category": "My Files",
         "notes": "",
         "paths": ('*/com.sec.android.app.myfiles/databases/FileCache.db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "file",
-        "function": "get_smyfilesStored",
     }
 }
 
-import sqlite3
-import textwrap
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
-def get_smyfilesStored(files_found, report_folder, seeker, text_wrap):
-    
-    file_found = str(files_found[0])
+@artifact_processor
+def get_smyfilesStored(files_found, report_folder, seeker, wrap_text):
+
+    source_path = str(files_found[0])
+    all_rows = []
     try:
-        db = open_sqlite_db_readonly(file_found)
+        db = open_sqlite_db_readonly(source_path)
         cursor = db.cursor()
         cursor.execute('''
         SELECT
@@ -36,16 +34,15 @@ def get_smyfilesStored(files_found, report_folder, seeker, text_wrap):
         size,
         datetime(latest /1000, "unixepoch")
         from FileCache
-        where path is not NULL 
+        where path is not NULL
         ''')
-    
+
         all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
     except:
-        usageentries = 0
-    
+        all_rows = []
+
     try:
-        db = open_sqlite_db_readonly(file_found)
+        db = open_sqlite_db_readonly(source_path)
         cursor = db.cursor()
         cursor.execute('''
         SELECT
@@ -55,32 +52,22 @@ def get_smyfilesStored(files_found, report_folder, seeker, text_wrap):
             size,
             datetime(latest /1000, "unixepoch")
             from FileCache
-            where _data is not NULL 
+            where _data is not NULL
         ''')
-        
+
         all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
     except:
-        usageentries = 0
+        all_rows = []
 
-    if usageentries > 0:
-        report = ArtifactHtmlReport('My Files DB - Stored Files')
-        report.start_artifact_report(report_folder, 'My Files DB - Stored Files')
-        report.add_script()
-        data_headers = ('Timestamp','Storage','Path','Size','Latest' ) # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = []
-        for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4]))
+    data_list = []
+    for row in all_rows:
+        data_list.append((row[0],row[1],row[2],row[3],row[4]))
 
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'my files db - stored files'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'My Files DB - Stored Files'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No My Files DB Stored data available')
-    
-    db.close()
+    data_headers = (
+        ('Timestamp', 'datetime'),
+        'Storage',
+        'Path',
+        'Size',
+        ('Latest', 'datetime'),
+    )
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts five single-report artifacts to the LAVA output pipeline.

Each now uses `@artifact_processor` and returns `(data_headers, data_list, source_path)`, adding LAVA output alongside the existing HTML/TSV (and timeline where a datetime column exists). Queries and row extraction are unchanged (verified structurally against `main`); datetime columns marked.

- **HideX** — locked apps (no datetime)
- **samsungSmartThings** — Quick Connect devices; also fixes a pre-existing typo where the file check looked for `QcDb.db` while the path/actual file is `QcDB.db`, so the artifact never fired
- **mega** — chat history (JSON attachment parsing preserved)
- **smyfilesStored** — My Files stored files (two datetime columns)
- **PodcastAddict** — episodes (three datetime columns)

Verified: all five parse, are lint-clean, the plugin loader resolves them with no warnings, and their queries / rows match the pre-conversion versions.

Deferred: `googleCallScreen` (embeds audio media + protobuf — needs the media handler).