### PR TITLE
Convert keepNotes, rarlabPreferences, googleTasks to LAVA

### DIFF
--- a/scripts/artifacts/googleTasks.py
+++ b/scripts/artifacts/googleTasks.py
@@ -1,4 +1,4 @@
-# pylint: disable=E0606,W0611,W0613
+# pylint: disable=E0606,W0613
 __artifacts_v2__ = {
     "get_googleTasks": {
         "name": "GoogleTasks",
@@ -10,25 +10,20 @@ __artifacts_v2__ = {
         "category": "Google Tasks",
         "notes": "",
         "paths": ('*/com.google.android.apps.tasks/files/tasks-*/data.db',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "file-text",
-        "function": "get_googleTasks",
     }
 }
 
-import os
-import textwrap
 from datetime import datetime
 import blackboxprotobuf
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-is_windows = is_platform_windows()
-slash = '\\' if is_windows else '/' 
 
 def b2s(a):
-    return "".join(list(map(chr, a))) 
+    return "".join(list(map(chr, a)))
+
 
 def protobuf_parse_not_completed(data):
     pb = blackboxprotobuf.decode_message(data, 'None')
@@ -37,10 +32,9 @@ def protobuf_parse_not_completed(data):
     modified = datetime.utcfromtimestamp(pb[0].get('3',{}).get('1','')).strftime('%Y-%m-%d %H:%M:%S')
     task = pb[0].get('2',{}).get('2','').decode()
     task_details = b2s(pb[0].get('2',{}).get('3',''))
-    # duetime = pb[0].get('9',{}).get('1',{}).get('6',{}).get('1','')
-    # duetime = datetime.utcfromtimestamp(duetime).strftime('%Y-%m-%d %H:%M:%S') # TypeError: an integer is required (got type str)
     timezone = b2s(pb[0].get('9',{}).get('1',{}).get('4',''))
     return task, task_details, created, completed, modified, timezone
+
 
 def protobuf_parse_completed(data):
     pb = blackboxprotobuf.decode_message(data, None)
@@ -49,18 +43,21 @@ def protobuf_parse_completed(data):
     completed = datetime.utcfromtimestamp(pb[0].get('2',{}).get('5',{}).get('1','')).strftime('%Y-%m-%d %H:%M:%S')
     created = datetime.utcfromtimestamp(pb[0].get('11',{}).get('1','')).strftime('%Y-%m-%d %H:%M:%S')
     modified = datetime.utcfromtimestamp(pb[0].get('3',{}).get('1','')).strftime('%Y-%m-%d %H:%M:%S')
-    # duetime = pb[0].get('9',{}).get('1',{}).get('6',{}).get('1','')
-    # duetime = datetime.utcfromtimestamp(duetime).strftime('%Y-%m-%d %H:%M:%S') # TypeError: an integer is required (got type str)
     timezone = b2s(pb[0].get('9',{}).get('1',{}).get('4',''))
     return task, task_details, created, completed, modified, timezone
 
+
+@artifact_processor
 def get_googleTasks(files_found, report_folder, seeker, wrap_text):
+    all_new_rows = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
+        source_path = file_found
 
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
-        
+
         cursor.execute('''
             SELECT
             TaskId, TaskListId, TaskRecurrenceId, EffectiveTask, Completed, HasDirtyState, DueDate
@@ -69,8 +66,6 @@ def get_googleTasks(files_found, report_folder, seeker, wrap_text):
         ''')
 
         all_rows = cursor.fetchall()
-        all_new_rows = []
-
         for row in all_rows:
             if(row[4] == 0):
                 task, task_details, created, completed, modified, timezone = protobuf_parse_not_completed(row[3])
@@ -79,28 +74,20 @@ def get_googleTasks(files_found, report_folder, seeker, wrap_text):
             new_data = (created, modified, completed, row[6], timezone, row[0], row[1], row[2], task, task_details, 'True' if row[4]==1 else 'False', 'True' if row[5]==1 else 'False')
             all_new_rows.append(new_data)
 
-        usageentries = len(all_new_rows)
-        if(usageentries > 0):
-            report = ArtifactHtmlReport('Google Tasks')
-            report.start_artifact_report(report_folder,"Google Tasks")
-            report.add_script()
-
-            data_headers=('Created Time', 'Last Modified Time', 'Completed Time', 'Task Due Date', 'Time Zone','Task ID', 'Task List ID', 'Task Recurrence Id', 'Task Name', 'Task Details', 'Completed', 'Has Dirty State')
-
-            data_list = all_new_rows
-
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-            report.end_artifact_report()
-
-            tsvname = "Google Tasks"
-            tsv(report_folder, data_headers, data_list, tsvname)
-
-            tlactivity = "Google Tasks"
-            timeline(report_folder, tlactivity, data_list, data_headers)
-
-        else:
-            logfunc('No Google Tasks found')
-
-        
         db.close()
-        
+
+    data_headers = (
+        ('Created Time', 'datetime'),
+        ('Last Modified Time', 'datetime'),
+        ('Completed Time', 'datetime'),
+        'Task Due Date',
+        'Time Zone',
+        'Task ID',
+        'Task List ID',
+        'Task Recurrence Id',
+        'Task Name',
+        'Task Details',
+        'Completed',
+        'Has Dirty State',
+    )
+    return data_headers, all_new_rows, source_path

--- a/scripts/artifacts/keepNotes.py
+++ b/scripts/artifacts/keepNotes.py
@@ -1,39 +1,39 @@
-# pylint: disable=W0611,W0613
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_keepNotes": {
         "name": "Google Keep Notes",
         "description": "Parses Google Keep Notes",
         "author": "Heather Charpentier",
-        "version": "0.0.1",
         "creation_date": "2024-12-02",
         "last_update_date": "2024-12-02",
         "requirements": "none",
         "category": "Google Keep Notes",
         "notes": "",
-        "paths": ('*/data/com.google.android.keep/databases/keep.db*'),
-        "output_types": None,
+        "paths": ('*/data/com.google.android.keep/databases/keep.db*',),
+        "output_types": "standard",
         "artifact_icon": "file-text",
-        "function": "get_keepNotes"
     }
 }
 
-import sqlite3
-import datetime
 import os
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_keepNotes(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
         filename = os.path.basename(file_found)
 
         if filename.endswith('keep.db'):
+            source_path = file_found
             db = open_sqlite_db_readonly(file_found)
             cursor = db.cursor()
             cursor.execute('''
-            SELECT 
+            SELECT
                 datetime(tree_entity.time_created/1000, 'unixepoch') AS "Time Created",
                 datetime(tree_entity.time_last_updated/1000, 'unixepoch') AS "Time Last Updated",
                 datetime(tree_entity.user_edited_timestamp/1000, 'unixepoch') AS "User Edited Timestamp",
@@ -45,26 +45,16 @@ def get_keepNotes(files_found, report_folder, seeker, wrap_text):
             ''')
 
             all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
+            for row in all_rows:
+                data_list.append(row)
+            db.close()
 
-            if usageentries > 0:
-                data_list = []
-                for row in all_rows:
-                    data_list.append(row)
-
-                report = ArtifactHtmlReport('Google Keep Notes')
-                report.start_artifact_report(report_folder, 'Google Keep Notes')
-                report.add_script()
-                data_headers = ('Time Created', 'Time Last Updated', 'User Edited Timestamp', 'Title', 'Text', 'Last Modifier Email')
-                report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-                report.end_artifact_report()
-
-                tsvname = 'Google Keep Notes'
-                tsv(report_folder, data_headers, data_list, tsvname)
-
-                tlactivity = 'Google Keep Notes'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-
-            else:
-                logfunc('No Google Keep Notes data available')
-
+    data_headers = (
+        ('Time Created', 'datetime'),
+        ('Time Last Updated', 'datetime'),
+        ('User Edited Timestamp', 'datetime'),
+        'Title',
+        'Text',
+        'Last Modifier Email',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/rarlabPreferences.py
+++ b/scripts/artifacts/rarlabPreferences.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_rarlabPreferences": {
         "name": "rarlabPreferences",
@@ -10,41 +10,42 @@ __artifacts_v2__ = {
         "category": "RAR Lab Prefs",
         "notes": "",
         "paths": ('*/com.rarlab.rar_preferences.xml',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "settings",
-        "function": "get_rarlabPreferences",
+        "html_columns": ['Text'],
     }
 }
 
-import os
-import datetime
 import json
-
 import xml.etree.ElementTree as ET
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, abxread, checkabx, logdevinfo
 
+from scripts.ilapfuncs import artifact_processor, abxread, checkabx
+
+
+@artifact_processor
 def get_rarlabPreferences(files_found, report_folder, seeker, wrap_text):
     data_list = []
-    
+    source_path = ''
+
     for file_found in files_found:
         file_found = str(file_found)
         if file_found.endswith('com.rarlab.rar_preferences.xml'):
-            
-            #check if file is abx
+            source_path = file_found
+
+            # check if file is abx
             if (checkabx(file_found)):
                 multi_root = False
                 tree = abxread(file_found, multi_root)
             else:
                 tree = ET.parse(file_found)
             root = tree.getroot()
-            
+
             for elem in root.iter():
                 name = elem.attrib.get('name')
                 value = elem.attrib.get('value')
-                text = elem.text 
+                text = elem.text
                 if name is not None:
-                    if name == 'ArcHistory' or name == 'ExtrPathHistory' :
+                    if name == 'ArcHistory' or name == 'ExtrPathHistory':
                         items = json.loads(text)
                         agg = ''
                         for x in items:
@@ -52,19 +53,6 @@ def get_rarlabPreferences(files_found, report_folder, seeker, wrap_text):
                         data_list.append((name,agg,value))
                     else:
                         data_list.append((name,text,value))
-                        
-                    
-        if data_list:
-            report = ArtifactHtmlReport(f'RAR Lab Preferences')
-            report.start_artifact_report(report_folder, f'RAR Lab Preferences')
-            report.add_script()
-            data_headers = ('Key','Text','Value')
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Text'])
-            report.end_artifact_report()
-            
-            tsvname = f'RAR Lab Preferences'
-            tsv(report_folder, data_headers, data_list, tsvname)
 
-        else:
-            logfunc(f'No RAR Lab Preferences data available')
-            
+    data_headers = ('Key', 'Text', 'Value')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts three single-report artifacts to the LAVA output pipeline.

Each now uses `@artifact_processor` and returns `(data_headers, data_list, source_path)`, adding LAVA output alongside HTML/TSV (and timeline where datetime columns exist). Queries and row extraction unchanged (verified structurally against `main`).

- **keepNotes** — three datetime columns marked; also fixed the `paths` value to be a proper one-tuple (it was missing its trailing comma) and dropped the obsolete `version` key.
- **rarlabPreferences** — HTML `Text` column preserved via `html_columns` (replacing the old `html_no_escape` report flag).
- **googleTasks** — protobuf parsing preserved; three datetime columns marked.

Verified: all three parse, are lint-clean, the plugin loader resolves them with no warnings, and queries/rows match `main`.