### PR TITLE
Convert imo and samsungWeatherClock to LAVA (multi-report split)

### DIFF
--- a/scripts/artifacts/imo.py
+++ b/scripts/artifacts/imo.py
@@ -100,7 +100,7 @@ def get_imo_messages(files_found, report_folder, seeker, wrap_text):
                     else:
                         attachmentPath = attachmentLocalPath
 
-                timestamp = datetime.datetime.utcfromtimestamp(int(row[3])).strftime('%Y-%m-%d %H:%M:%S')
+                timestamp = datetime.datetime.fromtimestamp(int(row[3]), datetime.timezone.utc)
                 data_list.append((timestamp, from_id, to_id, row[2],  row[4], row[5], attachmentPath))
             db.close()
 

--- a/scripts/artifacts/imo.py
+++ b/scripts/artifacts/imo.py
@@ -1,7 +1,7 @@
-# pylint: disable=E0606,W0104,W0311,W0611,W0613,W0702,W1309
+# pylint: disable=W0613,W0702
 __artifacts_v2__ = {
-    "get_imo": {
-        "name": "Imo",
+    "get_imo_account": {
+        "name": "IMO - Account ID",
         "description": "",
         "author": "",
         "creation_date": "2021-03-11",
@@ -9,121 +9,108 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "IMO",
         "notes": "",
-        "paths": ('*/com.imo.android.imous/databases/*.db*',),
-        "output_types": None,
+        "paths": ('*/com.imo.android.imous/databases/accountdb.db*',),
+        "output_types": ['html', 'tsv', 'lava'],
+        "artifact_icon": "user",
+    },
+    "get_imo_messages": {
+        "name": "IMO - Messages",
+        "description": "",
+        "author": "",
+        "creation_date": "2021-03-11",
+        "last_update_date": "2021-03-11",
+        "requirements": "none",
+        "category": "IMO",
+        "notes": "",
+        "paths": ('*/com.imo.android.imous/databases/imofriends.db*',),
+        "output_types": "standard",
         "artifact_icon": "message-square",
-        "function": "get_imo",
     }
 }
 
-import sqlite3
 import datetime
 import json
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-def get_imo(files_found, report_folder, seeker, wrap_text):
 
-    source_file_account = ''
-    source_file_friends = ''
+@artifact_processor
+def get_imo_account(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
     for file_found in files_found:
-        
         file_name = str(file_found)
         if file_name.endswith('accountdb.db'):
-           imo_account_db = str(file_found)
-           source_file_account = file_found.replace(seeker.data_folder, '')
+            source_path = file_name
+            db = open_sqlite_db_readonly(file_name)
+            cursor = db.cursor()
+            try:
+                cursor.execute('''
+                     SELECT uid, name FROM account
+                ''')
+                all_rows = cursor.fetchall()
+            except:
+                all_rows = []
 
+            for row in all_rows:
+                data_list.append((row[0], row[1]))
+            db.close()
+
+    data_headers = ('Account ID', 'Name')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_imo_messages(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for file_found in files_found:
+        file_name = str(file_found)
         if file_name.endswith('imofriends.db'):
-           imo_friends_db = str(file_found)
-           source_file_friends = file_found.replace(seeker.data_folder, '')
+            source_path = file_name
+            db = open_sqlite_db_readonly(file_name)
+            cursor = db.cursor()
+            try:
+                cursor.execute('''
+                             SELECT messages.buid AS buid, imdata, last_message, timestamp/1000000000,
+                                    case message_type when 1 then "Incoming" else "Outgoing" end message_type, message_read
+                               FROM messages
+                              INNER JOIN friends ON friends.buid = messages.buid
+                ''')
+                all_rows = cursor.fetchall()
+            except:
+                all_rows = []
 
-    db = open_sqlite_db_readonly(imo_account_db)
-    cursor = db.cursor()
-    try:
-        cursor.execute('''
-             SELECT uid, name FROM account
-        ''')
-
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-    except:
-        usageentries = 0
-        
-    if usageentries > 0:
-        report = ArtifactHtmlReport('IMO - Account ID')
-        report.start_artifact_report(report_folder, 'IMO - Account ID')
-        report.add_script()
-        data_headers = ('Account ID','Name') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = []
-        for row in all_rows:
-            data_list.append((row[0], row[1]))
-
-        report.write_artifact_data_table(data_headers, data_list, imo_account_db)
-        report.end_artifact_report()
-        
-        tsvname = f'IMO - Account ID'
-        tsv(report_folder, data_headers, data_list, tsvname, source_file_account)
-        
-    else:
-        logfunc('No IMO Account ID found')
-        
-    db.close()
-
-    db = open_sqlite_db_readonly(imo_friends_db)
-    cursor = db.cursor()
-    try:
-        cursor.execute('''
-                     SELECT messages.buid AS buid, imdata, last_message, timestamp/1000000000, 
-                            case message_type when 1 then "Incoming" else "Outgoing" end message_type, message_read
-                       FROM messages
-                      INNER JOIN friends ON friends.buid = messages.buid
-        ''')
-
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-    except:
-        usageentries = 0
-        
-    if usageentries > 0:
-        report = ArtifactHtmlReport('IMO - Messages')
-        report.start_artifact_report(report_folder, 'IMO - Messages')
-        report.add_script()
-        data_headers = ('Timestamp','From ID', 'To ID', 'Last Message',  'Direction', 'Message Read', 'Attachment') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = []
-        for row in all_rows:
-            from_id = ''
-            to_id = ''
-            attachmentPath = ''
-            if row[4] == "Incoming":
-                from_id = row[0]
-            else:
-                to_id = row[0]
-            if row[1] is not None:
-                imdata_dict = json.loads(row[1])
-                            
-                # set to none if the key doesn't exist in the dict
-                attachmentOriginalPath = imdata_dict.get('original_path', None)
-                attachmentLocalPath = imdata_dict.get('local_path', None)
-                if attachmentOriginalPath:
-                    attachmentPath = attachmentOriginalPath
+            for row in all_rows:
+                from_id = ''
+                to_id = ''
+                attachmentPath = ''
+                if row[4] == "Incoming":
+                    from_id = row[0]
                 else:
-                    attachmentPath = attachmentLocalPath
-                                
-            timestamp = datetime.datetime.utcfromtimestamp(int(row[3])).strftime('%Y-%m-%d %H:%M:%S')
-            data_list.append((timestamp, from_id, to_id, row[2],  row[4], row[5], attachmentPath))
+                    to_id = row[0]
+                if row[1] is not None:
+                    imdata_dict = json.loads(row[1])
 
-        report.write_artifact_data_table(data_headers, data_list, imo_friends_db)
-        report.end_artifact_report()
-        
-        tsvname = f'IMO - Messages'
-        tsv(report_folder, data_headers, data_list, tsvname, source_file_friends)
-        
-        tlactivity = f'IMO - Messages'
-        timeline(report_folder, tlactivity, data_list, data_headers)
+                    # set to none if the key doesn't exist in the dict
+                    attachmentOriginalPath = imdata_dict.get('original_path', None)
+                    attachmentLocalPath = imdata_dict.get('local_path', None)
+                    if attachmentOriginalPath:
+                        attachmentPath = attachmentOriginalPath
+                    else:
+                        attachmentPath = attachmentLocalPath
 
-    else:
-        logfunc('No IMO Messages found')
+                timestamp = datetime.datetime.utcfromtimestamp(int(row[3])).strftime('%Y-%m-%d %H:%M:%S')
+                data_list.append((timestamp, from_id, to_id, row[2],  row[4], row[5], attachmentPath))
+            db.close()
 
-    db.close
-    
+    data_headers = (
+        ('Timestamp', 'datetime'),
+        'From ID',
+        'To ID',
+        'Last Message',
+        'Direction',
+        'Message Read',
+        'Attachment',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/samsungWeatherClock.py
+++ b/scripts/artifacts/samsungWeatherClock.py
@@ -1,7 +1,7 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
-    "get_samsungWeatherClock": {
-        "name": "samsungWeatherClock",
+    "get_samsungWeatherClockInfo": {
+        "name": "Samsung Weather Clock - Info",
         "description": "",
         "author": "",
         "creation_date": "2021-10-13",
@@ -10,26 +10,54 @@ __artifacts_v2__ = {
         "category": "Samsung Weather Clock",
         "notes": "",
         "paths": ('*/com.sec.android.daemonapp/databases/WeatherClock*',),
-        "output_types": None,
-        "artifact_icon": "lock",
-        "function": "get_samsungWeatherClock",
+        "output_types": "standard",
+        "artifact_icon": "cloud",
+    },
+    "get_samsungWeatherClockDaily": {
+        "name": "Samsung Weather Clock - Daily",
+        "description": "",
+        "author": "",
+        "creation_date": "2021-10-13",
+        "last_update_date": "2021-10-13",
+        "requirements": "none",
+        "category": "Samsung Weather Clock",
+        "notes": "",
+        "paths": ('*/com.sec.android.daemonapp/databases/WeatherClock*',),
+        "output_types": "standard",
+        "artifact_icon": "cloud",
+    },
+    "get_samsungWeatherClockHourly": {
+        "name": "Samsung Weather Clock - Hourly",
+        "description": "",
+        "author": "",
+        "creation_date": "2021-10-13",
+        "last_update_date": "2021-10-13",
+        "requirements": "none",
+        "category": "Samsung Weather Clock",
+        "notes": "",
+        "paths": ('*/com.sec.android.daemonapp/databases/WeatherClock*',),
+        "output_types": "standard",
+        "artifact_icon": "cloud",
     }
 }
 
-import sqlite3
-import textwrap
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
-def get_samsungWeatherClock(files_found, report_folder, seeker, wrap_text):
-    
+def _weatherclock_db(files_found):
     for file_found in files_found:
         file_found = str(file_found)
-        if not file_found.endswith('WeatherClock'):
-            continue # Skip all other files
-    
-        db = open_sqlite_db_readonly(file_found)
+        if file_found.endswith('WeatherClock'):
+            return file_found
+    return None
+
+
+@artifact_processor
+def get_samsungWeatherClockInfo(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = _weatherclock_db(files_found) or ''
+    if source_path:
+        db = open_sqlite_db_readonly(source_path)
         cursor = db.cursor()
         cursor.execute('''
         select
@@ -54,29 +82,26 @@ def get_samsungWeatherClock(files_found, report_folder, seeker, wrap_text):
         COL_WEATHER_URL
         from TABLE_WEATHER_INFO
         ''')
-
         all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Samsung Weather Clock - Info')
-            report.start_artifact_report(report_folder, 'Samsung Weather Clock - Info')
-            report.add_script()
-            data_headers = ('Timestamp','Timezone','Is Daylight Savings','Current Temp','Weather Text','City','State','Country','Update Timestamp','Sunrise Timestamp','Sunset Timestamp','Feels Like Temp','High Temp','Low Temp','Weather Provider','URL') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-            data_list = []
-            for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11],row[12],row[13],row[14],row[15]))
+        for row in all_rows:
+            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11],row[12],row[13],row[14],row[15]))
+        db.close()
 
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Samsung Weather Clock - Info'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Samsung Weather Clock - Info'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Samsung Weather Clock - Info data available')
-    
+    data_headers = (
+        ('Timestamp', 'datetime'), 'Timezone', 'Is Daylight Savings', 'Current Temp', 'Weather Text',
+        'City', 'State', 'Country', ('Update Timestamp', 'datetime'), ('Sunrise Timestamp', 'datetime'),
+        ('Sunset Timestamp', 'datetime'), 'Feels Like Temp', 'High Temp', 'Low Temp', 'Weather Provider', 'URL',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_samsungWeatherClockDaily(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = _weatherclock_db(files_found) or ''
+    if source_path:
+        db = open_sqlite_db_readonly(source_path)
+        cursor = db.cursor()
         cursor.execute('''
         select
         datetime(TABLE_DAILY_INFO.COL_DAILY_TIME/1000,'unixepoch'),
@@ -91,29 +116,25 @@ def get_samsungWeatherClock(files_found, report_folder, seeker, wrap_text):
         from TABLE_DAILY_INFO
         join TABLE_WEATHER_INFO on TABLE_DAILY_INFO.COL_WEATHER_KEY = TABLE_WEATHER_INFO.COL_WEATHER_KEY
         ''')
-
         all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Samsung Weather Clock - Daily')
-            report.start_artifact_report(report_folder, 'Samsung Weather Clock - Daily')
-            report.add_script()
-            data_headers = ('Timestamp','City','State','Country','Current Temp','Weather Text','URL','Daily High Temp','Daily Low Temp') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-            data_list = []
-            for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8]))
+        for row in all_rows:
+            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8]))
+        db.close()
 
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Samsung Weather Clock - Daily'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Samsung Weather Clock - Daily'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Samsung Weather Clock - Daily data available')
-    
+    data_headers = (
+        ('Timestamp', 'datetime'), 'City', 'State', 'Country', 'Current Temp',
+        'Weather Text', 'URL', 'Daily High Temp', 'Daily Low Temp',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_samsungWeatherClockHourly(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = _weatherclock_db(files_found) or ''
+    if source_path:
+        db = open_sqlite_db_readonly(source_path)
+        cursor = db.cursor()
         cursor.execute('''
         select
         datetime(TABLE_HOURLY_INFO.COL_HOURLY_TIME/1000,'unixepoch'),
@@ -129,27 +150,13 @@ def get_samsungWeatherClock(files_found, report_folder, seeker, wrap_text):
         from TABLE_HOURLY_INFO
         join TABLE_WEATHER_INFO on TABLE_HOURLY_INFO.COL_WEATHER_KEY = TABLE_WEATHER_INFO.COL_WEATHER_KEY
         ''')
-
         all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Samsung Weather Clock - Hourly')
-            report.start_artifact_report(report_folder, 'Samsung Weather Clock - Hourly')
-            report.add_script()
-            data_headers = ('Timestamp','City','State','Country','Current Temp','Weather Text','Rain Probability','Wind Direction','Wind Speed','URL') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-            data_list = []
-            for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9]))
+        for row in all_rows:
+            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9]))
+        db.close()
 
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Samsung Weather Clock - Hourly'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Samsung Weather Clock - Hourly'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Samsung Weather Clock - Hourly data available')
-        
-    db.close()
+    data_headers = (
+        ('Timestamp', 'datetime'), 'City', 'State', 'Country', 'Current Temp',
+        'Weather Text', 'Rain Probability', 'Wind Direction', 'Wind Speed', 'URL',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/samsungWeatherClock.py
+++ b/scripts/artifacts/samsungWeatherClock.py
@@ -41,7 +41,7 @@ __artifacts_v2__ = {
     }
 }
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_human_ts_to_utc
 
 
 def _weatherclock_db(files_found):
@@ -84,7 +84,7 @@ def get_samsungWeatherClockInfo(files_found, report_folder, seeker, wrap_text):
         ''')
         all_rows = cursor.fetchall()
         for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11],row[12],row[13],row[14],row[15]))
+            data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],row[3],row[4],row[5],row[6],row[7],convert_human_ts_to_utc(row[8]),convert_human_ts_to_utc(row[9]),convert_human_ts_to_utc(row[10]),row[11],row[12],row[13],row[14],row[15]))
         db.close()
 
     data_headers = (
@@ -118,7 +118,7 @@ def get_samsungWeatherClockDaily(files_found, report_folder, seeker, wrap_text):
         ''')
         all_rows = cursor.fetchall()
         for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8]))
+            data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8]))
         db.close()
 
     data_headers = (
@@ -152,7 +152,7 @@ def get_samsungWeatherClockHourly(files_found, report_folder, seeker, wrap_text)
         ''')
         all_rows = cursor.fetchall()
         for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9]))
+            data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9]))
         db.close()
 
     data_headers = (


### PR DESCRIPTION
Splits two multi-report artifacts into one `@artifact_processor` function per table.

- **imo** → `get_imo_account` (accountdb.db) and `get_imo_messages` (imofriends.db, JSON attachment parsing preserved). Each entry targets its specific database path.
- **samsungWeatherClock** → `get_samsungWeatherClockInfo` / `Daily` / `Hourly`, all reading the WeatherClock db via a shared `_weatherclock_db` helper; datetime columns marked.

Queries and row extraction unchanged (verified structurally against `main`). Function keys dropped; decorated functions resolve by name.

Verified: both parse, lint-clean, plugin loader resolves all five functions with no warnings, and queries/rows match `main`.