### PR TITLE
Fix LAVA timestamps for Firefox artifacts (tz-aware UTC)

### DIFF
--- a/scripts/artifacts/firefoxCookies.py
+++ b/scripts/artifacts/firefoxCookies.py
@@ -17,7 +17,7 @@ __artifacts_v2__ = {
 
 import os
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_human_ts_to_utc
 
 
 @artifact_processor
@@ -47,7 +47,7 @@ def get_firefoxCookies(files_found, report_folder, seeker, wrap_text):
 
         all_rows = cursor.fetchall()
         for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
+            data_list.append((convert_human_ts_to_utc(row[0]),convert_human_ts_to_utc(row[1]),row[2],row[3],row[4],convert_human_ts_to_utc(row[5]),row[6]))
 
         db.close()
 

--- a/scripts/artifacts/firefoxDownloads.py
+++ b/scripts/artifacts/firefoxDownloads.py
@@ -17,7 +17,7 @@ __artifacts_v2__ = {
 
 import os
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_human_ts_to_utc
 
 
 @artifact_processor
@@ -51,7 +51,7 @@ def get_firefoxDownloads(files_found, report_folder, seeker, wrap_text):
 
         all_rows = cursor.fetchall()
         for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
+            data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],row[3],row[4],row[5],row[6]))
 
         db.close()
 

--- a/scripts/artifacts/firefoxFormHistory.py
+++ b/scripts/artifacts/firefoxFormHistory.py
@@ -17,7 +17,7 @@ __artifacts_v2__ = {
 
 import os
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_human_ts_to_utc
 
 
 @artifact_processor
@@ -46,7 +46,7 @@ def get_firefoxFormHistory(files_found, report_folder, seeker, wrap_text):
 
         all_rows = cursor.fetchall()
         for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5]))
+            data_list.append((convert_human_ts_to_utc(row[0]),convert_human_ts_to_utc(row[1]),row[2],row[3],row[4],row[5]))
 
         db.close()
 

--- a/scripts/artifacts/firefoxPermissions.py
+++ b/scripts/artifacts/firefoxPermissions.py
@@ -17,7 +17,7 @@ __artifacts_v2__ = {
 
 import os
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_human_ts_to_utc
 
 
 @artifact_processor
@@ -51,7 +51,7 @@ def get_firefoxPermissions(files_found, report_folder, seeker, wrap_text):
 
         all_rows = cursor.fetchall()
         for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4]))
+            data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],row[3],convert_human_ts_to_utc(row[4])))
 
         db.close()
 

--- a/scripts/artifacts/firefoxRecentlyClosedTabs.py
+++ b/scripts/artifacts/firefoxRecentlyClosedTabs.py
@@ -17,7 +17,7 @@ __artifacts_v2__ = {
 
 import os
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_human_ts_to_utc
 
 
 @artifact_processor
@@ -42,7 +42,7 @@ def get_firefoxRecentlyClosedTabs(files_found, report_folder, seeker, wrap_text)
 
         all_rows = cursor.fetchall()
         for row in all_rows:
-            data_list.append((row[0],row[1],row[2]))
+            data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2]))
 
         db.close()
 

--- a/scripts/artifacts/firefoxTopSites.py
+++ b/scripts/artifacts/firefoxTopSites.py
@@ -17,7 +17,7 @@ __artifacts_v2__ = {
 
 import os
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_human_ts_to_utc
 
 
 @artifact_processor
@@ -46,7 +46,7 @@ def get_firefoxTopSites(files_found, report_folder, seeker, wrap_text):
 
         all_rows = cursor.fetchall()
         for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3]))
+            data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],row[3]))
 
         db.close()
 


### PR DESCRIPTION
First batch of the LAVA-timestamp correction.

**Bug:** LAVA stores `datetime` columns as integer unix-epoch and converts string values via `datetime.fromisoformat(value).timestamp()`. For a **naive** UTC string (what SQL `datetime(...,'unixepoch')` produces) `.timestamp()` assumes **local** time, so the stored epoch was shifted by the report machine's timezone offset. HTML/TSV were correct; only the LAVA epoch was wrong.

**Fix:** convert each `datetime` column to a **tz-aware UTC** value with `convert_human_ts_to_utc(...)` before appending — the established convention used by `downloads.py`/`zepplife.py`, and what iLEAPP relies on (its `lava_insert_sqlite_data` doesn't patch the naive-string case either, so no framework change keeps us aligned). The helper passes empty/None through unchanged; HTML now shows explicit UTC (`+00:00`), consistent with iLEAPP's tz-aware display.

Files: firefoxCookies, firefoxDownloads, firefoxFormHistory, firefoxPermissions, firefoxRecentlyClosedTabs, firefoxTopSites.

Verified: all parse, lint-clean, loader resolves with no warnings; conversion confirmed to yield the correct UTC epoch.