### PR TITLE
Replace deprecated datetime.utcfromtimestamp in converted artifacts

### DIFF
--- a/scripts/artifacts/GarminPersistent.py
+++ b/scripts/artifacts/GarminPersistent.py
@@ -43,9 +43,9 @@ def get_presisted(files_found, report_folder, seeker, wrap_text):
         for i in attribute:
             if i in data:
                 if i == "TokenCreationEpochInSecs":
-                    user_info[i] = str(data[i]) + " (" + str(datetime.datetime.utcfromtimestamp(data[i])) + ")"
+                    user_info[i] = str(data[i]) + " (" + str(datetime.datetime.fromtimestamp(data[i], datetime.timezone.utc).replace(tzinfo=None)) + ")"
                 elif i == "ExpiresInSecs":
-                    user_info[i] = str(data[i]) + " (" + str(datetime.datetime.utcfromtimestamp(data[i] + data["TokenCreationEpochInSecs"])) + ")"
+                    user_info[i] = str(data[i]) + " (" + str(datetime.datetime.fromtimestamp(data[i] + data["TokenCreationEpochInSecs"], datetime.timezone.utc).replace(tzinfo=None)) + ")"
                 else:
                     user_info[i] = data[i]
 

--- a/scripts/artifacts/bittorrentClientpref.py
+++ b/scripts/artifacts/bittorrentClientpref.py
@@ -22,7 +22,7 @@ from scripts.ilapfuncs import artifact_processor, abxread, checkabx
 
 
 def timestampcalc(timevalue):
-    timestamp = (datetime.datetime.utcfromtimestamp(int(timevalue)/1000).strftime('%Y-%m-%d %H:%M:%S'))
+    timestamp = (datetime.datetime.fromtimestamp(int(timevalue)/1000, datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S'))
     return timestamp
 
 

--- a/scripts/artifacts/bittorrentDlhist.py
+++ b/scripts/artifacts/bittorrentDlhist.py
@@ -23,7 +23,7 @@ from scripts.ilapfuncs import artifact_processor
 
 
 def timestampcalc(timevalue):
-    timestamp = (datetime.datetime.utcfromtimestamp(int(timevalue)/1000).strftime('%Y-%m-%d %H:%M:%S'))
+    timestamp = datetime.datetime.fromtimestamp(int(timevalue)/1000, datetime.timezone.utc)
     return timestamp
 
 

--- a/scripts/artifacts/googleTasks.py
+++ b/scripts/artifacts/googleTasks.py
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     }
 }
 
-from datetime import datetime
+from datetime import datetime, timezone as dtimezone
 import blackboxprotobuf
 
 from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
@@ -28,8 +28,8 @@ def b2s(a):
 def protobuf_parse_not_completed(data):
     pb = blackboxprotobuf.decode_message(data, 'None')
     completed = pb[0].get('2',{}).get('5',{}).get('1','')
-    created = datetime.utcfromtimestamp(pb[0].get('11',{}).get('1','')).strftime('%Y-%m-%d %H:%M:%S')
-    modified = datetime.utcfromtimestamp(pb[0].get('3',{}).get('1','')).strftime('%Y-%m-%d %H:%M:%S')
+    created = datetime.fromtimestamp(pb[0].get('11',{}).get('1',''), dtimezone.utc)
+    modified = datetime.fromtimestamp(pb[0].get('3',{}).get('1',''), dtimezone.utc)
     task = pb[0].get('2',{}).get('2','').decode()
     task_details = b2s(pb[0].get('2',{}).get('3',''))
     timezone = b2s(pb[0].get('9',{}).get('1',{}).get('4',''))
@@ -40,9 +40,9 @@ def protobuf_parse_completed(data):
     pb = blackboxprotobuf.decode_message(data, None)
     task = pb[0].get('2',{}).get('2','').decode()
     task_details = b2s(pb[0].get('2',{}).get('3',''))
-    completed = datetime.utcfromtimestamp(pb[0].get('2',{}).get('5',{}).get('1','')).strftime('%Y-%m-%d %H:%M:%S')
-    created = datetime.utcfromtimestamp(pb[0].get('11',{}).get('1','')).strftime('%Y-%m-%d %H:%M:%S')
-    modified = datetime.utcfromtimestamp(pb[0].get('3',{}).get('1','')).strftime('%Y-%m-%d %H:%M:%S')
+    completed = datetime.fromtimestamp(pb[0].get('2',{}).get('5',{}).get('1',''), dtimezone.utc)
+    created = datetime.fromtimestamp(pb[0].get('11',{}).get('1',''), dtimezone.utc)
+    modified = datetime.fromtimestamp(pb[0].get('3',{}).get('1',''), dtimezone.utc)
     timezone = b2s(pb[0].get('9',{}).get('1',{}).get('4',''))
     return task, task_details, created, completed, modified, timezone
 

--- a/scripts/artifacts/protonVPN.py
+++ b/scripts/artifacts/protonVPN.py
@@ -83,7 +83,7 @@ def get_protonvpn_device_info(files_found, report_folder, seeker, wrap_text):
                         device_info("ProtonVPN", "Country", elem.text, source_path)
 
                     if (elem.attrib.get('name')) == 'ipAddressCheckTimestamp':
-                        timestamp = datetime.datetime.utcfromtimestamp(int(elem.attrib.get("value"))/1000).strftime('%Y-%m-%d %H:%M:%S.%f')
+                        timestamp = datetime.datetime.fromtimestamp(int(elem.attrib.get("value"))/1000, datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S.%f')
                         device_info("ProtonVPN", "Last IP Check Time", timestamp, source_path)
 
     data_headers = ('Key', 'Value')

--- a/scripts/artifacts/tangomessage.py
+++ b/scripts/artifacts/tangomessage.py
@@ -61,7 +61,7 @@ def get_tangomessage(files_found, report_folder, seeker, wrap_text):
     if usageentries > 0:
         for row in all_rows:
             message = _decodeMessage(row[0], row[1])
-            timestamp = datetime.datetime.utcfromtimestamp(int(row[2])).strftime('%Y-%m-%d %H:%M:%S')
+            timestamp = datetime.datetime.fromtimestamp(int(row[2]), datetime.timezone.utc)
 
             data_list.append((timestamp, row[3], message))
 

--- a/scripts/artifacts/textnow.py
+++ b/scripts/artifacts/textnow.py
@@ -76,8 +76,8 @@ def get_textnow_call_logs(files_found, report_folder, seeker, wrap_text):
                     phone_number_to = row[0]
                 else:
                     phone_number_from = row[0]
-                starttime = datetime.datetime.utcfromtimestamp(int(row[3])).strftime('%Y-%m-%d %H:%M:%S')
-                endtime = datetime.datetime.utcfromtimestamp(int(row[2])).strftime('%Y-%m-%d %H:%M:%S')
+                starttime = datetime.datetime.fromtimestamp(int(row[3]), datetime.timezone.utc)
+                endtime = datetime.datetime.fromtimestamp(int(row[2]), datetime.timezone.utc)
                 data_list.append((starttime, endtime, phone_number_from, phone_number_to, row[1]))
 
             db.close()
@@ -145,7 +145,7 @@ def get_textnow_messages(files_found, report_folder, seeker, wrap_text):
                 all_rows = []
 
             for row in all_rows:
-                sendtime = datetime.datetime.utcfromtimestamp(int(row[5])).strftime('%Y-%m-%d %H:%M:%S')
+                sendtime = datetime.datetime.fromtimestamp(int(row[5]), datetime.timezone.utc)
 
                 data_list.append((sendtime, row[7], row[0], row[1], row[2], row[3], row[4],  row[6]))
 

--- a/scripts/artifacts/torrentResumeinfo.py
+++ b/scripts/artifacts/torrentResumeinfo.py
@@ -25,7 +25,7 @@ from scripts.ilapfuncs import artifact_processor
 
 
 def timestampcalc(timevalue):
-    timestamp = (datetime.datetime.utcfromtimestamp(int(timevalue)).strftime('%Y-%m-%d %H:%M:%S'))
+    timestamp = (datetime.datetime.fromtimestamp(int(timevalue), datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S'))
     return timestamp
 
 

--- a/scripts/artifacts/torrentinfo.py
+++ b/scripts/artifacts/torrentinfo.py
@@ -25,7 +25,7 @@ from scripts.ilapfuncs import artifact_processor, logfunc
 
 
 def timestampcalc(timevalue):
-    timestamp = (datetime.datetime.utcfromtimestamp(int(timevalue)).strftime('%Y-%m-%d %H:%M:%S'))
+    timestamp = (datetime.datetime.fromtimestamp(int(timevalue), datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S'))
     return timestamp
 
 


### PR DESCRIPTION
`datetime.utcfromtimestamp()` is deprecated (scheduled for removal). Replaces it with `datetime.fromtimestamp(ts, timezone.utc)` across the converted artifacts where it was still present.

- **Feeds a LAVA `datetime` column** (`bittorrentDlhist`, `tangomessage`, `textnow`, `googleTasks`): now returns the **tz-aware** datetime directly (dropping the intermediate `strftime`). This also corrects the LAVA epoch for those columns (was shifted by the report machine's timezone).
- **Display-only** (`GarminPersistent` value string, `protonVPN` device_info, `torrentinfo`/`torrentResumeinfo`/`bittorrentClientpref`): rendered output preserved exactly via `.replace(tzinfo=None)` / `.strftime(...)`.

`googleTasks` aliases the `timezone` import because the module has a local `timezone` field.

Verified: all nine parse, lint-clean, loader resolves with no warnings, queries/rows match `main`, and display-only outputs confirmed identical.

(Scope = our converted artifacts. Pre-existing decorated ones still using `utcfromtimestamp` — DuckDuckGo, Grok, OrnetBrowser, TorBrowser, gmailEmails, shutdown_checkpoints — are out of scope here.)