### PR TITLE
Fix LAVA timestamps for the Chrome family (tz-aware UTC)

### DIFF
--- a/scripts/artifacts/chromeBookmarks.py
+++ b/scripts/artifacts/chromeBookmarks.py
@@ -65,7 +65,7 @@ def get_chromeBookmarks(files_found, report_folder, seeker, wrap_text):
                                     for index in range(len(valueb)):
                                         url = valueb[index].get('url', '')
                                         dateadd = valueb[index].get('date_added', '')
-                                        dateaddconv = datetime.datetime(1601, 1, 1) + datetime.timedelta(microseconds=int(dateadd))
+                                        dateaddconv = datetime.datetime(1601, 1, 1, tzinfo=datetime.timezone.utc) + datetime.timedelta(microseconds=int(dateadd))
                                         name = valueb[index].get('name', '')
                                         typed = valueb[index].get('type', '')
                                         children_items.append((url, dateaddconv, name, typed))

--- a/scripts/artifacts/chromeCookies.py
+++ b/scripts/artifacts/chromeCookies.py
@@ -19,7 +19,7 @@ import os
 import textwrap
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, get_next_unused_name, open_sqlite_db_readonly, lava_process_artifact, lava_insert_sqlite_data, artifact_processor
+from scripts.ilapfuncs import logfunc, get_next_unused_name, open_sqlite_db_readonly, lava_process_artifact, lava_insert_sqlite_data, artifact_processor, convert_human_ts_to_utc
 from scripts.artifacts.chrome import get_browser_name
 
 
@@ -92,9 +92,9 @@ def get_chromeCookies(files_found, report_folder, seeker, wrap_text):
             data_list = []
             for row in all_rows:
                 if wrap_text:
-                    data_list.append((row[0],row[1],(textwrap.fill(row[2], width=50)),row[3],row[4],row[5],row[6]))
+                    data_list.append((convert_human_ts_to_utc(row[0]),row[1],(textwrap.fill(row[2], width=50)),row[3],convert_human_ts_to_utc(row[4]),convert_human_ts_to_utc(row[5]),row[6]))
                 else:
-                    data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
+                    data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],row[3],convert_human_ts_to_utc(row[4]),convert_human_ts_to_utc(row[5]),row[6]))
 
             report_name = f'{browser_name} - Cookies'
             report = ArtifactHtmlReport(report_name)

--- a/scripts/artifacts/chromeLoginData.py
+++ b/scripts/artifacts/chromeLoginData.py
@@ -22,7 +22,7 @@ import re
 from Crypto.Cipher import AES
 from Crypto.Protocol.KDF import PBKDF2
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, get_next_unused_name, open_sqlite_db_readonly, lava_process_artifact, lava_insert_sqlite_data, artifact_processor
+from scripts.ilapfuncs import logfunc, get_next_unused_name, open_sqlite_db_readonly, lava_process_artifact, lava_insert_sqlite_data, artifact_processor, convert_human_ts_to_utc
 from scripts.artifacts.chrome import get_browser_name
 
 
@@ -111,7 +111,7 @@ def get_chromeLoginData(files_found, report_folder, seeker, wrap_text):
                 if password_enc:
                     password = decrypt(password_enc).decode("utf-8", 'replace')
                 valid_date = get_valid_date(row[2], row[3])
-                data_list.append((valid_date, row[0], password, row[4], row[5]))
+                data_list.append((convert_human_ts_to_utc(valid_date), row[0], password, row[4], row[5]))
 
             report_name = f'{browser_name} - Login Data'
             report = ArtifactHtmlReport(report_name)

--- a/scripts/artifacts/chromeMediaHistory.py
+++ b/scripts/artifacts/chromeMediaHistory.py
@@ -44,7 +44,7 @@ __artifacts_v2__ = {
 import os
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, get_next_unused_name, open_sqlite_db_readonly, lava_process_artifact, lava_insert_sqlite_data, artifact_processor
+from scripts.ilapfuncs import logfunc, get_next_unused_name, open_sqlite_db_readonly, lava_process_artifact, lava_insert_sqlite_data, artifact_processor, convert_human_ts_to_utc
 from scripts.artifacts.chrome import get_browser_name
 
 
@@ -92,7 +92,7 @@ def get_chromeMediaHistorySessions(files_found, report_folder, seeker, wrap_text
             report_file = file_found if report_file == 'Unknown' else report_file + ', ' + file_found
             data_list = []
             for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8]))
+                data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8]))
 
             report_name = f'{browser_name} - Media History - Sessions'
             report = ArtifactHtmlReport(report_name)
@@ -151,7 +151,7 @@ def get_chromeMediaHistoryPlaybacks(files_found, report_folder, seeker, wrap_tex
             report_file = file_found if report_file == 'Unknown' else report_file + ', ' + file_found
             data_list = []
             for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
+                data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],row[3],row[4],row[5],row[6]))
 
             report_name = f'{browser_name} - Media History - Playbacks'
             report = ArtifactHtmlReport(report_name)
@@ -201,7 +201,7 @@ def get_chromeMediaHistoryOrigins(files_found, report_folder, seeker, wrap_text)
             report_file = file_found if report_file == 'Unknown' else report_file + ', ' + file_found
             data_list = []
             for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3]))
+                data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],row[3]))
 
             report_name = f'{browser_name} - Media History - Origins'
             report = ArtifactHtmlReport(report_name)

--- a/scripts/artifacts/chromeOfflinePages.py
+++ b/scripts/artifacts/chromeOfflinePages.py
@@ -19,7 +19,7 @@ import os
 import textwrap
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, get_next_unused_name, open_sqlite_db_readonly, lava_process_artifact, lava_insert_sqlite_data, artifact_processor
+from scripts.ilapfuncs import logfunc, get_next_unused_name, open_sqlite_db_readonly, lava_process_artifact, lava_insert_sqlite_data, artifact_processor, convert_human_ts_to_utc
 from scripts.artifacts.chrome import get_browser_name
 
 
@@ -66,9 +66,9 @@ def get_chromeOfflinePages(files_found, report_folder, seeker, wrap_text):
             data_list = []
             for row in all_rows:
                 if wrap_text:
-                    data_list.append((row[0],row[1],(textwrap.fill(row[2], width=75)),row[3],row[4],row[5],row[6]))
+                    data_list.append((convert_human_ts_to_utc(row[0]),convert_human_ts_to_utc(row[1]),(textwrap.fill(row[2], width=75)),row[3],row[4],row[5],row[6]))
                 else:
-                    data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
+                    data_list.append((convert_human_ts_to_utc(row[0]),convert_human_ts_to_utc(row[1]),row[2],row[3],row[4],row[5],row[6]))
 
             report_name = f'{browser_name} - Offline Pages'
             report = ArtifactHtmlReport(report_name)


### PR DESCRIPTION
Corrects the LAVA epoch for the Chrome family's `datetime` columns (they were fed naive datetimes, so the stored epoch was shifted by the report machine's timezone — affecting both the per-browser tables and the combined output).

- **chromeBookmarks** built a **naive datetime object** (`datetime(1601,1,1)+timedelta`); now `tzinfo=timezone.utc` makes it UTC-aware.
- **chromeCookies** (3 datetime cols), **chromeOfflinePages** (2), **chromeLoginData** (1), **chromeMediaHistory** Sessions/Playbacks/Origins (1 each): wrap the SQL `datetime(...)` strings with `convert_human_ts_to_utc`.

No query changes; HTML/TSV now show explicit UTC (`+00:00`), consistent with iLEAPP.

Verified: all parse, lint-clean, loader resolves with no warnings; the conversion was confirmed to produce the correct UTC epoch.