### PR TITLE
Fix LAVA timestamps across remaining converted artifacts (tz-aware UTC)

### DIFF
--- a/scripts/artifacts/GarminNotifications.py
+++ b/scripts/artifacts/GarminNotifications.py
@@ -21,7 +21,7 @@ __artifacts_v2__ = {
 # Version: 1.0
 # Requirements: Python 3.7 or higher
 
-from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly, convert_human_ts_to_utc
 
 
 @artifact_processor
@@ -46,7 +46,7 @@ def get_garmin_notifications(files_found, report_folder, seeker, wrap_text):
     all_rows = cursor.fetchall()
     data_list = []
     for row in all_rows:
-        data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6]))
+        data_list.append((row[0], convert_human_ts_to_utc(row[1]), row[2], row[3], row[4], row[5], row[6]))
 
     db.close()
 

--- a/scripts/artifacts/GarminSync.py
+++ b/scripts/artifacts/GarminSync.py
@@ -21,7 +21,7 @@ __artifacts_v2__ = {
 # Version: 1.0
 # Requirements: Python 3.7 or higher
 
-from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly, convert_human_ts_to_utc
 
 
 @artifact_processor
@@ -44,7 +44,7 @@ def get_garmin_sync(files_found, report_folder, seeker, wrap_text):
     all_rows = cursor.fetchall()
     data_list = []
     for row in all_rows:
-        data_list.append((row[0], row[1], row[2], row[3]))
+        data_list.append((row[0], row[1], row[2], convert_human_ts_to_utc(row[3])))
 
     db.close()
 

--- a/scripts/artifacts/PodcastAddict.py
+++ b/scripts/artifacts/PodcastAddict.py
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     }
 }
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_human_ts_to_utc
 
 
 @artifact_processor
@@ -47,7 +47,7 @@ def get_podcasts(files_found, report_folder, seeker, wrap_text):
             all_rows = []
 
         for row in all_rows:
-            data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8]))
+            data_list.append((convert_human_ts_to_utc(row[0]), convert_human_ts_to_utc(row[1]), row[2], row[3], row[4], convert_human_ts_to_utc(row[5]), row[6], row[7], row[8]))
 
         db.close()
 

--- a/scripts/artifacts/cashApp.py
+++ b/scripts/artifacts/cashApp.py
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     }
 }
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_human_ts_to_utc
 
 
 @artifact_processor
@@ -50,7 +50,7 @@ def get_cashApp(files_found, report_folder, seeker, wrap_text):
 
     all_rows = cursor.fetchall()
     for row in all_rows:
-        data_list.append((row[8],row[0],row[3],row[1],row[2],row[6],row[4],row[5],row[10],row[7],row[9]))
+        data_list.append((convert_human_ts_to_utc(row[8]),row[0],row[3],row[1],row[2],row[6],row[4],row[5],row[10],row[7],row[9]))
     db.close()
 
     data_headers = (

--- a/scripts/artifacts/keepNotes.py
+++ b/scripts/artifacts/keepNotes.py
@@ -17,7 +17,7 @@ __artifacts_v2__ = {
 
 import os
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_human_ts_to_utc
 
 
 @artifact_processor
@@ -46,7 +46,7 @@ def get_keepNotes(files_found, report_folder, seeker, wrap_text):
 
             all_rows = cursor.fetchall()
             for row in all_rows:
-                data_list.append(row)
+                data_list.append((convert_human_ts_to_utc(row[0]), convert_human_ts_to_utc(row[1]), convert_human_ts_to_utc(row[2]), row[3], row[4], row[5]))
             db.close()
 
     data_headers = (

--- a/scripts/artifacts/mega.py
+++ b/scripts/artifacts/mega.py
@@ -24,7 +24,7 @@ __artifacts_v2__ = {
 
 import json
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_human_ts_to_utc
 
 
 @artifact_processor
@@ -66,7 +66,7 @@ def get_mega(files_found, report_folder, seeker, wrap_text):
                 chat_message = chat_contents[0:]
                 chat_message = (str(chat_message)[2:-1])
 
-                data_list.append((row[0],row[1],row[2],chat_message,attachment_name))
+                data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],chat_message,attachment_name))
 
             elif row[2] == 'Attachment':
                 json_contents = row[3]
@@ -77,9 +77,9 @@ def get_mega(files_found, report_folder, seeker, wrap_text):
 
                 attachment_name = json_export[0]['name']
 
-                data_list.append((row[0],row[1],row[2],chat_message,attachment_name))
+                data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],chat_message,attachment_name))
             else:
-                data_list.append((row[0],row[1],row[2],chat_message,attachment_name))
+                data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],chat_message,attachment_name))
 
         db.close()
 

--- a/scripts/artifacts/protonVPN.py
+++ b/scripts/artifacts/protonVPN.py
@@ -46,7 +46,7 @@ import socket
 import datetime
 import xml.etree.ElementTree as ET
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, device_info, checkabx, abxread
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, device_info, checkabx, abxread, convert_human_ts_to_utc
 
 
 @artifact_processor
@@ -106,7 +106,7 @@ def get_protonvpn_connection_history(files_found, report_folder, seeker, wrap_te
             for entry in log_entries:
                 initial_connect = entry.find('to:')
                 if initial_connect != -1:
-                    timestamp = entry[:entry.find('|')-1].split('.')[0].replace('T', ' ')
+                    timestamp = convert_human_ts_to_utc(entry[:entry.find('|')-1].split('.')[0].replace('T', ' '))
                     try:
                         server_hostname = regex.search(entry)[0]
                         server_ip = socket.gethostbyname(server_hostname)

--- a/scripts/artifacts/protonmail.py
+++ b/scripts/artifacts/protonmail.py
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
     }
 }
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_human_ts_to_utc
 
 
 @artifact_processor
@@ -91,7 +91,7 @@ def get_protonmail_messages(files_found, report_folder, seeker, wrap_text):
 
             all_rows = cursor.fetchall()
             for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11],row[12],row[13],row[14],row[15],row[16]))
+                data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],row[3],row[4],row[5],convert_human_ts_to_utc(row[6]),row[7],row[8],row[9],row[10],row[11],row[12],row[13],row[14],row[15],row[16]))
 
             db.close()
 
@@ -143,7 +143,7 @@ def get_protonmail_contacts(files_found, report_folder, seeker, wrap_text):
 
             all_rows = cursor.fetchall()
             for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3]))
+                data_list.append((convert_human_ts_to_utc(row[0]),convert_human_ts_to_utc(row[1]),row[2],row[3]))
 
             db.close()
 

--- a/scripts/artifacts/sChats.py
+++ b/scripts/artifacts/sChats.py
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     }
 }
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_human_ts_to_utc
 
 
 @artifact_processor
@@ -57,7 +57,7 @@ def get_schats(files_found, report_folder, seeker, wrap_text):
             usageentries = len(all_rows)
             if usageentries > 0:
                 for row in all_rows:
-                    data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
+                    data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],row[3],row[4],row[5],row[6]))
             db.close()
 
         else:

--- a/scripts/artifacts/samsungSmartThings.py
+++ b/scripts/artifacts/samsungSmartThings.py
@@ -21,7 +21,7 @@ __artifacts_v2__ = {
 # Artifact version: 0.0.1
 # Requirements: none
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_human_ts_to_utc
 
 
 @artifact_processor
@@ -51,7 +51,7 @@ def get_samsungSmartThings(files_found, report_folder, seeker, wrap_text):
 
         all_rows = cursor.fetchall()
         for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
+            data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],row[3],row[4],row[5],row[6]))
         db.close()
 
     data_headers = (

--- a/scripts/artifacts/skout.py
+++ b/scripts/artifacts/skout.py
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
     }
 }
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_human_ts_to_utc
 
 
 @artifact_processor
@@ -62,7 +62,7 @@ def get_skout_messages(files_found, report_folder, seeker, wrap_text):
 
             all_rows = cursor.fetchall()
             for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
+                data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],row[3],row[4],row[5],row[6]))
 
             db.close()
 
@@ -100,7 +100,7 @@ def get_skout_users(files_found, report_folder, seeker, wrap_text):
 
             all_rows = cursor.fetchall()
             for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3]))
+                data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],row[3]))
 
             db.close()
 

--- a/scripts/artifacts/smyfilesStored.py
+++ b/scripts/artifacts/smyfilesStored.py
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     }
 }
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_human_ts_to_utc
 
 
 @artifact_processor
@@ -61,7 +61,7 @@ def get_smyfilesStored(files_found, report_folder, seeker, wrap_text):
 
     data_list = []
     for row in all_rows:
-        data_list.append((row[0],row[1],row[2],row[3],row[4]))
+        data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],row[3],convert_human_ts_to_utc(row[4])))
 
     data_headers = (
         ('Timestamp', 'datetime'),

--- a/scripts/artifacts/vaulty_files.py
+++ b/scripts/artifacts/vaulty_files.py
@@ -17,7 +17,7 @@ __artifacts_v2__ = {
 
 import sqlite3
 
-from scripts.ilapfuncs import artifact_processor
+from scripts.ilapfuncs import artifact_processor, convert_human_ts_to_utc
 
 
 @artifact_processor
@@ -40,6 +40,6 @@ def get_vaulty_files(files_found, report_folder, seeker, wrap_text):
         'Original Path',
         'Vault Path',
     )
-    data_list = results
+    data_list = [(r[0], convert_human_ts_to_utc(r[1]), convert_human_ts_to_utc(r[2]), r[3], r[4]) for r in results]
 
     return data_headers, data_list, db_filepath


### PR DESCRIPTION
Continues the LAVA-timestamp correction. Wraps each `datetime` column's SQL/human string value with `convert_human_ts_to_utc` so LAVA stores the correct unix epoch (naive UTC strings were being read as local time and shifted by the report machine's offset).

Files: vaulty_files, cashApp, sChats, protonmail (messages + contacts), protonVPN (connection history), skout (messages + users), samsungSmartThings, mega, smyfilesStored, PodcastAddict, keepNotes, GarminSync, GarminNotifications. No query changes; HTML/TSV now show explicit UTC.

**Not changed:**
- `discordChats` — its Discord ISO-8601 timestamps already carry a UTC offset, so LAVA's `fromisoformat` produces the correct epoch.
- `meetme` — selects raw `sent_at` with no `datetime()` wrapper; its format needs confirming against real data before converting, so it's deferred.

Verified: all 13 parse, lint-clean, loader resolves with no warnings.