### PR TITLE
Convert DocList, wellbeingaccount, appopSetupWiz to LAVA

### DIFF
--- a/scripts/artifacts/DocList.py
+++ b/scripts/artifacts/DocList.py
@@ -1,7 +1,7 @@
-# pylint: disable=W0611,W0613,W0702,W1309
+# pylint: disable=W0613,W0702
 __artifacts_v2__ = {
     "get_DocList": {
-        "name": "DocList'",
+        "name": "DocList",
         "description": "",
         "author": "",
         "creation_date": "2020-12-21",
@@ -10,22 +10,19 @@ __artifacts_v2__ = {
         "category": "Google Drive",
         "notes": "",
         "paths": ('*/com.google.android.apps.docs/databases/DocList.db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "file",
-        "function": "get_DocList",
     }
 }
 
-import sqlite3
-import textwrap
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_human_ts_to_utc
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
+@artifact_processor
 def get_DocList(files_found, report_folder, seeker, wrap_text):
-    
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
+
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     try:
         cursor.execute('''
@@ -38,7 +35,7 @@ def get_DocList(files_found, report_folder, seeker, wrap_text):
             owner,
             case lastModifiedTime
                 when 0 then ''
-                else datetime("lastModifiedTime"/1000, 'unixepoch') 
+                else datetime("lastModifiedTime"/1000, 'unixepoch')
             end as lastModifiedTime,
             case lastOpenedTime
                 when 0 then ''
@@ -53,30 +50,19 @@ def get_DocList(files_found, report_folder, seeker, wrap_text):
             size
         from EntryView
         ''')
-
         all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
     except:
-        usageentries = 0
-    
-    if usageentries > 0:
-        report = ArtifactHtmlReport('DocList')
-        report.start_artifact_report(report_folder, 'DocList')
-        report.add_script()
-        data_headers = ('Created Date','File Name','Owner','Modified Date','Opened Date','Last Modifier Account Alias','Last Modifier Account Name','File Type','Shareable URI','HTML URI','MD5 Checkusm','Size') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = []
-        for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11],))
+        all_rows = []
 
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Google Drive - DocList'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Google Drive - DocList'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Google Drive - DocList data available')
-    
+    data_list = []
+    for row in all_rows:
+        data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],convert_human_ts_to_utc(row[3]),convert_human_ts_to_utc(row[4]),row[5],row[6],row[7],row[8],row[9],row[10],row[11],))
+
     db.close()
+
+    data_headers = (
+        ('Created Date', 'datetime'), 'File Name', 'Owner', ('Modified Date', 'datetime'),
+        ('Opened Date', 'datetime'), 'Last Modifier Account Alias', 'Last Modifier Account Name',
+        'File Type', 'Shareable URI', 'HTML URI', 'MD5 Checksum', 'Size',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/appopSetupWiz.py
+++ b/scripts/artifacts/appopSetupWiz.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_appopSetupWiz": {
         "name": "appopSetupWiz",
-        "description": "check if file is abx",
+        "description": "Setup Wizard app-op timestamps from appops.xml",
         "author": "",
         "creation_date": "2021-08-15",
         "last_update_date": "2021-08-15",
@@ -10,60 +10,48 @@ __artifacts_v2__ = {
         "category": "Wipe & Setup",
         "notes": "",
         "paths": ('*/system/appops.xml',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "package",
-        "function": "get_appopSetupWiz",
     }
 }
 
-import os
 import datetime
 import xml.etree.ElementTree as ET
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, abxread, checkabx
 
+from scripts.ilapfuncs import artifact_processor, abxread, checkabx
+
+
+@artifact_processor
 def get_appopSetupWiz(files_found, report_folder, seeker, wrap_text):
 
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('appops.xml'):
-            continue # Skip all other files
-        
-        data_list = []
-        #check if file is abx
+            continue  # Skip all other files
+
+        source_path = file_found
+        # check if file is abx
         if (checkabx(file_found)):
             multi_root = False
             tree = abxread(file_found, multi_root)
         else:
             tree = ET.parse(file_found)
         root = tree.getroot()
-        
+
         for elem in root.iter('pkg'):
             if elem.attrib['n'] == 'com.google.android.setupwizard':
                 pkg = elem.attrib['n']
                 for subelem in elem:
-                    #print(subelem.attrib)
                     for subelem2 in subelem:
-                        #print(subelem2.attrib)
                         for subelem3 in subelem2:
                             test = subelem3.attrib.get('t', 0)
                             if int(test) > 0:
-                                timestamp = (datetime.datetime.utcfromtimestamp(int(subelem3.attrib['t'])/1000).strftime('%Y-%m-%d %H:%M:%S'))
+                                timestamp = datetime.datetime.fromtimestamp(int(subelem3.attrib['t'])/1000, datetime.timezone.utc)
                             else:
                                 timestamp = ''
                             data_list.append((timestamp, pkg))
-        if data_list:
-            report = ArtifactHtmlReport('Appops.xml Setup Wizard')
-            report.start_artifact_report(report_folder, 'Appops.xml Setup Wizard')
-            report.add_script()
-            data_headers = ('Timestamp','Package')
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Appops Setup Wizard data'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Appops Setup Wizard data'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Appops Setup Wizard data available')
+
+    data_headers = (('Timestamp', 'datetime'), 'Package')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/wellbeingaccount.py
+++ b/scripts/artifacts/wellbeingaccount.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_wellbeingaccount": {
         "name": "wellbeingaccount",
@@ -10,34 +10,28 @@ __artifacts_v2__ = {
         "category": "Digital Wellbeing",
         "notes": "",
         "paths": ('*/com.google.android.apps.wellbeing/files/AccountData.pb',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "battery",
-        "function": "get_wellbeingaccount",
+        "html_columns": ['Protobuf Parsed Data'],
     }
 }
 
 import json
-import os
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows 
+from scripts.ilapfuncs import artifact_processor
 from scripts.parse3 import ParseProto
 
+
+@artifact_processor
 def get_wellbeingaccount(files_found, report_folder, seeker, wrap_text):
-    file_found = str(files_found[0])
-    content = ParseProto(file_found)
-    
+    source_path = str(files_found[0])
+    content = ParseProto(source_path)
+
     content_json_dump = json.dumps(content, indent=4, sort_keys=True, ensure_ascii=False)
     parsedContent = str(content_json_dump).encode(encoding='UTF-8',errors='ignore')
-    
-    report = ArtifactHtmlReport('Wellbeing Account')
-    report.start_artifact_report(report_folder, 'Account Data')
-    report.add_script()
-    data_headers = ('Protobuf Parsed Data', 'Protobuf Data')
+
     data_list = []
     data_list.append(('<pre id=\"json\">'+str(parsedContent).replace("\\n", "<br>")+'</pre>', str(content)))
-    report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-    report.end_artifact_report()
-    
-    tsvname = f'wellbeing account'
-    tsv(report_folder, data_headers, data_list, tsvname)
+
+    data_headers = ('Protobuf Parsed Data', 'Protobuf Data')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Three single-report conversions, using tz-aware UTC datetimes for LAVA from the start.

- **DocList** — three datetime columns via `convert_human_ts_to_utc`; also fixed the stray trailing quote in the artifact name (`DocList'` → `DocList`).
- **wellbeingaccount** — protobuf dump; the HTML-formatted column declared via `html_columns`.
- **appopSetupWiz** — replaces the deprecated `datetime.utcfromtimestamp` with the tz-aware `datetime.fromtimestamp(ts, timezone.utc)`, feeding the `Timestamp` column.

Verified: all three parse, lint-clean, loader resolves with no warnings.