### PR TITLE
Convert 5 Samsung/system text-parser artifacts to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/etc_hosts.py
+++ b/scripts/artifacts/etc_hosts.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0311,W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_etc_hosts": {
         "name": "Etc_hosts",
@@ -10,23 +10,22 @@ __artifacts_v2__ = {
         "category": "Etc Hosts",
         "notes": "",
         "paths": ('*/system/etc/hosts',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "file",
-        "function": "get_etc_hosts",
     }
 }
 
 import codecs
-import csv
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows
+from scripts.ilapfuncs import artifact_processor
 
+
+@artifact_processor
 def get_etc_hosts(files_found, report_folder, seeker, wrap_text):
     data_list = []
-    file_found = str(files_found[0])
-    
-    with codecs.open(file_found, 'r', 'utf-8-sig') as csvfile:
+    source_path = str(files_found[0])
+
+    with codecs.open(source_path, 'r', 'utf-8-sig') as csvfile:
         for row in csvfile:
             sline = '\t'.join(row.split())
             sline = sline.split('\t')
@@ -34,21 +33,9 @@ def get_etc_hosts(files_found, report_folder, seeker, wrap_text):
             sline_two = sline[1]
             if (sline_one == '127.0.0.1' and sline_two == 'localhost') or \
                 (sline_one == '::1' and sline_two == 'ip6-localhost'):
-                pass # Skipping the defaults, so only anomaly entries are seen
+                pass  # Skipping the defaults, so only anomaly entries are seen
             else:
-                 data_list.append((sline_one, sline_two))
+                data_list.append((sline_one, sline_two))
 
-    if len(data_list) > 0:
-        report = ArtifactHtmlReport('Etc Hosts')
-        report.start_artifact_report(report_folder, f'Etc Hosts')
-        report.add_script()
-        data_headers = ('IP Address', 'Hostname')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Etc Hosts'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-    else:
-        logfunc(f'No etc hosts file available, or nothing significant found.')
-        
+    data_headers = ('IP Address', 'Hostname')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/oldpowerOffReset.py
+++ b/scripts/artifacts/oldpowerOffReset.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W1309,W1514
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_oldpowerOffReset": {
         "name": "oldpowerOffReset",
@@ -10,47 +10,35 @@ __artifacts_v2__ = {
         "category": "Power Events",
         "notes": "",
         "paths": ('*/log/power_off_reset_reason.txt', '*/log/power_off_reset_reason_backup.txt'),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "battery",
-        "function": "get_oldpowerOffReset",
     }
 }
 
-from datetime import datetime
 import os
-from pathlib import Path
+from datetime import datetime, timezone
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows
+from scripts.ilapfuncs import artifact_processor
 
+
+@artifact_processor
 def get_oldpowerOffReset(files_found, report_folder, seeker, wrap_text):
     data_list = []
+    source_path = ''
     for file_found in files_found:
-    
+        source_path = os.path.dirname(file_found)
         filename = os.path.basename(file_found)
-        location = os.path.dirname(file_found)
-    
-        with open(file_found, 'r') as f:
+
+        with open(file_found, 'r', encoding='utf-8') as f:
             for line in f:
                 if '/' in line and len(line) == 18:
                     fecha = line.strip()
-                    fecha = (datetime.strptime(fecha,'%y/%m/%d %H:%M:%S'))
-                    
+                    fecha = datetime.strptime(fecha, '%y/%m/%d %H:%M:%S').replace(tzinfo=timezone.utc)
+
                     reason = next(f)
-                    reason = reason.split(':')[1].replace('\n','')
-                    
+                    reason = reason.split(':')[1].replace('\n', '')
+
                     data_list.append((fecha, reason, filename))
-    
-    if len(data_list) > 0:
-        report = ArtifactHtmlReport('Power Off Reset')
-        report.start_artifact_report(report_folder, f'Power Off Reset')
-        report.add_script()
-        data_headers = ('Timestamp', 'Reason', 'Filename')
-        report.write_artifact_data_table(data_headers, data_list, location)
-        report.end_artifact_report()
-        
-        tsvname = f'Power Off Reset'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-    else:
-        logfunc(f'Power Off Reset file available')
+
+    data_headers = (('Timestamp', 'datetime'), 'Reason', 'Filename')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/persistentProp.py
+++ b/scripts/artifacts/persistentProp.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_persistentProp": {
         "name": "persistentProp",
@@ -10,60 +10,48 @@ __artifacts_v2__ = {
         "category": "Wipe & Setup",
         "notes": "",
         "paths": ('*/property/persistent_properties',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "info",
-        "function": "get_persistentProp",
     }
 }
 
-import os
 import datetime
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
 
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
 def get_persistentProp(files_found, report_folder, seeker, wrap_text):
 
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('persistent_properties'):
-            continue # Skip all other files
-        
-        data_list = []
+            continue  # Skip all other files
+
+        source_path = file_found
         with open(file_found, 'r', encoding='utf-8', errors='replace') as f:
             for line in f:
                 clean = line.strip()
-                if clean.startswith('persist.sys.boot.reason.historyDreboot'):
+                if clean.startswith('persist.sys.boot.reason.historyDreboot'):
                     parts = clean.split(',')
-                    utctimestamp = (datetime.datetime.utcfromtimestamp(int(parts[-1])).strftime('%Y-%m-%d %H:%M:%S'))
+                    utctimestamp = datetime.datetime.fromtimestamp(int(parts[-1]), datetime.timezone.utc)
                     description = parts[0]
                     data_list.append((utctimestamp, description))
-                    
+
                 if clean.startswith('reboot,factory_reset,'):
                     parts = clean.split(',')
-                    utctimestamp = (datetime.datetime.utcfromtimestamp(int(parts[-1])).strftime('%Y-%m-%d %H:%M:%S'))
+                    utctimestamp = datetime.datetime.fromtimestamp(int(parts[-1]), datetime.timezone.utc)
                     description = parts[0] + ' ' + parts[1]
                     data_list.append((utctimestamp, description))
-                    
+
                 if clean.startswith('reboot'):
                     parts = clean.split(',')
                     if len(parts) == 2:
-                        utctimestamp = (datetime.datetime.utcfromtimestamp(int(parts[-1])).strftime('%Y-%m-%d %H:%M:%S'))
+                        utctimestamp = datetime.datetime.fromtimestamp(int(parts[-1]), datetime.timezone.utc)
                         description = parts[0]
                         data_list.append((utctimestamp, description))
-                            
-        if data_list:
-            report = ArtifactHtmlReport('Persistent Properties')
-            report.start_artifact_report(report_folder, 'Persistent Properties')
-            report.add_script()
-            data_headers = ('Timestamp', 'Event')
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Persistent Properties'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Persistent Properties'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Persistent Properties data available')
-            
+
+    data_headers = (('Timestamp', 'datetime'), 'Event')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/sRecoveryhist.py
+++ b/scripts/artifacts/sRecoveryhist.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W1309,W1514
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_sRecoveryhist": {
         "name": "sRecoveryhist",
@@ -10,36 +10,35 @@ __artifacts_v2__ = {
         "category": "Wipe & Setup",
         "notes": "",
         "paths": ('*/efs/recovery/history',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "file",
-        "function": "get_sRecoveryhist",
     }
 }
 
-import os
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import artifact_processor
 
+
+@artifact_processor
 def get_sRecoveryhist(files_found, report_folder, seeker, wrap_text):
 
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('history'):
-            continue # Skip all other files
-        
-        data_list = []
-        
+            continue  # Skip all other files
+
+        source_path = file_found
         timestamp = wipe = promptwipe = reason = rebootreason = locale = updateorg = updatepkg = reqtime = ''
-        with open(file_found, 'r') as f:
+        with open(file_found, 'r', encoding='utf-8', errors='replace') as f:
             for line in f:
-                #print(line)
                 if line.startswith('+'):
                     if '|' in line:
                         timestamp = line.split('|')
                         timestamp = timestamp[1].strip()
                         timestamp = timestamp.replace('/', '-')
                     else:
-                        timestamp = line.split(':',1)
+                        timestamp = line.split(':', 1)
                         timestamp = timestamp[1].strip()
                         timestamp = timestamp.replace(']', '')
                         timestamp = timestamp.replace('/', '-')
@@ -72,19 +71,6 @@ def get_sRecoveryhist(files_found, report_folder, seeker, wrap_text):
                 if line.startswith('-\n'):
                     data_list.append((timestamp, wipe, promptwipe, reason, rebootreason, locale, reqtime, updateorg, updatepkg))
                     timestamp = wipe = promptwipe = reason = rebootreason = locale = updateorg = updatepkg = reqtime = ''
-                    
-        if data_list:
-            report = ArtifactHtmlReport('Samsung Recovery History')
-            report.start_artifact_report(report_folder, 'Samsung Recovery History')
-            report.add_script()
-            data_headers = ('Timestamp', 'Wipe', 'Promtp & Wipe', 'Reason', 'Reboot Reason', 'Locale', 'Request Timestamp', 'Update ORG', 'Update PKG')
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Samsung Recovery History'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Samsung Recovery History'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Samsung Recovery History data available')
+
+    data_headers = ('Timestamp', 'Wipe', 'Prompt & Wipe', 'Reason', 'Reboot Reason', 'Locale', 'Request Timestamp', 'Update ORG', 'Update PKG')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/sWipehist.py
+++ b/scripts/artifacts/sWipehist.py
@@ -1,4 +1,4 @@
-# pylint: disable=E0606,W0611,W0613,W1309,W1514
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_sWipehist": {
         "name": "sWipehist",
@@ -10,42 +10,39 @@ __artifacts_v2__ = {
         "category": "Wipe & Setup",
         "notes": "",
         "paths": ('*/efs/recovery/history', '*/data/log/recovery_history.log'),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "file",
-        "function": "get_sWipehist",
     }
 }
 
-import os
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import artifact_processor
 
+
+@artifact_processor
 def get_sWipehist(files_found, report_folder, seeker, wrap_text):
 
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        if file_found.endswith('history'):
-            name = 'History'
-        if file_found.endswith('recovery_history.log'):
-            name = 'Recovery History Log'
-        
-        data_list = []
-        
-        timestamp = wipe = promptwipe = reason = rebootreason = locale = updateorg = updatepkg = reqtime = ''
-        with open(file_found, 'r') as f:
+        if not (file_found.endswith('history') or file_found.endswith('recovery_history.log')):
+            continue  # Skip all other files
+
+        source_path = file_found
+        timestamp = wipe = promptwipe = reason = provider = rebootreason = locale = updateorg = updatepkg = reqtime = ''
+        with open(file_found, 'r', encoding='utf-8', errors='replace') as f:
             for line in f:
-                #print(line)
                 if line.startswith('+'):
                     if '|' in line:
                         timestamp = line.split('|')
                         timestamp = timestamp[1].strip()
                         timestamp = timestamp.replace('/', '-')
                     else:
-                        timestamp = line.split(':',1)
+                        timestamp = line.split(':', 1)
                         timestamp = timestamp[1].strip()
                         timestamp = timestamp.replace(']', '')
                         timestamp = timestamp.replace('/', '-')
-                        
+
                 if line.startswith('--wipe_data'):
                     wipe = 'Yes'
                 if line.startswith('--reason'):
@@ -62,11 +59,10 @@ def get_sWipehist(files_found, report_folder, seeker, wrap_text):
                 if line.startswith('reboot_reason'):
                     rebootreason = line.split('=')
                     rebootreason = rebootreason[1]
-                    
+
                     if wipe == 'Yes':
-                        
                         data_list.append((timestamp, wipe, promptwipe, reason, provider, rebootreason, locale, reqtime))
-                        timestamp = wipe = promptwipe = reason = rebootreason = locale = updateorg = updatepkg = reqtime = ''
+                        timestamp = wipe = promptwipe = reason = provider = rebootreason = locale = updateorg = updatepkg = reqtime = ''
                 if line.startswith('reboot reason'):
                     rebootreason = line.split(':', 1)
                     rebootreason = rebootreason[1]
@@ -85,19 +81,6 @@ def get_sWipehist(files_found, report_folder, seeker, wrap_text):
                 if line.startswith('--prompt_and_wipe_data'):
                     promptwipe = 'Yes'
                     wipe = 'Yes'
-                        
-        if data_list:
-            report = ArtifactHtmlReport(f'Samsung Wipe {name}')
-            report.start_artifact_report(report_folder, f'Samsung Wipe {name}')
-            report.add_script()
-            data_headers = ('Timestamp', 'Wipe', 'Prompt & Wipe', 'Reason', 'Provider', 'Reboot Reason', 'Locale', 'Request Timestamp')
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Samsung Wipe {name}'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Samsung Wipe {name}'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc(f'No Samsung Wipe History data available')
+
+    data_headers = ('Timestamp', 'Wipe', 'Prompt & Wipe', 'Reason', 'Provider', 'Reboot Reason', 'Locale', 'Request Timestamp')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts five clean single-report text/db parsers to the LAVA `@artifact_processor` pattern (4-arg signature, returns `(data_headers, data_list, source_path)`).

- **etc_hosts** — no timestamps; outputs html/tsv/lava.
- **oldpowerOffReset** — parses naive datetime, now made tz-aware UTC via `.replace(tzinfo=timezone.utc)`; Timestamp marked `datetime`.
- **persistentProp** — replaced deprecated `utcfromtimestamp` with `datetime.fromtimestamp(ts, timezone.utc)` (aware); Timestamp marked `datetime`; standard outputs.
- **sRecoveryhist** / **sWipehist** — free-text Samsung histories; Timestamp kept as plain string (format too variable to safely mark datetime); html/tsv/lava. Removed stale `function` key; initialized `provider` to drop E0606.

Verified: parse, decorated 3-tuple returns, output_types valid, loader resolves all functions, no `function` keys remaining.