### PR TITLE
Convert Chess.com + Chess With Friends artifacts to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/ChessComAccount.py
+++ b/scripts/artifacts/ChessComAccount.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_ChessComAccount": {
         "name": "Chess.com Account",
@@ -10,58 +10,54 @@ __artifacts_v2__ = {
         "category": "Chess.com",
         "notes": "",
         "paths": ('*/com.chess/shared_prefs/com.chess.app.login_credentials.xml', '*/data/com.chess/shared_prefs/com.chess.app.session_preferences.xml'),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "grid",
-        "function": "get_ChessComAccount",
     }
 }
 
-import sqlite3
-import textwrap
-import xml.etree.ElementTree as ET
 import datetime
+import xml.etree.ElementTree as ET
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor
 
+
+@artifact_processor
 def get_ChessComAccount(files_found, report_folder, seeker, wrap_text):
-    
-    title = "Chess.com Account"
 
-    # Data results
-    data_headers = ('Key', 'Value')
     data_list = []
+    source_path = ''
+
+    credentials_file = ''
+    session_file = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if file_found.endswith('login_credentials.xml'):
+            credentials_file = file_found
+        elif file_found.endswith('session_preferences.xml'):
+            session_file = file_found
 
     # Login credentials
-    credentials_file = str(files_found[0])
-    cred_tree = ET.parse(credentials_file)
-    cred_root = cred_tree.getroot()
-    cred_strings = cred_root.findall("string")
-    for item in cred_strings:
-        key = item.attrib.get("name")
-        value = item.text
-        if key in ["pref_username_or_email", "pref_password"]:
-            data_list.append([key, value])
+    if credentials_file:
+        source_path = credentials_file
+        cred_root = ET.parse(credentials_file).getroot()
+        for item in cred_root.findall("string"):
+            key = item.attrib.get("name")
+            value = item.text
+            if key in ["pref_username_or_email", "pref_password"]:
+                data_list.append((key, value))
 
-    # Session 
-    session_file = str(files_found[1])
-    sesh_tree = ET.parse(session_file)
-    sesh_root = sesh_tree.getroot()
-    sesh_strings = sesh_root.findall("string")
-    for item in sesh_strings:
-        key = item.attrib.get("name")
-        value = item.text
-        if key in ["pref_username", "pref_email", "pref_member_since"]:
-            if key == "pref_member_since":
-                value = datetime.datetime.utcfromtimestamp(int(value)).isoformat(sep=" ", timespec="seconds")
-            data_list.append([key, value])
+    # Session
+    if session_file:
+        if not source_path:
+            source_path = session_file
+        sesh_root = ET.parse(session_file).getroot()
+        for item in sesh_root.findall("string"):
+            key = item.attrib.get("name")
+            value = item.text
+            if key in ["pref_username", "pref_email", "pref_member_since"]:
+                if key == "pref_member_since" and value:
+                    value = datetime.datetime.fromtimestamp(int(value), datetime.timezone.utc).isoformat(sep=" ", timespec="seconds")
+                data_list.append((key, value))
 
-    # Reporting
-    description = "Chess.com Account"
-    report = ArtifactHtmlReport(title)
-    report.start_artifact_report(report_folder, title, description)
-    report.add_script()
-    report.write_artifact_data_table(data_headers, data_list, credentials_file, html_escape=False)
-    report.end_artifact_report()
-    
-    tsv(report_folder, data_headers, data_list, title)
+    data_headers = ('Key', 'Value')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/ChessComFriends.py
+++ b/scripts/artifacts/ChessComFriends.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_ChessComFriends": {
         "name": "ChessComFriends",
@@ -10,41 +10,35 @@ __artifacts_v2__ = {
         "category": "Chess.com",
         "notes": "",
         "paths": ('*/com.chess/databases/chess-database*',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "grid",
-        "function": "get_ChessComFriends",
     }
 }
 
-import sqlite3
-import textwrap
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_ChessComFriends(files_found, report_folder, seeker, wrap_text):
-    
-    title = "Chess.com Friends"
 
-    # Chess database
-    db_filepath = str(files_found[0])
-    conn = sqlite3.connect(db_filepath)
-    c = conn.cursor()
-    sql = """SELECT friends.id AS "ID", friends.username AS "Username", friends.first_name AS "First Name", friends.last_name AS "Last Name", datetime(friends.last_login_date, 'unixepoch') AS "Last Login" FROM friends"""
-    c.execute(sql)
-    results = c.fetchall()
-    conn.close()
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
+    cursor = db.cursor()
+    cursor.execute('''
+        SELECT friends.id, friends.username, friends.first_name, friends.last_name, friends.last_login_date
+        FROM friends
+    ''')
+    all_rows = cursor.fetchall()
+    db.close()
 
-    # Data results
-    data_headers = ('ID', 'Username', 'First Name', 'Last Name', 'Last Login')
-    data_list = results
-    
-    # Reporting
-    description = "Chess.com Friends"
-    report = ArtifactHtmlReport(title)
-    report.start_artifact_report(report_folder, title, description)
-    report.add_script()
-    report.write_artifact_data_table(data_headers, data_list, db_filepath, html_escape=False)
-    report.end_artifact_report()
-    
-    tsv(report_folder, data_headers, data_list, title)
+    data_list = []
+    for row in all_rows:
+        last_login = ''
+        if row[4]:
+            last_login = datetime.datetime.fromtimestamp(int(row[4]), datetime.timezone.utc)
+        data_list.append((row[0], row[1], row[2], row[3], last_login))
+
+    data_headers = ('ID', 'Username', 'First Name', 'Last Name', ('Last Login', 'datetime'))
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/ChessComGames.py
+++ b/scripts/artifacts/ChessComGames.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_ChessComGames": {
         "name": "Chess.com Games",
@@ -10,53 +10,50 @@ __artifacts_v2__ = {
         "category": "Chess.com",
         "notes": "",
         "paths": ('*/com.chess/databases/chess-database*', '*/data/com.chess/shared_prefs/com.chess.app.session_preferences.xml'),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "grid",
-        "function": "get_ChessComGames",
     }
 }
 
-import sqlite3
-import textwrap
+import datetime
 import xml.etree.ElementTree as ET
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_ChessComGames(files_found, report_folder, seeker, wrap_text):
-    
-    title = "Chess.com Games"
 
     # Username
     username = "None"
-    session_file = list(filter(lambda x: "xml" in x, files_found))[0]
-    sesh_tree = ET.parse(session_file)
-    sesh_root = sesh_tree.getroot()
-    sesh_strings = sesh_root.findall("string")
-    for item in sesh_strings:
-        key = item.attrib.get("name")
-        if key == "pref_username":
-            username = item.text
+    session_files = [str(x) for x in files_found if str(x).endswith('.xml')]
+    if session_files:
+        sesh_root = ET.parse(session_files[0]).getroot()
+        for item in sesh_root.findall("string"):
+            if item.attrib.get("name") == "pref_username":
+                username = item.text
 
     # Chess database
-    db_filepath = list(filter(lambda x: "chess-database" in x, files_found))[0]
-    conn = sqlite3.connect(db_filepath)
-    c = conn.cursor()
-    sql = f"""SELECT datetime(daily_games.game_start_time, 'unixepoch') AS "First Move", datetime(daily_games.timestamp, 'unixepoch') AS "Last Move", daily_games.game_id AS "Game ID", daily_games.white_username AS "White", daily_games.black_username AS "Black", CASE daily_games.is_opponent_friend WHEN 1 THEN "Friend" WHEN 0 THEN "User" ELSE "ERROR" END AS "Friend Status", daily_games.result_message AS "Result" FROM daily_games WHERE daily_games.white_username = "{username}" OR daily_games.black_username = "{username}" ORDER BY daily_games.timestamp"""
-    c.execute(sql)
-    results = c.fetchall()
-    conn.close()
+    source_path = [str(x) for x in files_found if "chess-database" in str(x)][0]
+    db = open_sqlite_db_readonly(source_path)
+    cursor = db.cursor()
+    cursor.execute('''
+        SELECT daily_games.game_start_time, daily_games.timestamp, daily_games.game_id,
+               daily_games.white_username, daily_games.black_username,
+               CASE daily_games.is_opponent_friend WHEN 1 THEN "Friend" WHEN 0 THEN "User" ELSE "ERROR" END,
+               daily_games.result_message
+        FROM daily_games
+        WHERE daily_games.white_username = ? OR daily_games.black_username = ?
+        ORDER BY daily_games.timestamp
+    ''', (username, username))
+    all_rows = cursor.fetchall()
+    db.close()
 
-    # Data results
-    data_headers = ('First Move', 'Last Move', 'Game ID', 'White', 'Black', 'Friend Status', 'Result')
-    data_list = results
-    
-    # Reporting
-    description = "Chess.com Games"
-    report = ArtifactHtmlReport(title)
-    report.start_artifact_report(report_folder, title, description)
-    report.add_script()
-    report.write_artifact_data_table(data_headers, data_list, db_filepath, html_escape=False)
-    report.end_artifact_report()
-    
-    tsv(report_folder, data_headers, data_list, title)
+    data_list = []
+    for row in all_rows:
+        first_move = datetime.datetime.fromtimestamp(int(row[0]), datetime.timezone.utc) if row[0] else ''
+        last_move = datetime.datetime.fromtimestamp(int(row[1]), datetime.timezone.utc) if row[1] else ''
+        data_list.append((first_move, last_move, row[2], row[3], row[4], row[5], row[6]))
+
+    data_headers = (('First Move', 'datetime'), ('Last Move', 'datetime'), 'Game ID', 'White', 'Black', 'Friend Status', 'Result')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/ChessComMessages.py
+++ b/scripts/artifacts/ChessComMessages.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_ChessComMessages": {
         "name": "ChessComMessages",
@@ -10,41 +10,33 @@ __artifacts_v2__ = {
         "category": "Chess.com",
         "notes": "",
         "paths": ('*/com.chess/databases/chess-database*',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "message-square",
-        "function": "get_ChessComMessages",
     }
 }
 
-import sqlite3
-import textwrap
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_ChessComMessages(files_found, report_folder, seeker, wrap_text):
-    
-    title = "Chess.com Messages"
 
-    # Chess database
-    db_filepath = str(files_found[0])
-    conn = sqlite3.connect(db_filepath)
-    c = conn.cursor()
-    sql = """SELECT datetime(messages.created_at, 'unixepoch') AS Sent, messages.conversation_id AS Conversation, messages.sender_username AS Sender, messages.content AS Message FROM messages"""
-    c.execute(sql)
-    results = c.fetchall()
-    conn.close()
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
+    cursor = db.cursor()
+    cursor.execute('''
+        SELECT messages.created_at, messages.conversation_id, messages.sender_username, messages.content
+        FROM messages
+    ''')
+    all_rows = cursor.fetchall()
+    db.close()
 
-    # Data results
-    data_headers = ('Sent', 'Conversation', 'Sender', 'Message')
-    data_list = results
-    
-    # Reporting
-    description = "Chess.com Messages"
-    report = ArtifactHtmlReport(title)
-    report.start_artifact_report(report_folder, title, description)
-    report.add_script()
-    report.write_artifact_data_table(data_headers, data_list, db_filepath, html_escape=False)
-    report.end_artifact_report()
-    
-    tsv(report_folder, data_headers, data_list, title)
+    data_list = []
+    for row in all_rows:
+        sent = datetime.datetime.fromtimestamp(int(row[0]), datetime.timezone.utc) if row[0] else ''
+        data_list.append((sent, row[1], row[2], row[3]))
+
+    data_headers = (('Sent', 'datetime'), 'Conversation', 'Sender', 'Message')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/ChessWithFriends.py
+++ b/scripts/artifacts/ChessWithFriends.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_ChessWithFriends": {
         "name": "Chess With Friends",
@@ -10,58 +10,37 @@ __artifacts_v2__ = {
         "category": "Chats",
         "notes": "",
         "paths": ('*/com.zynga.chess.googleplay/databases/wf_database.sqlite', '*/data/com.zynga.chess.googleplay/db/wf_database.sqlite'),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "grid",
-        "function": "get_ChessWithFriends",
     }
 }
 
-import sqlite3
-import textwrap
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, open_sqlite_db_readonly
 
+@artifact_processor
 def get_ChessWithFriends(files_found, report_folder, seeker, wrap_text):
-    
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
+
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     cursor.execute('''
-    SELECT
-    chat_messages.chat_message_id,
-    users.name,
-    users.email_address,
-    chat_messages.message,
-    chat_messages.created_at
-    FROM
-    chat_messages
-    INNER JOIN
-    users
-    ON
-    chat_messages.user_id=users.user_id
-    ORDER BY
-    chat_messages.created_at DESC
+        SELECT
+        chat_messages.chat_message_id,
+        users.name,
+        users.email_address,
+        chat_messages.message,
+        chat_messages.created_at
+        FROM chat_messages
+        INNER JOIN users ON chat_messages.user_id = users.user_id
+        ORDER BY chat_messages.created_at DESC
     ''')
-
     all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Chats')
-        report.start_artifact_report(report_folder, 'Chess With Friends')
-        report.add_script()
-        data_headers = ('Message_ID','User_Name','User_Email','Chat_Message','Chat_Message_Creation' )
-        data_list = []
-        for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4]))
-
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Chess With Friends Chats'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc('No Chess With Friends data available')
-    
     db.close()
-    
+
+    data_list = []
+    for row in all_rows:
+        data_list.append((row[0], row[1], row[2], row[3], row[4]))
+
+    data_headers = ('Message ID', 'User Name', 'User Email', 'Chat Message', 'Chat Message Creation')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts the Chess.com app family and Chess With Friends to the LAVA `@artifact_processor` pattern.

- **ChessComAccount** — credentials/session XML; now selects files by name instead of positional index; `pref_member_since` converted with aware UTC (`fromtimestamp(..., timezone.utc)`, replacing deprecated `utcfromtimestamp`). Key/Value layout so it stays a string column.
- **ChessComFriends** — `last_login_date` now returned as raw epoch and converted to aware UTC; `Last Login` marked `datetime`.
- **ChessComGames** — `game_start_time`/`timestamp` returned as raw epochs, converted to aware UTC; `First Move`/`Last Move` marked `datetime`. SQL username filter parameterized.
- **ChessComMessages** — `created_at` returned as raw epoch, converted to aware UTC; `Sent` marked `datetime`.
- **ChessWithFriends** — flat conversion; `created_at` kept as plain string (raw format unverified, original did not convert it).

All previously used SQL `datetime(col,'unixepoch')` which yields naive UTC strings — these are switched to raw epochs + Python aware-UTC conversion so the LAVA `datetime` columns store correct unix-epoch UTC integers.

Verified: parse, decorated 4-arg signature, returns 3-tuple, output_types html/tsv/lava, loader resolves, no stale `function` keys, byte-compile + pylint (errors/unused-imports) clean.