### PR TITLE
Convert build, packageInfo, roles, runtimePerms to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/build.py
+++ b/scripts/artifacts/build.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W1309,W1514
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_build": {
         "name": "Build",
@@ -10,30 +10,30 @@ __artifacts_v2__ = {
         "category": "Device Info",
         "notes": "",
         "paths": ('*/vendor/build.prop',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "info",
-        "function": "get_build",
     }
 }
 
-import os
-import scripts.artifacts.artGlobals 
+import scripts.artifacts.artGlobals
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, logdevinfo, tsv, is_platform_windows
+from scripts.ilapfuncs import artifact_processor, logfunc, logdevinfo
 
+
+@artifact_processor
 def get_build(files_found, report_folder, seeker, wrap_text):
     data_list = []
     Androidversion = scripts.artifacts.artGlobals.versionf
-    
-    file_found = str(files_found[0])
-    with open(file_found, "r") as f:
-        for line in f: 
+
+    source_path = str(files_found[0])
+    with open(source_path, "r", encoding='utf-8', errors='replace') as f:
+        for line in f:
             splits = line.split('=')
             if splits[0] == 'ro.product.vendor.manufacturer':
                 key = 'Manufacturer'
                 value = splits[1]
                 logdevinfo(f"<b>Manufacturer: </b>{value}")
+                data_list.append((key, value))
             elif splits[0] == 'ro.product.vendor.brand':
                 key = 'Brand'
                 value = splits[1]
@@ -63,25 +63,10 @@ def get_build(files_found, report_folder, seeker, wrap_text):
                 logdevinfo(f"<b>SDK: </b>{value}")
                 data_list.append((key, value))
             elif splits[0] == 'ro.system.build.version.release':
-                key = ''
+                key = 'Version Release'
                 value = splits[1]
                 logdevinfo(f"<b>Version release: </b>{value}")
                 data_list.append((key, value))
-            elif splits[0] == 'ro.system.build.version.release':
-                key = ''
-                value = splits[1]
-                data_list.append((key, value))
-    
-    itemqty = len(data_list)
-    if itemqty > 0:
-        report = ArtifactHtmlReport('Build Info')
-        report.start_artifact_report(report_folder, f'Build Info')
-        report.add_script()
-        data_headers = ('Key', 'Value')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Build Info'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc(f'No Build Info data available')    
+
+    data_headers = ('Key', 'Value')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/packageInfo.py
+++ b/scripts/artifacts/packageInfo.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0612,W0613,W0631,W1309,W1514
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_package_info": {
         "name": "package_info",
@@ -10,9 +10,8 @@ __artifacts_v2__ = {
         "category": "Installed Apps",
         "notes": "",
         "paths": ('*/system/packages.xml',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "package",
-        "function": "get_package_info",
     }
 }
 
@@ -20,11 +19,12 @@ import datetime
 import os
 import xmltodict
 import xml.etree.ElementTree as etree
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, abxread, checkabx
+
+from scripts.ilapfuncs import artifact_processor, logfunc, is_platform_windows, abxread, checkabx
 
 is_windows = is_platform_windows()
-slash = '\\' if is_windows else '/' 
+slash = '\\' if is_windows else '/'
+
 
 class Package:
     # Represents an app
@@ -39,28 +39,32 @@ class Package:
         self.public_flags = public_flags
         self.private_flags = private_flags
 
-def ReadUnixTimeMs(unix_time_ms): # Unix timestamp is time epoch beginning 1970/1/1
-    '''Returns datetime object, or empty string upon error'''
-    if unix_time_ms not in ( 0, None, ''):
+
+def ReadUnixTimeMs(unix_time_ms):  # Unix timestamp is time epoch beginning 1970/1/1
+    '''Returns datetime object (tz-aware UTC), or empty string upon error'''
+    if unix_time_ms not in (0, None, ''):
         try:
             if isinstance(unix_time_ms, str):
                 unix_time_ms = float.fromhex(unix_time_ms)
-            return datetime.datetime(1970, 1, 1) + datetime.timedelta(seconds=unix_time_ms/1000)
+            return datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc) + datetime.timedelta(seconds=unix_time_ms / 1000)
         except (ValueError, OverflowError, TypeError) as ex:
             logfunc("ReadUnixTimeMs() Failed to convert timestamp from value " + str(unix_time_ms) + " Error was: " + str(ex))
     return ''
 
+
+@artifact_processor
 def get_package_info(files_found, report_folder, seeker, wrap_text):
     packages = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
         if file_found.find('{0}mirror{0}'.format(slash)) >= 0:
             # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data
             continue
-        elif os.path.isdir(file_found): # skip folders (there shouldn't be any)
+        elif os.path.isdir(file_found):  # skip folders (there shouldn't be any)
             continue
-        
-        file_name = os.path.basename(file_found)
+
+        source_path = file_found
         if (checkabx(file_found)):
             multi_root = False
             tree = abxread(file_found, multi_root)
@@ -69,7 +73,7 @@ def get_package_info(files_found, report_folder, seeker, wrap_text):
         else:
             with open(file_found) as fd:
                 doc = xmltodict.parse(fd.read())
-        
+
         package_dict = doc.get('packages', {}).get('package', {})
         for package in package_dict:
             name = package.get('@name', '')
@@ -79,36 +83,16 @@ def get_package_info(files_found, report_folder, seeker, wrap_text):
             install_originator = package.get('@installOriginator', '')
             installer = package.get('@installer', '')
             code_path = package.get('@codePath', '')
-            public_flags  = hex(int(package.get('@publicFlags', 0)) & (2**32-1))
-            private_flags = hex(int(package.get('@privateFlags', 0)) & (2**32-1))
-            package = Package(name, ft, it, ut, install_originator, installer, code_path, public_flags, private_flags)
-            packages.append(package)
-        
+            public_flags = hex(int(package.get('@publicFlags', 0)) & (2**32 - 1))
+            private_flags = hex(int(package.get('@privateFlags', 0)) & (2**32 - 1))
+            packages.append(Package(name, ft, it, ut, install_originator, installer, code_path, public_flags, private_flags))
+
         if len(packages):
             break
 
-    if report_folder[-1] == slash: 
-        folder_name = os.path.basename(report_folder[:-1])
-    else:
-        folder_name = os.path.basename(report_folder)
-    entries = len(packages)
-    if entries > 0:
-        description = "All packages (user installed, oem installed and system) appear here. Many of these are not user apps"
-        report = ArtifactHtmlReport('Packages')
-        report.start_artifact_report(report_folder, 'Packages', description)
-        report.add_script()
-        data_headers = ('ft','Name', 'Install Time', 'Update Time', 'Install Originator', 'Installer', 'Code Path', 'Public Flags', 'Private Flags')
-        data_list = []
-        for p in packages:
-            data_list.append( (p.ft, p.name, p.install_time, p.update_time, p.install_originator, p.installer, p.code_path, p.public_flags, p.private_flags) )
+    data_list = []
+    for p in packages:
+        data_list.append((p.ft, p.name, p.install_time, p.update_time, p.install_originator, p.installer, p.code_path, p.public_flags, p.private_flags))
 
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Packages'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Packages'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No package data available')            
+    data_headers = (('ft', 'datetime'), 'Name', ('Install Time', 'datetime'), ('Update Time', 'datetime'), 'Install Originator', 'Installer', 'Code Path', 'Public Flags', 'Private Flags')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/packageInfo.py
+++ b/scripts/artifacts/packageInfo.py
@@ -71,7 +71,7 @@ def get_package_info(files_found, report_folder, seeker, wrap_text):
             xlmstring = (etree.tostring(tree.getroot()).decode())
             doc = xmltodict.parse(xlmstring)
         else:
-            with open(file_found) as fd:
+            with open(file_found, encoding='utf-8', errors='replace') as fd:
                 doc = xmltodict.parse(fd.read())
 
         package_dict = doc.get('packages', {}).get('package', {})

--- a/scripts/artifacts/roles.py
+++ b/scripts/artifacts/roles.py
@@ -1,4 +1,4 @@
-# pylint: disable=E0601,E0606,W0611,W0613
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_roles": {
         "name": "roles",
@@ -10,68 +10,53 @@ __artifacts_v2__ = {
         "category": "App Roles",
         "notes": "",
         "paths": ('*/system/users/*/roles.xml', '*/misc_de/*/apexdata/com.android.permission/roles.xml'),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "package",
-        "function": "get_roles",
     }
 }
 
-import xml.etree.ElementTree as ET 
+import xml.etree.ElementTree as ET
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows
+from scripts.ilapfuncs import artifact_processor, logfunc, is_platform_windows
 
+
+@artifact_processor
 def get_roles(files_found, report_folder, seeker, wrap_text):
-    
-    run = 0
-    slash = '\\' if is_platform_windows() else '/' 
-    
+
+    slash = '\\' if is_platform_windows() else '/'
+    data_list = []
+    source_path = ''
+
     for file_found in files_found:
         file_found = str(file_found)
-        
-        data_list = []
-        run = run + 1
-        err = 0
-        
-        
+
         parts = file_found.split(slash)
+        ver = ''
         if 'mirror' in parts:
-            user = 'mirror'
+            continue
         elif 'users' in parts:
             user = parts[-2]
             ver = 'Android 10'
         elif 'misc_de' in parts:
             user = parts[-4]
             ver = 'Android 11'
-        
-        if user == 'mirror':
-            continue
         else:
-            try:
-                ET.parse(file_found)
-            except ET.ParseError:
-                print('Parse error - Non XML file.') #change to logfunc
-                err = 1
-                
-            if err == 0:
-                tree = ET.parse(file_found)
-                root = tree.getroot()
+            continue
 
-                for elem in root:
-                    holder = ''
-                    role = elem.attrib['name']
-                    for subelem in elem:
-                        holder = subelem.attrib['name']
-                        
-                    data_list.append((role, holder))
-                
-                if len(data_list) > 0:
-                    report = ArtifactHtmlReport('App Roles')
-                    report.start_artifact_report(report_folder, f'{ver} Roles_{user}')
-                    report.add_script()
-                    data_headers = ('Role', 'Holder')
-                    report.write_artifact_data_table(data_headers, data_list, file_found)
-                    report.end_artifact_report()
-                    
-                    tsvname = f'App Roles_{user}'
-                    tsv(report_folder, data_headers, data_list, tsvname)
+        try:
+            tree = ET.parse(file_found)
+        except ET.ParseError:
+            logfunc('Parse error - Non XML file.')
+            continue
+
+        source_path = file_found
+        root = tree.getroot()
+        for elem in root:
+            holder = ''
+            role = elem.attrib['name']
+            for subelem in elem:
+                holder = subelem.attrib['name']
+            data_list.append((ver, user, role, holder))
+
+    data_headers = ('Android Version', 'User', 'Role', 'Holder')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/runtimePerms.py
+++ b/scripts/artifacts/runtimePerms.py
@@ -1,4 +1,4 @@
-# pylint: disable=E0606,W0613
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_runtimePerms": {
         "name": "runtimePerms",
@@ -10,72 +10,52 @@ __artifacts_v2__ = {
         "category": "Permissions",
         "notes": "",
         "paths": ('*/system/users/*/runtime-permissions.xml', '*/misc_de/*/apexdata/com.android.permission/runtime-permissions.xml'),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "activity",
-        "function": "get_runtimePerms",
     }
 }
 
-import xml.etree.ElementTree as ET 
+import xml.etree.ElementTree as ET
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows
+from scripts.ilapfuncs import artifact_processor, logfunc, is_platform_windows
 
+
+@artifact_processor
 def get_runtimePerms(files_found, report_folder, seeker, wrap_text):
-    
-    run = 0
-    slash = '\\' if is_platform_windows() else '/' 
-    
+
+    slash = '\\' if is_platform_windows() else '/'
+    data_list = []
+    source_path = ''
+
     for file_found in files_found:
         file_found = str(file_found)
-        
-        data_list = []
-        run = run + 1
-        err = 0
-        
-        
+
         parts = file_found.split(slash)
         if 'mirror' in parts:
-            user = 'mirror'
+            continue
         elif 'system' in parts:
             user = parts[-2]
         elif 'misc_de' in parts:
             user = parts[-4]
-        
-        if user == 'mirror':
-            continue
         else:
-            try:
-                ET.parse(file_found)
-            except ET.ParseError:
-                logfunc('Parse error - Non XML file.') 
-                err = 1
-                
-            if err == 0:
-                tree = ET.parse(file_found)
-                root = tree.getroot()
+            continue
 
-                for elem in root:
-                    #print(elem.tag)
-                    usagetype = elem.tag
-                    name = elem.attrib['name']
-                    #print("Usage type: "+usagetype)
-                    #print('name')
-                    for subelem in elem:
-                        permission = subelem.attrib['name']
-                        granted = subelem.attrib['granted']
-                        flags = subelem.attrib['flags']
-                        
-                        data_list.append((usagetype, name, permission, granted, flags))
-    
-                if len(data_list) > 0:
-                    report = ArtifactHtmlReport('Runtime Permissions')
-                    report.start_artifact_report(report_folder, f'Runtime Permissions_{user}')
-                    report.add_script()
-                    data_headers = ('Type', 'Name', 'Permission', 'Granted?','Flag')
-                    report.write_artifact_data_table(data_headers, data_list, file_found)
-                    report.end_artifact_report()
-                    
-                    tsvname = f'Runtime Permissions_{user}'
-                    tsv(report_folder, data_headers, data_list, tsvname)
-                
+        try:
+            tree = ET.parse(file_found)
+        except ET.ParseError:
+            logfunc('Parse error - Non XML file.')
+            continue
+
+        source_path = file_found
+        root = tree.getroot()
+        for elem in root:
+            usagetype = elem.tag
+            name = elem.attrib['name']
+            for subelem in elem:
+                permission = subelem.attrib['name']
+                granted = subelem.attrib['granted']
+                flags = subelem.attrib['flags']
+                data_list.append((user, usagetype, name, permission, granted, flags))
+
+    data_headers = ('User', 'Type', 'Name', 'Permission', 'Granted?', 'Flag')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts four Device Info / Installed Apps / Permissions parsers to the LAVA `@artifact_processor` pattern.

- **build** — Key/Value build.prop parser. Fixed a latent bug where Manufacturer was captured but never appended, and removed a dead duplicate `ro.system.build.version.release` branch.
- **packageInfo** — `ReadUnixTimeMs` now returns tz-aware UTC datetimes (epoch anchored with `tzinfo=timezone.utc`); `ft`/`Install Time`/`Update Time` marked `datetime`. Package class retained.
- **roles** — previously emitted one HTML report per user file; now flattened into a single table with `Android Version` and `User` discriminator columns.
- **runtimePerms** — same flattening, with a `User` discriminator column.

Verified: byte-compile, decorated 4-arg signature, returns 3-tuple, output_types valid, loader resolves, no stale `function` keys.