### PR TITLE
Consolidate all Garmin artifacts under a single 'Garmin' category

### DIFF
--- a/scripts/artifacts/GarminActAPI.py
+++ b/scripts/artifacts/GarminActAPI.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2023-02-24",
         "last_update_date": "2023-02-24",
         "requirements": "Python 3.7 or higher, json",
-        "category": "Garmin-API",
+        "category": "Garmin",
         "notes": "",
         "paths": ('*/garmin.api/activities*',),
         "output_types": None,

--- a/scripts/artifacts/GarminActivities.py
+++ b/scripts/artifacts/GarminActivities.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2023-02-24",
         "last_update_date": "2023-02-24",
         "requirements": "Python 3.7 or higher and json",
-        "category": "Garmin-Cache",
+        "category": "Garmin",
         "notes": "",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
         "output_types": None,

--- a/scripts/artifacts/GarminChart.py
+++ b/scripts/artifacts/GarminChart.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2023-02-24",
         "last_update_date": "2023-02-24",
         "requirements": "Python 3.7 or higher",
-        "category": "Garmin-Cache",
+        "category": "Garmin",
         "notes": "",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
         "output_types": None,

--- a/scripts/artifacts/GarminDailies.py
+++ b/scripts/artifacts/GarminDailies.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2023-02-24",
         "last_update_date": "2023-02-24",
         "requirements": "Python 3.7 or higher",
-        "category": "Garmin-Cache",
+        "category": "Garmin",
         "notes": "",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
         "output_types": None,

--- a/scripts/artifacts/GarminDailiesAPI.py
+++ b/scripts/artifacts/GarminDailiesAPI.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2023-02-28",
         "last_update_date": "2023-02-28",
         "requirements": "Python 3.7 or higher, json",
-        "category": "Garmin-API",
+        "category": "Garmin",
         "notes": "",
         "paths": ('*/garmin.api/daily*',),
         "output_types": None,

--- a/scripts/artifacts/GarminFacebook.py
+++ b/scripts/artifacts/GarminFacebook.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2023-02-24",
         "last_update_date": "2023-02-24",
         "requirements": "Python 3.7 or higher, ElementTree, json and datetime, http.client",
-        "category": "Garmin-SharedPrefs",
+        "category": "Garmin",
         "notes": "",
         "paths": ('*/com.garmin.android.apps.connectmobile/shared_prefs/com.facebook*',),
         "output_types": None,

--- a/scripts/artifacts/GarminGcmJsonActivities.py
+++ b/scripts/artifacts/GarminGcmJsonActivities.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2023-02-24",
         "last_update_date": "2023-02-24",
         "requirements": "Python 3.7 or higher and json module",
-        "category": "Garmin-GCM",
+        "category": "Garmin",
         "notes": "",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/gcm_cache.db*',),
         "output_types": None,

--- a/scripts/artifacts/GarminHRAPI.py
+++ b/scripts/artifacts/GarminHRAPI.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2023-02-24",
         "last_update_date": "2023-02-24",
         "requirements": "Python 3.7 or higher, json",
-        "category": "Garmin-API",
+        "category": "Garmin",
         "notes": "",
         "paths": ('*/garmin.api/heart_rate*',),
         "output_types": None,

--- a/scripts/artifacts/GarminJson.py
+++ b/scripts/artifacts/GarminJson.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2023-02-24",
         "last_update_date": "2023-02-24",
         "requirements": "Python 3.7 or higher and json module",
-        "category": "Garmin-GCM",
+        "category": "Garmin",
         "notes": "",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/gcm_cache*',),
         "output_types": None,

--- a/scripts/artifacts/GarminLog.py
+++ b/scripts/artifacts/GarminLog.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2023-02-24",
         "last_update_date": "2023-02-24",
         "requirements": "Python 3.7 or higher",
-        "category": "Garmin-Files",
+        "category": "Garmin",
         "notes": "",
         "paths": ('*/com.garmin.android.apps.connectmobile/files/logs/app.log*',),
         "output_types": None,

--- a/scripts/artifacts/GarminNotifications.py
+++ b/scripts/artifacts/GarminNotifications.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2023-02-24",
         "last_update_date": "2023-02-24",
         "requirements": "Python 3.7 or higher",
-        "category": "Garmin-Notifications",
+        "category": "Garmin",
         "notes": "",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/notification-database*',),
         "output_types": "standard",

--- a/scripts/artifacts/GarminPersistent.py
+++ b/scripts/artifacts/GarminPersistent.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2023-02-24",
         "last_update_date": "2023-02-24",
         "requirements": "Python 3.7 or higher, json and datetime",
-        "category": "Garmin-Files",
+        "category": "Garmin",
         "notes": "",
         "paths": ('*/com.garmin.android.apps.connectmobile/files/PersistedInstallation*',),
         "output_types": ['html', 'tsv', 'lava'],

--- a/scripts/artifacts/GarminPolyAPI.py
+++ b/scripts/artifacts/GarminPolyAPI.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2023-02-24",
         "last_update_date": "2023-02-24",
         "requirements": "Python 3.7 or higher, json and datetime",
-        "category": "Garmin-API",
+        "category": "Garmin",
         "notes": "",
         "paths": ('*/garmin.api/activity_details*',),
         "output_types": None,

--- a/scripts/artifacts/GarminPolyline.py
+++ b/scripts/artifacts/GarminPolyline.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2023-02-24",
         "last_update_date": "2023-02-24",
         "requirements": "Python 3.7 or higher, folium and polyline, datetime",
-        "category": "Garmin-Cache",
+        "category": "Garmin",
         "notes": "",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
         "output_types": None,

--- a/scripts/artifacts/GarminResponse.py
+++ b/scripts/artifacts/GarminResponse.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2023-02-24",
         "last_update_date": "2023-02-24",
         "requirements": "Python 3.7 or higher and json",
-        "category": "Garmin-Cache",
+        "category": "Garmin",
         "notes": "",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
         "output_types": None,

--- a/scripts/artifacts/GarminSPo2.py
+++ b/scripts/artifacts/GarminSPo2.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2023-02-24",
         "last_update_date": "2023-02-24",
         "requirements": "Python 3.7 or higher",
-        "category": "Garmin-Cache",
+        "category": "Garmin",
         "notes": "",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
         "output_types": None,

--- a/scripts/artifacts/GarminSleep.py
+++ b/scripts/artifacts/GarminSleep.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2023-02-24",
         "last_update_date": "2023-02-24",
         "requirements": "Python 3.7 or higher",
-        "category": "Garmin-Cache",
+        "category": "Garmin",
         "notes": "",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
         "output_types": None,

--- a/scripts/artifacts/GarminSleepAPI.py
+++ b/scripts/artifacts/GarminSleepAPI.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2023-02-24",
         "last_update_date": "2023-02-24",
         "requirements": "Python 3.7 or higher, json and datetime",
-        "category": "Garmin-API",
+        "category": "Garmin",
         "notes": "",
         "paths": ('*/garmin.api/sleep*',),
         "output_types": None,

--- a/scripts/artifacts/GarminStepsAPI.py
+++ b/scripts/artifacts/GarminStepsAPI.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2023-02-24",
         "last_update_date": "2023-02-24",
         "requirements": "Python 3.7 or higher, json",
-        "category": "Garmin-API",
+        "category": "Garmin",
         "notes": "",
         "paths": ('*/garmin.api/steps*',),
         "output_types": None,

--- a/scripts/artifacts/GarminStressAPI.py
+++ b/scripts/artifacts/GarminStressAPI.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2023-02-24",
         "last_update_date": "2023-02-24",
         "requirements": "Python 3.7 or higher, json and datetime",
-        "category": "Garmin-API",
+        "category": "Garmin",
         "notes": "",
         "paths": ('*/garmin.api/stress*',),
         "output_types": None,

--- a/scripts/artifacts/GarminSync.py
+++ b/scripts/artifacts/GarminSync.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2023-02-24",
         "last_update_date": "2023-02-24",
         "requirements": "Python 3.7 or higher",
-        "category": "Garmin-Sync",
+        "category": "Garmin",
         "notes": "",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/sync_cache*',),
         "output_types": "standard",

--- a/scripts/artifacts/GarminUser.py
+++ b/scripts/artifacts/GarminUser.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2023-02-24",
         "last_update_date": "2023-02-24",
         "requirements": "Python 3.7 or higher and ElementTree",
-        "category": "Garmin-SharedPrefs",
+        "category": "Garmin",
         "notes": "",
         "paths": ('*/com.garmin.android.apps.connectmobile/shared_prefs/gcm_user_preferences*',),
         "output_types": ['html', 'tsv', 'lava'],

--- a/scripts/artifacts/GarminWeight.py
+++ b/scripts/artifacts/GarminWeight.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2023-02-24",
         "last_update_date": "2023-02-24",
         "requirements": "Python 3.7 or higher",
-        "category": "Garmin-Cache",
+        "category": "Garmin",
         "notes": "",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
         "output_types": None,


### PR DESCRIPTION
Per request: groups every `Garmin*` artifact under one **Garmin** category instead of being spread across 7 sub-categories (Garmin-API, Garmin-Cache, Garmin-GCM, Garmin-Files, Garmin-SharedPrefs, Garmin-Notifications, Garmin-Sync).

23 files updated — category value only, no logic changes.