### PR TITLE
Consolidate Kijiji and Google Maps voice guidance categories

### DIFF
--- a/scripts/artifacts/googlemapaudioTemp.py
+++ b/scripts/artifacts/googlemapaudioTemp.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2023-04-27",
         "last_update_date": "2023-04-27",
         "requirements": "none",
-        "category": "Google Maps Temp Voice Guidance",
+        "category": "Google Maps Voice Guidance",
         "notes": "",
         "paths": ('*/com.google.android.apps.maps/app_tts-temp/**',),
         "output_types": None,

--- a/scripts/artifacts/kijijiConversations.py
+++ b/scripts/artifacts/kijijiConversations.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2022-05-13",
         "last_update_date": "2022-05-13",
         "requirements": "None",
-        "category": "Kijiji Conversations",
+        "category": "Kijiji",
         "notes": "",
         "paths": ('*/com.ebay.kijiji.ca/databases/messageBoxDatabase.*',),
         "output_types": None,

--- a/scripts/artifacts/kijijiLocalUserInfo.py
+++ b/scripts/artifacts/kijijiLocalUserInfo.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2022-05-13",
         "last_update_date": "2022-05-13",
         "requirements": "None",
-        "category": "Kijiji Local User Information",
+        "category": "Kijiji",
         "notes": "",
         "paths": ('*/com.ebay.kijiji.ca/shared_prefs/LoginData.xml',),
         "output_types": None,

--- a/scripts/artifacts/kijijiRecentSearches.py
+++ b/scripts/artifacts/kijijiRecentSearches.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
         "creation_date": "2022-05-13",
         "last_update_date": "2022-05-13",
         "requirements": "None",
-        "category": "Kijiji Recent Searches",
+        "category": "Kijiji",
         "notes": "",
         "paths": ('*/com.ebay.kijiji.ca/databases/searches.*',),
         "output_types": None,


### PR DESCRIPTION
Follow-up to the Garmin consolidation: groups single-app artifacts that were split across categories.

- **Kijiji** — 'Kijiji Conversations', 'Kijiji Local User Information', 'Kijiji Recent Searches' → single **Kijiji** category (3 files).
- **Google Maps voice** — 'Google Maps Temp Voice Guidance' merged into **Google Maps Voice Guidance** (1 file).

Category value only, no logic changes.