### PR TITLE
Convert settingsSecure, suggestions, pkgPredictions, smanager* to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/pkgPredictions.py
+++ b/scripts/artifacts/pkgPredictions.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0631,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_pkgPredictions": {
         "name": "pkgPredictions",
@@ -10,91 +10,68 @@ __artifacts_v2__ = {
         "category": "Package Predictions",
         "notes": "",
         "paths": ('*/system/PkgPredictions.db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "package",
-        "function": "get_pkgPredictions",
     }
 }
 
-# Package Predictions - Parses Samsung package prediction details
-# Author:  Kevin Pagano (https://startme.stark4n6.com)
-# Date 2023-05-01
-# Version: 0.1
-# Requirements:  None
+import datetime
 
-import sqlite3
-import textwrap
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, kmlgen
 
+@artifact_processor
 def get_pkgPredictions(files_found, report_folder, seeker, wrap_text):
-    
+
+    source_path = ''
     for file_found in files_found:
-        file_found = str(file_found)  
+        file_found = str(file_found)
         if file_found.endswith('PkgPredictions.db'):
+            source_path = file_found
             break
-        else:
-            continue # Skip all other files
-            
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    cursor.execute('''
-    select
-    datetime(launch_time/1000,'unixepoch') as "Launch Timestamp",
-    running_pkg,
-    apk_version,
-    activity_name,
-    previous_one,
-    previous_two,
-    previous_three,
-    case screen_orientation
-        when 0 then 'Vertical'
-        when 1 then 'Horizontal'
-    end as "Screen Orientation",
-    wifi_status,
-    bt_status,
-    hour_of_day,
-    case day_of_week
-        when 1 then 'Sunday'
-        when 2 then 'Monday'
-        when 3 then 'Tuesday'
-        when 4 then 'Wednesday'
-        when 5 then 'Thursday'
-        when 6 then 'Friday'
-        when 7 then 'Saturday'
-    end as "Day of Week",
-    prediction,
-    predict_time,
-    user_id,
-    id
-    from tbl_Sample
-    ''')
-    
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Package Predictions')
-        report.start_artifact_report(report_folder, 'Package Predictions')
-        report.add_script()
-        data_headers = ('Launch Timestamp','Running Package','APK Version','Activity Name','Previous Launch (1)','Previous Launch (2)','Previous Launch (3)','Screen Orientation','Wifi Status','Bluetooth Status','Hour of Launch (Local)','Day of Launch','Prediction','Predict Time','User ID','ID')
-        
-        data_list = []
+
+    data_list = []
+    if source_path:
+        db = open_sqlite_db_readonly(source_path)
+        cursor = db.cursor()
+        cursor.execute('''
+        select
+        launch_time,
+        running_pkg,
+        apk_version,
+        activity_name,
+        previous_one,
+        previous_two,
+        previous_three,
+        case screen_orientation
+            when 0 then 'Vertical'
+            when 1 then 'Horizontal'
+        end as "Screen Orientation",
+        wifi_status,
+        bt_status,
+        hour_of_day,
+        case day_of_week
+            when 1 then 'Sunday'
+            when 2 then 'Monday'
+            when 3 then 'Tuesday'
+            when 4 then 'Wednesday'
+            when 5 then 'Thursday'
+            when 6 then 'Friday'
+            when 7 then 'Saturday'
+        end as "Day of Week",
+        prediction,
+        predict_time,
+        user_id,
+        id
+        from tbl_Sample
+        ''')
+        all_rows = cursor.fetchall()
+        db.close()
+
         for row in all_rows:
-            predictions = row[12].replace('0_&_','').replace(';','\n')
-        
-            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11],predictions,row[13],row[14],row[15]))
-            
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Package Predictions'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Package Predictions'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-    else:
-        logfunc('No Package Predictions data available')
-                
-    db.close()
+            launch_ts = datetime.datetime.fromtimestamp(int(row[0]) / 1000, datetime.timezone.utc) if row[0] else ''
+            predictions = row[12].replace('0_&_', '').replace(';', '\n') if row[12] else row[12]
+            data_list.append((launch_ts, row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11], predictions, row[13], row[14], row[15]))
+
+    data_headers = (('Launch Timestamp', 'datetime'), 'Running Package', 'APK Version', 'Activity Name', 'Previous Launch (1)', 'Previous Launch (2)', 'Previous Launch (3)', 'Screen Orientation', 'Wifi Status', 'Bluetooth Status', 'Hour of Launch (Local)', 'Day of Launch', 'Prediction', 'Predict Time', 'User ID', 'ID')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/settingsSecure.py
+++ b/scripts/artifacts/settingsSecure.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0311,W0611,W0612,W0613,W1309,W1514
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_settingsSecure": {
         "name": "settingsSecure",
@@ -10,78 +10,60 @@ __artifacts_v2__ = {
         "category": "Device Info",
         "notes": "",
         "paths": ('*/system/users/*/settings_secure.xml',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "settings",
-        "function": "get_settingsSecure",
     }
 }
 
-import glob
-import json
-import os
 import re
 import xml.etree.ElementTree as ET
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, logdevinfo, is_platform_windows, abxread, checkabx
+from scripts.ilapfuncs import artifact_processor, logdevinfo, is_platform_windows, abxread, checkabx
 
+
+@artifact_processor
 def get_settingsSecure(files_found, report_folder, seeker, wrap_text):
 
-    slash = '\\' if is_platform_windows() else '/' 
-    # Filter for path xxx/yyy/system_ce/0
+    slash = '\\' if is_platform_windows() else '/'
+    data_list = []
+    source_path = ''
+
     for file_found in files_found:
         file_found = str(file_found)
         parts = file_found.split(slash)
         uid = parts[-2]
         try:
-            uid_int = int(uid)
-            # Skip sbin/.magisk/mirror/data/system_de/0 , it should be duplicate data??
-            if file_found.find('{0}mirror{0}'.format(slash)) >= 0:
-                continue
-            process_ssecure(file_found, uid, report_folder)
+            int(uid)
         except ValueError:
-                pass # uid was not a number
+            continue  # uid was not a number
+        if file_found.find('{0}mirror{0}'.format(slash)) >= 0:
+            continue  # Skip mirror, it should be duplicate data
 
-def process_ssecure(file_path, uid, report_folder):
-     
-    if (checkabx(file_path)):
-        multi_root = True
-        tree = abxread(file_path, multi_root)
-        root = tree.getroot()
-    else:
-        try:
-            tree = ET.parse(file_path)
-            root = tree.getroot()
-        except ET.ParseError: # Fix for android 11 invalid XML file (no root element present)
-            with open(file_path) as f:
-                xml = f.read()
-                root = ET.fromstring(re.sub(r"(<\?xml[^>]+\?>)", r"\1<root>", xml) + "</root>")
-    
-    data_list = []
-    for setting in root.iter('setting'):
-        nme = setting.get('name')
-        val = setting.get('value')
-        if nme == 'bluetooth_name':
-            data_list.append((nme, val))
-            logdevinfo(f"<b>Bluetooth name: </b>{val}")
-        elif nme == 'mock_location':
-            data_list.append((nme, val))
-        elif nme == 'android_id':
-            data_list.append((nme, val))
-        elif nme == 'bluetooth_address':
-            data_list.append((nme, val))
-            logdevinfo(f"<b>Bluetooth address: </b>{val}")
-     
-    if len(data_list) > 0:
-        report = ArtifactHtmlReport('Settings Secure')
-        report.start_artifact_report(report_folder, f'Settings_Secure_{uid}')
-        report.add_script()
-        data_headers = ('Name', 'Value')
-        report.write_artifact_data_table(data_headers, data_list, file_path)
-        report.end_artifact_report()
-        
-        tsvname = f'settings secure'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc('No Settings Secure data available')
-        
+        if (checkabx(file_found)):
+            multi_root = True
+            root = abxread(file_found, multi_root).getroot()
+        else:
+            try:
+                root = ET.parse(file_found).getroot()
+            except ET.ParseError:  # Fix for android 11 invalid XML file (no root element present)
+                with open(file_found, encoding='utf-8', errors='replace') as f:
+                    xml = f.read()
+                    root = ET.fromstring(re.sub(r"(<\?xml[^>]+\?>)", r"\1<root>", xml) + "</root>")
+
+        source_path = file_found
+        for setting in root.iter('setting'):
+            nme = setting.get('name')
+            val = setting.get('value')
+            if nme == 'bluetooth_name':
+                data_list.append((uid, nme, val))
+                logdevinfo(f"<b>Bluetooth name: </b>{val}")
+            elif nme == 'mock_location':
+                data_list.append((uid, nme, val))
+            elif nme == 'android_id':
+                data_list.append((uid, nme, val))
+            elif nme == 'bluetooth_address':
+                data_list.append((uid, nme, val))
+                logdevinfo(f"<b>Bluetooth address: </b>{val}")
+
+    data_headers = ('User', 'Name', 'Value')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/smanagerCrash.py
+++ b/scripts/artifacts/smanagerCrash.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_smanagerCrash": {
         "name": "smanagerCrash",
@@ -10,50 +10,33 @@ __artifacts_v2__ = {
         "category": "App Interaction",
         "notes": "",
         "paths": ('*/com.samsung.android.sm/databases/sm.db',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "package",
-        "function": "get_smanagerCrash",
     }
 }
 
-import sqlite3
-import textwrap
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_smanagerCrash(files_found, report_folder, seeker, wrap_text):
-    
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
+
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     cursor.execute('''
-    SELECT
-    datetime(crash_time / 1000, "unixepoch"),
-    package_name
-    from crash_info
+        SELECT crash_time, package_name
+        FROM crash_info
     ''')
-
     all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Samsung Smart Manager - Crash')
-        report.start_artifact_report(report_folder, 'Samsung Smart Manager - Crash')
-        report.add_script()
-        data_headers = ('Timestamp','Package Name')
-        data_list = []
-        for row in all_rows:
-            data_list.append((row[0],row[1]))
-
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'samsung smart manager - crash'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Samsung Smart Manager - Crash'
-        timeline(report_folder, tlactivity, data_list, data_headers) 
-    else:
-        logfunc('No Samsung Smart Manager - Crash data available')
-    
     db.close()
+
+    data_list = []
+    for row in all_rows:
+        timestamp = datetime.datetime.fromtimestamp(int(row[0]) / 1000, datetime.timezone.utc) if row[0] else ''
+        data_list.append((timestamp, row[1]))
+
+    data_headers = (('Timestamp', 'datetime'), 'Package Name')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/smanagerLow.py
+++ b/scripts/artifacts/smanagerLow.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_smanagerLow": {
         "name": "smanagerLow",
@@ -10,55 +10,38 @@ __artifacts_v2__ = {
         "category": "App Interaction",
         "notes": "",
         "paths": ('*/com.samsung.android.sm/databases/lowpowercontext-system-db',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "package",
-        "function": "get_smanagerLow",
     }
 }
 
-import sqlite3
-import textwrap
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+def _ms_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    return ''
+
+
+@artifact_processor
 def get_smanagerLow(files_found, report_folder, seeker, wrap_text):
-    
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
+
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     cursor.execute('''
-    SELECT 
-    datetime(start_time /1000, "unixepoch"),
-    datetime(end_time /1000, "unixepoch"),
-    id,
-    package_name,
-    uploaded,
-    datetime(created_at /1000, "unixepoch"),
-    datetime(modified_at /1000, "unixepoch")
-    from usage_log
+        SELECT start_time, end_time, id, package_name, uploaded, created_at, modified_at
+        FROM usage_log
     ''')
-
     all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Samsung Smart Manager - Usage')
-        report.start_artifact_report(report_folder, 'Samsung Smart Manager - Usage')
-        report.add_script()
-        data_headers = ('Start Time','End Time','ID','Package Name', 'Uploaded?', 'Created', 'Modified' )
-        data_list = []
-        for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
-
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'samsung smart manager - usage'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Samsung Smart Manager - Usage'
-        timeline(report_folder, tlactivity, data_list, data_headers) 
-    else:
-        logfunc('No Samsung Smart Manager - Usage data available')
-    
     db.close()
+
+    data_list = []
+    for row in all_rows:
+        data_list.append((_ms_to_utc(row[0]), _ms_to_utc(row[1]), row[2], row[3], row[4], _ms_to_utc(row[5]), _ms_to_utc(row[6])))
+
+    data_headers = (('Start Time', 'datetime'), ('End Time', 'datetime'), 'ID', 'Package Name', 'Uploaded?', ('Created', 'datetime'), ('Modified', 'datetime'))
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/suggestions.py
+++ b/scripts/artifacts/suggestions.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_suggestions": {
         "name": "suggestions",
@@ -10,53 +10,40 @@ __artifacts_v2__ = {
         "category": "Wipe & Setup",
         "notes": "",
         "paths": ('*/com.google.android.settings.intelligence/shared_prefs/suggestions.xml',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "clock",
-        "function": "get_suggestions",
     }
 }
 
-import os
 import datetime
 import xml.etree.ElementTree as ET
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
 
+from scripts.ilapfuncs import artifact_processor
+
+SETUP_TIME_KEYS = (
+    'com.android.settings.suggested.category.DEFERRED_SETUP_setup_time',
+    'com.android.settings/com.android.settings.biometrics.fingerprint.FingerprintEnrollSuggestionActivity_setup_time',
+    'com.google.android.setupwizard/com.google.android.setupwizard.deferred.DeferredSettingsSuggestionActivity_setup_time',
+)
+
+
+@artifact_processor
 def get_suggestions(files_found, report_folder, seeker, wrap_text):
 
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('suggestions.xml'):
-            continue # Skip all other files
-        
-        data_list = []
-        tree = ET.parse(file_found)
-        root = tree.getroot()
-        
+            continue  # Skip all other files
+
+        source_path = file_found
+        root = ET.parse(file_found).getroot()
         for elem in root:
             item = elem.attrib
-            if item['name'] == 'com.android.settings.suggested.category.DEFERRED_SETUP_setup_time':
-                timestamp = (datetime.datetime.utcfromtimestamp(int(item['value'])/1000).strftime('%Y-%m-%d %H:%M:%S'))
+            if item['name'] in SETUP_TIME_KEYS:
+                timestamp = datetime.datetime.fromtimestamp(int(item['value']) / 1000, datetime.timezone.utc)
                 data_list.append((timestamp, item['name']))
-            if item['name'] == 'com.android.settings/com.android.settings.biometrics.fingerprint.FingerprintEnrollSuggestionActivity_setup_time':
-                timestamp = (datetime.datetime.utcfromtimestamp(int(item['value'])/1000).strftime('%Y-%m-%d %H:%M:%S'))
-                data_list.append((timestamp, item['name']))
-            if item['name'] == 'com.google.android.setupwizard/com.google.android.setupwizard.deferred.DeferredSettingsSuggestionActivity_setup_time':
-                timestamp = (datetime.datetime.utcfromtimestamp(int(item['value'])/1000).strftime('%Y-%m-%d %H:%M:%S'))
-                data_list.append((timestamp, item['name']))
-        
-        if data_list:
-            report = ArtifactHtmlReport('Suggestions.xml')
-            report.start_artifact_report(report_folder, 'Suggestions.xml')
-            report.add_script()
-            data_headers = ('Timestamp','Name')
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Suggestions XML data'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Suggestions XML data'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Suggestions XML data available')
+
+    data_headers = (('Timestamp', 'datetime'), 'Name')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts five more parsers to the LAVA `@artifact_processor` pattern.

- **settingsSecure** — previously emitted one report per user file; flattened into a single table with a `User` discriminator column. Kept the ABX + Android-11 invalid-XML fallback; added `encoding` to the fallback `open()`.
- **suggestions** — setup-time keys converted from epoch-ms to aware UTC (`fromtimestamp(ms/1000, timezone.utc)`, replacing `utcfromtimestamp`); `Timestamp` marked `datetime`.
- **pkgPredictions** — `launch_time` now selected raw and converted to aware UTC; `Launch Timestamp` marked `datetime`. Dropped unused `kmlgen`/`textwrap` imports.
- **smanagerCrash** — `crash_time` raw → aware UTC; `Timestamp` marked `datetime`.
- **smanagerLow** — `start/end/created/modified` raw → aware UTC; all four marked `datetime`.

All SQL `datetime(col/1000,'unixepoch')` strings (which are naive UTC and would shift in LAVA) replaced with raw epochs + Python aware-UTC conversion.

Verified: byte-compile, decorated 4-arg signature, returns 3-tuple, output_types valid, loader resolves, pylint (W1514/unused/errors) clean.