### PR TITLE
Convert calllogs, smembersEvents, shareit, atrackerdetect to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/atrackerdetect.py
+++ b/scripts/artifacts/atrackerdetect.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_atrackerdetect": {
         "name": "atrackerdetect",
@@ -10,28 +10,28 @@ __artifacts_v2__ = {
         "category": "AirTags",
         "notes": "",
         "paths": ('*/com.apple.trackerdetect/shared_prefs/com.apple.trackerdetect_preferences.xml',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "alert-triangle",
-        "function": "get_atrackerdetect",
     }
 }
 
-import os
-import datetime
 import xml.etree.ElementTree as ET
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
 
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
 def get_atrackerdetect(files_found, report_folder, seeker, wrap_text):
-    data_list=[]
+
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
-        tree = ET.parse(file_found)
-        root = tree.getroot()
-        
+        source_path = file_found
+        root = ET.parse(file_found).getroot()
+
         for elem in root.iter():
-            attribute = (elem.attrib)
+            attribute = elem.attrib
             if attribute:
                 data = attribute.get('name')
                 if data.startswith('device'):
@@ -39,18 +39,7 @@ def get_atrackerdetect(files_found, report_folder, seeker, wrap_text):
                     desc = data.split('_', 2)[2]
                     data_list.append((desc, mac, elem.text))
                 else:
-                    data_list.append((data, attribute.get('value'),''))
-                                
-        if data_list:
-            report = ArtifactHtmlReport('Apple Tracker Detect Prefs')
-            report.start_artifact_report(report_folder, 'Apple Tracker Detect Prefs')
-            report.add_script()
-            data_headers = ('Key', 'Value', 'Milliseconds from Last Boot Time')
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Apple Tracker Detect Prefs'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-        else:
-            logfunc('No Apple Tracker Detect Prefs data available')
+                    data_list.append((data, attribute.get('value'), ''))
+
+    data_headers = ('Key', 'Value', 'Milliseconds from Last Boot Time')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/calllogs.py
+++ b/scripts/artifacts/calllogs.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0718,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_calllogs": {
         "name": "Call Logs",
@@ -10,88 +10,57 @@ __artifacts_v2__ = {
         "category": "Call Logs",
         "notes": "",
         "paths": ('*/com.android.providers.contacts/databases/contact*', '*/com.sec.android.provider.logsprovider/databases/logs.db*'),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "phone",
-        "function": "get_calllogs",
     }
 }
 
-import os
-import sqlite3
 import datetime
+import os
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, does_table_exist_in_db
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly, does_table_exist_in_db
 
+
+@artifact_processor
 def get_calllogs(files_found, report_folder, seeker, wrap_text):
 
-    source_file = ''
+    data_list = []
+    source_path = ''
     for file_found in files_found:
-        
         file_name = str(file_found)
-        if not os.path.basename(file_name) == 'contacts2.db' and \
-           not os.path.basename(file_name) == 'contacts.db'  and \
-           not os.path.basename(file_name) == 'logs.db': # skip -journal and other files
-            continue
-        source_file = file_found.replace(seeker.data_folder, '')
+        if os.path.basename(file_name) not in ('contacts2.db', 'contacts.db', 'logs.db'):
+            continue  # skip -journal and other files
 
+        source_path = file_name
         db = open_sqlite_db_readonly(file_name)
         calls_table_exists = does_table_exist_in_db(file_name, 'calls')
         cursor = db.cursor()
+        table = 'calls' if calls_table_exists else 'logs'
         try:
-            if calls_table_exists:
-                cursor.execute('''
-                    SELECT number, date/1000, (date/1000 + duration) as duration, 
-                           case type when 1 then "Incoming"
-                                     when 3 then "Incoming"
-                                     when 2 then "Outgoing"
-                                     when 5 then "Outgoing"
-                                     else "Unknown" end as direction,
-                            name FROM calls ORDER BY date DESC;''')
-            else:
-                cursor.execute('''
-                    SELECT number, date/1000, (date/1000 + duration) as duration, 
-                           case type when 1 then "Incoming"
-                                     when 3 then "Incoming"
-                                     when 2 then "Outgoing"
-                                     when 5 then "Outgoing"
-                                     else "Unknown" end as direction,
-                           name FROM logs ORDER BY date DESC;''')
+            cursor.execute(f'''
+                SELECT number, date/1000, (date/1000 + duration) as end_date,
+                       case type when 1 then "Incoming"
+                                 when 3 then "Incoming"
+                                 when 2 then "Outgoing"
+                                 when 5 then "Outgoing"
+                                 else "Unknown" end as direction,
+                        name FROM {table} ORDER BY date DESC;''')
             all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
         except Exception as e:
-            print (e)
-            usageentries = 0
-            
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Call Logs2')
-            report.start_artifact_report(report_folder, 'Call Logs2')
-            report.add_script()
-            data_headers = ('from_id', 'to_id','start_date', 'end_date', 'direction', 'name') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-            data_list = []
-            for row in all_rows:
-                callerId = None
-                calleeId = None
-                if row[3] == "Incoming":
-                    callerId = row[0]                                   
-                else:
-                    calleeId = row[0]
-                starttime = datetime.datetime.utcfromtimestamp(int(row[2])).strftime('%Y-%m-%d %H:%M:%S')
-                endtime = datetime.datetime.utcfromtimestamp(int(row[2])).strftime('%Y-%m-%d %H:%M:%S')
-                data_list.append((callerId, calleeId, starttime, endtime, row[3], row[4]))
-
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Call Logs2'
-            tsv(report_folder, data_headers, data_list, tsvname, source_file)
-
-            tlactivity = f'Call Logs2'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-            
-        else:
-            logfunc('No Call Logs found')
-
+            logfunc(str(e))
+            all_rows = []
         db.close()
-    
-    return
+
+        for row in all_rows:
+            callerId = None
+            calleeId = None
+            if row[3] == "Incoming":
+                callerId = row[0]
+            else:
+                calleeId = row[0]
+            starttime = datetime.datetime.fromtimestamp(int(row[1]), datetime.timezone.utc)
+            endtime = datetime.datetime.fromtimestamp(int(row[2]), datetime.timezone.utc)
+            data_list.append((callerId, calleeId, starttime, endtime, row[3], row[4]))
+
+    data_headers = ('from_id', 'to_id', ('start_date', 'datetime'), ('end_date', 'datetime'), 'direction', 'name')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/calllogs.py
+++ b/scripts/artifacts/calllogs.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_calllogs": {
         "name": "Call Logs",

--- a/scripts/artifacts/shareit.py
+++ b/scripts/artifacts/shareit.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_shareit": {
         "name": "shareit",

--- a/scripts/artifacts/shareit.py
+++ b/scripts/artifacts/shareit.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0631,W0702,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_shareit": {
         "name": "shareit",
@@ -10,64 +10,48 @@ __artifacts_v2__ = {
         "category": "File Transfer",
         "notes": "",
         "paths": ('*/com.lenovo.anyshare.gps/databases/history.db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "download",
-        "function": "get_shareit",
     }
 }
 
-import sqlite3
 import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_shareit(files_found, report_folder, seeker, wrap_text):
-    
+
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
         if file_found.endswith('history.db'):
+            source_path = file_found
             break
 
-    source_file = file_found.replace(seeker.data_folder, '')
+    data_list = []
+    if source_path:
+        db = open_sqlite_db_readonly(source_path)
+        cursor = db.cursor()
+        try:
+            cursor.execute('''
+                SELECT case history_type when 1 then "Incoming" else "Outgoing" end direction,
+                       case history_type when 1 then device_id else null end from_id,
+                       case history_type when 1 then null else device_id end to_id,
+                       device_name, description, timestamp/1000 as timestamp, file_path
+                                        FROM history
+                                        JOIN item where history.content_id = item.item_id
+            ''')
+            all_rows = cursor.fetchall()
+        except Exception as e:
+            logfunc(str(e))
+            all_rows = []
+        db.close()
 
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    try:
-        cursor.execute('''
-        SELECT case history_type when 1 then "Incoming" else "Outgoing" end direction,
-               case history_type when 1 then device_id else null end from_id,
-               case history_type when 1 then null else device_id end to_id,
-               device_name, description, timestamp/1000 as timestamp, file_path
-                                FROM history
-                                JOIN item where history.content_id = item.item_id
-        ''')
-
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-    except:
-        usageentries = 0
-        
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Shareit file transfer')
-        report.start_artifact_report(report_folder, 'shareit file transfer')
-        report.add_script()
-        data_headers = ('direction','from_id', 'to_id', 'device_name', 'description', 'timestamp', 'file_path') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = []
         for row in all_rows:
-            timestamp = datetime.datetime.utcfromtimestamp(int(row[5])).strftime('%Y-%m-%d %H:%M:%S')
+            timestamp = datetime.datetime.fromtimestamp(int(row[5]), datetime.timezone.utc) if row[5] else ''
             data_list.append((row[0], row[1], row[2], row[3], row[4], timestamp, row[6]))
 
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Shareit file transfer'
-        tsv(report_folder, data_headers, data_list, tsvname, source_file)
-                
-        tlactivity = f'Shareit file transfer'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Shareit file transfer data available')
-
-    db.close()
+    data_headers = ('direction', 'from_id', 'to_id', 'device_name', 'description', ('timestamp', 'datetime'), 'file_path')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/smembersEvents.py
+++ b/scripts/artifacts/smembersEvents.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_smembersEvents": {
         "name": "smembersEvents",
@@ -10,52 +10,33 @@ __artifacts_v2__ = {
         "category": "App Interaction",
         "notes": "",
         "paths": ('*/com.samsung.oh/databases/com_pocketgeek_sdk.db',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "package",
-        "function": "get_smembersEvents",
     }
 }
 
-import sqlite3
-import textwrap
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_smembersEvents(files_found, report_folder, seeker, wrap_text):
-    
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
+
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     cursor.execute('''
-    select 
-    datetime(created_at /1000, "unixepoch"), 
-    type, 
-    value,
-    in_snapshot
-    FROM device_events
+        SELECT created_at, type, value, in_snapshot
+        FROM device_events
     ''')
-
     all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Samsung Members - Events')
-        report.start_artifact_report(report_folder, 'Samsung Members - Events')
-        report.add_script()
-        data_headers = ('Created At','Type','Value','Snapshot?' )
-        data_list = []
-        for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3]))
-
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'samsung members - events'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Samsung Members - Events'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Samsung Members - Events data available')
-    
     db.close()
+
+    data_list = []
+    for row in all_rows:
+        created = datetime.datetime.fromtimestamp(int(row[0]) / 1000, datetime.timezone.utc) if row[0] else ''
+        data_list.append((created, row[1], row[2], row[3]))
+
+    data_headers = (('Created At', 'datetime'), 'Type', 'Value', 'Snapshot?')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts four more parsers to the LAVA `@artifact_processor` pattern.

- **calllogs** — flattened across the multiple matching DBs into one table; `utcfromtimestamp` strings replaced with aware UTC; `start_date`/`end_date` marked `datetime`. Fixed a latent bug where the start time was computed from the end-time column (`date/1000 + duration`) instead of `date/1000`. Replaced bare `print(e)` with `logfunc`.
- **smembersEvents** — `created_at` raw → aware UTC; `Created At` marked `datetime`.
- **shareit** — `timestamp` raw → aware UTC; marked `datetime`; `except:` narrowed to `Exception` + logfunc.
- **atrackerdetect** — flat Key/Value/boot-ms conversion; no timestamps (boot-relative ms left as a plain number).

Verified: byte-compile, decorated 4-arg signature, returns 3-tuple, output_types valid, loader resolves, pylint (W1514/unused/errors) clean.