### PR TITLE
Convert vlcMedia, libretorrent, libretorrentFR, torrentData to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/libretorrent.py
+++ b/scripts/artifacts/libretorrent.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0612,W0613,W0631,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_libretorrent": {
         "name": "Libretorrent",
@@ -10,64 +10,40 @@ __artifacts_v2__ = {
         "category": "Libre Torrent",
         "notes": "",
         "paths": ('*/data/com.houseoflife.bitlord/databases/libretorrent.db*', '*/libretorrent.db*'),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "download",
-        "function": "get_libretorrent",
     }
 }
 
-import sqlite3
-import textwrap
-from datetime import datetime
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, kmlgen
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_libretorrent(files_found, report_folder, seeker, wrap_text):
-    
+
+    source_path = ''
     for file_found in files_found:
-        file_name = str(file_found)
+        file_found = str(file_found)
         if file_found.endswith('libretorrent.db'):
-            break # Skip all other files
-    
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    cursor.execute('''
-    SELECT
-        id,
-        name,
-        downloadPath,
-        dateAdded,
-        error,
-        manuallyPaused,
-        magnet,
-        downloadingMetadata,
-        visibility
-        FROM Torrent
-    ''')
-    
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Libre Torrent - Torrents')
-        report.start_artifact_report(report_folder, 'Libre Torrent - Torrents')
-        report.add_script()
-        data_headers = ('Timestamp','ID','Name','Download Path','Error','Manually Paused','Magnet','Downloading Metadata','Visibility')
-        data_list = []
+            source_path = file_found
+            break
+
+    data_list = []
+    if source_path:
+        db = open_sqlite_db_readonly(source_path)
+        cursor = db.cursor()
+        cursor.execute('''
+            SELECT id, name, downloadPath, dateAdded, error, manuallyPaused, magnet, downloadingMetadata, visibility
+            FROM Torrent
+        ''')
+        all_rows = cursor.fetchall()
+        db.close()
+
         for row in all_rows:
-            timestamp = datetime.utcfromtimestamp(row[3]/1000)
-            data_list.append((timestamp,row[0],row[1],row[2],row[4],row[5],row[6],row[7],row[8]))
-        
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Libre Torrent - Torrents'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Libre Torrent - Torrents'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-    else:
-        logfunc('No Libre Torrents data available')
-        
-    db.close()
+            timestamp = datetime.datetime.fromtimestamp(row[3] / 1000, datetime.timezone.utc) if row[3] else ''
+            data_list.append((timestamp, row[0], row[1], row[2], row[4], row[5], row[6], row[7], row[8]))
+
+    data_headers = (('Timestamp', 'datetime'), 'ID', 'Name', 'Download Path', 'Error', 'Manually Paused', 'Magnet', 'Downloading Metadata', 'Visibility')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/libretorrentFR.py
+++ b/scripts/artifacts/libretorrentFR.py
@@ -1,4 +1,4 @@
-# pylint: disable=E0606,W0107,W0127,W0611,W0612,W0613,W0631,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_libretorrentFR": {
         "name": "LibretorrentFR",
@@ -10,84 +10,55 @@ __artifacts_v2__ = {
         "category": "Libre Torrent",
         "notes": "",
         "paths": ('*/data/com.houseoflife.bitlord/databases/libretorrent.db*', '*/libretorrent.db*'),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "download",
-        "function": "get_libretorrentFR",
+        "html_columns": ['Length - Path', 'Key - Value'],
     }
 }
 
-import sqlite3
-import textwrap
 import bencoding
-from datetime import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, kmlgen
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_libretorrentFR(files_found, report_folder, seeker, wrap_text):
-    
+
+    source_path = ''
     for file_found in files_found:
-        file_name = str(file_found)
+        file_found = str(file_found)
         if file_found.endswith('libretorrent.db'):
-            break # Skip all other files
-    
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    cursor.execute('''
-    SELECT
-    * from FastResume
-    ''')
-    
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        data_list = []
-        
+            source_path = file_found
+            break
+
+    data_list = []
+    if source_path:
+        db = open_sqlite_db_readonly(source_path)
+        cursor = db.cursor()
+        cursor.execute('SELECT * from FastResume')
+        all_rows = cursor.fetchall()
+        db.close()
+
         for row in all_rows:
-            pass
             torrentihash = row[0]
             encoded_data = row[1]
             decodedDict = bencoding.bdecode(encoded_data)
-            
-            torrentihas = torrentname = spath = iname = tdown = tup = aggf = agg = ''
-            for key,value in decodedDict.items():
-                #print(key,value)
+
+            torrentname = spath = iname = tdown = tup = aggf = agg = ''
+            for key, value in decodedDict.items():
                 if key == b'info':
                     for ikey, ivalue in value.items():
-                        if ikey == b'piece length':
-                            pass
                         if ikey == b'name':
-                            torrentname = (ivalue.decode())
+                            torrentname = ivalue.decode()
                         if ikey == b'files':
                             for files in ivalue:
+                                lenghtf = pathf = ''
                                 for iikey, iivalue in files.items():
                                     if iikey == b'length':
-                                        lenghtf = (iivalue)
+                                        lenghtf = iivalue
                                     if iikey == b'path':
-                                        pathf = (iivalue[0].decode())
+                                        pathf = iivalue[0].decode()
                                 aggf = aggf + f'Lenght: {lenghtf} Path: {pathf} <br>'
-                elif key == b'trackers':
-                    pass
-                elif key == b'pieces':
-                    pass
-                elif key == b'peers':
-                    pass
-                elif key == b'banned_peers':
-                    pass
-                elif key == b'banned_peers6':
-                    pass
-                elif key == b'peers6':
-                    pass
-                elif key == b'mapped_files':
-                    pass
-                elif key == b'piece_priority':
-                    pass
-                elif key == b'file_priority':
-                    pass
-                elif key == b'info-hash':
-                    pass #need to use bencode tools to reverse engineer the number
-                elif key == b'info-hash2':
-                    pass
                 elif key == b'save_path':
                     spath = value.decode()
                 elif key == b'name':
@@ -96,28 +67,20 @@ def get_libretorrentFR(files_found, report_folder, seeker, wrap_text):
                     tdown = value
                 elif key == b'total_uploaded':
                     tup = value
+                elif key in (b'trackers', b'pieces', b'peers', b'banned_peers', b'banned_peers6',
+                             b'peers6', b'mapped_files', b'piece_priority', b'file_priority',
+                             b'info-hash', b'info-hash2'):
+                    pass
                 else:
-                    if (isinstance(value, int)):
-                        value = value
-                    elif (isinstance(value, list)):
+                    if isinstance(value, int):
+                        pass
+                    elif isinstance(value, list):
                         value = str(value)
                     else:
                         value = value.decode()
                     agg = agg + f'{key.decode()}: {value} <br>'
-                    
-            data_list.append((torrentihash,torrentname,spath,iname,tdown,tup,aggf,agg))
-        
-        report = ArtifactHtmlReport('Libre Torrent - Fast Resume')
-        report.start_artifact_report(report_folder, 'Libre Torrent - Fast Resume')
-        report.add_script()
-        data_headers = ('Torrent InfoHash','Torrent Name','Save Path','Name','Total Downloaded','Total Uploaded','Length - Path','Key - Value')
-        report.write_artifact_data_table(data_headers, data_list, file_found,html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = f'Libre Torrent - Fast Resume'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-    else:
-        logfunc('No Libre Torrents Fast Resume data available')
-        
-    db.close()
+
+            data_list.append((torrentihash, torrentname, spath, iname, tdown, tup, aggf, agg))
+
+    data_headers = ('Torrent InfoHash', 'Torrent Name', 'Save Path', 'Name', 'Total Downloaded', 'Total Uploaded', 'Length - Path', 'Key - Value')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/torrentData.py
+++ b/scripts/artifacts/torrentData.py
@@ -1,4 +1,4 @@
-# pylint: disable=E0606,W0127,W0611,W0612,W0613,W0631,W0702,W1309
+# pylint: disable=W0613,W0702
 __artifacts_v2__ = {
     "get_TorrentData": {
         "name": "TorrentData",
@@ -10,124 +10,64 @@ __artifacts_v2__ = {
         "category": "Torrent Data",
         "notes": "",
         "paths": ('*/*.torrent',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "download",
-        "function": "get_TorrentData",
+        "html_columns": ['Path'],
     }
 }
 
-import sqlite3
-import textwrap
-import bencoding
 import hashlib
-from datetime import datetime
+import bencoding
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, kmlgen
+from scripts.ilapfuncs import artifact_processor
 
+
+@artifact_processor
 def get_TorrentData(files_found, report_folder, seeker, wrap_text):
-    
+
     data_list = []
-    
+    source_path = ''
     for file_found in files_found:
-        file_name = str(file_found)
-        if file_found.endswith('.torrent'):
-            
-            with open(file_found, 'rb') as f:
-                encoded_data = f.read()
-                
-            decodedDict = bencoding.bdecode(encoded_data)
-            info_hash = hashlib.sha1(bencoding.bencode(decodedDict[b"info"])).hexdigest().upper()
-                
-            torrentihas = torrentname = spath = iname = tdown = tup = aggf = agg = ''
-            for key,value in decodedDict.items():
-                #print(key,value)
-                if key == b'info':
-                    for ikey, ivalue in value.items():
-                        if ikey == b'piece length':
-                            pass
-                        if ikey == b'name':
-                            try:
-                                torrentname = (ivalue.decode())
-                            except:
-                                torrentname = ivalue
-                            #print(torrentname)
-                        if ikey == b'files':
-                            aggf = '<table>'
-                            for files in ivalue:
-                                for iikey, iivalue in files.items():
-                                    if iikey == b'length':
-                                        lenghtf = (iivalue)
-                                    if iikey == b'path':
-                                        if len(iivalue) > 1:
-                                            try:
-                                                dirr = (iivalue[0].decode())
-                                                filen = (iivalue[1].decode())
-                                            except:
-                                                dirr = (iivalue[0])
-                                                filen = (iivalue[1])
-                                        else:
-                                            dirr = ''
-                                            try:
-                                                filen = (iivalue[0].decode())
-                                            except:
-                                                filen = (iivalue[0])
-                                                
-                                    #print(f'Path: {dirr}/{filen}')
-                                aggf = aggf + f'<tr><td>{dirr}</td><td>{filen}</td></tr>'
-                            aggf = aggf + f'</table>'    
-                        #print(ikey, ivalue)
-                elif key == b'trackers':
-                    pass
-                elif key == b'pieces':
-                    pass
-                elif key == b'peers':
-                    pass
-                elif key == b'banned_peers':
-                    pass
-                elif key == b'banned_peers6':
-                    pass
-                elif key == b'peers6':
-                    pass
-                elif key == b'mapped_files':
-                    pass
-                elif key == b'piece_priority':
-                    pass
-                elif key == b'file_priority':
-                    pass
-                elif key == b'info-hash':
-                    pass #need to use bencode tools to reverse engineer the number
-                elif key == b'info-hash2':
-                    pass
-                elif key == b'save_path':
-                    spath = value.decode()
-                elif key == b'name':
-                    iname = value.decode()
-                elif key == b'total_downloaded':
-                    tdown = value
-                elif key == b'total_uploaded':
-                    tup = value
-                else:
-                    if (isinstance(value, int)):
-                        value = value
-                    elif (isinstance(value, list)):
-                        value = str(value)
-                    else:
-                        value = value
-                    
-            data_list.append((torrentname,info_hash,aggf))
-    
-    if len(data_list) > 0:
-        report = ArtifactHtmlReport('Torrent Data')
-        report.start_artifact_report(report_folder, 'Torrent Data')
-        report.add_script()
-        data_headers = ('Torrent Name','Info Hash','Path')
-        report.write_artifact_data_table(data_headers, data_list, file_found,html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = f'Torrent Data'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-    else:
-        logfunc('No Torrent Data available')
-        
+        file_found = str(file_found)
+        if not file_found.endswith('.torrent'):
+            continue
+
+        source_path = file_found
+        with open(file_found, 'rb') as f:
+            encoded_data = f.read()
+
+        decodedDict = bencoding.bdecode(encoded_data)
+        info_hash = hashlib.sha1(bencoding.bencode(decodedDict[b"info"])).hexdigest().upper()
+
+        torrentname = aggf = ''
+        for key, value in decodedDict.items():
+            if key == b'info':
+                for ikey, ivalue in value.items():
+                    if ikey == b'name':
+                        torrentname = ivalue.decode()
+                    if ikey == b'files':
+                        aggf = '<table>'
+                        for files in ivalue:
+                            dirr = filen = ''
+                            for iikey, iivalue in files.items():
+                                if iikey == b'path':
+                                    if len(iivalue) > 1:
+                                        try:
+                                            dirr = iivalue[0].decode()
+                                            filen = iivalue[1].decode()
+                                        except:
+                                            dirr = iivalue[0]
+                                            filen = iivalue[1]
+                                    else:
+                                        dirr = ''
+                                        try:
+                                            filen = iivalue[0].decode()
+                                        except:
+                                            filen = iivalue[0]
+                            aggf = aggf + f'<tr><td>{dirr}</td><td>{filen}</td></tr>'
+                        aggf = aggf + '</table>'
+
+        data_list.append((torrentname, info_hash, aggf))
+
+    data_headers = ('Torrent Name', 'Info Hash', 'Path')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/vlcMedia.py
+++ b/scripts/artifacts/vlcMedia.py
@@ -1,4 +1,4 @@
-# pylint: disable=E0602,W0611,W0613,W0631
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_vlcMedia": {
         "name": "VLC",
@@ -10,62 +10,46 @@ __artifacts_v2__ = {
         "category": "VLC",
         "notes": "",
         "paths": ('*vlc_media.db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "image",
-        "function": "get_vlcMedia",
     }
 }
 
-import sqlite3
-import os
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import timeline, tsv, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
+def _ts_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value), datetime.timezone.utc)
+    return ''
+
+
+@artifact_processor
 def get_vlcMedia(files_found, report_folder, seeker, wrap_text):
-    
+
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
         if file_found.endswith('vlc_media.db'):
+            source_path = file_found
             break
-            
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    cursor.execute('''
-    SELECT
-    datetime(insertion_date, 'unixepoch'),
-    datetime(last_played_date,'unixepoch'),
-    filename,
-    path,
-    is_favorite
-    from Media
-    left join Folder
-    on Media.folder_id = Folder.id_folder
-    ''')
 
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    data_list = []  
-    
-    if usageentries > 0:
+    data_list = []
+    if source_path:
+        db = open_sqlite_db_readonly(source_path)
+        cursor = db.cursor()
+        cursor.execute('''
+            SELECT insertion_date, last_played_date, filename, path, is_favorite
+            from Media
+            left join Folder on Media.folder_id = Folder.id_folder
+        ''')
+        all_rows = cursor.fetchall()
+        db.close()
+
         for row in all_rows:
-            data_list.append((row[0], row[1], row[2], row[3], row[4]))
+            data_list.append((_ts_to_utc(row[0]), _ts_to_utc(row[1]), row[2], row[3], row[4]))
 
-        description = 'VLC Media List'
-        report = ArtifactHtmlReport('VLC Media List')
-        report.start_artifact_report(report_folder, 'VLC Media List', description)
-        report.add_script()
-        data_headers = ('Insertion Date', 'Last Played Date', 'Filename', 'Path', 'Is Favorite?' )
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'VLC Media'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = 'VLC Media'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No VLC Media data available')
-    
+    data_headers = (('Insertion Date', 'datetime'), ('Last Played Date', 'datetime'), 'Filename', 'Path', 'Is Favorite?')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts four media/torrent parsers to the LAVA `@artifact_processor` pattern.

- **vlcMedia** — `insertion_date`/`last_played_date` selected raw and converted to aware UTC (replacing SQL `datetime(...,'unixepoch')`); both marked `datetime`. Fixed latent `E0602` (logfunc was used but never imported on the empty path — that branch is now removed).
- **libretorrent** — `dateAdded` epoch-ms → aware UTC (replacing `utcfromtimestamp`); `Timestamp` marked `datetime`. Dropped unused `kmlgen`/`textwrap` imports.
- **libretorrentFR** — bencoded FastResume parser; no timestamps. `html_columns` declared for the two `<br>`-bearing columns; initialized `lenghtf`/`pathf` to fix `E0606`; removed no-op `pass`/self-assignments.
- **torrentData** — bencoded `.torrent` parser; no timestamps. `html_columns` declared for the `<table>` Path column; removed dead else-branch; kept `W0702` for the path-decode fallbacks.

Verified: byte-compile, decorated 4-arg signature, returns 3-tuple, output_types valid, loader resolves, pylint (errors + W0718/W0702/W1514/unused) clean.