### PR TITLE
Convert PikPak family, blueskysearches, errp to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/blueskysearches.py
+++ b/scripts/artifacts/blueskysearches.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0631
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_blueskysearches": {
         "name": "Bluesky",
@@ -9,65 +9,42 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Bluesky",
         "notes": "",
-        "paths": ('*/xyz.blueskyweb.app/databases/RKStorage*'),
-        "output_types": None,
+        "paths": ('*/xyz.blueskyweb.app/databases/RKStorage*',),
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "search",
-        "function": "get_blueskysearches",
     }
 }
 
-import sqlite3
-import json 
+import json
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, timeline, tsv, is_platform_windows, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_blueskysearches(files_found, report_folder, seeker, wrap_text):
-    
+
     data_list = []
-    
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
-        if file_found.endswith('RKStorage'):
-            db = open_sqlite_db_readonly(file_found)
-            #SQL QUERY TIME!
-            cursor = db.cursor()
-            cursor.execute('''
-            SELECT
-            key, value
+        if not file_found.endswith('RKStorage'):
+            continue
+
+        source_path = file_found
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        cursor.execute('''
+            SELECT key, value
             FROM catalystLocalStorage
             WHERE key like 'searchHistory'
-            ''')
+        ''')
+        all_rows = cursor.fetchall()
+        db.close()
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            
-            if usageentries > 0:
-                for row in all_rows:
-            
-                    searches = row[1]
-                    searches = json.loads(searches)
-                    for item in searches:
-                        data_list.append((item,))
-            db.close()
-                    
-        else:
-            continue
-        
-    if data_list:
-        description = 'Bluesky'
-        report = ArtifactHtmlReport('Bluesky user generated searches')
-        report.start_artifact_report(report_folder, 'Bluesky Searches', description)
-        report.add_script()
-        data_headers = ('Searches',)
-        report.write_artifact_data_table(data_headers, data_list, file_found,html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = 'Bluesky Searches'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    
-    
-    else:
-        logfunc('No Bluesky searches available')
-        
+        for row in all_rows:
+            searches = json.loads(row[1])
+            for item in searches:
+                data_list.append((item,))
+
+    data_headers = ('Searches',)
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/errp.py
+++ b/scripts/artifacts/errp.py
@@ -1,4 +1,4 @@
-# pylint: disable=E0606,W0611,W0613,W1309,W1514
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_errp": {
         "name": "Errp",
@@ -10,77 +10,38 @@ __artifacts_v2__ = {
         "category": "Wipe & Setup",
         "notes": "",
         "paths": ('*/system/users/service/eRR.p',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "file",
-        "function": "get_errp",
     }
 }
 
-import os
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, convert_local_to_utc
+from scripts.ilapfuncs import artifact_processor, convert_local_to_utc
 
+
+@artifact_processor
 def get_errp(files_found, report_folder, seeker, wrap_text):
 
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('eRR.p'):
-            continue # Skip all other files
-        
-        data_list = []
-        timestamp = event = code = details = ''
-        with open(file_found, 'r') as f:
+            continue  # Skip all other files
+
+        source_path = file_found
+        with open(file_found, 'r', encoding='utf-8', errors='replace') as f:
             for line in f:
                 line = line.strip()
-                if line.startswith('\n'):
-                    pass
-                elif line.startswith('LOGM'):
-                    pass
-                elif line == '':
-                    pass
-                else:	
-                    line = line.split('|')
-                    if(len(line) == 1):
-                        timestamp = line[0].strip()
-                        timestamp_utc = str(convert_local_to_utc(timestamp))
-                        event = ''
-                        code = ''
-                        details = ''
-                    elif(len(line) == 2):
-                        timestamp = line[0].strip()
-                        timestamp_utc = str(convert_local_to_utc(timestamp))
-                        event = line[1].strip()
-                        code = ''
-                        details = ''                  
-                    elif(len(line) == 3):
-                        timestamp = line[0].strip()
-                        timestamp_utc = str(convert_local_to_utc(timestamp))
-                        event = line[1].strip()                
-                        code = line[2].strip()
-                        details = ''
-                    elif(len(line) == 4):
-                        timestamp = line[0].strip()
-                        timestamp_utc = str(convert_local_to_utc(timestamp))
-                        event = line[1].strip()
-                        code = line[2].strip()
-                        details = line[3].strip()
-                    
-                    data_list.append((timestamp_utc,timestamp,event,code,details))
-                    timestamp = event = code = details = ''
-                            
-        if data_list:
-            report = ArtifactHtmlReport('Samsung eRR.p')
-            report.start_artifact_report(report_folder, 'Samsung eRR.p')
-            report.add_script()
-            data_headers = ('Timestamp','Timestamp (Local)','Event','Code','Details')
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Samsung Samsung eRR.p'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Samsung Samsung eRR.p'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Samsung Samsung eRR.p data available')
-            
+                if line.startswith('LOGM') or line == '':
+                    continue
+
+                parts = line.split('|')
+                timestamp = parts[0].strip()
+                timestamp_utc = str(convert_local_to_utc(timestamp))
+                event = parts[1].strip() if len(parts) >= 2 else ''
+                code = parts[2].strip() if len(parts) >= 3 else ''
+                details = parts[3].strip() if len(parts) >= 4 else ''
+                data_list.append((timestamp_utc, timestamp, event, code, details))
+
+    data_headers = ('Timestamp', 'Timestamp (Local)', 'Event', 'Code', 'Details')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/pikpakCloudlist.py
+++ b/scripts/artifacts/pikpakCloudlist.py
@@ -1,4 +1,4 @@
-# pylint: disable=E0602,W0611,W0613,W0631
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_pikpakCloudlist": {
         "name": "PikPak Cloud List",
@@ -10,65 +10,43 @@ __artifacts_v2__ = {
         "category": "PikPak",
         "notes": "",
         "paths": ('*/com.pikcloud.pikpak/databases/pikpak_files_*.db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "file",
-        "function": "get_pikpakCloudlist",
+        "html_columns": ['Thumbnail Link'],
     }
 }
 
-import sqlite3
-import os
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import timeline, tsv, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
+@artifact_processor
 def get_pikpakCloudlist(files_found, report_folder, seeker, wrap_text):
-    
+
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
         if file_found.endswith('.db'):
+            source_path = file_found
             break
-            
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    cursor.execute('''
-    SELECT
-    create_time,
-    modify_time,
-    delete_time,
-    datetime(local_update_time/1000, 'unixepoch' ),
-    user_id,
-    name,
-    kind,
-    url,
-    thumbnail_link
-    FROM xpan_files
-    ''')
 
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    data_list = []  
-    
-    if usageentries > 0:
+    data_list = []
+    if source_path:
+        db = open_sqlite_db_readonly(source_path)
+        cursor = db.cursor()
+        cursor.execute('''
+            SELECT create_time, modify_time, delete_time, local_update_time,
+                   user_id, name, kind, url, thumbnail_link
+            FROM xpan_files
+        ''')
+        all_rows = cursor.fetchall()
+        db.close()
+
         for row in all_rows:
+            local_update = datetime.datetime.fromtimestamp(int(row[3]) / 1000, datetime.timezone.utc) if row[3] else ''
             link = f'<a href="{row[8]}" target="_blank">{row[8]}</a>'
-            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],link))
+            data_list.append((row[0], row[1], row[2], local_update, row[4], row[5], row[6], row[7], link))
 
-        description = 'PikPak Cloud List links are clickable!!!!! If connected to the internet and pressed the browser will try to open them in a new tab.'
-        report = ArtifactHtmlReport('PikPak Cloud List')
-        report.start_artifact_report(report_folder, 'PikPak Cloud List', description)
-        report.add_script()
-        data_headers = ('Create Time', 'Modify Time','Delete Time', 'Local Update Time', 'User ID', 'Name', 'Kind', 'URL','Thumbnail Link')
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Thumbnail Link'])
-        report.end_artifact_report()
-        
-        tsvname = 'PikPak Cloud List'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = 'PikPak Cloud List'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No PikPak Cloud List data available')
-    
+    data_headers = ('Create Time', 'Modify Time', 'Delete Time', ('Local Update Time', 'datetime'), 'User ID', 'Name', 'Kind', 'URL', 'Thumbnail Link')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/pikpakDownloads.py
+++ b/scripts/artifacts/pikpakDownloads.py
@@ -1,4 +1,4 @@
-# pylint: disable=E0602,W0611,W0613,W0631
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_pikpakDownloads": {
         "name": "PikPak Downloads",
@@ -10,60 +10,45 @@ __artifacts_v2__ = {
         "category": "PikPak",
         "notes": "",
         "paths": ('*/com.pikcloud.pikpak/databases/pikpak_downloads.db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "download",
-        "function": "get_pikpakDownloads",
     }
 }
 
-import sqlite3
-import os
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import timeline, tsv, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
+def _ms_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    return ''
+
+
+@artifact_processor
 def get_pikpakDownloads(files_found, report_folder, seeker, wrap_text):
-    
+
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
         if file_found.endswith('.db'):
+            source_path = file_found
             break
-            
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    cursor.execute('''
-    SELECT
-    datetime(create_time/1000, 'unixepoch'),
-    datetime(lastmod/1000, 'unixepoch'),
-    title,
-    _data,
-    uri
-    from xl_downloads
-    ''')
 
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    data_list = []  
-    
-    if usageentries > 0:
+    data_list = []
+    if source_path:
+        db = open_sqlite_db_readonly(source_path)
+        cursor = db.cursor()
+        cursor.execute('''
+            SELECT create_time, lastmod, title, _data, uri
+            from xl_downloads
+        ''')
+        all_rows = cursor.fetchall()
+        db.close()
+
         for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4]))
+            data_list.append((_ms_to_utc(row[0]), _ms_to_utc(row[1]), row[2], row[3], row[4]))
 
-        description = 'PikPak Downloads'
-        report = ArtifactHtmlReport('PikPak Downloads')
-        report.start_artifact_report(report_folder, 'PikPak Downloads', description)
-        report.add_script()
-        data_headers = ('Create Time', 'Modify Time','Title', 'Local Storage', 'URL')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'PikPak Downloads'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = 'PikPak Downloads'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No PikPak Downloads data available')
-    
+    data_headers = (('Create Time', 'datetime'), ('Modify Time', 'datetime'), 'Title', 'Local Storage', 'URL')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/pikpakPlay.py
+++ b/scripts/artifacts/pikpakPlay.py
@@ -1,4 +1,4 @@
-# pylint: disable=E0602,W0611,W0613,W0631
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_pikpakPlay": {
         "name": "PikPak Play",
@@ -10,60 +10,40 @@ __artifacts_v2__ = {
         "category": "PikPak",
         "notes": "",
         "paths": ('*/com.pikcloud.pikpak/databases/greendao.db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "file",
-        "function": "get_pikpakPlay",
     }
 }
 
-import sqlite3
-import os
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import timeline, tsv, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
+@artifact_processor
 def get_pikpakPlay(files_found, report_folder, seeker, wrap_text):
-    
+
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
         if file_found.endswith('greendao.db'):
+            source_path = file_found
             break
-            
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    cursor.execute('''
-    SELECT
-    datetime(last_play_timestamp/1000, 'unixepoch'),
-    duration,
-    played_time,
-    max_played_time,
-    name
-    from VIDEO_PLAY_RECORD
-    ''')
 
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    data_list = []  
-    
-    if usageentries > 0:
+    data_list = []
+    if source_path:
+        db = open_sqlite_db_readonly(source_path)
+        cursor = db.cursor()
+        cursor.execute('''
+            SELECT last_play_timestamp, duration, played_time, max_played_time, name
+            from VIDEO_PLAY_RECORD
+        ''')
+        all_rows = cursor.fetchall()
+        db.close()
+
         for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4]))
+            last_play = datetime.datetime.fromtimestamp(int(row[0]) / 1000, datetime.timezone.utc) if row[0] else ''
+            data_list.append((last_play, row[1], row[2], row[3], row[4]))
 
-        description = 'PikPak Play'
-        report = ArtifactHtmlReport('PikPak Play')
-        report.start_artifact_report(report_folder, 'PikPak Play', description)
-        report.add_script()
-        data_headers = ('Last Play Timestamp', 'Duration','Played Time', 'Max Played Time', 'Name')
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Thumbnail Link'])
-        report.end_artifact_report()
-        
-        tsvname = 'PikPak Play'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = 'PikPak Play'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No PikPak Play data available')
-    
+    data_headers = (('Last Play Timestamp', 'datetime'), 'Duration', 'Played Time', 'Max Played Time', 'Name')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts five more parsers to the LAVA `@artifact_processor` pattern.

- **pikpakCloudlist** — `local_update_time` (epoch-ms) → aware UTC `datetime`; `create/modify/delete_time` left as plain strings (raw app format, unverified). `Thumbnail Link` declared in `html_columns`. Fixed latent `E0602` (logfunc unimported).
- **pikpakPlay** — `last_play_timestamp` → aware UTC `datetime`. Removed a copy-paste `html_no_escape=['Thumbnail Link']` referencing a non-existent column.
- **pikpakDownloads** — `create_time`/`lastmod` → aware UTC `datetime`.
- **blueskysearches** — flat JSON search-history; fixed `paths` (was a bare string, not a 1-tuple → glob iterated char-by-char). Dropped unused convert_* imports.
- **errp** — Samsung eRR.p log; both timestamp columns kept as plain strings (`convert_local_to_utc` output format unverified). Simplified the 1–4 field split; added `encoding` to `open()`.

All SQL `datetime(...,'unixepoch')` strings replaced with raw epochs + aware-UTC conversion. Verified: byte-compile, decorated 4-arg signature, returns 3-tuple, output_types valid, paths are tuples, loader resolves, pylint clean.