### PR TITLE
Convert Installed Apps family (packageGplinks, userDict, installedapps*) to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/installedappsGass.py
+++ b/scripts/artifacts/installedappsGass.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_installedappsGass": {
         "name": "installedappsGass",
@@ -10,59 +10,43 @@ __artifacts_v2__ = {
         "category": "Installed Apps",
         "notes": "",
         "paths": ('*/com.google.android.gms/databases/gass.db*', '*/user/*/com.google.android.gms/databases/gass.db*'),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "package",
-        "function": "get_installedappsGass",
     }
 }
 
-import sqlite3
+from scripts.ilapfuncs import artifact_processor, is_platform_windows, open_sqlite_db_readonly
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, open_sqlite_db_readonly
 
+@artifact_processor
 def get_installedappsGass(files_found, report_folder, seeker, wrap_text):
 
     slash = '\\' if is_platform_windows() else '/'
+    data_list = []
+    source_path = ''
 
     for file_found in files_found:
         file_found = str(file_found)
-        if file_found.endswith('.db'):
-            
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            cursor.execute('''
-            SELECT 
-                distinct(package_name),
-                version_code,
-                digest_sha256
-                FROM
-                app_info  
-            ''')
-            
-            if 'user' in file_found:
-                usernum = file_found.split(slash)
-                usernum = str(usernum[-4])
-            else:
-                usernum = '0'
+        if not file_found.endswith('.db'):
+            continue
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                report = ArtifactHtmlReport('Installed Apps')
-                report.start_artifact_report(report_folder, f'Installed Apps (GMS) for user {usernum}')
-                report.add_script()
-                data_headers = ('Bundle ID','Version Code','SHA-256 Hash') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-                data_list = []
-                for row in all_rows:
-                    data_list.append((row[0],row[1],row[2]))
-        
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'installed apps - GMS for user {usernum}'
-                tsv(report_folder, data_headers, data_list, tsvname)
-            else:
-                logfunc('No Installed Apps data available for user {usernum}')
-            
-            db.close()
+        source_path = file_found
+        if 'user' in file_found:
+            usernum = str(file_found.split(slash)[-4])
+        else:
+            usernum = '0'
+
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        cursor.execute('''
+            SELECT distinct(package_name), version_code, digest_sha256
+            FROM app_info
+        ''')
+        all_rows = cursor.fetchall()
+        db.close()
+
+        for row in all_rows:
+            data_list.append((usernum, row[0], row[1], row[2]))
+
+    data_headers = ('User', 'Bundle ID', 'Version Code', 'SHA-256 Hash')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/installedappsLibrary.py
+++ b/scripts/artifacts/installedappsLibrary.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0612,W0613
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_installedappsLibrary": {
         "name": "InstalledappsLibrary",
@@ -10,62 +10,45 @@ __artifacts_v2__ = {
         "category": "Installed Apps",
         "notes": "",
         "paths": ('*/com.android.vending/databases/library.db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "package",
-        "function": "get_installedappsLibrary",
     }
 }
 
-import sqlite3
+import datetime
 from pathlib import Path
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_installedappsLibrary(files_found, report_folder, seeker, wrap_text):
-    
-    
+
+    data_list = []
+    source_path = ''
+
     for file_found in files_found:
-        file_name = str(file_found)
-        fullpath = Path(file_found)
-        user = fullpath.parts[-4]
+        file_found = str(file_found)
+        if not file_found.endswith('library.db'):
+            continue
+
+        user = Path(file_found).parts[-4]
         if user == 'data':
             user = '0'
-        if file_found.endswith('library.db'):
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            cursor.execute('''
-            SELECT
-                case
-                when purchase_time = 0 THEN ''
-                when purchase_time > 0 THEN datetime(purchase_time / 1000, "unixepoch")
-                END as pt,
-                account,
-                doc_id
-            FROM
-            ownership  
-            ''')
-        
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                report = ArtifactHtmlReport(f'Installed Apps (Library) for user {user}')
-                report.start_artifact_report(report_folder, f'Installed Apps (Library) for user {user}')
-                report.add_script()
-                data_headers = ('Purchase Time', 'Account', 'Doc ID')
-                data_list = []
-                for row in all_rows:
-                    data_list.append((row[0], row[1], row[2]))
-        
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'installed apps library for user {user}'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-                tlactivity = f'Installed Apps Library for user {user}'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc(f'No Installed Apps (Library) data available for user {user}')
-            
-    db.close()
+
+        source_path = file_found
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        cursor.execute('''
+            SELECT purchase_time, account, doc_id
+            FROM ownership
+        ''')
+        all_rows = cursor.fetchall()
+        db.close()
+
+        for row in all_rows:
+            purchase_time = datetime.datetime.fromtimestamp(int(row[0]) / 1000, datetime.timezone.utc) if row[0] else ''
+            data_list.append((user, purchase_time, row[1], row[2]))
+
+    data_headers = ('User', ('Purchase Time', 'datetime'), 'Account', 'Doc ID')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/packageGplinks.py
+++ b/scripts/artifacts/packageGplinks.py
@@ -1,4 +1,4 @@
-# pylint: disable=E0606,W0611,W0613,W0631,W1309,W1514
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_packageGplinks": {
         "name": "packageGplinks",
@@ -10,42 +10,33 @@ __artifacts_v2__ = {
         "category": "Installed Apps",
         "notes": "",
         "paths": ('*/system/packages.list',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "package",
-        "function": "get_packageGplinks",
+        "html_columns": ['Possible Google Play Store Link'],
     }
 }
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor
 
+
+@artifact_processor
 def get_packageGplinks(files_found, report_folder, seeker, wrap_text):
-    data_list =[]
-    
-    for file_found in files_found:
-        if 'sbin' not in file_found:
-            file_found = str(file_found)
-            source_file = file_found.replace(seeker.data_folder, '')
-    
-    with open(file_found) as data:
-        values = data.readlines()
-        
-    for x in values:
-        bundleid = x.split(' ', 1)
-        url = f'<a href="https://play.google.com/store/apps/details?id={bundleid[0]}" target="_blank"><font color="blue">https://play.google.com/store/apps/details?id={bundleid[0]}</font></a>'
-        data_list.append((bundleid[0], url))
 
-    usageentries = len(data_list)
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Google Play Links for Apps')
-        report.start_artifact_report(report_folder, 'Google Play Links for Apps')
-        report.add_script()
-        data_headers = ('Bundle ID', 'Possible Google Play Store Link')
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = f'Google Play Links for Apps'
-        tsv(report_folder, data_headers, data_list, tsvname, source_file)
-        
-    else:
-        logfunc('No Google Play Links for Apps data available')
+    source_path = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if 'sbin' not in file_found:
+            source_path = file_found
+
+    data_list = []
+    if source_path:
+        with open(source_path, encoding='utf-8', errors='replace') as data:
+            values = data.readlines()
+
+        for x in values:
+            bundleid = x.split(' ', 1)
+            url = f'<a href="https://play.google.com/store/apps/details?id={bundleid[0]}" target="_blank"><font color="blue">https://play.google.com/store/apps/details?id={bundleid[0]}</font></a>'
+            data_list.append((bundleid[0], url))
+
+    data_headers = ('Bundle ID', 'Possible Google Play Store Link')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/userDict.py
+++ b/scripts/artifacts/userDict.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_userDict": {
         "name": "userDict",
@@ -10,50 +10,30 @@ __artifacts_v2__ = {
         "category": "User Dictionary",
         "notes": "",
         "paths": ('*/com.android.providers.userdictionary/databases/user_dict.db*',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "user",
-        "function": "get_userDict",
     }
 }
 
-import sqlite3
-import textwrap
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, open_sqlite_db_readonly
 
+@artifact_processor
 def get_userDict(files_found, report_folder, seeker, wrap_text):
-    
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
+
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     cursor.execute('''
-    select 
-    word,
-    frequency,
-    locale,
-    appid,
-    shortcut
-    from words
+        select word, frequency, locale, appid, shortcut
+        from words
     ''')
-
     all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        report = ArtifactHtmlReport('User Dictionary')
-        report.start_artifact_report(report_folder, 'User Dictionary')
-        report.add_script()
-        data_headers = ('Word','Frequency','Locale','AppID','Shortcut' ) # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = []
-        for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4]))
-
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'user dictionary'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc('No User Dictionary data available')
-    
     db.close()
+
+    data_list = []
+    for row in all_rows:
+        data_list.append((row[0], row[1], row[2], row[3], row[4]))
+
+    data_headers = ('Word', 'Frequency', 'Locale', 'AppID', 'Shortcut')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts four parsers to the LAVA `@artifact_processor` pattern.

- **packageGplinks** — packages.list → Play Store links; `Possible Google Play Store Link` declared in `html_columns`; fixed latent `E0606`/unbound `source_file` by tracking the matched path in-loop; added `encoding` to `open()`.
- **userDict** — flat User Dictionary DB; no timestamps.
- **installedappsGass** — previously one report per user DB; flattened into a single table with a `User` discriminator column.
- **installedappsLibrary** — flattened per-user; `purchase_time` selected raw and converted to aware UTC (replacing SQL `datetime(...,'unixepoch')`); `Purchase Time` marked `datetime`; `User` discriminator column added.

Verified: byte-compile, decorated 4-arg signature, returns 3-tuple, output_types valid, loader resolves, pylint clean.