### PR TITLE
Convert setupWizardinfo, pSettings, ulrUserprefs, smembersAppInv to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/pSettings.py
+++ b/scripts/artifacts/pSettings.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0631,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_pSettings": {
         "name": "pSettings",
@@ -10,53 +10,36 @@ __artifacts_v2__ = {
         "category": "Device Info",
         "notes": "",
         "paths": ('*/com.google.android.gsf/databases/googlesettings.db*',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "settings",
-        "function": "get_pSettings",
     }
 }
 
-import sqlite3
-import textwrap
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, open_sqlite_db_readonly
 
+@artifact_processor
 def get_pSettings(files_found, report_folder, seeker, wrap_text):
-    
+
     data_list = []
-    
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        if file_found.endswith('googlesettings.db'):
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            cursor.execute('''
-            select 
-            name,
-            value
-            from partner
-            ''')
-
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                for row in all_rows:
-                    data_list.append((row[0],row[1],file_found))
-            db.close()
-        else:
+        if not file_found.endswith('googlesettings.db'):
             continue
-    if data_list:
-        report = ArtifactHtmlReport('Partner Settings')
-        report.start_artifact_report(report_folder, 'Partner Settings')
-        report.add_script()
-        data_headers = ('Name','Value','Source File') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
 
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'partner settings'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc('No Partner Settings data available')
-            
+        source_path = file_found
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        cursor.execute('''
+            select name, value
+            from partner
+        ''')
+        all_rows = cursor.fetchall()
+        db.close()
+
+        for row in all_rows:
+            data_list.append((row[0], row[1]))
+
+    data_headers = ('Name', 'Value')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/setupWizardinfo.py
+++ b/scripts/artifacts/setupWizardinfo.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_setupWizardinfo": {
         "name": "setupWizardinfo",
@@ -10,48 +10,34 @@ __artifacts_v2__ = {
         "category": "Wipe & Setup",
         "notes": "",
         "paths": ('*/com.google.android.settings.intelligence/shared_prefs/setup_wizard_info.xml',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "info",
-        "function": "get_setupWizardinfo",
     }
 }
 
-import os
 import datetime
 import xml.etree.ElementTree as ET
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
 
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
 def get_setupWizardinfo(files_found, report_folder, seeker, wrap_text):
 
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('setup_wizard_info.xml'):
-            continue # Skip all other files
-        
-        data_list = []
-        tree = ET.parse(file_found)
-        root = tree.getroot()
-        
+            continue  # Skip all other files
+
+        source_path = file_found
+        root = ET.parse(file_found).getroot()
         for elem in root:
             item = elem.attrib
             if item['name'] == 'suw_finished_time_ms':
-                timestamp = (datetime.datetime.utcfromtimestamp(int(item['value'])/1000).strftime('%Y-%m-%d %H:%M:%S'))
+                timestamp = datetime.datetime.fromtimestamp(int(item['value']) / 1000, datetime.timezone.utc)
                 data_list.append((timestamp, item['name']))
-        
-        if data_list:
-            report = ArtifactHtmlReport('Setup_Wizard_Info.xml')
-            report.start_artifact_report(report_folder, 'Setup_Wizard_Info.xml')
-            report.add_script()
-            data_headers = ('Timestamp','Name')
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Setup_Wizard_Info XML data'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Setup_Wizard_Info XML data'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Setup_Wizard_Info XML data available')
-            
+
+    data_headers = (('Timestamp', 'datetime'), 'Name')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/smembersAppInv.py
+++ b/scripts/artifacts/smembersAppInv.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_smembersAppInv": {
         "name": "smembersAppInv",
@@ -10,55 +10,33 @@ __artifacts_v2__ = {
         "category": "App Interaction",
         "notes": "",
         "paths": ('*/com.samsung.oh/databases/com_pocketgeek_sdk_app_inventory.db',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "package",
-        "function": "get_smembersAppInv",
     }
 }
 
-import sqlite3
-import textwrap
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_smembersAppInv(files_found, report_folder, seeker, wrap_text):
-    
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
+
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     cursor.execute('''
-    select
-    datetime(last_used / 1000, "unixepoch"),  
-    display_name, 
-    package_name, 
-    system_app, 
-    confidence_hash,
-    sha1,
-    classification
-    from android_app
+        select last_used, display_name, package_name, system_app, confidence_hash, sha1, classification
+        from android_app
     ''')
-
     all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Samsung Members - Apps')
-        report.start_artifact_report(report_folder, 'Samsung Members - Apps')
-        report.add_script()
-        data_headers = ('Timestamp','Display Name','Package Name','System App?','Confidence Hash','SHA1','Classification' ) 
-        data_list = []
-        for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
-
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'samsung members - apps'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Samsung Members - Apps'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Samsung Members - Apps data available')
-    
     db.close()
+
+    data_list = []
+    for row in all_rows:
+        last_used = datetime.datetime.fromtimestamp(int(row[0]) / 1000, datetime.timezone.utc) if row[0] else ''
+        data_list.append((last_used, row[1], row[2], row[3], row[4], row[5], row[6]))
+
+    data_headers = (('Timestamp', 'datetime'), 'Display Name', 'Package Name', 'System App?', 'Confidence Hash', 'SHA1', 'Classification')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/ulrUserprefs.py
+++ b/scripts/artifacts/ulrUserprefs.py
@@ -1,65 +1,42 @@
-# pylint: disable=W0611,W0613,W0631
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_urluser": {
         "name": "ULR User Prefs",
         "description": "ULR User Prefs",
         "author": "Alexis 'Brigs' Brignoni",
-        "creation_date": "2024/06/21",
-        "last_update_date": "2024/06/21",
+        "creation_date": "2024-06-21",
+        "last_update_date": "2024-06-21",
         "requirements": "",
         "category": "App Semantic Locations",
         "notes": "Thanks to Josh Hickman for the research",
-        "paths": (
-            '*/com.google.android.gms/shared_prefs/ULR_USER_PREFS.xml',
-        ),
-        "output_types": None,
-        "function": "get_urluser",
+        "paths": ('*/com.google.android.gms/shared_prefs/ULR_USER_PREFS.xml',),
+        "output_types": ['html', 'tsv', 'lava'],
+        "artifact_icon": "map-pin",
     }
 }
 
-import json
 import xml.etree.ElementTree as ET
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, timeline, kmlgen 
 
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
 def get_urluser(files_found, report_folder, seeker, wrap_text):
-    
+
     data_list = []
-    
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        if file_found.endswith('ULR_USER_PREFS.xml'):
-        
-            data_list = []
-            tree = ET.parse(file_found)
-            root = tree.getroot()
-            #print('Processed: '+filename)
-            
-            for child in root:
-                jsondata = (child.attrib)
-                name = (jsondata['name'])
-                value = (jsondata.get('value',''))
-                data_list.append((name,value))
-        
-                    
-        
-    if len(data_list) > 0:
-        description = ''
-        report = ArtifactHtmlReport('ULR User Preferences')
-        report.start_artifact_report(report_folder, 'ULR User Preferences', description)
-        report.add_script()
-        data_headers = ('Name','Value')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-            
-        tsvname = 'ULR User Preferences'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = 'ULR User Preferences'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-    else:
-        logfunc('No ULR User Preferences Data available')
-                        
-                
-    
+        if not file_found.endswith('ULR_USER_PREFS.xml'):
+            continue
+
+        source_path = file_found
+        root = ET.parse(file_found).getroot()
+        for child in root:
+            jsondata = child.attrib
+            name = jsondata['name']
+            value = jsondata.get('value', '')
+            data_list.append((name, value))
+
+    data_headers = ('Name', 'Value')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts four more parsers to the LAVA `@artifact_processor` pattern.

- **setupWizardinfo** — `suw_finished_time_ms` (epoch-ms) → aware UTC (replacing `utcfromtimestamp`); `Timestamp` marked `datetime`.
- **pSettings** — flat partner-settings; dropped the redundant per-row `Source File` column (the framework records the source path).
- **ulrUserprefs** — flat Name/Value; added missing `artifact_icon`; dropped unused `kmlgen`/`timeline` imports; normalized ISO-style `creation_date`.
- **smembersAppInv** — `last_used` raw → aware UTC (replacing SQL `datetime(...,'unixepoch')`); `Timestamp` marked `datetime`.

Verified: byte-compile, decorated 4-arg signature, returns 3-tuple, output_types valid, loader resolves, pylint clean.