### PR TITLE
Convert browserlocation, waze, Zapya, WordsWithFriends, cachelocation to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/WordsWithFriends.py
+++ b/scripts/artifacts/WordsWithFriends.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_WordsWithFriends": {
         "name": "WordsWithFriends",
@@ -10,60 +10,35 @@ __artifacts_v2__ = {
         "category": "Chats",
         "notes": "",
         "paths": ('*/com.zynga.words/db/wf_database.sqlite',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "message-square",
-        "function": "get_WordsWithFriends",
     }
 }
 
-import sqlite3
-import textwrap
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_WordsWithFriends(files_found, report_folder, seeker, wrap_text):
-    
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
+
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     cursor.execute('''
-    SELECT
-    datetime(messages.created_at/1000, 'unixepoch'),
-    messages.conv_id,
-    users.name,
-    users.email_address,
-    messages.text
-    FROM
-    messages
-    INNER JOIN
-    users
-    ON
-    messages.user_zynga_id=users.zynga_account_id
-    ORDER BY
-    messages.created_at DESC
+        SELECT messages.created_at, messages.conv_id, users.name, users.email_address, messages.text
+        FROM messages
+        INNER JOIN users ON messages.user_zynga_id = users.zynga_account_id
+        ORDER BY messages.created_at DESC
     ''')
-
     all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Chats')
-        report.start_artifact_report(report_folder, 'Words With Friends')
-        report.add_script()
-        data_headers = ('Chat_Message_Creation','Message_ID','User_Name','User_Email','Chat_Message' ) # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = []
-        for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4]))
-
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Words With Friends Chats'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Words with Friends Chats'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Words With Friends data available')
-    
     db.close()
+
+    data_list = []
+    for row in all_rows:
+        creation = datetime.datetime.fromtimestamp(int(row[0]) / 1000, datetime.timezone.utc) if row[0] else ''
+        data_list.append((creation, row[1], row[2], row[3], row[4]))
+
+    data_headers = (('Chat Message Creation', 'datetime'), 'Message ID', 'User Name', 'User Email', 'Chat Message')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/Zapya.py
+++ b/scripts/artifacts/Zapya.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_Zapya": {
         "name": "Zapya",
@@ -10,58 +10,41 @@ __artifacts_v2__ = {
         "category": "File Transfer",
         "notes": "",
         "paths": ('*/com.dewmobile.kuaiya.play/databases/transfer20.db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "download",
-        "function": "get_Zapya",
     }
 }
 
-import sqlite3
 import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_Zapya(files_found, report_folder, seeker, wrap_text):
-    file_found = str(files_found[0])
-    source_file = file_found.replace(seeker.data_folder, '')
-    db = open_sqlite_db_readonly(file_found)
+
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     cursor.execute('''
-    SELECT device, name, direction, createtime/1000, path, title FROM transfer
+        SELECT device, name, direction, createtime/1000, path, title FROM transfer
     ''')
-
     all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Zapya')
-        report.start_artifact_report(report_folder, 'Zapya')
-        report.add_script()
-        data_headers = ('Device','Name','direction', 'fromid', 'toid', 'createtime','path', 'title') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = []
-                        
-        for row in all_rows:
-            from_id = ''
-            to_id = ''
-            if (row[2] == 1):
-                direction = 'Outgoing'
-                to_id = row[0]
-            else:
-                direction = 'Incoming'
-                from_id = row[0]
-            
-            createtime = datetime.datetime.utcfromtimestamp(int(row[3])).strftime('%Y-%m-%d %H:%M:%S')            
-            data_list.append((row[0], row[1], direction, from_id, to_id, createtime, row[4], row[5]))
-
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Zapya'
-        tsv(report_folder, data_headers, data_list, tsvname, source_file)
-        
-        tlactivity = f'Zapya'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Zapya data available')
-    
     db.close()
+
+    data_list = []
+    for row in all_rows:
+        from_id = ''
+        to_id = ''
+        if row[2] == 1:
+            direction = 'Outgoing'
+            to_id = row[0]
+        else:
+            direction = 'Incoming'
+            from_id = row[0]
+
+        createtime = datetime.datetime.fromtimestamp(int(row[3]), datetime.timezone.utc) if row[3] else ''
+        data_list.append((row[0], row[1], direction, from_id, to_id, createtime, row[4], row[5]))
+
+    data_headers = ('Device', 'Name', 'direction', 'fromid', 'toid', ('createtime', 'datetime'), 'path', 'title')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/browserlocation.py
+++ b/scripts/artifacts/browserlocation.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0702,W1309
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_browserlocation": {
         "name": "Browser Location",
@@ -10,61 +10,40 @@ __artifacts_v2__ = {
         "category": "GEO Location",
         "notes": "",
         "paths": ('*/com.android.browser/app_geolocation/CachedGeoposition.db',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "map-pin",
-        "function": "get_browserlocation",
     }
 }
 
-import sqlite3
 import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_browserlocation(files_found, report_folder, seeker, wrap_text):
 
-    source_file = ''
-
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
         if file_found.endswith('-db'):
-            source_file = file_found.replace(seeker.data_folder, '')
             continue
-  
-        source_file = file_found.replace(seeker.data_folder, '')
-        
+
+        source_path = file_found
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         try:
-            cursor.execute('''
-            SELECT timestamp/1000, latitude, longitude, accuracy FROM CachedPosition;
-            ''')
-
+            cursor.execute('SELECT timestamp/1000, latitude, longitude, accuracy FROM CachedPosition;')
             all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-        except:
-            usageentries = 0
-            
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Browser Locations')
-            report.start_artifact_report(report_folder, 'Browser Locations')
-            report.add_script()
-            data_headers = ('timestamp','latitude', 'longitude', 'accuracy') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-            data_list = []
-            for row in all_rows:
-                timestamp = datetime.datetime.utcfromtimestamp(int(row[0])).strftime('%Y-%m-%d %H:%M:%S') 
-                data_list.append((timestamp, row[1], row[2], row[3]))
-
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Browser Locations'
-            tsv(report_folder, data_headers, data_list, tsvname, source_file)
-            
-        else:
-            logfunc('No Browser Locations found')
-            
+        except Exception as e:
+            logfunc(str(e))
+            all_rows = []
         db.close()
-        
+
+        for row in all_rows:
+            timestamp = datetime.datetime.fromtimestamp(int(row[0]), datetime.timezone.utc) if row[0] else ''
+            data_list.append((timestamp, row[1], row[2], row[3]))
+
+    data_headers = (('timestamp', 'datetime'), 'latitude', 'longitude', 'accuracy')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/cachelocation.py
+++ b/scripts/artifacts/cachelocation.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0612,W0613,W1309
+# pylint: disable=W0612,W0613
 __artifacts_v2__ = {
     "get_cachelocation": {
         "name": "Cache Location",
@@ -10,61 +10,41 @@ __artifacts_v2__ = {
         "category": "GEO Location",
         "notes": "",
         "paths": ('*/com.google.android.location/files/cache.cell/cache.cell', '*/com.google.android.location/files/cache.wifi/cache.wifi'),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "map-pin",
-        "function": "get_cachelocation",
     }
 }
 
-import sqlite3
 import datetime
-import struct
 import os
+import struct
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor
 
+
+@artifact_processor
 def get_cachelocation(files_found, report_folder, seeker, wrap_text):
 
-    source_file = ''
-    
+    data_list = []
+    source_path = ''
     for file_found in files_found:
-        
         file_name = str(file_found)
-        source_file = file_found.replace(seeker.data_folder, '')
- 
-        data_list = []
- 
-        # code to parse the cache.wifi and cache.cell taken from https://forensics.spreitzenbarth.de/2011/10/28/decoding-cache-cell-and-cache-wifi-files/
-        cacheFile = open(str(file_name), 'rb')
-        (version, entries) = struct.unpack('>hh', cacheFile.read(4))
-        # Check the number of entries * 32 (entry record size) to see if it is bigger then the file, this is a indication the file is malformed or corrupted
-        cache_file_size = os.stat(file_name).st_size
-        if ((entries * 32) < cache_file_size):            
-            i = 0
-            while i < entries:
-                key = cacheFile.read(struct.unpack('>h', cacheFile.read(2))[0])
-                (accuracy, confidence, latitude, longitude, readtime) = struct.unpack('>iiddQ', cacheFile.read(32))
-                timestamp = readtime/1000
-                i = i + 1
-                
-                starttime = datetime.datetime.utcfromtimestamp(timestamp).strftime('%Y-%m-%d %H:%M:%S')
-                data_list.append((accuracy, confidence, latitude, longitude, starttime))
-            cacheFile.close()
+        source_path = file_name
 
-            report = ArtifactHtmlReport('Cache Locations')
-            report.start_artifact_report(report_folder, 'Cache Locations')
-            report.add_script()
-            data_headers = ('Accuracy', 'Confidence', 'Latitude', 'Longitude', 'Readtime') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
+        # code to parse the cache.wifi and cache.cell taken from
+        # https://forensics.spreitzenbarth.de/2011/10/28/decoding-cache-cell-and-cache-wifi-files/
+        with open(file_name, 'rb') as cacheFile:
+            (version, entries) = struct.unpack('>hh', cacheFile.read(4))
+            # Check entries * 32 (entry record size) against file size to detect malformed/corrupt files
+            cache_file_size = os.stat(file_name).st_size
+            if (entries * 32) < cache_file_size:
+                i = 0
+                while i < entries:
+                    key = cacheFile.read(struct.unpack('>h', cacheFile.read(2))[0])
+                    (accuracy, confidence, latitude, longitude, readtime) = struct.unpack('>iiddQ', cacheFile.read(32))
+                    readtime_utc = datetime.datetime.fromtimestamp(readtime / 1000, datetime.timezone.utc)
+                    i = i + 1
+                    data_list.append((accuracy, confidence, latitude, longitude, readtime_utc))
 
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Cache Locations'
-            tsv(report_folder, data_headers, data_list, tsvname, source_file)
-
-            tlactivity = f'Cache Locations'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-
-        else:
-            logfunc('No Cachelocation Logs found')
+    data_headers = ('Accuracy', 'Confidence', 'Latitude', 'Longitude', ('Readtime', 'datetime'))
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/waze.py
+++ b/scripts/artifacts/waze.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_waze": {
         "name": "waze",
@@ -10,61 +10,45 @@ __artifacts_v2__ = {
         "category": "Waze",
         "notes": "",
         "paths": ('*/com.waze/user.db*',),
-        "output_types": None,
+        "output_types": "all",
         "artifact_icon": "map-pin",
-        "function": "get_waze",
     }
 }
 
-import sqlite3
-import textwrap
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, kmlgen
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+def _ts_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value), datetime.timezone.utc)
+    return ''
+
+
+@artifact_processor
 def get_waze(files_found, report_folder, seeker, wrap_text):
-    
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
-    
+
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     cursor.execute('''
-    select
-    datetime(PLACES.created_time, 'unixepoch'),
-    datetime(RECENTS.access_time, 'unixepoch'),
-    RECENTS.name,
-    PLACES.name as "Address",
-    round(PLACES.latitude*.000001,6),
-    round(PLACES.longitude*.000001,6)
-    from PLACES
-    join RECENTS on PLACES.id = RECENTS.place_id
+        select
+        PLACES.created_time,
+        RECENTS.access_time,
+        RECENTS.name,
+        PLACES.name as "Address",
+        round(PLACES.latitude*.000001,6),
+        round(PLACES.longitude*.000001,6)
+        from PLACES
+        join RECENTS on PLACES.id = RECENTS.place_id
     ''')
-    
     all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Waze - Recently Searched Locations')
-        report.start_artifact_report(report_folder, 'Waze - Recently Searched Locations')
-        report.add_script()
-        data_headers = ('Created Timestamp','Accessed Timestamp','Location Name','Address','Latitude','Longitude')
-        data_headers_kml = ('Timestamp','Accessed Timestamp','Location Name','Address','Latitude','Longitude')
-        data_list = []
-        for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5]))
-            
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Waze - Recently Searched Locations'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Waze - Recently Searched Locations'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-        kmlactivity = 'Waze - Recently Searched Locations'
-        kmlgen(report_folder, kmlactivity, data_list, data_headers_kml)
-        
-    else:
-        logfunc('No Waze - Recently Searched Locations data available')
-        
     db.close()
+
+    data_list = []
+    for row in all_rows:
+        data_list.append((_ts_to_utc(row[0]), _ts_to_utc(row[1]), row[2], row[3], row[4], row[5]))
+
+    data_headers = (('Created Timestamp', 'datetime'), ('Accessed Timestamp', 'datetime'), 'Location Name', 'Address', 'Latitude', 'Longitude')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts five location/transfer/chat parsers to the LAVA `@artifact_processor` pattern.

- **browserlocation** — `timestamp` raw → aware UTC `datetime`; narrowed bare `except`.
- **waze** — `created_time`/`access_time` raw → aware UTC `datetime`; `output_types: all` so the KML export is preserved (Latitude/Longitude columns kept exactly for auto-KML).
- **Zapya** — `createtime` raw → aware UTC `datetime`.
- **WordsWithFriends** — `created_at` raw → aware UTC `datetime` (replacing SQL `datetime(...,'unixepoch')`).
- **cachelocation** — struct-parsed cache.cell/cache.wifi flattened into one table; `readtime` → aware UTC `datetime`; kept `W0612` for the struct reads that advance the file cursor.

All SQL `datetime(...,'unixepoch')`/`utcfromtimestamp` strings replaced with aware-UTC datetimes. Verified: byte-compile, decorated 4-arg signature, returns 3-tuple, output_types valid, loader resolves, pylint clean.