### PR TITLE
Convert burnerUser, NikeNotifications, MMWUsers, wifiHotspot to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/MMWUsers.py
+++ b/scripts/artifacts/MMWUsers.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_map_users": {
         "name": "MapUsers",
@@ -10,68 +10,50 @@ __artifacts_v2__ = {
         "category": "Map-My-Walk",
         "notes": "",
         "paths": ('*com.mapmywalk.android2/databases/mmdk_user*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "map-pin",
-        "function": "get_map_users",
+        "html_columns": ['Profile Image URL'],
     }
 }
 
-# Get Information related to the user from the Map My Walk app
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-03-25
-# Version: 1.0
-# Requirements: Python 3.7 or higher
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
 
+def _ms_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    return ''
+
+
+@artifact_processor
 def get_map_users(files_found, report_folder, seeker, wrap_text):
-    logfunc("Processing data for Map My Walk Users")
-    files_found = [x for x in files_found if not x.endswith('-journal') and not x.endswith('_gear') and not x.endswith('_gear-journal')]
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
 
-    # Get information from the table device_sync_audit
+    files_found = [x for x in files_found if not str(x).endswith('-journal')
+                   and not str(x).endswith('_gear') and not str(x).endswith('_gear-journal')]
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     cursor.execute('''
-        Select id, username, email, display_name, birthdate, gender, height, weight, timezone,  datetime("date_joined"/1000,'unixepoch'),  datetime("last_login"/1000,'unixepoch'), location_country, profile_image_medium
+        Select id, username, email, display_name, birthdate, gender, height, weight, timezone,
+               date_joined, last_login, location_country, profile_image_medium
         from user_entity
     ''')
-
     all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        logfunc(f"Found {usageentries} entries in users")
-        report = ArtifactHtmlReport('User')
-        report.start_artifact_report(report_folder, 'Map-My-Walk User')
-        report.add_script()
-        data_headers = ('ID', 'Username', 'Email', 'Name', 'Birthdate', 'Gender', 'Height', 'Weight', 'Timezone', 'Date Joined', 'Last Login', 'Location Country', 'Profile Image URL')
-        data_list = []
-        for row in all_rows:
-            height = row[6]
-            height = round(height, 2)
-            weight = row[7]
-            weight = round(weight, 2)
-            if row[12]:
-                image = '<img src="'+row[12]+'" alt="'+row[10]+'" width="50" height="50">'
-            else:
-                image = 'N/A'
-
-            data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], height, weight, row[8], row[9], row[10], row[11], image))
-
-        # Filter by date
-        table_id = "MapUsers"
-        report.write_artifact_data_table(data_headers, data_list, file_found, table_id=table_id, html_escape=False)
-        report.end_artifact_report()
-
-        tsvname = f'Map - User'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = f'Map - User'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-
-    else:
-        logfunc('No Map My Walk Users data available')
-
     db.close()
+    logfunc(f"Found {len(all_rows)} entries in users")
+
+    data_list = []
+    for row in all_rows:
+        height = round(row[6], 2) if row[6] is not None else row[6]
+        weight = round(row[7], 2) if row[7] is not None else row[7]
+        if row[12]:
+            image = '<img src="' + row[12] + '" alt="' + str(row[10]) + '" width="50" height="50">'
+        else:
+            image = 'N/A'
+        data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], height, weight, row[8],
+                          _ms_to_utc(row[9]), _ms_to_utc(row[10]), row[11], image))
+
+    data_headers = ('ID', 'Username', 'Email', 'Name', 'Birthdate', 'Gender', 'Height', 'Weight', 'Timezone', ('Date Joined', 'datetime'), ('Last Login', 'datetime'), 'Location Country', 'Profile Image URL')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/NikeNotifications.py
+++ b/scripts/artifacts/NikeNotifications.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_nike_notifications": {
         "name": "NikeNotifications",
@@ -10,77 +10,38 @@ __artifacts_v2__ = {
         "category": "Nike-Run",
         "notes": "",
         "paths": ('*/com.nike.plusgps/databases/ns_inbox.db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "activity",
-        "function": "get_nike_notifications",
     }
 }
 
-# Get Information relative to the notifications stored in the database of the Nike Run Club Mobile application
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-03-18
-# Version: 1.0
-# Requirements: Python 3.7 or higher
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
 
+@artifact_processor
 def get_nike_notifications(files_found, report_folder, seeker, wrap_text):
-    logfunc("Processing data for Nike Notifications")
-    files_found = [x for x in files_found if not x.endswith('-journal')]
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
 
+    files_found = [x for x in files_found if not str(x).endswith('-journal')]
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     cursor.execute('''
-        Select
-        _id,
-        sender_user_id,
-        sender_app_id,
-         datetime("notification_timestamp"/1000,'unixepoch'), 
-        notification_type,
-        message, 
-        read,
-        deleted
+        Select _id, sender_user_id, sender_app_id, notification_timestamp,
+               notification_type, message, read, deleted
         from inbox
     ''')
-
     all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        logfunc(f"Found {usageentries} notifications")
-        report = ArtifactHtmlReport('Nike - Notifications')
-        report.start_artifact_report(report_folder, 'Nike - Notifications')
-        report.add_script()
-        data_headers = ('ID', 'Sender User ID', 'Sender App ID', 'Notification Timestamp', 'Notification Type', 'Message', 'Read', 'Deleted')
-        data_list = []
-        for row in all_rows:
-            read = row[6]
-            if read == 0:
-                read = 'No'
-            else:
-                read = 'Yes'
-            deleted = row[7]
-            if deleted == 0:
-                deleted = 'No'
-            else:
-                deleted = 'Yes'
-
-            data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], read, deleted))
-
-        table_id = "nike_notifications"
-        report.filter_by_date(table_id, 1)
-        report.write_artifact_data_table(data_headers, data_list, file_found, table_id=table_id)
-        report.end_artifact_report()
-
-        tsvname = f'Notifications'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = f'Notifications'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-
-    else:
-        logfunc('No Nike Notifications data available')
-
     db.close()
+    logfunc(f"Found {len(all_rows)} notifications")
+
+    data_list = []
+    for row in all_rows:
+        timestamp = datetime.datetime.fromtimestamp(int(row[3]) / 1000, datetime.timezone.utc) if row[3] else ''
+        read = 'No' if row[6] == 0 else 'Yes'
+        deleted = 'No' if row[7] == 0 else 'Yes'
+        data_list.append((row[0], row[1], row[2], timestamp, row[4], row[5], read, deleted))
+
+    data_headers = ('ID', 'Sender User ID', 'Sender App ID', ('Notification Timestamp', 'datetime'), 'Notification Type', 'Message', 'Read', 'Deleted')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/burnerUser.py
+++ b/scripts/artifacts/burnerUser.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0631
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_burnerUser": {
         "name": "Burner: Second Phone Number",
@@ -10,63 +10,44 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Burner",
         "notes": "",
-        "paths": ('*/data/com.adhoclabs.burner/databases/burnerDatabase.db*'),
-        "output_types": None,
+        "paths": ('*/data/com.adhoclabs.burner/databases/burnerDatabase.db*',),
+        "output_types": "standard",
         "artifact_icon": "user",
-        "function": "get_burnerUser"
     }
 }
 
-import sqlite3
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, timeline, tsv, is_platform_windows, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_burnerUser(files_found, report_folder, seeker, wrap_text):
-    
+
     data_list = []
-    
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
-        if file_found.endswith('burnerDatabase.db'):
-            db = open_sqlite_db_readonly(file_found)
-            #SQL QUERY TIME!
-            cursor = db.cursor()
-            cursor.execute('''
+        if not file_found.endswith('burnerDatabase.db'):
+            continue
+
+        source_path = file_found
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        cursor.execute('''
             SELECT
-            datetime(json_extract(BurnerEntity.value, '$.dateCreated')/1000, 'unixepoch') as  'Date Created', 
+            json_extract(BurnerEntity.value, '$.dateCreated') as 'Date Created',
             id as 'User ID',
             json_extract(BurnerEntity.value, '$.phoneNumberId') as 'Phone Number',
             json_extract(BurnerEntity.value, '$.autoReplyText') as 'Auto Reply Message'
             FROM BurnerEntity
-            ''')
+        ''')
+        all_rows = cursor.fetchall()
+        db.close()
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                for row in all_rows:
-               
-                    data_list.append((row[0],row[1],row[2],row[3]))
-            db.close()
-                    
-        else:
-            continue
-        
-    if data_list:
-        description = 'Burner: Second Phone Number'
-        report = ArtifactHtmlReport('Burner User Information')
-        report.start_artifact_report(report_folder, 'Burner User', description)
-        report.add_script()
-        data_headers = ('Timestamp','User ID','Phone Number','Auto Reply Message')
-        report.write_artifact_data_table(data_headers, data_list, file_found,html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = 'Burner User'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = 'Burner User'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    
-    else:
-        logfunc('No Burner data available')
+        for row in all_rows:
+            created = datetime.datetime.fromtimestamp(int(row[0]) / 1000, datetime.timezone.utc) if row[0] else ''
+            data_list.append((created, row[1], row[2], row[3]))
+
+    data_headers = (('Timestamp', 'datetime'), 'User ID', ('Phone Number', 'phonenumber'), 'Auto Reply Message')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/wifiHotspot.py
+++ b/scripts/artifacts/wifiHotspot.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_wifiHotspot": {
         "name": "wifiHotspot",
@@ -10,23 +10,25 @@ __artifacts_v2__ = {
         "category": "WiFi Profiles",
         "notes": "",
         "paths": ('*/misc/wifi/softap.conf', '*/misc**/apexdata/com.android.wifi/WifiConfigStoreSoftAp.xml'),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "wifi",
-        "function": "get_wifiHotspot",
     }
 }
 
-import struct
 import xml.etree.ElementTree as ET
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline
+from scripts.ilapfuncs import artifact_processor
 
+
+@artifact_processor
 def get_wifiHotspot(files_found, report_folder, seeker, wrap_text):
+
     data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
+        source_path = file_found
+
         ssid = ''
         security_type = ''
         passphrase = ''
@@ -35,7 +37,7 @@ def get_wifiHotspot(files_found, report_folder, seeker, wrap_text):
             with open(file_found, 'rb') as f:
                 data = f.read()
                 ssid_len = data[5]
-                ssid = data[6 : 6 + ssid_len].decode('utf8', 'ignore')
+                ssid = data[6: 6 + ssid_len].decode('utf8', 'ignore')
 
                 data_len = len(data)
                 start_pos = -1
@@ -46,28 +48,18 @@ def get_wifiHotspot(files_found, report_folder, seeker, wrap_text):
             tree = ET.parse(file_found)
             for node in tree.iter('SoftAp'):
                 for elem in node.iter():
-                    if not elem.tag==node.tag:
-                        #print(elem.attrib)
+                    if elem.tag != node.tag:
                         data = elem.attrib
                         name = data.get('name', '')
-                        if name == 'SSID' or name == 'WifiSsid':
+                        if name in ('SSID', 'WifiSsid'):
                             ssid = elem.text
                         elif name == 'SecurityType':
                             security_type = data.get('value', '')
                         elif name == 'Passphrase':
                             passphrase = elem.text
+
         if ssid:
             data_list.append((ssid, passphrase, security_type))
 
-    if data_list:
-        report = ArtifactHtmlReport('Wi-Fi Hotspot')
-        report.start_artifact_report(report_folder, 'Wi-Fi Hotspot')
-        report.add_script()
-        data_headers = ('SSID', 'Passphrase', 'SecurityType')
-        report.write_artifact_data_table(data_headers, data_list, ", ".join(files_found))
-        report.end_artifact_report()
-        
-        tsvname = f'wifi hotspot'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc('No Wi-Fi Hotspot data available')
+    data_headers = ('SSID', 'Passphrase', 'SecurityType')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts four more parsers to the LAVA `@artifact_processor` pattern.

- **burnerUser** — `dateCreated` json-extracted raw → aware UTC `datetime`; `Phone Number` marked `phonenumber`. Fixed `paths` (was a bare string, not a 1-tuple). Completes the Burner family.
- **NikeNotifications** — `notification_timestamp` raw → aware UTC `datetime` (replacing SQL `datetime(...,'unixepoch')`); dropped the HTML-only `filter_by_date` call.
- **MMWUsers** — `date_joined`/`last_login` raw → aware UTC `datetime`; `Profile Image URL` declared in `html_columns`; guarded `round()` against NULL height/weight.
- **wifiHotspot** — flat binary `.conf` + SoftAp XML parser; no timestamps.

Verified: byte-compile, decorated 4-arg signature, returns 3-tuple, output_types valid, paths are tuples, loader resolves, pylint clean.