### PR TITLE
Convert BadooConnections, deviceHealthServices_AppUsage, gmail to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/BadooConnections.py
+++ b/scripts/artifacts/BadooConnections.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0622,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_badoo_conn": {
         "name": "BadooConnections",
@@ -10,65 +10,37 @@ __artifacts_v2__ = {
         "category": "Badoo",
         "notes": "",
         "paths": ('*com.badoo.mobile/databases/CombinedConnectionsDatabase*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "users",
-        "function": "get_badoo_conn",
+        "html_columns": ['Avatar URL'],
     }
 }
 
-# Get Information related to possible connections (messages, views etc) of the user with other users from the Badoo app (com.badoo.mobile)
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-05-03
-# Version: 1.0
-# Requirements: Python 3.7 or higher
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
 
+@artifact_processor
 def get_badoo_conn(files_found, report_folder, seeker, wrap_text):
-    logfunc("Processing data for Badoo Conections")
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
 
+    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     cursor.execute('''
-        Select id, name, gender, origin, datetime("sort_timestamp"/1000,'unixepoch'), avatar_url, display_message
+        Select id, name, gender, origin, sort_timestamp, avatar_url, display_message
         from connection
     ''')
-
     all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        logfunc(f"Found {usageentries} entries in connection")
-        report = ArtifactHtmlReport('Chat')
-        report.start_artifact_report(report_folder, 'Badoo Connections')
-        report.add_script()
-        data_headers = ('ID', 'Name', 'Gender', 'Origin', 'Sort Timestamp', 'Avatar URL', 'Display Message')
-        data_list = []
-
-        for row in all_rows:
-            id = row[0]
-            name = row[1]
-            gender = row[2]
-            origin = row[3]
-            sort_timestamp = row[4]
-            avatar_url = '<img src="' + row[5] + '" width="100" height="100">'
-            display_message = row[6]
-            data_list.append((id, name, gender, origin, sort_timestamp, avatar_url, display_message))
-        # Filter by date
-        table_id = "BadooConnection"
-        report.write_artifact_data_table(data_headers, data_list, file_found, table_id=table_id, html_escape=False)
-        report.end_artifact_report()
-
-        tsvname = f'Badoo - Connections'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = f'Badoo - Connections'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-
-    else:
-        logfunc('No Badoo Connection data available')
-
     db.close()
+    logfunc(f"Found {len(all_rows)} entries in connection")
+
+    data_list = []
+    for row in all_rows:
+        sort_timestamp = datetime.datetime.fromtimestamp(int(row[4]) / 1000, datetime.timezone.utc) if row[4] else ''
+        avatar_url = '<img src="' + row[5] + '" width="100" height="100">' if row[5] else ''
+        data_list.append((row[0], row[1], row[2], row[3], sort_timestamp, avatar_url, row[6]))
+
+    data_headers = ('ID', 'Name', 'Gender', 'Origin', ('Sort Timestamp', 'datetime'), 'Avatar URL', 'Display Message')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/deviceHealthServices_AppUsage.py
+++ b/scripts/artifacts/deviceHealthServices_AppUsage.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0612,W0613,W0631,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_Turbo_AppUsage": {
         "name": "Turbo_AppUsage",
@@ -9,57 +9,36 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Device Health Services",
         "notes": "",
-        "paths": ('*/com.google.android.apps.turbo/shared_prefs/app_usage_stats.xml'),
-        "output_types": None,
+        "paths": ('*/com.google.android.apps.turbo/shared_prefs/app_usage_stats.xml',),
+        "output_types": "standard",
         "artifact_icon": "bar-chart-2",
-        "function": "get_Turbo_AppUsage",
     }
 }
 
 import datetime
-import struct
 import xml.etree.ElementTree as ET
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import artifact_processor
 
+
+@artifact_processor
 def get_Turbo_AppUsage(files_found, report_folder, seeker, wrap_text):
-    
+
     data_list = []
-    splits = []
-    app_name = ''
-    timestamp_split = ''
-    
+    source_path = ''
     for file_found in files_found:
-        file_name = str(file_found)
+        file_found = str(file_found)
+        source_path = file_found
         tree = ET.parse(file_found)
-        
+
         for elem in tree.iter(tag='string'):
             splits = elem.text.split('#')
-            
             app_name = splits[0]
             timesplitter = splits[1].split(',')
-            count = len(timesplitter)
 
-            for i in range(len(timesplitter)):
-                timestamp_split = datetime.datetime.utcfromtimestamp(int(timesplitter[i])/1000).strftime('%Y-%m-%d %H:%M:%S.%f')
-                timestamp_split = timestamp_split.strip('0')
+            for ts in timesplitter:
+                timestamp_split = datetime.datetime.fromtimestamp(int(ts) / 1000, datetime.timezone.utc)
+                data_list.append((timestamp_split, app_name))
 
-                data_list.append((timestamp_split, app_name, file_found))
-        
-    if data_list:
-        report = ArtifactHtmlReport('Turbo - Application Usage')
-        report.start_artifact_report(report_folder, f'Turbo - Application Usage')
-        report.add_script()
-        data_headers = ('App Launch Timestamp','App Name','Source')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Turbo - Application Usage'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Turbo - Application Usage'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc(f'No Turbo - Application Usage data available')
-
+    data_headers = (('App Launch Timestamp', 'datetime'), 'App Name')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/gmail.py
+++ b/scripts/artifacts/gmail.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0622,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_gmailActive": {
         "name": "GmailActive",
@@ -10,58 +10,26 @@ __artifacts_v2__ = {
         "category": "Gmail",
         "notes": "",
         "paths": ('*/com.google.android.gm/shared_prefs/Gmail.xml',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "mail",
-        "function": "get_gmailActive",
     }
 }
 
-# gmailActive: Get gmail account information
-# Author: Joshua James {joshua@dfirscience.org}
-# Date: 2021-11-08
-# Artifact version: 0.0.1
-# Android version tested: 11
-# Requirements: none
-
 import xml.etree.ElementTree as ET
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import artifact_processor, logfunc
 
-class keyboard_event:
-    def __init__(self, id, app, text, textbox_name, textbox_id, event_date, start_date='', end_date=''):
-        self.id = id
-        self.app = app
-        self.text = text
-        self.textbox_name = textbox_name
-        self.textbox_id = textbox_id
-        self.event_date = event_date
-        self.start_date = start_date
-        self.end_date = end_date
 
+@artifact_processor
 def get_gmailActive(files_found, report_folder, seeker, wrap_text):
-    #logfunc("If you can read this, the module is working!")
-    #logfunc(files_found)
-    activeAccount = ''
-    file_found = str(files_found[0])
-    xmlTree = ET.parse(file_found)
-    root = xmlTree.getroot()
+
+    data_list = []
+    source_path = str(files_found[0])
+    root = ET.parse(source_path).getroot()
     for child in root:
         if child.attrib['name'] == "active-account":
             logfunc("Active gmail account found: " + child.text)
-            activeAccount = child.text
+            data_list.append((child.text,))
 
-    if activeAccount != '':
-        report = ArtifactHtmlReport('Gmail - Active')
-        report.start_artifact_report(report_folder, 'Gmail - Active')
-        report.add_script()
-        data_headers = ('Active Gmail Address','') # final , needed for table formatting
-        data_list = []
-        data_list.append((activeAccount, ''))# We only expect one active account
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-            
-        tsvname = f'Gmail - Active'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc('No active Gmail account found')
+    data_headers = ('Active Gmail Address',)
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts three more parsers to the LAVA `@artifact_processor` pattern.

- **BadooConnections** — `sort_timestamp` raw → aware UTC `datetime` (replacing SQL `datetime(...,'unixepoch')`); `Avatar URL` declared in `html_columns`; guarded the avatar `<img>` against NULL.
- **deviceHealthServices_AppUsage** (Turbo_AppUsage) — per-launch timestamps → aware UTC `datetime`; dropped the redundant per-row `Source` column; fixed `paths` (was a bare string, not a 1-tuple).
- **gmail** (GmailActive) — active-account lookup; dropped dead `keyboard_event` class and the empty filler column.

Verified: byte-compile, decorated 4-arg signature, returns 3-tuple, output_types valid, paths are tuples, loader resolves, pylint clean.