### PR TITLE
Convert burnerMessages, MicrosoftAuthenticator, installedappsVending, PumaUsers to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/MicrosoftAuthenticator.py
+++ b/scripts/artifacts/MicrosoftAuthenticator.py
@@ -1,7 +1,5 @@
-# pylint: disable=W0612,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
-
-    
     "get_MSAuth_accounts": {
         "name": "Microsoft Authenticator - Accounts",
         "description": "Parses the existing Accounts out of the Microsoft Authenticator App.",
@@ -11,72 +9,36 @@ __artifacts_v2__ = {
         "requirements": "",
         "category": "MS Authenticator",
         "notes": "Get Account information from MS authenticator app.",
-        "paths": ('*/com.azure.authenticator/databases/PhoneFactor*'),
-        "output_types": None,
+        "paths": ('*/com.azure.authenticator/databases/PhoneFactor*',),
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "shield",
-        "function": "get_MSAuth_accounts",
     }
 }
 
-# Microsoft Authenticator (com.azure.authenticator)
-# Author:  Marco Neumann (kalinko@be-binary.de)
-# Version: 0.0.1
-# 
-# Tested with the following versions:
-# 2024-05-11: Android 14, App: 6.2404.2229
-
-# Requirements: -
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
 
-
-
+@artifact_processor
 def get_MSAuth_accounts(files_found, report_folder, seeker, wrap_text):
     logfunc("Processing data for Microsoft Authenticator - Accounts")
- 
-    accountUUIDS = []
-    mail_addresses = []
- 
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
-    
+
+    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
+
+    data_list = []
+    source_path = ''
     for file_found in files_found:
-        db = open_sqlite_db_readonly(file_found)
+        source_path = str(file_found)
+        db = open_sqlite_db_readonly(source_path)
         cursor = db.cursor()
         cursor.execute('''
             SELECT name, username, oath_secret_key
             FROM accounts
         ''')
         data_rows = cursor.fetchall()
-        
-        if len(data_rows):
-            logfunc(f"Found {len(data_rows)}  Microsoft Authenticator - Accounts")
-
-            description = f"Existing accounts in the Microsoft Authenticator App. These accounts are set up for 2FA on the device. Service Name is a user given label that can give hint to existing cloud accounts."
-            report = ArtifactHtmlReport('Microsoft Authenticator - Accounts')
-            report.start_artifact_report(report_folder, 'Microsoft Authenticator - Accounts', description)
-            report.add_script()
-            data_headers = ('Service Name', 'User Name', 'OATH Secret Key')
-            data_list = []
-            for row in data_rows:
-                service_name = row[0]
-                user_name = row[1]
-                secret = row[2]
-
-                data_list.append((service_name, user_name, secret))                          
-            tableID = 'msauth_accounts'
-
-            report.write_artifact_data_table(data_headers, data_list, ','.join(files_found))
-            report.end_artifact_report()
-
-            tsvname = f'MS Authenticator - Accounts'
-            tsv(report_folder, data_headers, data_list, tsvname)
-
-            tlactivity = f'MS Authenticator - Accounts'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No entries found for MS Authenticator.')
-
         db.close()
-        
-        
+
+        for row in data_rows:
+            data_list.append((row[0], row[1], row[2]))
+
+    data_headers = ('Service Name', 'User Name', 'OATH Secret Key')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/PumaUsers.py
+++ b/scripts/artifacts/PumaUsers.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_puma_users": {
         "name": "PumaUsers",
@@ -10,70 +10,40 @@ __artifacts_v2__ = {
         "category": "Puma-Trac",
         "notes": "",
         "paths": ('*com.pumapumatrac/databases/pumatrac-db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "user",
-        "function": "get_puma_users",
+        "html_columns": ['Profile Image URL'],
     }
 }
 
-# Get Information related to the users table in the Puma Trac database
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-03-25
-# Version: 1.0
-# Requirements: Python 3.7 or higher
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
 
+@artifact_processor
 def get_puma_users(files_found, report_folder, seeker, wrap_text):
-    logfunc("Processing data for Puma Users")
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
 
-    # Get information from the table device_sync_audit
+    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     cursor.execute('''
-        Select id, email, name, sex, datetime("dateOfBirth"/1000,'unixepoch'), weight, height, country, location, interestsIds, profileImageUrl, totalScore, followingCount, followersCount, goal_id, preferences_workoutTimeOfDay, preferences_workoutDuration
+        Select id, email, name, sex, dateOfBirth, weight, height, country, location, interestsIds,
+               profileImageUrl, totalScore, followingCount, followersCount, goal_id,
+               preferences_workoutTimeOfDay, preferences_workoutDuration
         from users
     ''')
-
     all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        logfunc(f"Found {usageentries} entries in users")
-        report = ArtifactHtmlReport('User')
-        report.start_artifact_report(report_folder, 'Puma User')
-        report.add_script()
-        data_headers = ('ID', 'Email', 'Name', 'Gender', 'Date of Birth', 'Weight', 'Height', 'Country', 'Location', 'Interests', 'Profile Image URL', 'Total Score', 'Following Count', 'Followers Count', 'Goal', 'Workout Time of Day', 'Workout Duration')
-        data_list = []
-        for row in all_rows:
-            work_time = row[16]
-            if work_time:
-                # convert to minutes
-                work_time = work_time / 60
-            else:
-                work_time = 'N/A'
-            if row[10]:
-                image = '<img src="'+row[10]+'" alt="'+row[10]+'" width="50" height="50">'
-            else:
-                image = 'N/A'
-
-            data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], image, row[11], row[12], row[13], row[14], row[15], work_time))
-
-        # Filter by date
-        table_id = "PumaUsers"
-        report.write_artifact_data_table(data_headers, data_list, file_found, table_id=table_id, html_escape=False)
-        report.end_artifact_report()
-
-        tsvname = f'Puma - User'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = f'Puma - User'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-
-    else:
-        logfunc('No Puma Users data available')
-
     db.close()
+    logfunc(f"Found {len(all_rows)} entries in users")
+
+    data_list = []
+    for row in all_rows:
+        dob = datetime.datetime.fromtimestamp(int(row[4]) / 1000, datetime.timezone.utc) if row[4] else ''
+        work_time = row[16] / 60 if row[16] else 'N/A'
+        image = '<img src="' + row[10] + '" alt="' + row[10] + '" width="50" height="50">' if row[10] else 'N/A'
+        data_list.append((row[0], row[1], row[2], row[3], dob, row[5], row[6], row[7], row[8], row[9], image, row[11], row[12], row[13], row[14], row[15], work_time))
+
+    data_headers = ('ID', 'Email', 'Name', 'Gender', ('Date of Birth', 'datetime'), 'Weight', 'Height', 'Country', 'Location', 'Interests', 'Profile Image URL', 'Total Score', 'Following Count', 'Followers Count', 'Goal', 'Workout Time of Day', 'Workout Duration')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/burnerMessages.py
+++ b/scripts/artifacts/burnerMessages.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0631
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_burnerMessages": {
         "name": "Burner: Second Phone Number",
@@ -10,35 +10,36 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Burner",
         "notes": "",
-        "paths": ('*/data/com.adhoclabs.burner/databases/burnerDatabase.db*'),
-        "output_types": None,
+        "paths": ('*/data/com.adhoclabs.burner/databases/burnerDatabase.db*',),
+        "output_types": "standard",
         "artifact_icon": "message-square",
-        "function": "get_burnerMessages"
     }
 }
 
-import sqlite3
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, timeline, tsv, is_platform_windows, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_burnerMessages(files_found, report_folder, seeker, wrap_text):
-    
+
     data_list = []
-    
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
-        if file_found.endswith('burnerDatabase.db'):
-            db = open_sqlite_db_readonly(file_found)
-            #SQL QUERY TIME!
-            cursor = db.cursor()
-            cursor.execute('''
+        if not file_found.endswith('burnerDatabase.db'):
+            continue
+
+        source_path = file_found
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        cursor.execute('''
             SELECT
-            datetime(json_extract(MessageEntity.value, '$.dateCreated')/1000, 'unixepoch') as Date_Created,
+            json_extract(MessageEntity.value, '$.dateCreated') as Date_Created,
             json_extract(MessageEntity.value, '$.contactPhoneNumber') as Contact,
             json_extract(MessageEntity.value, '$.message') as Message,
-            CASE json_extract(MessageEntity.value, '$.direction') 
+            CASE json_extract(MessageEntity.value, '$.direction')
                 WHEN 1 THEN 'Incoming'
                 WHEN 2 THEN 'Outgoing'
                 ELSE 'Unknown'
@@ -49,33 +50,13 @@ def get_burnerMessages(files_found, report_folder, seeker, wrap_text):
                 ELSE 'Unknown'
             END as Read
             FROM MessageEntity
-            ''')
+        ''')
+        all_rows = cursor.fetchall()
+        db.close()
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                for row in all_rows:
-               
-                    data_list.append((row[0],row[1],row[2],row[3],row[4]))
-            db.close()
-                    
-        else:
-            continue
-        
-    if data_list:
-        description = 'Burner: Second Phone Number'
-        report = ArtifactHtmlReport('Burner Messages')
-        report.start_artifact_report(report_folder, 'Burner Messages', description)
-        report.add_script()
-        data_headers = ('Timestamp','Contact','Message Text','Direction','Read Status')
-        report.write_artifact_data_table(data_headers, data_list, file_found,html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = 'Burner Messages'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = 'Burner Messages'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    
-    else:
-        logfunc('No Burner data available')
+        for row in all_rows:
+            created = datetime.datetime.fromtimestamp(int(row[0]) / 1000, datetime.timezone.utc) if row[0] else ''
+            data_list.append((created, row[1], row[2], row[3], row[4]))
+
+    data_headers = (('Timestamp', 'datetime'), ('Contact', 'phonenumber'), 'Message Text', 'Direction', 'Read Status')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/installedappsVending.py
+++ b/scripts/artifacts/installedappsVending.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0311,W0611,W0612,W0613
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_installedappsVending": {
         "name": "InstalledappsVending",
@@ -10,78 +10,58 @@ __artifacts_v2__ = {
         "category": "Installed Apps",
         "notes": "",
         "paths": ('*/com.android.vending/databases/localappstate.db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "package",
-        "function": "get_installedappsVending",
     }
 }
 
-import sqlite3
+import datetime
 from pathlib import Path
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly, does_column_exist_in_db
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, does_column_exist_in_db
 
+
+def _ms_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    return ''
+
+
+@artifact_processor
 def get_installedappsVending(files_found, report_folder, seeker, wrap_text):
-    
+
+    data_list = []
+    source_path = ''
     for file_found in files_found:
-        file_name = str(file_found)
-        fullpath = Path(file_found)
-        user = fullpath.parts[-4]
+        file_found = str(file_found)
+        if not file_found.endswith('localappstate.db'):
+            continue
+
+        user = Path(file_found).parts[-4]
         if user == 'data':
             user = '0'
-        if file_found.endswith('localappstate.db'):
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            
-            if does_column_exist_in_db(file_found, 'appstate','install_reason') == True:
-                install_reason_query = '''install_reason'''
-            else:
-                install_reason_query = "'' as install_reason"
-        
-            cursor.execute(f'''
-            SELECT
-            CASE first_download_ms
-                WHEN '0' THEN '' 
-                ELSE
-                    datetime(first_download_ms / 1000, "unixepoch")
-            END AS 'First_Download_DT',
-            package_name,
-            title,
-            {install_reason_query},
-            CASE last_update_timestamp_ms
-                WHEN '0' THEN '' 
-                ELSE
-                    datetime(last_update_timestamp_ms / 1000, "unixepoch")
-            END AS 'Last_Updated_DT',
-            CASE auto_update
-                WHEN '0' THEN ''
-                WHEN '1' THEN 'Yes'
-            END AS 'Auto_Updated',
-            account
-            FROM appstate  
-            ''')
-        
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                report = ArtifactHtmlReport(f'Installed Apps (Vending) {user}')
-                report.start_artifact_report(report_folder, f'Installed Apps (Vending) for user {user}')
-                report.add_script()
-                data_headers = ('First Download','Package Name', 'Title', 'Install Reason', 'Last Updated', 'Auto Update?', 'Account')
-                data_list = []
-                for row in all_rows:
-                    data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6]))
-        
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Installed Apps Vending {user}'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-                tlactivity = f'Installed Apps Vending {user}'
-                timeline(report_folder, tlactivity, data_list, data_headers)        
-            else:
-                    logfunc(f'No Installed Apps data available for user {user}')
-    
-    db.close()
+
+        source_path = file_found
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+
+        if does_column_exist_in_db(file_found, 'appstate', 'install_reason'):
+            install_reason_query = 'install_reason'
+        else:
+            install_reason_query = "'' as install_reason"
+
+        cursor.execute(f'''
+            SELECT first_download_ms, package_name, title, {install_reason_query},
+                   last_update_timestamp_ms,
+                   CASE auto_update WHEN '0' THEN '' WHEN '1' THEN 'Yes' END AS 'Auto_Updated',
+                   account
+            FROM appstate
+        ''')
+        all_rows = cursor.fetchall()
+        db.close()
+
+        for row in all_rows:
+            data_list.append((user, _ms_to_utc(row[0]), row[1], row[2], row[3], _ms_to_utc(row[4]), row[5], row[6]))
+
+    data_headers = ('User', ('First Download', 'datetime'), 'Package Name', 'Title', 'Install Reason', ('Last Updated', 'datetime'), 'Auto Update?', 'Account')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts four more parsers to the LAVA `@artifact_processor` pattern.

- **burnerMessages** — `dateCreated` json-extracted raw → aware UTC `datetime`; `Contact` marked `phonenumber`; fixed `paths` (bare string → 1-tuple). Completes the Burner family.
- **MicrosoftAuthenticator** — flat accounts table across DBs; no timestamps; fixed `paths` tuple.
- **installedappsVending** — flattened per-user reports → one table with a `User` column; `first_download_ms`/`last_update_timestamp_ms` raw → aware UTC `datetime`; kept the dynamic `install_reason` column probe.
- **PumaUsers** — `dateOfBirth` raw → aware UTC `datetime`; `Profile Image URL` declared in `html_columns`; NULL-guarded workout-duration/image.

All SQL `datetime(...,'unixepoch')` strings replaced with aware-UTC datetimes. Verified: byte-compile, decorated 4-arg signature, returns 3-tuple, output_types valid, paths are tuples, loader resolves, pylint clean.