### PR TITLE
Convert VerizonRDDWIFI, VerizonRDDAnalytics, swellbeing to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/VerizonRDDAnalytics.py
+++ b/scripts/artifacts/VerizonRDDAnalytics.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0718,W1309
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_rdd_analytics": {
         "name": "VerizonRDD-Battery",
@@ -10,72 +10,39 @@ __artifacts_v2__ = {
         "category": "Verizon RDD Analytics",
         "notes": "",
         "paths": ('*/com.verizon.mips.services/databases/RDD_ANALYTICS_DATABASE',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "battery",
-        "function": "get_rdd_analytics",
     }
 }
 
-# Module Description: Parses Verizon RDD Analytics Battery History
-# Author: John Hyla
-# Date: 2023-07-07
-# Artifact version: 0.0.1
-# Requirements: none
-
-import os
-import sqlite3
 import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_rdd_analytics(files_found, report_folder, seeker, wrap_text):
 
-    source_file = ''
+    data_list = []
+    source_path = ''
     for file_found in files_found:
-        file_name = str(file_found)
-
-        db = open_sqlite_db_readonly(file_name)
+        source_path = str(file_found)
+        db = open_sqlite_db_readonly(source_path)
         cursor = db.cursor()
         try:
-
             cursor.execute('''
-                SELECT datetime(ActualTime/1000, "UNIXEPOCH") as actual_time, 
-                FormattedTime,
-                BatteryLevel, 
-                GPS, 
-                Charging, 
-                ScreenOn,
-                Brightness, 
-                BatteryTemp
-                  FROM TableBatteryHistory
-                  ''')
-
+                SELECT ActualTime, FormattedTime, BatteryLevel, GPS, Charging, ScreenOn, Brightness, BatteryTemp
+                FROM TableBatteryHistory
+            ''')
             all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
         except Exception as e:
-            print (e)
-            usageentries = 0
-            
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Verizon RDD - Battery History')
-            report.start_artifact_report(report_folder, 'Verizon RDD - Battery History')
-            report.add_script()
-            data_headers = ('ActualTime', 'FormattedTime', 'BatteryLevel', 'GPS', 'Charging', 'ScreenOn', 'Brightness', 'BatteryTemp') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-            data_list = []
-            for row in all_rows:
-                data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7]))
-
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Verizon RDD - Battery History'
-            tsv(report_folder, data_headers, data_list, tsvname, source_file)
-            
-        else:
-            logfunc('No Battery History found')
-            
-
+            logfunc(str(e))
+            all_rows = []
         db.close()
-    
-    return
+
+        for row in all_rows:
+            actual_time = datetime.datetime.fromtimestamp(int(row[0]) / 1000, datetime.timezone.utc) if row[0] else ''
+            data_list.append((actual_time, row[1], row[2], row[3], row[4], row[5], row[6], row[7]))
+
+    data_headers = (('ActualTime', 'datetime'), 'FormattedTime', 'BatteryLevel', 'GPS', 'Charging', 'ScreenOn', 'Brightness', 'BatteryTemp')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/VerizonRDDWIFI.py
+++ b/scripts/artifacts/VerizonRDDWIFI.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0718,W1309
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_rdd_wifi": {
         "name": "VerizonRDD-WIFI",
@@ -10,71 +10,48 @@ __artifacts_v2__ = {
         "category": "Verizon RDD Analytics",
         "notes": "",
         "paths": ('*/com.verizon.mips.services/databases/RDD_WIFI_DATA_DATABASE',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "wifi",
-        "function": "get_rdd_wifi",
     }
 }
 
-# Module Description: Parses Verizon RDD Wifi Data
-# Author: John Hyla
-# Date: 2023-07-07
-# Artifact version: 0.0.1
-# Requirements: none
-
-import os
-import sqlite3
 import datetime
 import json
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
+
+@artifact_processor
 def get_rdd_wifi(files_found, report_folder, seeker, wrap_text):
 
-    source_file = ''
+    data_list = []
+    source_path = ''
     for file_found in files_found:
-        file_name = str(file_found)
-
-        db = open_sqlite_db_readonly(file_name)
+        source_path = str(file_found)
+        db = open_sqlite_db_readonly(source_path)
         cursor = db.cursor()
         try:
-
             cursor.execute('''
-                SELECT datetime(timestamp/1000, "UNIXEPOCH") as timestamp, 
-                eventid,
-                event, 
-                data
-                  FROM TABLERDDWIFIDATA
-                  ''')
-
+                SELECT timestamp, eventid, event, data
+                FROM TABLERDDWIFIDATA
+            ''')
             all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
         except Exception as e:
-            print (e)
-            usageentries = 0
-            
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Verizon RDD - WIFI Data')
-            report.start_artifact_report(report_folder, 'Verizon RDD - WIFI Data')
-            report.add_script()
-            data_headers = ('Timestamp', 'Event ID', 'Event', 'BSSID', 'SSID', 'IP', 'SessionTime', 'DataTx', 'DataRx', 'Cell ID') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-            data_list = []
-
-            for row in all_rows:
-                json_data = json.loads(row[3])
-                data_list.append((row[0], row[1], row[2], json_data.get('wifiinfo').get('bssid'), json_data.get('wifiinfo').get('ssid'), json_data.get('returnedIP'), json_data.get('totalSessionTime'), json_data.get('sessionWifiTx'), json_data.get('sessionWifiRx'), json_data.get('cellId')))
-
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Verizon RDD - WIFI Data'
-            tsv(report_folder, data_headers, data_list, tsvname, source_file)
-            
-        else:
-            logfunc('No WIFI Data found')
-            
-
+            logfunc(str(e))
+            all_rows = []
         db.close()
-    
-    return
+
+        for row in all_rows:
+            timestamp = datetime.datetime.fromtimestamp(int(row[0]) / 1000, datetime.timezone.utc) if row[0] else ''
+            json_data = json.loads(row[3])
+            data_list.append((timestamp, row[1], row[2],
+                              json_data.get('wifiinfo').get('bssid'),
+                              json_data.get('wifiinfo').get('ssid'),
+                              json_data.get('returnedIP'),
+                              json_data.get('totalSessionTime'),
+                              json_data.get('sessionWifiTx'),
+                              json_data.get('sessionWifiRx'),
+                              json_data.get('cellId')))
+
+    data_headers = (('Timestamp', 'datetime'), 'Event ID', 'Event', 'BSSID', 'SSID', 'IP', 'SessionTime', 'DataTx', 'DataRx', 'Cell ID')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/swellbeing.py
+++ b/scripts/artifacts/swellbeing.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0631,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_swellbeing": {
         "name": "swellbeing",
@@ -10,31 +10,34 @@ __artifacts_v2__ = {
         "category": "Digital Wellbeing",
         "notes": "",
         "paths": ('*/com.samsung.android.forest/databases/dwbCommon.db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "battery",
-        "function": "get_swellbeing",
     }
 }
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+import datetime
 
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+
+
+@artifact_processor
 def get_swellbeing(files_found, report_folder, seeker, wrap_text):
 
     data_list = []
-    
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('dwbCommon.db'):
-            continue # Skip all other files
-        
+            continue  # Skip all other files
+
+        source_path = file_found
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
         SELECT
-        datetime(usageEvents.timeStamp/1000, "UNIXEPOCH") as timestamps,
+        usageEvents.timeStamp,
         usageEvents.eventId,
-        foundPackages.name, 
+        foundPackages.name,
         usageEvents.eventType,
         CASE
         when usageEvents.eventType=1 THEN 'ACTIVITY_RESUMED'
@@ -59,27 +62,12 @@ def get_swellbeing(files_found, report_folder, seeker, wrap_text):
         FROM usageEvents
         INNER JOIN foundPackages ON usageEvents.pkgId=foundPackages.pkgId
         ''')
-
         all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0: 
-            for row in all_rows:
-                data_list.append((row[0], row[1], row[2], row[3], row[4], file_found))
         db.close()
-        
-    if data_list:
-        report = ArtifactHtmlReport('Samsung Digital Wellbeing - Events')
-        report.start_artifact_report(report_folder, 'Samsung Digital Wellbeing - Events')
-        report.add_script()
-        data_headers = ('Timestamp','Event ID','Package Name','Event Type','Event Type Description','Source File')
-        
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Samsung Digital Wellbeing - Events'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Samsung Digital Wellbeing - Events'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Samsung Digital Wellbeing - Events data available')
+
+        for row in all_rows:
+            timestamp = datetime.datetime.fromtimestamp(int(row[0]) / 1000, datetime.timezone.utc) if row[0] else ''
+            data_list.append((timestamp, row[1], row[2], row[3], row[4]))
+
+    data_headers = (('Timestamp', 'datetime'), 'Event ID', 'Package Name', 'Event Type', 'Event Type Description')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts three more parsers to the LAVA `@artifact_processor` pattern.

- **VerizonRDDWIFI** — `timestamp` raw → aware UTC `datetime` (replacing SQL `datetime(...,'UNIXEPOCH')`); JSON wifiinfo extraction retained; `print(e)`→`logfunc`.
- **VerizonRDDAnalytics** — `ActualTime` raw → aware UTC `datetime`; `FormattedTime` kept as the app's plain string; `print(e)`→`logfunc`.
- **swellbeing** — `timeStamp` raw → aware UTC `datetime`; dropped the redundant per-row `Source File` column; preserved the full eventType CASE mapping.

Verified: byte-compile, decorated 4-arg signature, returns 3-tuple, output_types valid, loader resolves, pylint clean.