### PR TITLE
Fix RunkeeperUser source-file mutation; convert to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/RunkeeperUser.py
+++ b/scripts/artifacts/RunkeeperUser.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W1309,W1514
+# pylint: disable=W0613,W1309
 __artifacts_v2__ = {
     "get_run_user": {
         "name": "RunkeeperUser",
@@ -10,9 +10,8 @@ __artifacts_v2__ = {
         "category": "Runkeeper",
         "notes": "",
         "paths": ('*/com.fitnesskeeper.runkeeper.pro/shared_prefs/com.fitnesskeeper.runkeeper.pro_preferences*',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "user",
-        "function": "get_run_user",
     }
 }
 
@@ -24,21 +23,30 @@ __artifacts_v2__ = {
 import datetime
 import xml.etree.ElementTree as ET
 
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline
+from scripts.ilapfuncs import artifact_processor, logfunc
 
 
-# remove whitespace from xml first line
-def remove_whitespace_from_xml_first_line(xml_file):
-    with open(xml_file, 'r') as f:
-        lines = f.readlines()
-    #replace first line with <?xml version='1.0' encoding='utf-8' standalone='yes' ?>
-    lines[0] = '<?xml version=\'1.0\' encoding=\'utf-8\' standalone=\'yes\' ?>\n'
-    with open(xml_file, 'w') as f:
-        f.writelines(lines)
+# The source XML's first line may carry leading whitespace that makes ElementTree
+# choke on the declaration. Normalize it in memory only; the evidence file on disk
+# is never modified.
+def _read_xml_with_fixed_first_line(xml_file):
+    with open(xml_file, 'r', encoding='utf-8') as f:
+        text = f.read()
+    lines = text.splitlines()
+    if lines:
+        lines[0] = "<?xml version='1.0' encoding='utf-8' standalone='yes' ?>"
+    return "\n".join(lines)
 
 
+def _ms_to_utc(value):
+    return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+
+
+def _s_to_utc(value):
+    return datetime.datetime.fromtimestamp(int(value), datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+
+
+@artifact_processor
 def get_run_user(files_found, report_folder, seeker, wrap_text):
     # Dictionary to store the user information
     user_info = {}
@@ -47,51 +55,41 @@ def get_run_user(files_found, report_folder, seeker, wrap_text):
                  "server_locale", "name", "gender", "birthday", "height", "userWeight", "profilePrivacy", "lifetimeTotalDistance",
                  "email_preference", 'asicsId']
 
-    logfunc("Processing data for Garmin User Profile XML")
-    file = str(files_found[0])
-    logfunc("Processing file: " + file)
-    # File is not well formatted, remove first element from first line
-    remove_whitespace_from_xml_first_line(file)
-    tree = ET.parse(file)
-    root = tree.getroot()
+    data_headers = ('Name', 'Value')
+    data_list = []
+    source_path = ''
+
+    logfunc("Processing data for Runkeeper User Profile XML")
+    source_path = str(files_found[0])
+    logfunc("Processing file: " + source_path)
+
+    # File is not well formatted; fix the malformed first line in memory only.
+    xml_text = _read_xml_with_fixed_first_line(source_path)
+    root = ET.fromstring(xml_text)
     for child in root:
         for i in attribute:
             if child.attrib["name"] == i:
                 # Does the attribute have a value?
                 if "value" in child.attrib:
-                    if i == "lastActive" or i == "lastWeightSyncTime" or i == "birthday":
-                        time = child.attrib["value"]
-                        time = int(time)
-                        user_info[i] = datetime.datetime.utcfromtimestamp(time / 1000).strftime('%Y-%m-%d %H:%M:%S')
+                    if i in ("lastActive", "lastWeightSyncTime", "birthday"):
+                        user_info[i] = _ms_to_utc(child.attrib["value"])
                     elif i == "creationTime":
-                        time = child.attrib["value"]
-                        time = int(time)
-                        user_info[i] = datetime.datetime.utcfromtimestamp(time).strftime('%Y-%m-%d %H:%M:%S')
+                        user_info[i] = _s_to_utc(child.attrib["value"])
                     else:
                         user_info[i] = child.attrib["value"]
                 else:
                     # Does the attribute have text?
                     if child.text:
                         if i == "profilePictureUrl":
-                            user_info[i] = '<img src="'+child.text+'" alt="'+child.text+'" width="50" height="50">'
+                            user_info[i] = '<img src="' + child.text + '" alt="' + child.text + '" width="50" height="50">'
                         else:
                             user_info[i] = child.text
 
     if len(user_info) > 0:
         logfunc("Found Runkeeper User Profile XML")
-        report = ArtifactHtmlReport('User')
-        report.start_artifact_report(report_folder, 'Runkeeper User')
-        report.add_script()
-        data_headers = ('Name', 'Value')
-        data_list = []
         for key, value in user_info.items():
             data_list.append((key, value))
-        report.write_artifact_data_table(data_headers, data_list, file, html_escape=False)
-        report.end_artifact_report()
-        tsvname = f'User'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = f'User'
-        timeline(report_folder, tlactivity, data_list, data_headers)
     else:
         logfunc("No Runkeeper XML data found")
+
+    return data_headers, data_list, source_path


### PR DESCRIPTION
## Summary

`RunkeeperUser.py` previously opened the source evidence XML in **write mode** (`open(xml_file, 'w')`) and overwrote its first line in place during parsing. This mutated the original input artifact — unacceptable for a forensic tool, where the extraction must be treated as read-only.

### Changes
- **Read-only fix:** the malformed `<?xml ... ?>` first line is now normalized **in memory** and parsed with `ET.fromstring(...)`. No `open(..., 'w')` is performed on any extraction path.
- **LAVA conversion:** migrated from old-style `ArtifactHtmlReport` to the `@artifact_processor` pattern:
  - 4-arg signature `(files_found, report_folder, seeker, wrap_text)`
  - returns `(data_headers, data_list, source_path)`
  - dropped the `"function"` key from `__artifacts_v2__`
  - `output_types` set to `['html','tsv','lava']`
- Epoch→UTC conversion kept as per-file local helpers; every `open()` has an explicit `encoding=`.

### Verification
- `py_compile`: OK
- `pylint --disable=C,R` (matches CI `lint-changed-files`): **10.00/10**