### PR TITLE
Convert kijijiLocalUserInfo, googlemaplocation, discreteNative, calllog to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/calllog.py
+++ b/scripts/artifacts/calllog.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0631,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_calllog": {
         "name": "Call logs ",
@@ -10,34 +10,44 @@ __artifacts_v2__ = {
         "category": "Call Logs",
         "notes": "",
         "paths": ('*/com.android.providers.contacts/databases/calllog.db*', '*/com.samsung.android.providers.contacts/databases/calllog.db*'),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "phone",
-        "function": "get_calllog",
+        "html_columns": ['Type'],
     }
 }
 
-import sqlite3
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+CALL_TYPE_ICONS = {
+    'Incoming': ' <i data-feather="phone-incoming" stroke="green"></i>',
+    'Outgoing': ' <i data-feather="phone-outgoing" stroke="green"></i>',
+    'Missed': ' <i data-feather="phone-missed" stroke="red"></i>',
+    'Voicemail': ' <i data-feather="voicemail" stroke="brown"></i>',
+    'Rejected': ' <i data-feather="x" stroke="red"></i>',
+    'Blocked': ' <i data-feather="phone-off" stroke="red"></i>',
+    'Answered Externally': ' <i data-feather="phone-forwarded"></i>',
+}
+
+
+@artifact_processor
 def get_calllog(files_found, report_folder, seeker, wrap_text):
-    
+
     data_list = []
-    
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
-        if file_found.endswith('calllog.db'):
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            cursor.execute('''
+        if not file_found.endswith('calllog.db'):
+            continue
+
+        source_path = file_found
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        cursor.execute('''
             SELECT
-            datetime(date /1000, 'unixepoch') as date,
-            CASE
-                WHEN phone_account_address is NULL THEN ' '
-                ELSE phone_account_address
-                end as phone_account_address,
+            date,
+            CASE WHEN phone_account_address is NULL THEN ' ' ELSE phone_account_address END as phone_account_address,
             number,
             CASE
                 WHEN type = 1 THEN  'Incoming'
@@ -48,62 +58,24 @@ def get_calllog(files_found, report_folder, seeker, wrap_text):
                 WHEN type = 6 THEN  'Blocked'
                 WHEN type = 7 THEN  'Answered Externally'
                 ELSE 'Unknown'
-                end as types,
+            END as types,
             duration,
-            CASE
-                WHEN geocoded_location is NULL THEN ' '
-                ELSE geocoded_location
-                end as geocoded_location,
+            CASE WHEN geocoded_location is NULL THEN ' ' ELSE geocoded_location END as geocoded_location,
             countryiso,
-            CASE
-                WHEN _data is NULL THEN ' '
-                ELSE _data
-                END as _data,
-            CASE
-                WHEN mime_type is NULL THEN ' '
-                ELSE mime_type
-                END as mime_type,
-            CASE
-                WHEN transcription is NULL THEN ' '
-                ELSE transcription
-                END as transcription,
+            CASE WHEN _data is NULL THEN ' ' ELSE _data END as _data,
+            CASE WHEN mime_type is NULL THEN ' ' ELSE mime_type END as mime_type,
+            CASE WHEN transcription is NULL THEN ' ' ELSE transcription END as transcription,
             deleted
-            FROM
-            calls
-            ''')
+            FROM calls
+        ''')
+        all_rows = cursor.fetchall()
+        db.close()
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                for row in all_rows:
-                    # Setup icons for call type
-                    call_type = row[3]
-                    if   call_type == 'Incoming':  call_type_html = call_type + ' <i data-feather="phone-incoming" stroke="green"></i>'
-                    elif call_type == 'Outgoing':  call_type_html = call_type + ' <i data-feather="phone-outgoing" stroke="green"></i>'
-                    elif call_type == 'Missed':    call_type_html = call_type + ' <i data-feather="phone-missed" stroke="red"></i>'
-                    elif call_type == 'Voicemail': call_type_html = call_type + ' <i data-feather="voicemail" stroke="brown"></i>'
-                    elif call_type == 'Rejected':  call_type_html = call_type + ' <i data-feather="x" stroke="red"></i>'
-                    elif call_type == 'Blocked':   call_type_html = call_type + ' <i data-feather="phone-off" stroke="red"></i>'
-                    elif call_type == 'Answered Externally': call_type_html = call_type + ' <i data-feather="phone-forwarded"></i>'
-                    else:
-                        call_type_html = call_type
+        for row in all_rows:
+            call_date = datetime.datetime.fromtimestamp(int(row[0]) / 1000, datetime.timezone.utc) if row[0] else ''
+            call_type = row[3]
+            call_type_html = call_type + CALL_TYPE_ICONS.get(call_type, '')
+            data_list.append((call_date, row[1], row[2], call_type_html, str(row[4]), row[5], row[6], row[7], row[8], row[9], str(row[10])))
 
-                    data_list.append((row[0], row[1], row[2], call_type_html, str(row[4]), row[5], row[6], row[7], row[8], row[9], str(row[10]), file_found))
-            db.close()
-            
-    if data_list:
-        report = ArtifactHtmlReport('Call logs')
-        report.start_artifact_report(report_folder, 'Call logs')
-        report.add_script()
-        data_headers = ('Call Date', 'Phone Account Address', 'Partner', 'Type','Duration in Secs','Partner Location','Country ISO','Data','Mime Type','Transcription','Deleted','Source File')
-        
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = f'Call Logs'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = 'Call Logs'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Call Log data available')
+    data_headers = (('Call Date', 'datetime'), 'Phone Account Address', ('Partner', 'phonenumber'), 'Type', 'Duration in Secs', 'Partner Location', 'Country ISO', 'Data', 'Mime Type', 'Transcription', 'Deleted')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/discreteNative.py
+++ b/scripts/artifacts/discreteNative.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0612,W0613,W0631,W1309
+# pylint: disable=W0612,W0613
 __artifacts_v2__ = {
     "get_discreteNative": {
         "name": "DiscreteNative",
@@ -10,18 +10,18 @@ __artifacts_v2__ = {
         "category": "Privacy Dashboard",
         "notes": "",
         "paths": ('*/system/appops/discrete/**',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "file",
-        "function": "get_discreteNative",
     }
 }
 
-import os
 import datetime
+import os
 import pathlib
 import xml.etree.ElementTree as ET
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, abxread, checkabx, logdevinfo
+
+from scripts.ilapfuncs import artifact_processor, abxread, checkabx
+
 
 def oplist(opvalue):
     thisdict = {
@@ -29,70 +29,56 @@ def oplist(opvalue):
         "1": "Location",
         "27": "Microphone"
     }
-    
     result = thisdict.get(opvalue)
     if result is None:
-        result = opvalue
-    else:
-        return result
-    
-def timestampcalc(timevalue):
-    timestamp = (datetime.datetime.utcfromtimestamp(int(timevalue)/1000).strftime('%Y-%m-%d %H:%M:%S'))
-    return timestamp
+        return opvalue
+    return result
 
+
+def timestampcalc(timevalue):
+    if timevalue in (None, ''):
+        return ''
+    return datetime.datetime.fromtimestamp(int(timevalue) / 1000, datetime.timezone.utc)
+
+
+@artifact_processor
 def get_discreteNative(files_found, report_folder, seeker, wrap_text):
     data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
         filename = str(pathlib.Path(file_found).name)
-        
-        if os.path.isfile(file_found):
-            #check if file is abx
-            if (checkabx(file_found)):
-                multi_root = False
-                tree = abxread(file_found, multi_root)
-            else:
-                tree = ET.parse(file_found)
-            root = tree.getroot()
-        
-            for elem in root:
-                for subelem1 in elem:
-                    ptag = subelem1.tag
-                    ptagattrib = subelem1.attrib
-                    ptagattrib = ptagattrib["pn"]
-                    for subelem2 in subelem1:
-                        otag = subelem2.tag
-                        otagattrib = subelem2.attrib
-                        otagattrib = otagattrib['op']
-                        for subelem3 in subelem2:
-                            atag = subelem3.tag
-                            atagattrib = subelem3.attrib
-                            atagattrib = atagattrib.get('at', '')
-                            
-                            for subelem4 in subelem3:
-                                etag = subelem4.tag
-                                etagattrib = subelem4.attrib
-                                ntattrib = etagattrib.get('nt')
-                                ndattrib = etagattrib.get('nd')
-                                if ndattrib is None:
-                                    ndattrib = ''
-                                else:
-                                    ndattrib = round(int(ndattrib) / 1000, 1)
-                        data_list.append((timestampcalc(ntattrib), ptagattrib, atagattrib, oplist(otagattrib), ndattrib, filename ))
-                    
-    if data_list:
-        report = ArtifactHtmlReport('Privacy Dashboard')
-        report.start_artifact_report(report_folder, 'Privacy Dashboard')
-        report.add_script()
-        data_headers = ('Timestamp', 'Bundle', 'Module', 'Operation', 'Usage in Seconds', 'Source Filename')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Privacy Dashboard'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Privacy Dashboard'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Privacy Dashboard data available')
-        
+
+        if not os.path.isfile(file_found):
+            continue
+
+        source_path = file_found
+        if (checkabx(file_found)):
+            multi_root = False
+            tree = abxread(file_found, multi_root)
+        else:
+            tree = ET.parse(file_found)
+        root = tree.getroot()
+
+        for elem in root:
+            for subelem1 in elem:
+                ptagattrib = subelem1.attrib["pn"]
+                for subelem2 in subelem1:
+                    otagattrib = subelem2.attrib['op']
+                    ntattrib = ''
+                    ndattrib = ''
+                    atagattrib = ''
+                    for subelem3 in subelem2:
+                        atagattrib = subelem3.attrib.get('at', '')
+                        for subelem4 in subelem3:
+                            etagattrib = subelem4.attrib
+                            ntattrib = etagattrib.get('nt')
+                            ndattrib = etagattrib.get('nd')
+                            if ndattrib is None:
+                                ndattrib = ''
+                            else:
+                                ndattrib = round(int(ndattrib) / 1000, 1)
+                    data_list.append((timestampcalc(ntattrib), ptagattrib, atagattrib, oplist(otagattrib), ndattrib, filename))
+
+    data_headers = (('Timestamp', 'datetime'), 'Bundle', 'Module', 'Operation', 'Usage in Seconds', 'Source Filename')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/googlemaplocation.py
+++ b/scripts/artifacts/googlemaplocation.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0702,W1309
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_googlemaplocation": {
         "name": "Googlemaplocation",
@@ -10,69 +10,50 @@ __artifacts_v2__ = {
         "category": "GEO Location",
         "notes": "",
         "paths": ('*/com.google.android.apps.maps/databases/da_destination_history*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "map-pin",
-        "function": "get_googlemaplocation",
     }
 }
 
-import sqlite3
 import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
+
 
 def convertGeo(s):
     length = len(s)
     if length > 6:
-        return (s[0 : length-6] + "." + s[length-6 : length])
-    else:
-        return (s)
+        return s[0: length - 6] + "." + s[length - 6: length]
+    return s
 
+
+@artifact_processor
 def get_googlemaplocation(files_found, report_folder, seeker, wrap_text):
 
-    source_file = ''
-
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
         if 'journal' in file_found:
-            source_file = file_found.replace(seeker.data_folder, '')
             continue
-  
-        source_file = file_found.replace(seeker.data_folder, '')
-        
+
+        source_path = file_found
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         try:
             cursor.execute('''
-            SELECT time/1000, dest_lat, dest_lng, dest_title, dest_address, 
-                   source_lat, source_lng FROM destination_history;
+                SELECT time/1000, dest_lat, dest_lng, dest_title, dest_address,
+                       source_lat, source_lng FROM destination_history;
             ''')
-
             all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-        except:
-            usageentries = 0
-            
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Google Map Locations')
-            report.start_artifact_report(report_folder, 'Google Map Locations')
-            report.add_script()
-            data_headers = ('timestamp','destination_latitude', 'destination_longitude', 'destination_title','destination_address', 'source_latitude', 'source_longitude') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-            data_list = []
-            for row in all_rows:
-                timestamp = datetime.datetime.utcfromtimestamp(int(row[0])).strftime('%Y-%m-%d %H:%M:%S') 
-                data_list.append((timestamp, convertGeo(str(row[1])), convertGeo(str(row[2])), row[3], row[4], convertGeo(str(row[5])), convertGeo(str(row[6]))))
-
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Google Map Locations'
-            tsv(report_folder, data_headers, data_list, tsvname, source_file)
-            
-        else:
-            logfunc('No Google Map Locations found')
-            
+        except Exception as e:
+            logfunc(str(e))
+            all_rows = []
         db.close()
-        
+
+        for row in all_rows:
+            timestamp = datetime.datetime.fromtimestamp(int(row[0]), datetime.timezone.utc) if row[0] else ''
+            data_list.append((timestamp, convertGeo(str(row[1])), convertGeo(str(row[2])), row[3], row[4], convertGeo(str(row[5])), convertGeo(str(row[6]))))
+
+    data_headers = (('timestamp', 'datetime'), 'destination_latitude', 'destination_longitude', 'destination_title', 'destination_address', 'source_latitude', 'source_longitude')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/kijijiLocalUserInfo.py
+++ b/scripts/artifacts/kijijiLocalUserInfo.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_kijijiLocalUserInfo": {
         "name": "kijijiLocalUserInfo",
@@ -10,65 +10,43 @@ __artifacts_v2__ = {
         "category": "Kijiji",
         "notes": "",
         "paths": ('*/com.ebay.kijiji.ca/shared_prefs/LoginData.xml',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "user",
-        "function": "get_kijijiLocalUserInfo",
     }
 }
 
-# Kijiji Local User Information
-# Author:  Terry Chabot (Krypterry)
-# Version: 1.0.1
-# Kijiji App Version Tested: v17.5.0b172 (2022-05-06)
-# Requirements:  None
-#
-#   Description:
-#   Obtains information about the logged-in Kijiji application user.
-#
-#   Additional Info:
-#       Kijiji.ca is a Canadian online classified advertising website and part of eBay Classifieds Group, with over 16 million unique visitors per month.
-#
-#       Kijiji, May 2022 <https://help.kijiji.ca/helpdesk/basics/what-is-kijiji>
-#       Wikipedia - The Free Encyclopedia, May 2022, <https://en.wikipedia.org/wiki/Kijiji>
 import xml.etree.ElementTree as ET
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv
+from scripts.ilapfuncs import artifact_processor, logfunc
 
 userEmailXPath = "./string/[@name='UserEmailAddress']"
 loggedInUserXPath = "./string/[@name='LoggedInAsUser']"
 userDisplayNameXPath = "./string/[@name='UserDisplayName']"
 eBayUserIdXPath = "./string/[@name='userEbayId{userEmailAddressPlaceholder}']"
 
+
+def GetFirstChild(element):
+    return element[0].text if len(element) else ''
+
+
 def TryGetStringValue(root, xPathExpression):
     elems = root.findall(xPathExpression)
     return GetFirstChild(elems)
 
-def GetFirstChild(element): 
-    return element[0].text if len(element) else ''
 
+@artifact_processor
 def get_kijijiLocalUserInfo(files_found, report_folder, seeker, wrap_text):
-    file_found = str(files_found[0])
-    logfunc(f'XML file {file_found} is being interrogated...')
-    report = ArtifactHtmlReport('Kijiji Local User Information')
-    report.start_artifact_report(report_folder, 'Kijiji Local User Information')
-    report.add_script()
+    source_path = str(files_found[0])
+    logfunc(f'XML file {source_path} is being interrogated...')
 
-    document = ET.parse(file_found)
-    root = document.getroot()
-    userEmailAddress = TryGetStringValue(root, userEmailXPath) # May be available when logged-in/out.
+    root = ET.parse(source_path).getroot()
+    userEmailAddress = TryGetStringValue(root, userEmailXPath)  # May be available when logged-in/out.
     loggedInAsUser = TryGetStringValue(root, loggedInUserXPath)
     userDisplayName = TryGetStringValue(root, userDisplayNameXPath)
 
     # Build a unique user XPath expression in order to obtain their eBay user Id.
-    userEbayId = TryGetStringValue(root, eBayUserIdXPath.format(userEmailAddressPlaceholder = userEmailAddress))
+    userEbayId = TryGetStringValue(root, eBayUserIdXPath.format(userEmailAddressPlaceholder=userEmailAddress))
 
-    data_headers = ('User Email', 'User Ebay ID', 'User Display Name', 'Logged In User',)
-    data_list = []
-    data_list.append((userEmailAddress, userEbayId, userDisplayName, loggedInAsUser))
-
-    report.write_artifact_data_table(data_headers, data_list, file_found)
-    report.end_artifact_report()
-    
-    tsvname = f'Kijiji Local User Information'
-    tsv(report_folder, data_headers, data_list, tsvname)    
+    data_list = [(userEmailAddress, userEbayId, userDisplayName, loggedInAsUser)]
+    data_headers = ('User Email', 'User Ebay ID', 'User Display Name', 'Logged In User')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts four more parsers to the LAVA `@artifact_processor` pattern.

- **kijijiLocalUserInfo** — flat XML user info; no timestamps; XPath helpers retained.
- **googlemaplocation** — `time` raw → aware UTC `datetime` (replacing `utcfromtimestamp`); `convertGeo` helper kept; bare `except` narrowed to `Exception` + logfunc.
- **discreteNative** — `timestampcalc` now returns aware UTC datetimes (and guards None); `Timestamp` marked `datetime`; initialized inner-loop vars to avoid unbound use.
- **calllog** — `date` raw → aware UTC `datetime` (replacing SQL `datetime(...,'unixepoch')`); `number` marked `phonenumber`; call-type feather icons moved to a lookup dict and `Type` declared in `html_columns`; dropped redundant per-row Source File column.

Verified: byte-compile, decorated 4-arg signature, returns 3-tuple, output_types valid, loader resolves, pylint clean.