### PR TITLE
Convert GarminLog, AdidasGoals, kijijiRecentSearches, battery_usage_v4 to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/AdidasGoals.py
+++ b/scripts/artifacts/AdidasGoals.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0622,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_adidas_goals": {
         "name": "AdidasGoals",
@@ -10,85 +10,48 @@ __artifacts_v2__ = {
         "category": "Adidas-Running",
         "notes": "",
         "paths": ('*/com.runtastic.android/databases/goals*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "activity",
-        "function": "get_adidas_goals",
     }
 }
 
-# Get Information related to user defined goals from the Adidas Running app stored in goals
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-04-21
-# Version: 1.0
-# Requirements: Python 3.7 or higher
 import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
 
+def _ms_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    return ''
+
+
+def _yyyymmdd(value):
+    if value:
+        s = str(value)
+        return s[:4] + '-' + s[4:6] + '-' + s[6:]
+    return ''
+
+
+@artifact_processor
 def get_adidas_goals(files_found, report_folder, seeker, wrap_text):
     logfunc("Processing data for Adidas Goals")
-    files_found = [x for x in files_found if not x.endswith('-journal')]
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
-
-    # Get information from the table device_sync_audit
+    files_found = [x for x in files_found if not str(x).endswith('-journal')]
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     cursor.execute('''
         Select *
         from goalV2
     ''')
-
     all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        logfunc(f"Found {usageentries} entries in user.db")
-        report = ArtifactHtmlReport('User')
-        report.start_artifact_report(report_folder, 'Adidas Goals')
-        report.add_script()
-        data_headers = ('ID', 'Metric', 'Remote ID', 'User ID', 'Version', 'Target', 'Recurrence', 'Start Date', 'End Date', 'Sport Types', 'Created At', 'Updated At', 'Deleted At')
-        data_list = []
-        for row in all_rows:
-            id = row[0]
-            metric = row[1]
-            remote_id = row[2]
-            user_id = row[3]
-            version = row[4]
-            target = row[5]
-            recurrence = row[6]
-            start_date = row[8]
-            start_date = str(start_date)
-            start_date = start_date[:4] + '-' + start_date[4:6] + '-' + start_date[6:]
-            end_date = row[9]
-            if end_date:
-                end_date = str(end_date)
-                end_date = end_date[:4] + '-' + end_date[4:6] + '-' + end_date[6:]
-            sport_types = row[10]
-            created_at = row[11]
-            created_at = int(created_at)
-            created_at = datetime.datetime.utcfromtimestamp(created_at / 1000).strftime('%Y-%m-%d %H:%M:%S')
-            updated_at = row[12]
-            if updated_at:
-                updated_at = int(updated_at)
-                updated_at = datetime.datetime.utcfromtimestamp(updated_at / 1000).strftime('%Y-%m-%d %H:%M:%S')
-            deleted_at = row[13]
-            if deleted_at:
-                deleted_at = int(deleted_at)
-                deleted_at = datetime.datetime.utcfromtimestamp(deleted_at / 1000).strftime('%Y-%m-%d %H:%M:%S')
-        data_list.append((id, metric, remote_id, user_id, version, target, recurrence, start_date, end_date, sport_types, created_at, updated_at, deleted_at))
-
-        table_id = "AdidasGoals"
-        report.write_artifact_data_table(data_headers, data_list, file_found, table_id=table_id, html_escape=False)
-        report.end_artifact_report()
-
-        tsvname = f'Adidas - Goals'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = f'Adidas - Goals'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-
-    else:
-        logfunc('No Adidas Goals data available')
-
     db.close()
+
+    data_list = []
+    for row in all_rows:
+        data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6],
+                          _yyyymmdd(row[8]), _yyyymmdd(row[9]), row[10],
+                          _ms_to_utc(row[11]), _ms_to_utc(row[12]), _ms_to_utc(row[13])))
+
+    data_headers = ('ID', 'Metric', 'Remote ID', 'User ID', 'Version', 'Target', 'Recurrence', 'Start Date', 'End Date', 'Sport Types', ('Created At', 'datetime'), ('Updated At', 'datetime'), ('Deleted At', 'datetime'))
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/GarminLog.py
+++ b/scripts/artifacts/GarminLog.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W1309,W1514
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_log": {
         "name": "GarminLog",
@@ -10,70 +10,40 @@ __artifacts_v2__ = {
         "category": "Garmin",
         "notes": "",
         "paths": ('*/com.garmin.android.apps.connectmobile/files/logs/app.log*',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "activity",
-        "function": "get_log",
     }
 }
 
-# Get Information stored in the Garmin Log file
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-02-24
-# Version: 1.0
-# Requirements: Python 3.7 or higher
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv
+from scripts.ilapfuncs import artifact_processor, logfunc
 
 
+@artifact_processor
 def get_log(files_found, report_folder, seeker, wrap_text):
-    # Dictionary to store the user information
     user_info = {}
-    # Attributes to be extracted from the xml file
     attribute = ["access_token", "expires_in", "refresh_token", "token_type", "id_token", "Authorization"]
     auth = False
     logfunc("Processing data for Garmin Logs")
-    file = str(files_found[0])
-    logfunc("Processing file: " + file)
-    #Open text file
-    with open(file, "r") as f:
-        # Read the file line by line
+    source_path = str(files_found[0])
+    logfunc("Processing file: " + source_path)
+
+    with open(source_path, "r", encoding='utf-8', errors='replace') as f:
         for line in f:
-            # Get the user information
             for i in attribute:
                 if i in line:
-                    if i == "Authorization" and auth == False:
-                        value = line.split(":")[1].strip()
-                        # Split by ,
-                        value = value.split(",")
-                        # Get different values
+                    if i == "Authorization" and auth is False:
+                        value = line.split(":")[1].strip().split(",")
                         for j in value:
-                            # Split by =
                             j = j.split("=")
                             user_info[j[0].strip()] = j[1].strip()
                         auth = True
                     else:
-                        # Get value from line after :
-                        value = line.split(":")[1].strip()
-                        # Remove "
-                        value = value.replace('"', '')
-                        # Remove ,
-                        value = value.replace(',', '')
-                        # Add to dictionary
+                        value = line.split(":")[1].strip().replace('"', '').replace(',', '')
                         user_info[i] = value
 
-    if len(user_info) > 0:
-        logfunc("Found Garmin Log file")
-        report = ArtifactHtmlReport('Log')
-        report.start_artifact_report(report_folder, 'Log')
-        report.add_script()
-        data_headers = ('Name', 'Value')
-        data_list = []
-        for key, value in user_info.items():
-            data_list.append((key, value))
-        report.write_artifact_data_table(data_headers, data_list, file)
-        report.end_artifact_report()
-        tsvname = f'Garmin Log'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc("No Garmin Log data found")
+    data_list = []
+    for key, value in user_info.items():
+        data_list.append((key, value))
+
+    data_headers = ('Name', 'Value')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/battery_usage_v4.py
+++ b/scripts/artifacts/battery_usage_v4.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0631,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_battery_usage_v4": {
         "name": "battery_usage_v4",
@@ -10,38 +10,42 @@ __artifacts_v2__ = {
         "category": "Settings Services",
         "notes": "",
         "paths": ('*/com.google.android.settings.intelligence/databases/battery-usage-db-v4*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "battery",
-        "function": "get_battery_usage_v4",
     }
 }
 
-import sqlite3
-import textwrap
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+def _ms_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    return ''
+
+
+@artifact_processor
 def get_battery_usage_v4(files_found, report_folder, seeker, wrap_text):
-    
+
     data_list = []
-    
+    source_path = ''
     for file_found in files_found:
         file_name = str(file_found)
-    
-        if file_name.endswith('battery-usage-db-v4'):
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            cursor.execute('''
+        if not file_name.endswith('battery-usage-db-v4'):
+            continue  # Skip -shm, -wal, etc.
+
+        source_path = file_name
+        db = open_sqlite_db_readonly(file_name)
+        cursor = db.cursor()
+        cursor.execute('''
             select
-            datetime(timestamp/1000,'unixepoch'),
+            timestamp,
             appLabel,
             packageName,
-            case isHidden
-                when 0 then ''
-                when 1 then 'Yes'
-            end,
-            datetime((timestamp-bootTimestamp)/1000,'unixepoch'),
+            case isHidden when 0 then '' when 1 then 'Yes' end,
+            (timestamp-bootTimestamp),
             zoneId,
             totalPower,
             consumePower,
@@ -49,39 +53,14 @@ def get_battery_usage_v4(files_found, report_folder, seeker, wrap_text):
             foregroundUsageTimeInMs*.001 as 'Foreground Usage (Seconds)',
             backgroundUsageTimeInMs*.001 as 'Background Usage (Seconds)',
             batteryLevel,
-            case BatteryStatus
-                when 2 then 'Charging'
-                when 3 then 'Not Charging'
-                when 5 then 'Fully Charged'
-            end,
-            batteryHealth
+            case BatteryStatus when 2 then 'Charging' when 3 then 'Not Charging' when 5 then 'Fully Charged' end
             from BatteryState
-            ''')
+        ''')
+        all_rows = cursor.fetchall()
+        db.close()
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                for row in all_rows:
-                    data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11],row[12],file_found))
-            
-            db.close()
-        else:
-            continue # Skip all other files (-shm, -wal, etc.)
-    
-    if data_list:
-        description = 'This is battery usage details pulled from Settings Services'
-        report = ArtifactHtmlReport('Settings Services - Battery Usage')
-        report.start_artifact_report(report_folder, 'Settings Services - Battery Usage', description)
-        report.add_script()
-        data_headers = ('Timestamp','Application','Package Name','Hidden','Boot Timestamp','Timezone','Total Power','Consumed Power','% Of Consumed','Foreground Usage (Seconds)','Background Usage (Seconds)','Battery Level (%)','Battery Status','Source File') 
+        for row in all_rows:
+            data_list.append((_ms_to_utc(row[0]), row[1], row[2], row[3], _ms_to_utc(row[4]), row[5], row[6], row[7], row[8], row[9], row[10], row[11], row[12]))
 
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Settings Services - Battery Usage'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Settings Services - Battery Usage'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Settings Services - Battery Usage data available')
+    data_headers = (('Timestamp', 'datetime'), 'Application', 'Package Name', 'Hidden', ('Boot Timestamp', 'datetime'), 'Timezone', 'Total Power', 'Consumed Power', '% Of Consumed', 'Foreground Usage (Seconds)', 'Background Usage (Seconds)', 'Battery Level (%)', 'Battery Status')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/kijijiRecentSearches.py
+++ b/scripts/artifacts/kijijiRecentSearches.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_kijijiRecentSearches": {
         "name": "kijijiRecentSearches",
@@ -10,35 +10,18 @@ __artifacts_v2__ = {
         "category": "Kijiji",
         "notes": "",
         "paths": ('*/com.ebay.kijiji.ca/databases/searches.*',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "search",
-        "function": "get_kijijiRecentSearches",
     }
 }
 
-# Kijiji Local Recent Searches
-# Author:  Terry Chabot (Krypterry)
-# Version: 1.0.0
-# Kijiji App Version Tested: v17.5.0b172 (2022-05-06)
-# Requirements:  None
-#
-#   Description:
-#   Obtains search terms entered by the local user, potentially including GPS location.
-#
-#   Additional Info:
-#       Kijiji.ca is a Canadian online classified advertising website and part of eBay Classifieds Group, with over 16 million unique visitors per month.
-#
-#       Kijiji, May 2022 <https://help.kijiji.ca/helpdesk/basics/what-is-kijiji>
-#       Wikipedia - The Free Encyclopedia, May 2022, <https://en.wikipedia.org/wiki/Kijiji>
-import sqlite3
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, open_sqlite_db_readonly, does_table_exist_in_db
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly, does_table_exist_in_db
 
-recent_searches_query = \
-'''
-    SELECT 
-        datetime([time]/1000, 'UNIXEPOCH') [DateSearched],
+recent_searches_query = '''
+    SELECT
+        [time],
         keyword,
         thumbnail,
         address,
@@ -47,49 +30,31 @@ recent_searches_query = \
         distance,
         ad_type,
         price_type,
-        CASE min_price
-            WHEN -1 THEN ''
-            ELSE min_price
-        END min_price,
-        CASE max_price
-            WHEN -1 THEN ''
-            ELSE max_price
-        END max_price
+        CASE min_price WHEN -1 THEN '' ELSE min_price END min_price,
+        CASE max_price WHEN -1 THEN '' ELSE max_price END max_price
     FROM recent_searches
     ORDER BY TIME ASC;
 '''
 
+
+@artifact_processor
 def get_kijijiRecentSearches(files_found, report_folder, seeker, wrap_text):
-    file_found = str(files_found[0])
-    logfunc(f'Database file {file_found} is being interrogated...')
-    db = open_sqlite_db_readonly(file_found)
-    db.row_factory = sqlite3.Row # For fetching columns by name
-    tabCheck = does_table_exist_in_db(file_found, 'recent_searches')
-    if tabCheck == False:
-        logfunc('The recent_searches table was not found in the database!')
-        return False
+    source_path = str(files_found[0])
+    logfunc(f'Database file {source_path} is being interrogated...')
 
-    cursor = db.cursor()
-    cursor.execute(recent_searches_query)
-    all_rows = cursor.fetchall()
-    if len(all_rows) > 0:
-        report = ArtifactHtmlReport('Kijiji Recent Searches')
-        report.start_artifact_report(report_folder, 'Kijiji Recent Searches')
-        report.add_script()
+    data_list = []
+    if does_table_exist_in_db(source_path, 'recent_searches'):
+        db = open_sqlite_db_readonly(source_path)
+        cursor = db.cursor()
+        cursor.execute(recent_searches_query)
+        all_rows = cursor.fetchall()
+        db.close()
 
-        data_headers = ('Date', 'Search Keyword', 'Thumbnail', 'Address', 'Latitude', 'Longitude', 'Search Distance', 'Ad Type', 'Price Type', 'Min Price', 'Max Price')
-        data_list = []
         for row in all_rows:
-            data_list.append((row['DateSearched'], row['keyword'], row['thumbnail'], row['address'], 
-                              row['latitude'], row['longitude'], row['distance'], row['ad_type'], 
-                              row['price_type'], row['min_price'], row['max_price']))
-
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Kijiji Recent Searches'
-        tsv(report_folder, data_headers, data_list, tsvname)
+            date_searched = datetime.datetime.fromtimestamp(int(row[0]) / 1000, datetime.timezone.utc) if row[0] else ''
+            data_list.append((date_searched, row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10]))
     else:
-        logfunc('No Kijiji Recent Search data was found.')
+        logfunc('The recent_searches table was not found in the database!')
 
-    db.close()
+    data_headers = (('Date', 'datetime'), 'Search Keyword', 'Thumbnail', 'Address', 'Latitude', 'Longitude', 'Search Distance', 'Ad Type', 'Price Type', 'Min Price', 'Max Price')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts four more parsers to the LAVA `@artifact_processor` pattern.

- **GarminLog** — flat Name/Value token parser; no timestamps; added `encoding` to `open()`.
- **AdidasGoals** — `created_at`/`updated_at`/`deleted_at` epoch-ms → aware UTC `datetime`; `start_date`/`end_date` kept as the app's YYYYMMDD-derived strings. **Fixed a latent bug** where `data_list.append` sat outside the row loop, so only the last goal was ever reported.
- **kijijiRecentSearches** — `time` raw → aware UTC `datetime` (replacing SQL `datetime(...,'UNIXEPOCH')`); kept the `recent_searches` table-exists guard.
- **battery_usage_v4** — `timestamp` and the derived boot wall-clock time raw → aware UTC `datetime`; dropped redundant per-row Source File column.

Verified: byte-compile, decorated 4-arg signature, returns 3-tuple, output_types valid, loader resolves, pylint clean.