### PR TITLE
Convert vaulty_info, mega_transfers, AdidasUser to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/AdidasUser.py
+++ b/scripts/artifacts/AdidasUser.py
@@ -1,4 +1,4 @@
-# pylint: disable=E0606,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_adidas_user": {
         "name": "AdidasUser",
@@ -10,102 +10,73 @@ __artifacts_v2__ = {
         "category": "Adidas-Running",
         "notes": "",
         "paths": ('*com.runtastic.android/databases/user.db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "user",
-        "function": "get_adidas_user",
+        "html_columns": ['Image'],
     }
 }
 
-# Get Information related to users from the Adidas Running app stored in user.db
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-03-24
-# Version: 1.0
-# Requirements: Python 3.7 or higher
 import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
 
+def _ms_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    return ''
+
+
+@artifact_processor
 def get_adidas_user(files_found, report_folder, seeker, wrap_text):
     logfunc("Processing data for Adidas User")
-    files_found = [x for x in files_found if not x.endswith('-journal')]
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
-
-    # Get information from the table device_sync_audit
+    files_found = [x for x in files_found if not str(x).endswith('-journal')]
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     cursor.execute('''
         Select *
         from userProperty
     ''')
-
     all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        logfunc(f"Found {usageentries} entries in user.db")
-        report = ArtifactHtmlReport('User')
-        report.start_artifact_report(report_folder, 'Adidas User')
-        report.add_script()
-        data_headers = ('ID', 'Name', 'Height', 'Weight', 'Country', 'Gender', 'Email', 'Created At', 'Image', 'My Fitness Pal', 'Garmin Connect', 'Polar', 'LastSync')
-        data_list = []
-        for row in all_rows:
-            if row[2] == 'userId':
-                user_id = row[1]
-            if row[2] == 'FirstName':
-                name = row[1]
-            if row[2] == 'LastName':
-                name = name + ' ' + row[1]
-            if row[2] == 'Height':
-                height = row[1]
-            if row[2] == 'Weight':
-                weight = row[1]
-            if row[2] == 'CountryCode':
-                country = row[1]
-            if row[2] == 'Gender':
-                gender = row[1]
-            if row[2] == 'EMail':
-                email = row[1]
-            if row[2] == 'createdAt':
-                created_at = row[1]
-                #convert from timestamp to date
-                created_at = int(created_at)
-                created_at = datetime.datetime.utcfromtimestamp(created_at/1000).strftime('%Y-%m-%d %H:%M:%S')
-            if row[2] == 'AvatarUrl':
-                image = row[1]
-            if row[2] == 'MY_FITNESS_PAL_CONNECTED':
-                if row[1] == 'true':
-                    my_fitness_pal = 'Connected'
-                else:
-                    my_fitness_pal = 'Not Connected'
-            if row[2] == 'isGarminConnected':
-                if row[1] == 'true':
-                    garmin_connect = 'Connected'
-                else:
-                    garmin_connect = 'Not Connected'
-            if row[2] == 'isPolarConnected':
-                if row[1] == 'true':
-                    polar = 'Connected'
-                else:
-                    polar = 'Not Connected'
-            if row[2] == 'lastV3SessionSyncAtLocalTime':
-                last_sync = row[1]
-                #convert from timestamp to date
-                last_sync = int(last_sync)
-                last_sync = datetime.datetime.utcfromtimestamp(last_sync/1000).strftime('%Y-%m-%d %H:%M:%S')
-        data_list.append((user_id, name, height, weight, country, gender, email, created_at, '<img src="'+image+'" alt="'+image+'" width="50" height="50">', my_fitness_pal, garmin_connect, polar, last_sync))
-
-        table_id = "AdidasUser"
-        report.write_artifact_data_table(data_headers, data_list, file_found, table_id=table_id, html_escape=False)
-        report.end_artifact_report()
-
-        tsvname = f'Adidas - User'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = f'Adidas - User'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-
-    else:
-        logfunc('No Adidas User data available')
-
     db.close()
+
+    user_id = name = height = weight = country = gender = email = ''
+    created_at = image = my_fitness_pal = garmin_connect = polar = last_sync = ''
+    for row in all_rows:
+        key = row[2]
+        val = row[1]
+        if key == 'userId':
+            user_id = val
+        elif key == 'FirstName':
+            name = val
+        elif key == 'LastName':
+            name = (name + ' ' + val).strip()
+        elif key == 'Height':
+            height = val
+        elif key == 'Weight':
+            weight = val
+        elif key == 'CountryCode':
+            country = val
+        elif key == 'Gender':
+            gender = val
+        elif key == 'EMail':
+            email = val
+        elif key == 'createdAt':
+            created_at = _ms_to_utc(val)
+        elif key == 'AvatarUrl':
+            image = val
+        elif key == 'MY_FITNESS_PAL_CONNECTED':
+            my_fitness_pal = 'Connected' if val == 'true' else 'Not Connected'
+        elif key == 'isGarminConnected':
+            garmin_connect = 'Connected' if val == 'true' else 'Not Connected'
+        elif key == 'isPolarConnected':
+            polar = 'Connected' if val == 'true' else 'Not Connected'
+        elif key == 'lastV3SessionSyncAtLocalTime':
+            last_sync = _ms_to_utc(val)
+
+    image_html = f'<img src="{image}" alt="{image}" width="50" height="50">' if image else ''
+    data_list = [(user_id, name, height, weight, country, gender, email, created_at, image_html, my_fitness_pal, garmin_connect, polar, last_sync)]
+
+    data_headers = ('ID', 'Name', 'Height', 'Weight', 'Country', 'Gender', 'Email', ('Created At', 'datetime'), 'Image', 'My Fitness Pal', 'Garmin Connect', 'Polar', ('LastSync', 'datetime'))
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/mega_transfers.py
+++ b/scripts/artifacts/mega_transfers.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0108,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_mega_transfers": {
         "name": "mega_transfers",
@@ -10,103 +10,56 @@ __artifacts_v2__ = {
         "category": "Mega",
         "notes": "",
         "paths": ('*/mega.privacy.android.app/databases/megapreferences',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "download",
-        "function": "get_mega_transfers",
     }
 }
 
-import sqlite3
 import base64
-from Crypto.Cipher import AES
 import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv
+from Crypto.Cipher import AES
+
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+
+DIRECTION = {"0": "Download", "1": "Upload", "2": "Download"}
+STATE = {
+    "0": "None", "1": "Queued", "2": "Active", "3": "Paused", "4": "Retrying",
+    "5": "Completing", "6": "Completed", "7": "Cancelled", "8": "Failed",
+}
 
 
-
-def decrypt(cell: str):
+def decrypt(cell):
     cipher_text = base64.b64decode(cell)
     secret_key = "android_idfkvn8 w4y*(NC$G*(G($*GR*(#)*huio4h389$G"[0:32].encode('utf-8')
     algorithm = AES.new(secret_key, AES.MODE_ECB)
     plain_text = algorithm.decrypt(cipher_text).decode('utf-8')
     last_char = plain_text[-1]
     first_of_the_last_chars = plain_text.index(last_char)
-    plain_text = plain_text[:first_of_the_last_chars]
-    return plain_text
+    return plain_text[:first_of_the_last_chars]
 
 
+@artifact_processor
 def get_mega_transfers(files_found, report_folder, seeker, wrap_text):
-    
-    db_filename = str(files_found[0])
 
-    conn = sqlite3.connect(db_filename)
-    cursor = conn.cursor()
-
-    sql = """
-        SELECT
-            transfertimestamp,
-            transferpath,
-            transferfilename,
-            transfersize,
-            transfertype,
-            transferstate,
-            transferoriginalpath
-        FROM 
-            completedtransfers
-        """
-    cursor.execute(sql)
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
+    cursor = db.cursor()
+    cursor.execute('''
+        SELECT transfertimestamp, transferpath, transferfilename, transfersize,
+               transfertype, transferstate, transferoriginalpath
+        FROM completedtransfers
+    ''')
     results = cursor.fetchall()
-    conn.close()
+    db.close()
 
-    data_headers = [
-            "Timestamp",
-            "Mega Folder",
-            "Filename",
-            "Size",
-            "Direction",
-            "State",
-            "Transfer Path",
-            ]
     data_list = []
-
-    direction = {
-            "0": "Download",
-            "1": "Upload",
-            "2": "Download",
-            }
-
-    state = {
-            "0": "None",
-            "1": "Queued",
-            "2": "Active",
-            "3": "Paused",
-            "4": "Retrying",
-            "5": "Completing",
-            "6": "Completed",
-            "7": "Cancelled",
-            "8": "Failed",
-            }
-
     for r in results:
-        decrypted = list(map(lambda x: decrypt(x), r))
-        timestamp = datetime.datetime.utcfromtimestamp(int(decrypted[0]) / 1000)
-        decrypted[0] = f"{timestamp}" 
-        decrypted[4] = direction[decrypted[4]]
-        decrypted[5] = state[decrypted[5]]
+        decrypted = [decrypt(x) for x in r]
+        decrypted[0] = datetime.datetime.fromtimestamp(int(decrypted[0]) / 1000, datetime.timezone.utc)
+        decrypted[4] = DIRECTION.get(decrypted[4], decrypted[4])
+        decrypted[5] = STATE.get(decrypted[5], decrypted[5])
         data_list.append(decrypted)
 
-    if data_list:
-        report = ArtifactHtmlReport('MEGA - Files')
-        report.start_artifact_report(report_folder, "MEGA - Files")
-        report.add_script()
-        report.write_artifact_data_table(data_headers, data_list, db_filename)
-        report.end_artifact_report()
-        
-        tsvname = f'MEGA - Files'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-    else:
-        logfunc('No MEGA files data available')
-    
+    data_headers = (('Timestamp', 'datetime'), 'Mega Folder', 'Filename', 'Size', 'Direction', 'State', 'Transfer Path')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/vaulty_info.py
+++ b/scripts/artifacts/vaulty_info.py
@@ -1,4 +1,4 @@
-# pylint: disable=E0606,E1101,W0120,W0611,W0613,W1514
+# pylint: disable=E1101,W0613
 __artifacts_v2__ = {
     "get_vaulty_info": {
         "name": "vaulty_info",
@@ -10,95 +10,59 @@ __artifacts_v2__ = {
         "category": "Vaulty",
         "notes": "",
         "paths": ('*/com.theronrogers.vaultyfree/shared_prefs/com.theronrogers.vaultyfree_preferences.xml',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "lock",
-        "function": "get_vaulty_info",
     }
 }
 
-import xmltodict
-from hashlib import md5
 import base64
 import binascii
+from hashlib import md5
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows 
-from scripts.parse3 import ParseProto
+import xmltodict
 
+from scripts.ilapfuncs import artifact_processor
+
+
+def _brute_force(target):
+    four_digit_pins = [f"{x:04}" for x in range(0, 10000)]
+    six_digit_pins = [f"{x:06}" for x in range(0, 1000000)]
+    for item in four_digit_pins + six_digit_pins:
+        if md5(item.encode()).hexdigest() == target:
+            return item
+    return "Brute Force was Unsuccessful - this is not the password"
+
+
+@artifact_processor
 def get_vaulty_info(files_found, report_folder, seeker, wrap_text):
 
-    title = "Vaulty - Info"
+    source_path = str(files_found[0])
+    with open(source_path, "r", encoding='utf-8', errors='replace') as file:
+        prefs = xmltodict.parse(file.read())
 
-    # Prefs File
-    file_found = str(files_found[0])
+    data_list = []
+
+    strings = prefs["map"]["string"]
+    values = {item.get("@name"): item.get("#text") for item in strings}
+
+    password_hash = values.get("password_hash")
+    if password_hash:
+        md5_hash = binascii.hexlify(base64.decodebytes(password_hash.encode())).decode()
+        data_list.append(("Password MD5", md5_hash))
+        data_list.append(("Password", _brute_force(md5_hash)))
+
+    if values.get("security_question") is not None:
+        data_list.append(("Security Question", values.get("security_question")))
+
+    if values.get("security_answer_hash") is not None:
+        answer = binascii.hexlify(base64.decodebytes(values["security_answer_hash"].encode())).decode()
+        data_list.append(("Security Answer MD5", answer))
+
+    if values.get("location") is not None:
+        data_list.append(("Location", values.get("location")))
+
+    if values.get("drive_account_name") is not None:
+        data_list.append(("Drive Account", values.get("drive_account_name")))
 
     data_headers = ('Key', 'Value')
-    data_list = []
-    
-    with open(file_found, "r") as file:
-        xml = file.read()
-    prefs = xmltodict.parse(xml)
-
-    
-    # PIN
-    for item in prefs["map"]["string"]:
-        if item.get("@name", None) == "password_hash":
-            password_hash = item.get("#text", None)
-
-    if password_hash:
-        md5_hash_binary = base64.decodebytes(password_hash.encode())
-        md5_hash = binascii.hexlify(md5_hash_binary).decode()
-
-        data_list.append(["Password MD5", md5_hash])
-
-        def brute_force(target):
-            four_digit_pins = list(map(lambda x: f"{x:04}", range(0, 10000)))
-            six_digit_pins = list(map(lambda x: f"{x:06}", range(0, 1000000)))
-            pins = four_digit_pins + six_digit_pins
-
-            for index, item in enumerate(pins):
-                pin = item.encode()
-                guess = md5(pin).hexdigest()
-                if guess == target:
-                    return pins[index]
-            else:
-                return "Brute Force was Unsuccessful - this is not the password"
-
-        password = brute_force(md5_hash)
-        data_list.append(["Password", password])
-
-    # Security question
-    for item in prefs["map"]["string"]:
-        if item.get("@name", None) == "security_question":
-            question = item.get("#text", None)
-            data_list.append(["Security Question", question])
-        
-    # Security Answer
-    for item in prefs["map"]["string"]:
-        if item.get("@name", None) == "security_answer_hash":
-            answer = item.get("#text", None)
-            answer = base64.decodebytes(answer.encode())
-            answer = binascii.hexlify(answer).decode()
-            data_list.append(["Security Answer MD5", answer])
-
-    # Store
-    for item in prefs["map"]["string"]:
-        if item.get("@name", None) == "location":
-            location = item.get("#text", None)
-            data_list.append(["Location", location])
-
-    # Drive
-    for item in prefs["map"]["string"]:
-        if item.get("@name", None) == "drive_account_name":
-            drive = item.get("#text", None)
-            data_list.append(["Drive Account", drive])
-
-
-    # Reporting
-    report = ArtifactHtmlReport(title)
-    report.start_artifact_report(report_folder, title)
-    report.add_script()
-    report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-    report.end_artifact_report()
-    
-    tsv(report_folder, data_headers, data_list, title)
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts three more parsers to the LAVA `@artifact_processor` pattern.

- **vaulty_info** — flat prefs Key/Value with MD5/PIN brute-force; no timestamps. Refactored the prefs lookup into a single dict pass, replaced the `for/else` (W0120) brute-force with a clean loop, and added `encoding` to `open()`.
- **mega_transfers** — AES-decrypted completed-transfers; `transfertimestamp` decrypted then → aware UTC `datetime` (replacing `utcfromtimestamp`); direction/state lookups hoisted to module constants; switched to `open_sqlite_db_readonly`.
- **AdidasUser** — key/value userProperty assembled into one row; `createdAt`/`lastV3SessionSyncAtLocalTime` → aware UTC `datetime`; `Image` declared in `html_columns` and NULL-guarded; initialized all fields to '' to remove the `E0606` unbound-variable risk.

Verified: byte-compile, decorated 4-arg signature, returns 3-tuple, output_types valid, loader resolves, pylint clean.