### PR TITLE
Convert googleMessages, kijijiConversations, smyfilesOpHistory to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/googleMessages.py
+++ b/scripts/artifacts/googleMessages.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_googleMessages": {
         "name": "GoogleMessages",
@@ -10,37 +10,32 @@ __artifacts_v2__ = {
         "category": "Google Messages",
         "notes": "",
         "paths": ('*/com.google.android.apps.messaging/databases/bugle_db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "message-square",
-        "function": "get_googleMessages",
     }
 }
 
-# Google Messages
-# Author:  Josh Hickman (josh@thebinaryhick.blog)
-# Date 2021-01-30
-# Version: 0.1
-# Requirements:  None
+import datetime
 
-import os
-import sqlite3
-import textwrap
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
+@artifact_processor
 def get_googleMessages(files_found, report_folder, seeker, wrap_text):
-    
+
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('bugle_db'):
-            continue # Skip all other files
-        
+            continue  # Skip all other files
+
+        source_path = file_found
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
         SELECT
-        datetime(parts.timestamp/1000,'unixepoch') AS "Timestamp (UTC)",
+        parts.timestamp,
         parts.content_type AS "Message Type",
         conversations.name AS "Other Participant/Conversation Name",
         participants.display_destination AS "Message Sender",
@@ -55,29 +50,14 @@ def get_googleMessages(files_found, report_folder, seeker, wrap_text):
         JOIN messages ON messages._id=parts.message_id
         JOIN participants ON participants._id=messages.sender_id
         JOIN conversations ON conversations._id=parts.conversation_id
-        ORDER BY "Timestamp (UTC)" ASC
+        ORDER BY parts.timestamp ASC
         ''')
-
         all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Google Messages')
-            report.start_artifact_report(report_folder, 'Google Messages')
-            report.add_script()
-            data_headers = ('Message Timestamp (UTC)','Message Type','Other Participant/Conversation Name','Message Sender','Message','Attachment Byte Size','Attachment Location') 
-            data_list = []
-            for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
-
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Google Messages'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Google Messages'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Google Messages data available')
-        
         db.close()
+
+        for row in all_rows:
+            timestamp = datetime.datetime.fromtimestamp(int(row[0]) / 1000, datetime.timezone.utc) if row[0] else ''
+            data_list.append((timestamp, row[1], row[2], row[3], row[4], row[5], row[6]))
+
+    data_headers = (('Message Timestamp', 'datetime'), 'Message Type', 'Other Participant/Conversation Name', ('Message Sender', 'phonenumber'), 'Message', 'Attachment Byte Size', 'Attachment Location')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/kijijiConversations.py
+++ b/scripts/artifacts/kijijiConversations.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_kijijiConversations": {
         "name": "kijijiConversations",
@@ -10,37 +10,20 @@ __artifacts_v2__ = {
         "category": "Kijiji",
         "notes": "",
         "paths": ('*/com.ebay.kijiji.ca/databases/messageBoxDatabase.*',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "file",
-        "function": "get_kijijiConversations",
     }
 }
 
-# Kijiji Conversations
-# Author:  Terry Chabot (Krypterry)
-# Version: 1.0.2
-# Kijiji App Version Tested: v17.5.0b172 (2022-05-06)
-# Requirements:  None
-#
-#   Description:
-#   Obtains individual chat messages that were sent and received using the Kijiji application.
-#
-#   Additional Info:
-#       Kijiji.ca is a Canadian online classified advertising website and part of eBay Classifieds Group, with over 16 million unique visitors per month.
-#
-#       Kijiji, May 2022 <https://help.kijiji.ca/helpdesk/basics/what-is-kijiji>
-#       Wikipedia - The Free Encyclopedia, May 2022, <https://en.wikipedia.org/wiki/Kijiji>
-import sqlite3
 import json
+import sqlite3
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, open_sqlite_db_readonly, does_table_exist_in_db
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly, does_table_exist_in_db
 
 LOCAL_USER = 'Local User'
 LOCAL_USER_INDICATOR = 'ME'
 
-conversations_query = \
-'''
+conversations_query = '''
     SELECT
         identifier,
         ad,
@@ -50,82 +33,53 @@ conversations_query = \
     ORDER BY sortByDate ASC;
 '''
 
-def get_kijijiConversations(files_found, report_folder, seeker, wrap_text):
-    file_found = str(files_found[0])
-    logfunc(f'Database file {file_found} is being interrogated...')
-    db = open_sqlite_db_readonly(file_found)
-    db.row_factory = sqlite3.Row # For fetching columns by name
-    tabCheck = does_table_exist_in_db(file_found, 'conversations')
-    if tabCheck == False:
-        logfunc('The conversations table was not found in the database!')
-        return False
 
-    cursor = db.cursor()
-    cursor.execute(conversations_query)
-    all_rows = cursor.fetchall()
-    if len(all_rows) > 0:
-        report = ArtifactHtmlReport('Kijiji Conversations')
-        report.start_artifact_report(report_folder, 'Kijiji Conversations')
-        report.add_script()
-
-        data_headers = ('Date Sent', 'Conversation ID', 'Ad ID', 'Ad Title', 'Message ID', 'Sender ID', 'Sender Name', 'Recipient ID', 'Recipient Name', 'State', 'Message')
-        data_list = []
-        for row in all_rows:
-            # Each row is for a conversation thread, with JSON for the individual message data.
-            conversationId = row['identifier']
-            
-            # Determine the counter party for the conversation thread.
-            counterPartyJson = row['counterParty']
-            counterPartyInfo = json.loads(counterPartyJson)
-            counterPartyId = counterPartyInfo["identifier"]
-            counterPartyName = counterPartyInfo["name"]
-            messagesJson = row['messages']
-
-            advertJson = row['ad']
-            advertInfo = json.loads(advertJson)
-            advertId = advertInfo["identifier"]
-            advertTitle = advertInfo["displayTitle"]
-
-            AppendMessageRowsToDataList(data_list,
-                conversationId,
-                advertId,
-                advertTitle,
-                counterPartyId,
-                counterPartyName,
-                messagesJson)
-
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Kijiji Conversations'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc('No Kijiji Conversations data was found.')
-
-    db.close()
-    return True
-
-# Appends a row for each message sent in a unique conversation thread.
-#  Row ordinal: Date Sent, Message ID, Sender ID, Sender Name, Recipient ID, Recipient Name, State, Message
-def AppendMessageRowsToDataList(data_list, 
-    conversationId, 
-    advertId,
-    advertTitle,    
-    conversationPartyId,
-    conversationPartyName, 
-    messagesJson):
+def AppendMessageRowsToDataList(data_list, conversationId, advertId, advertTitle,
+                                conversationPartyId, conversationPartyName, messagesJson):
     messages = json.loads(messagesJson)
     for message in messages:
-        # Determine sender (local user or counter party)
         if message['sender'] == LOCAL_USER_INDICATOR:
             senderId = ''
             senderName = LOCAL_USER
             recipientId = conversationPartyId
             recipientName = conversationPartyName
-        else:            
+        else:
             senderId = conversationPartyId
             senderName = conversationPartyName
             recipientId = ''
             recipientName = LOCAL_USER
 
-        data_list.append((message['sortByDate'], conversationId, advertId, advertTitle, message['identifier'], senderId, senderName, recipientId, recipientName, message['state'], message['text']))
+        data_list.append((message['sortByDate'], conversationId, advertId, advertTitle, message['identifier'],
+                          senderId, senderName, recipientId, recipientName, message['state'], message['text']))
+
+
+@artifact_processor
+def get_kijijiConversations(files_found, report_folder, seeker, wrap_text):
+    source_path = str(files_found[0])
+    logfunc(f'Database file {source_path} is being interrogated...')
+
+    data_list = []
+    if does_table_exist_in_db(source_path, 'conversations'):
+        db = open_sqlite_db_readonly(source_path)
+        db.row_factory = sqlite3.Row  # For fetching columns by name
+        cursor = db.cursor()
+        cursor.execute(conversations_query)
+        all_rows = cursor.fetchall()
+        db.close()
+
+        for row in all_rows:
+            conversationId = row['identifier']
+            counterPartyInfo = json.loads(row['counterParty'])
+            counterPartyId = counterPartyInfo["identifier"]
+            counterPartyName = counterPartyInfo["name"]
+            advertInfo = json.loads(row['ad'])
+            advertId = advertInfo["identifier"]
+            advertTitle = advertInfo["displayTitle"]
+
+            AppendMessageRowsToDataList(data_list, conversationId, advertId, advertTitle,
+                                        counterPartyId, counterPartyName, row['messages'])
+    else:
+        logfunc('The conversations table was not found in the database!')
+
+    data_headers = ('Date Sent', 'Conversation ID', 'Ad ID', 'Ad Title', 'Message ID', 'Sender ID', 'Sender Name', 'Recipient ID', 'Recipient Name', 'State', 'Message')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/smyfilesOpHistory.py
+++ b/scripts/artifacts/smyfilesOpHistory.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0702,W1309
+# pylint: disable=W0613,W0702
 __artifacts_v2__ = {
     "get_smyfiles_OpHistory": {
         "name": "My Files Operation History",
@@ -9,43 +9,32 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "My Files",
         "notes": "Current decode works with Android versions 10-12. Subscripted/accented/unknown characters will be replaced with '?'.",
-        "paths": '*/com.sec.android.app.myfiles/databases/OperationHistory.db*',
-        "output_types": None,
+        "paths": ('*/com.sec.android.app.myfiles/databases/OperationHistory.db*',),
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "clock",
-        "function": "get_smyfiles_OpHistory",
     }
 }
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 import scripts.artifacts.artGlobals as aG
-from packaging import version
-# database locations found at
-# /data/data/com.sec.android.app.myfiles/databases/OperationHistory.db
-# /data/user/150/com.sec.android.app.myfiles/databases/OperationHistory.db
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
+
+DECODE_DIC = {'a': 'b', 'b': 'a', 'c': 'c', 'd': 'd', 'e': 'f', 'f': 'e', 'g': 'g', 'h': 'p', 'i': 'r', 'j': 'q',
+              'k': 's', 'l': 't', 'm': 'v', 'n': 'u', 'o': 'w', 'p': 'h', 'q': 'j', 'r': 'i', 's': 'k', 't': 'l',
+              'u': 'n', 'v': 'm', 'w': 'o', 'x': 'x', 'y': 'z', 'z': 'y', '0': '(', '1': '*', '2': ')', '3': '+',
+              '4': ',', '5': '.', '6': '-', '7': '/', '8': '8', '9': ':', '(': '0', '*': '1', ')': '2', '+': '3',
+              ',': '4', '.': '5', '-': '6', '/': '7', ':': '9', ' ': ' ', '_': '_', '[': '[', ']': '^', '^': ']',
+              '£': '£', '&': '%', '%': '&', '\'': '\'', '$': '$', '\"': '!', '!': '\"', '#': '#', '@': '@'}
 
 
 def check_value(value):
-    decode_dic = {'a': 'b', 'b': 'a', 'c': 'c', 'd': 'd', 'e': 'f', 'f': 'e', 'g': 'g', 'h': 'p', 'i': 'r', 'j': 'q',
-                  'k': 's', 'l': 't', 'm': 'v', 'n': 'u', 'o': 'w', 'p': 'h', 'q': 'j', 'r': 'i', 's': 'k', 't': 'l',
-                  'u': 'n', 'v': 'm', 'w': 'o', 'x': 'x', 'y': 'z', 'z': 'y', '0': '(', '1': '*', '2': ')', '3': '+',
-                  '4': ',', '5': '.', '6': '-', '7': '/', '8': '8', '9': ':', '(': '0', '*': '1', ')': '2', '+': '3',
-                  ',': '4', '.': '5', '-': '6', '/': '7', ':': '9', ' ': ' ', '_': '_', '[': '[', ']': '^', '^': ']',
-                  '£': '£', '&': '%', '%': '&', '\'': '\'', '$': '$', '\"': '!', '!': '\"', '#': '#', '@': '@'}
-    if value in decode_dic:
-        result = decode_dic[value]
-    else:
-        result = '?'
-    return result
+    return DECODE_DIC.get(value, '?')
 
 
 def process_string(old_string):
     new_string = ''
     for char in old_string:
-
         if char.isalpha() and char.isupper():
-            char = check_value(char.lower())
-            char = char.upper()
+            char = check_value(char.lower()).upper()
         else:
             char = check_value(char)
         new_string += char
@@ -55,77 +44,54 @@ def process_string(old_string):
 def get_db_data(file_found):
     db = open_sqlite_db_readonly(file_found)
     cursor = db.cursor()
-
     try:
         cursor.execute("""Select * from operation_history""")
         all_rows = cursor.fetchall()
     except:
         all_rows = 0
-
+    db.close()
     return all_rows
 
 
 def get_user(file_found):
     """If record located within secure folder path, retrieve user value (usually 150)"""
     if '/user/1' in file_found:
-        finder = file_found.find('/user/')
-        start = finder + 6
-        end = start + 3
-        user = file_found[start:end]
-    else:
-        user = 0
-    return user
+        start = file_found.find('/user/') + 6
+        return file_found[start:start + 3]
+    return 0
 
 
+@artifact_processor
 def get_smyfiles_OpHistory(files_found, report_folder, seeker, wrap_text):
-    html_source = ''
+    data_list = []
+    source_path = ''
     Androidversion = aG.versionf
 
     if not 9 < int(Androidversion) < 13:
         logfunc(f'Android artifact My Files Operation History is not compatible with Android version {Androidversion}')
+        data_headers = ('Account', 'Item Path', 'Operation Date (Handset Timezone)', 'Operation Type', 'Item Count', 'Folder Count', 'Page Type')
+        return data_headers, data_list, source_path
 
-    else:
-        data_list = []
-        for file_found in files_found:
-            file_found = str(file_found)
-            user = get_user(file_found)
-            if file_found.lower().endswith('.db'):
-                html_source = file_found
-                all_rows = get_db_data(file_found)
-                usageentries = 0
-                if all_rows != 0:
-                    usageentries = len(all_rows)
+    for file_found in files_found:
+        file_found = str(file_found)
+        if not file_found.lower().endswith('.db'):
+            continue
 
-                if usageentries > 0:
-                    for entry in all_rows:
-                        cipher = entry[1]
-                        # mod_ts = entry[2]
-                        # op_type = entry[3]
-                        # item_count = entry[4]
-                        # folder_count = entry[5]
-                        # page_type = entry[6]
-                        #print(repr(cipher))
-                        if cipher != '':
-                            clear_path = process_string(cipher)
-                        elif cipher[:3] == '#G$':  # not supported, have seen in Android 13/14.
-                            clear_path = '*unsupported entry*'
-                        else:
-                            clear_path = '*blank entry*'
-                        data_list.append((user, clear_path, entry[2], entry[3], entry[4], entry[5], entry[6]))
+        user = get_user(file_found)
+        source_path = file_found
+        all_rows = get_db_data(file_found)
+        if all_rows == 0:
+            continue
 
-        if data_list:
-            report = ArtifactHtmlReport('My Files DB - Operation History')
-            report.start_artifact_report(report_folder, 'My Files DB - Operation History')
-            report.add_script()
-            data_headers = ('Account', 'Item Path', 'Operation Date (Handset Timezone)', 'Operation Type',
-                            'Item Count', 'Folder Count', 'Page Type')
-            report.write_artifact_data_table(data_headers, data_list, html_source)
-            report.end_artifact_report()
+        for entry in all_rows:
+            cipher = entry[1]
+            if cipher != '':
+                clear_path = process_string(cipher)
+            elif cipher[:3] == '#G$':  # not supported, have seen in Android 13/14.
+                clear_path = '*unsupported entry*'
+            else:
+                clear_path = '*blank entry*'
+            data_list.append((user, clear_path, entry[2], entry[3], entry[4], entry[5], entry[6]))
 
-            tsvname = f'My Files db - Operation History'
-            tsv(report_folder, data_headers, data_list, tsvname)
-
-            tlactivity = f'My Files DB - Operation History'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No My Files DB Operation History data available')
+    data_headers = ('Account', 'Item Path', 'Operation Date (Handset Timezone)', 'Operation Type', 'Item Count', 'Folder Count', 'Page Type')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts three more parsers to the LAVA `@artifact_processor` pattern.

- **googleMessages** — flat message table; `parts.timestamp` raw → aware UTC `datetime` (replacing SQL `datetime(...,'unixepoch')`); `Message Sender` marked `phonenumber`.
- **kijijiConversations** — per-thread JSON message expansion retained via the `AppendMessageRowsToDataList` helper; `Date Sent` kept as the app's raw value (format unverified); kept the `conversations` table-exists guard.
- **smyfilesOpHistory** — Samsung My Files op-history with the custom char-substitution decoder; Android-version gate retained; `Operation Date (Handset Timezone)` kept as the stored handset-local string. Fixed `paths` (was a bare string, not a 1-tuple → glob iterated char-by-char) and now closes the DB handle in the helper.

Verified: byte-compile, decorated 4-arg signature, returns 3-tuple, output_types valid, paths are tuples, loader resolves, pylint clean.