### PR TITLE
Convert mewe and walStrings to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/mewe.py
+++ b/scripts/artifacts/mewe.py
@@ -1,7 +1,7 @@
 # pylint: disable=W0613,W0702
 __artifacts_v2__ = {
-    "get_mewe": {
-        "name": "mewe",
+    "get_mewe_chat": {
+        "name": "MeWe - Chat",
         "description": "",
         "author": "",
         "creation_date": "2021-11-10",
@@ -9,149 +9,95 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "MeWe",
         "notes": "",
-        "paths": ('*/com.mewe/databases/app_database', '*/com.mewe/shared_prefs/SGSession.xml'),
-        "output_types": None,
+        "paths": ('*/com.mewe/databases/app_database',),
+        "output_types": "standard",
         "artifact_icon": "message-square",
-        "function": "get_mewe",
+    },
+    "get_mewe_session": {
+        "name": "MeWe - SGSession",
+        "description": "",
+        "author": "",
+        "creation_date": "2021-11-10",
+        "last_update_date": "2021-11-10",
+        "requirements": "none",
+        "category": "MeWe",
+        "notes": "",
+        "paths": ('*/com.mewe/shared_prefs/SGSession.xml',),
+        "output_types": ['html', 'tsv', 'lava'],
+        "artifact_icon": "key",
     }
 }
 
+import datetime
 import xml.etree.ElementTree as ET
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-APP_NAME = 'MeWe'
-DB_NAME = 'app_database'
-SGSESSION_FILE = 'SGSession.xml'
 CHAT_MESSAGES_QUERY = '''
     SELECT
-        DATETIME(createdAt, 'unixepoch'),
+        createdAt,
         threadId,
         groupId,
         ownerId,
         ownerName,
         textPlain,
-        CASE currentUserMessage
-            WHEN 1 THEN "Sent"
-            ELSE "Received"
-        END currentUserMessage,
-        CASE attachmentType
-            WHEN "UNSUPPORTED" THEN ''
-            ELSE attachmentType
-        END attachmentType,
+        CASE currentUserMessage WHEN 1 THEN "Sent" ELSE "Received" END currentUserMessage,
+        CASE attachmentType WHEN "UNSUPPORTED" THEN '' ELSE attachmentType END attachmentType,
         attachmentName,
-        CASE deleted
-            WHEN 1 THEN "YES"
-            ELSE "NO"
-        END deleted
+        CASE deleted WHEN 1 THEN "YES" ELSE "NO" END deleted
     FROM CHAT_MESSAGE
     JOIN CHAT_THREAD ON threadId = CHAT_THREAD.id
 '''
 
-def _perform_query(cursor, query):
-    try:
-        cursor.execute(query)
-        rows = cursor.fetchall()
-        return len(rows), rows
-    except:
-        return 0, None
 
-
-def _make_reports(title, data_headers, data_list, report_folder, db_file_name, tl_bool):
-    report = ArtifactHtmlReport(title)
-    report.start_artifact_report(report_folder, title)
-    report.add_script()
-    report.write_artifact_data_table(data_headers, data_list, db_file_name)
-    report.end_artifact_report()
-
-    tsv(report_folder, data_headers, data_list, title, db_file_name)
-
-    if tl_bool == True:
-        timeline(report_folder, title, data_list, data_headers)
-
-
-def _parse_xml(xml_file, xml_file_name, report_folder, title, report_name):
-    logfunc(f'{title} found')
-
-    tree = ET.parse(xml_file)
-    data_headers = ('Key', 'Value')
+@artifact_processor
+def get_mewe_chat(files_found, report_folder, seeker, wrap_text):
     data_list = []
-
-    root = tree.getroot()
-    for node in root:
-        # skip not relevant keys
-        if '.' in node.attrib['name']:
+    source_path = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if not file_found.endswith('app_database'):
             continue
 
-        value = None
+        source_path = file_found
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
         try:
-            value = node.attrib['value']
+            cursor.execute(CHAT_MESSAGES_QUERY)
+            rows = cursor.fetchall()
         except:
-            value = node.text
-            
-        data_list.append((node.attrib['name'], value))
+            rows = []
+        db.close()
 
-    tl_bool = False
-    
-    _make_reports(f'{APP_NAME} - {report_name}', data_headers, data_list, report_folder, xml_file_name, tl_bool)
+        for row in rows:
+            timestamp = datetime.datetime.fromtimestamp(int(row[0]), datetime.timezone.utc) if row[0] else ''
+            data_list.append((timestamp, row[1], row[2], row[3], row[4], row[5], row[6], row[7],
+                              row[8] if row[8] else '', row[9]))
 
-
-def _parse_chat_messages(messages_count, rows, report_folder, db_file_name):
-    logfunc(f'{messages_count} messages found')
-
-    data_headers = (
-        'Timestamp', 'Thread Id', 'Thread Name', 'User Id', 'User Name',
-        'Message Text', 'Message Direction', 'Message Type',
-        'Attachment Name', 'Deleted'
-    )
-    data_list = [(
-        row[0], row[1], row[2], row[3], row[4], row[5],
-        row[6], row[7], row[8] if row[8] else '', row[9]
-    ) for row in rows]
-
-    tl_bool = True
-
-    _make_reports(f'{APP_NAME} - Chat', data_headers, data_list, report_folder, db_file_name, tl_bool)
+    data_headers = (('Timestamp', 'datetime'), 'Thread Id', 'Thread Name', 'User Id', 'User Name',
+                    'Message Text', 'Message Direction', 'Message Type', 'Attachment Name', 'Deleted')
+    return data_headers, data_list, source_path
 
 
-def _parse_app_database(db_file, db_file_name, report_folder):
-    db = open_sqlite_db_readonly(db_file)
-    cursor = db.cursor()
+@artifact_processor
+def get_mewe_session(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if not file_found.endswith('SGSession.xml'):
+            continue
 
-    messages_count, rows = _perform_query(cursor, CHAT_MESSAGES_QUERY)
-    if messages_count > 0 and rows:
-        _parse_chat_messages(messages_count, rows, report_folder, db_file_name)
-    else:
-        logfunc(f'No {APP_NAME} chat data found')
+        source_path = file_found
+        root = ET.parse(file_found).getroot()
+        for node in root:
+            if '.' in node.attrib['name']:
+                continue  # skip not relevant keys
+            try:
+                value = node.attrib['value']
+            except:
+                value = node.text
+            data_list.append((node.attrib['name'], value))
 
-    cursor.close()
-    db.close()
-
-
-def get_mewe(files_found, report_folder, seeker, wrap_text):
-    db_file = None
-    db_file_name = None
-    xml_file = None
-    xml_file_name = None
-    
-    app_database_processed = False
-    sgsession_processed = False
-
-    for ff in files_found:
-        if ff.endswith(DB_NAME) and not app_database_processed:
-            db_file = ff
-            db_file_name = ff.replace(seeker.data_folder, '')
-            _parse_app_database(db_file, db_file_name, report_folder)
-            app_database_processed = True
-        if ff.endswith(SGSESSION_FILE) and not sgsession_processed:
-            xml_file = ff
-            xml_file_name = ff.replace(seeker.data_folder, '')
-            _parse_xml(xml_file, xml_file_name, report_folder, SGSESSION_FILE, 'SGSession')
-            sgsession_processed = True
-            
-    artifacts = [
-        app_database_processed, sgsession_processed
-    ]
-    if not (True in artifacts):
-        logfunc(f'{APP_NAME} data not found')
+    data_headers = ('Key', 'Value')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/walStrings.py
+++ b/scripts/artifacts/walStrings.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W1514
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_walStrings": {
         "name": "walStrings",
@@ -10,68 +10,60 @@ __artifacts_v2__ = {
         "category": "SQLite Journaling",
         "notes": "",
         "paths": ('*/*-wal', '*/*-journal'),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "file",
-        "function": "get_walStrings",
+        "html_columns": ['Report'],
     }
 }
 
 import os
 import re
 import string
-
 from pathlib import Path
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, is_platform_windows
 
-control_chars = ''.join(map(chr, range(0,32))) + ''.join(map(chr, range(127,160)))
+from scripts.ilapfuncs import artifact_processor
+
+control_chars = ''.join(map(chr, range(0, 32))) + ''.join(map(chr, range(127, 160)))
 not_control_char_re = re.compile(f'[^{control_chars}]' + '{4,}')
 # If  we only want ascii, use 'ascii_chars_re' below
 printable_chars_for_re = string.printable.replace('\\', '\\\\').replace('[', '\\[').replace(']', '\\]')
 ascii_chars_re = re.compile(f'[{printable_chars_for_re}]' + '{4,}')
 
+
+@artifact_processor
 def get_walStrings(files_found, report_folder, seeker, wrap_text):
     x = 1
     data_list = []
     for file_found in files_found:
-        filesize = Path(file_found).stat().st_size
-        if filesize == 0:
+        if Path(file_found).stat().st_size == 0:
             continue
 
         journalName = os.path.basename(file_found)
-        outputpath = os.path.join(report_folder, str(x) + '_' + journalName + '.txt') # name of file in txt
+        outputpath = os.path.join(report_folder, str(x) + '_' + journalName + '.txt')  # name of file in txt
 
-        level2, level1 = (os.path.split(outputpath))
-        level2 = (os.path.split(level2)[1])
+        level2, level1 = os.path.split(outputpath)
+        level2 = os.path.split(level2)[1]
         final = level2 + '/' + level1
-        
-        unique_items = set() # For deduplication of strings found
-        with open(outputpath, 'w') as g:
-            with open(file_found, errors="ignore") as f:  # Python 3.x
-                data =  f.read()
-                #for match in not_control_char_re.finditer(data): # This gets all unicode chars, can include lot of garbage if you only care about English, will miss out other languages
-                for match in ascii_chars_re.finditer(data): # Matches ONLY Ascii (old behavior) , good if you only care about English
+
+        unique_items = set()  # For deduplication of strings found
+        with open(outputpath, 'w', encoding='utf-8', errors='ignore') as g:
+            with open(file_found, encoding='utf-8', errors="ignore") as f:
+                data = f.read()
+                for match in ascii_chars_re.finditer(data):  # Matches ONLY Ascii
                     if match.group() not in unique_items:
                         g.write(match.group())
                         g.write('\n')
                         unique_items.add(match.group())
-            g.close()
 
         if unique_items:
-            out = (f'<a href="{final}" style = "color:blue" target="_blank">{journalName}</a>')
+            out = f'<a href="{final}" style = "color:blue" target="_blank">{journalName}</a>'
             data_list.append((out, file_found))
         else:
             try:
-                os.remove(outputpath) # delete empty file
+                os.remove(outputpath)  # delete empty file
             except OSError:
                 pass
         x = x + 1
 
-    location = ''
-    description = 'ASCII strings extracted from SQLite journal and WAL files.'
-    report = ArtifactHtmlReport('Strings - SQLite Journal & WAL')
-    report.start_artifact_report(report_folder, 'Strings - SQLite Journal & WAL', description)
-    report.add_script()
     data_headers = ('Report', 'Location')
-    report.write_artifact_data_table(data_headers, data_list, location, html_escape=False)
-    report.end_artifact_report()
+    return data_headers, data_list, ''


### PR DESCRIPTION
Converts two more parsers to the LAVA `@artifact_processor` pattern.

- **mewe** — split the single old function into two decorated artifacts: **MeWe - Chat** (`CHAT_MESSAGE` join; `createdAt` raw → aware UTC `datetime`, replacing SQL `DATETIME(...,'unixepoch')`) and **MeWe - SGSession** (Key/Value from SGSession.xml). Each now has its own path so it only opens the file it needs.
- **walStrings** — extracts ASCII strings from SQLite WAL/journal files into per-file `.txt` reports under the report folder and links them; `Report` declared in `html_columns`; added `encoding` to both `open()` calls. (Writes only into the report output folder, never the source.)

Verified: byte-compile, decorated 4-arg signatures, return 3-tuples, output_types valid, paths are tuples, loader resolves all functions, pylint clean.