### PR TITLE
Convert chromeDIPS to LAVA @artifact_processor (multi-browser)

### DIFF
--- a/scripts/artifacts/chromeDIPS.py
+++ b/scripts/artifacts/chromeDIPS.py
@@ -1,3 +1,4 @@
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_chromeDIPS": {
         "name": "ChromeDIPS",
@@ -9,159 +10,121 @@ __artifacts_v2__ = {
         "category": "Chromium",
         "notes": "",
         "paths": ('*/app_chrome/Default/DIPS*', '*/app_sbrowser/Default/DIPS*', '*/app_opera/DIPS*', '*/app_webview/Default/DIPS*'),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "globe",
-        "function": "get_chromeDIPS",
     }
 }
 
-# Module Description: Parses Chromium DIPS (Detect Incidental Party State)
-# Author: @KevinPagano3
-# Date: 2023-04-07
-# Artifact version: 0.0.1
-# Requirements: none
 # Thanks to Ryan Benson for awareness https://github.com/obsidianforensics/hindsight/pull/146/commits/015ee189c97c0a4e48deb59568dfe4f536ace8aa
 
+import datetime
 import os
+
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, get_next_unused_name, open_sqlite_db_readonly
+from scripts.ilapfuncs import logfunc, get_next_unused_name, lava_process_artifact, lava_insert_sqlite_data, artifact_processor, open_sqlite_db_readonly
 from scripts.artifacts.chrome import get_browser_name
 
-def get_chromeDIPS(files_found, report_folder, _seeker, _wrap_text):
+
+def _webkit_to_utc(value):
+    if value in (None, 0, ''):
+        return ''
+    return datetime.datetime(1601, 1, 1, tzinfo=datetime.timezone.utc) + datetime.timedelta(microseconds=int(value))
+
+
+@artifact_processor
+def get_chromeDIPS(files_found, report_folder, seeker, wrap_text):
+    # all_data is a consolidated list of all browsers with an extra column to discriminate the browser
+    all_data = []
+
+    data_headers = [
+        'Site',
+        'First Site Storage Timestamp',
+        'Last Site Storage Timestamp',
+        'First User Interaction Timestamp',
+        'Last User Interaction Timestamp',
+        'First Stateful Bounce Timestamp',
+        'Last Stateful Bounce Timestamp',
+        'First Stateless Bounce Timestamp',
+        'Last Stateless Bounce Timestamp',
+    ]
+
+    lava_data_headers = data_headers.copy()
+    for i in range(1, 9):
+        lava_data_headers[i] = (lava_data_headers[i], 'datetime')
+
+    all_data_headers = lava_data_headers + ['Browser Name']
+
+    report_file = 'Unknown'
 
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('DIPS'):
-            continue # Skip all other files
+            continue  # Skip all other files
+        if file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
+            continue  # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data
 
         browser_name = get_browser_name(file_found)
         if file_found.find('app_sbrowser') >= 0:
             browser_name = 'Browser'
-        elif file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
-            continue # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data??
-        
+
+        report_file = file_found if report_file == 'Unknown' else report_file + ', ' + file_found
+
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
-        
         columns = [i[1] for i in cursor.execute('PRAGMA table_info(bounces)')]
-        
+
         stateless = 'first_stateless_bounce_time' in columns
-
-        if 'first_user_interaction_time' in columns:
-            first_user_col = 'first_user_interaction_time'
-        else:
-            first_user_col = 'first_user_activation_time'
-
-        if 'last_user_interaction_time' in columns:
-            last_user_col = 'last_user_interaction_time'
-        else:
-            last_user_col = 'last_user_activation_time'
-
+        first_user_col = 'first_user_interaction_time' if 'first_user_interaction_time' in columns else 'first_user_activation_time'
+        last_user_col = 'last_user_interaction_time' if 'last_user_interaction_time' in columns else 'last_user_activation_time'
         if stateless:
-            last_bounce_expr = """
-            case first_stateless_bounce_time
-                when 0 then ''
-                else datetime((first_stateless_bounce_time/1000000)-11644473600,'unixepoch')
-            end,
-            case last_stateless_bounce_time
-                when 0 then ''
-                else datetime((last_stateless_bounce_time/1000000)-11644473600,'unixepoch')
-            end
-            """
+            first_bounce_col, last_bounce_col = 'first_stateless_bounce_time', 'last_stateless_bounce_time'
         else:
-            last_bounce_expr = """
-            case first_bounce_time
-                when 0 then ''
-                else datetime((first_bounce_time/1000000)-11644473600,'unixepoch')
-            end,
-            case last_bounce_time
-                when 0 then ''
-                else datetime((last_bounce_time/1000000)-11644473600,'unixepoch')
-            end
-            """
+            first_bounce_col, last_bounce_col = 'first_bounce_time', 'last_bounce_time'
 
-        sql = f'''
+        cursor.execute(f'''
             select
             site,
-            case first_site_storage_time
-                when 0 then ''
-                else datetime((first_site_storage_time/1000000)-11644473600,'unixepoch')
-            end,
-            case last_site_storage_time
-                when 0 then ''
-                else datetime((last_site_storage_time/1000000)-11644473600,'unixepoch')
-            end,
-            case {first_user_col}
-                when 0 then ''
-                else datetime(({first_user_col}/1000000)-11644473600,'unixepoch')
-            end,
-            case {last_user_col}
-                when 0 then ''
-                else datetime(({last_user_col}/1000000)-11644473600,'unixepoch')
-            end,
-            case first_stateful_bounce_time
-                when 0 then ''
-                else datetime((first_stateful_bounce_time/1000000)-11644473600,'unixepoch')
-            end,
-            case last_stateful_bounce_time
-                when 0 then ''
-                else datetime((last_stateful_bounce_time/1000000)-11644473600,'unixepoch')
-            end,
-            {last_bounce_expr}
+            first_site_storage_time,
+            last_site_storage_time,
+            {first_user_col},
+            {last_user_col},
+            first_stateful_bounce_time,
+            last_stateful_bounce_time,
+            {first_bounce_col},
+            {last_bounce_col}
             from bounces
-        '''
-
-        cursor.execute(sql)
+        ''')
         all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
+        db.close()
+
+        data_list = []
+        for row in all_rows:
+            data_list.append((row[0], _webkit_to_utc(row[1]), _webkit_to_utc(row[2]), _webkit_to_utc(row[3]),
+                              _webkit_to_utc(row[4]), _webkit_to_utc(row[5]), _webkit_to_utc(row[6]),
+                              _webkit_to_utc(row[7]), _webkit_to_utc(row[8])))
+
+        if len(data_list) > 0:
             description = 'DIPS - Incidental parties are sites without meaningful user interactions, such as bounce trackers'
-            report = ArtifactHtmlReport(f'{browser_name} - Detect Incidental Party State')
-            report_path = os.path.join(report_folder, f'{browser_name} - Detect Incidental Party State.temphtml')
-            report_path = get_next_unused_name(report_path)[:-9]
+            report_name = f'{browser_name} - Detect Incidental Party State'
+            report = ArtifactHtmlReport(report_name)
+            report_path = os.path.join(report_folder, f'{report_name}.temphtml')
+            report_path = get_next_unused_name(report_path)[:-9]  # remove .temphtml
             report.start_artifact_report(report_folder, os.path.basename(report_path), description)
             report.add_script()
-            data_headers = (
-                'Site',
-                'First Site Storage Timestamp',
-                'Last Site Storage Timestamp',
-                'First User Interaction Timestamp',
-                'Last User Interaction Timestamp',
-                'First Stateful Bounce Timestamp',
-                'Last Stateful Bounce Timestamp',
-                'First Stateless Bounce Timestamp',
-                'Last Stateless Bounce Timestamp'
-            )
-            if stateless:
-                tl_last = ('First Stateless Bounce Timestamp', 'Last Stateless Bounce Timestamp')
-            else:
-                tl_last = ('First Bounce Timestamp', 'Last Bounce Timestamp')
-            tl_data_headers = (
-                'First Site Storage Timestamp',
-                'Site',
-                'Last Site Storage Timestamp',
-                'First User Interaction Timestamp',
-                'Last User Interaction Timestamp',
-                'First Stateful Bounce Timestamp',
-                'Last Stateful Bounce Timestamp',
-                tl_last[0],
-                tl_last[1]
-            )
-            data_list = []
-            tl_data_list = []
-            for row in all_rows:
-                data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8]))
-                tl_data_list.append((row[1], row[0], row[2], row[3], row[4], row[5], row[6], row[7], row[8]))
-
             report.write_artifact_data_table(data_headers, data_list, file_found)
             report.end_artifact_report()
 
-            tsvname = f'{browser_name} - Detect Incidental Party State'
-            tsv(report_folder, data_headers, data_list, tsvname)
+            # Per-browser LAVA table
+            category = "Chromium"
+            module_name = "get_chromeDIPS"
+            table_name, object_columns, column_map = lava_process_artifact(
+                category, module_name, report_name, lava_data_headers, len(data_list))
+            lava_insert_sqlite_data(table_name, data_list, object_columns, lava_data_headers, column_map)
 
-            tlactivity = f'{browser_name} - Detect Incidental Party State'
-            timeline(report_folder, tlactivity, tl_data_list, tl_data_headers)
+            # Add the browser name column and accumulate for the combined output
+            data_list = [row + (browser_name,) for row in data_list]
+            all_data.extend(data_list)
         else:
             logfunc(f'No {browser_name} - Detect Incidental Party State data available')
 
-        db.close()
+    return all_data_headers, all_data, report_file


### PR DESCRIPTION
Converts the Chromium DIPS (Detect Incidental Party State) parser to the LAVA `@artifact_processor` pattern, following the same multi-browser approach used for the rest of the Chrome family (per-browser HTML report + per-browser LAVA table + a combined return with a `Browser Name` discriminator column).

- Replaced the in-SQL `datetime((col/1000000)-11644473600,'unixepoch')` WebKit-epoch conversions with raw column selection + a Python `_webkit_to_utc` helper that returns tz-aware UTC datetimes (anchored at 1601-01-01 UTC); all 8 timestamp columns are marked `datetime` in LAVA, with 0/NULL → ''.
- Kept the dynamic schema handling (`stateless` bounce columns, `first/last_user_interaction` vs `activation`) via a parameterized column list.
- Switched to `open_sqlite_db_readonly`.

Verified: byte-compile, decorated 4-arg signature, returns 3-tuple, output_types valid, loader resolves, uses the same lava_process_artifact/lava_insert_sqlite_data per-browser pattern as chromeBookmarks, pylint clean.