### PR TITLE
Convert chrome.py to LAVA @artifact_processor (multi-browser)

### DIFF
--- a/scripts/artifacts/chrome.py
+++ b/scripts/artifacts/chrome.py
@@ -1,8 +1,8 @@
 # pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_chrome": {
-        "name": "Chrome",
-        "description": "",
+        "name": "Chrome - Web History",
+        "description": "Parses Web History from Chromium based browsers",
         "author": "",
         "creation_date": "2020-03-19",
         "last_update_date": "2020-03-19",
@@ -10,19 +10,72 @@ __artifacts_v2__ = {
         "category": "Chromium",
         "notes": "",
         "paths": ('*/app_chrome/Default/History*', '*/app_sbrowser/Default/History*', '*/app_opera/History*', '*/app_webview/Default/History*'),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "globe",
-        "function": "get_chrome",
+    },
+    "get_chromeWebVisits": {
+        "name": "Chrome - Web Visits",
+        "description": "Parses Web Visits from Chromium based browsers",
+        "author": "",
+        "creation_date": "2020-03-19",
+        "last_update_date": "2020-03-19",
+        "requirements": "none",
+        "category": "Chromium",
+        "notes": "",
+        "paths": ('*/app_chrome/Default/History*', '*/app_sbrowser/Default/History*', '*/app_opera/History*', '*/app_webview/Default/History*'),
+        "output_types": "standard",
+        "artifact_icon": "globe",
+    },
+    "get_chromeSearchTerms": {
+        "name": "Chrome - Search Terms",
+        "description": "Parses Search Terms from Chromium based browsers",
+        "author": "",
+        "creation_date": "2020-03-19",
+        "last_update_date": "2020-03-19",
+        "requirements": "none",
+        "category": "Chromium",
+        "notes": "",
+        "paths": ('*/app_chrome/Default/History*', '*/app_sbrowser/Default/History*', '*/app_opera/History*', '*/app_webview/Default/History*'),
+        "output_types": "standard",
+        "artifact_icon": "search",
+    },
+    "get_chromeDownloads": {
+        "name": "Chrome - Downloads",
+        "description": "Parses Downloads from Chromium based browsers",
+        "author": "",
+        "creation_date": "2020-03-19",
+        "last_update_date": "2020-03-19",
+        "requirements": "none",
+        "category": "Chromium",
+        "notes": "",
+        "paths": ('*/app_chrome/Default/History*', '*/app_sbrowser/Default/History*', '*/app_opera/History*', '*/app_webview/Default/History*'),
+        "output_types": "standard",
+        "artifact_icon": "download",
+    },
+    "get_chromeKeywordSearchTerms": {
+        "name": "Chrome - Keyword Search Terms",
+        "description": "Parses Keyword Search Terms from Chromium based browsers",
+        "author": "",
+        "creation_date": "2020-03-19",
+        "last_update_date": "2020-03-19",
+        "requirements": "none",
+        "category": "Chromium",
+        "notes": "",
+        "paths": ('*/app_chrome/Default/History*', '*/app_sbrowser/Default/History*', '*/app_opera/History*', '*/app_webview/Default/History*'),
+        "output_types": "standard",
+        "artifact_icon": "search",
     }
 }
 
+import datetime
 import os
-import textwrap
-import urllib.parse
 import re
+import urllib.parse
 
 from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, get_next_unused_name, open_sqlite_db_readonly, does_column_exist_in_db
+from scripts.ilapfuncs import logfunc, get_next_unused_name, open_sqlite_db_readonly, does_column_exist_in_db, \
+    lava_process_artifact, lava_insert_sqlite_data, artifact_processor
+
 
 def get_browser_name(file_name):
 
@@ -43,68 +96,90 @@ def get_browser_name(file_name):
     else:
         return 'Unknown'
 
-def get_chrome(files_found, report_folder, seeker, wrap_text):
-    
+
+def _webkit_to_utc(value):
+    '''Chromium/WebKit timestamp = microseconds since 1601-01-01 UTC'''
+    if value in (None, 0, ''):
+        return ''
+    return datetime.datetime(1601, 1, 1, tzinfo=datetime.timezone.utc) + datetime.timedelta(microseconds=int(value))
+
+
+def _history_files(files_found):
+    '''Yield (file_found, browser_name) for the real History DBs, skipping journals/mirrors.'''
     for file_found in files_found:
         file_found = str(file_found)
-        if not os.path.basename(file_found) == 'History': # skip -journal and other files
+        if not os.path.basename(file_found) == 'History':  # skip -journal and other files
             continue
+        if file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
+            continue  # Skip mirror, it should be duplicate data
         browser_name = get_browser_name(file_found)
         if file_found.find('app_sbrowser') >= 0:
             browser_name = 'Browser'
-        elif file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
-            continue # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data??
+        yield file_found, browser_name
 
+
+def _emit(report_folder, report_name, data_headers, data_list, file_found, lava_data_headers, module_name):
+    report = ArtifactHtmlReport(report_name)
+    report_path = os.path.join(report_folder, f'{report_name}.temphtml')
+    report_path = get_next_unused_name(report_path)[:-9]  # remove .temphtml
+    report.start_artifact_report(report_folder, os.path.basename(report_path))
+    report.add_script()
+    report.write_artifact_data_table(data_headers, data_list, file_found)
+    report.end_artifact_report()
+
+    table_name, object_columns, column_map = lava_process_artifact(
+        "Chromium", module_name, report_name, lava_data_headers, len(data_list))
+    lava_insert_sqlite_data(table_name, data_list, object_columns, lava_data_headers, column_map)
+
+
+@artifact_processor
+def get_chrome(files_found, report_folder, seeker, wrap_text):
+    all_data = []
+    data_headers = ['Last Visit Time', 'URL', 'Title', 'Visit Count', 'Typed Count', 'ID', 'Hidden']
+    lava_data_headers = data_headers.copy()
+    lava_data_headers[0] = (lava_data_headers[0], 'datetime')
+    all_data_headers = lava_data_headers + ['Browser Name']
+    report_file = 'Unknown'
+
+    for file_found, browser_name in _history_files(files_found):
+        report_file = file_found if report_file == 'Unknown' else report_file + ', ' + file_found
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
-        
-        #Web History
         cursor.execute('''
-        SELECT
-        datetime(last_visit_time/1000000 + (strftime('%s','1601-01-01')),'unixepoch') AS LastVisitDate,
-        url AS URL,
-        title AS Title,
-        visit_count AS VisitCount,
-        typed_count AS TypedCount,
-        id AS ID,
-        CASE hidden
-            WHEN 0 THEN ''
-            WHEN 1 THEN 'Yes'
-        END as Hidden
-        FROM urls  
+        SELECT last_visit_time, url, title, visit_count, typed_count, id,
+        CASE hidden WHEN 0 THEN '' WHEN 1 THEN 'Yes' END as Hidden
+        FROM urls
         ''')
+        rows = cursor.fetchall()
+        db.close()
 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport(f'{browser_name} - Web History')
-            #check for existing and get next name for report file, so report from another file does not get overwritten
-            report_path = os.path.join(report_folder, f'{browser_name} - Web History.temphtml')
-            report_path = get_next_unused_name(report_path)[:-9] # remove .temphtml
-            report.start_artifact_report(report_folder, os.path.basename(report_path))
-            report.add_script()
-            data_headers = ('Last Visit Time','URL','Title','Visit Count','Typed Count','ID','Hidden')
-            data_list = []
-            for row in all_rows:
-                if wrap_text:
-                    data_list.append((row[0],textwrap.fill(row[1], width=100),row[2],row[3],row[4],row[5],row[6]))
-                else:
-                    data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'{browser_name} - Web History'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'{browser_name} - Web History'
-            timeline(report_folder, tlactivity, data_list, data_headers)
+        data_list = [(_webkit_to_utc(r[0]), r[1], r[2], r[3], r[4], r[5], r[6]) for r in rows]
+        if data_list:
+            _emit(report_folder, f'{browser_name} - Web History', data_headers, data_list, file_found,
+                  lava_data_headers, "get_chrome")
+            all_data.extend([row + (browser_name,) for row in data_list])
         else:
             logfunc(f'No {browser_name} - Web History data available')
-        
-        #Web Visits
+
+    return all_data_headers, all_data, report_file
+
+
+@artifact_processor
+def get_chromeWebVisits(files_found, report_folder, seeker, wrap_text):
+    all_data = []
+    data_headers = ['Visit Timestamp', 'URL', 'Title', 'Duration', 'Transition Type', 'Qualifier(s)', 'From Visit URL']
+    lava_data_headers = data_headers.copy()
+    lava_data_headers[0] = (lava_data_headers[0], 'datetime')
+    all_data_headers = lava_data_headers + ['Browser Name']
+    report_file = 'Unknown'
+
+    for file_found, browser_name in _history_files(files_found):
+        report_file = file_found if report_file == 'Unknown' else report_file + ', ' + file_found
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
         cursor.execute('''
         SELECT
-        datetime(visits.visit_time/1000000 + (strftime('%s','1601-01-01')),'unixepoch'),
+        visits.visit_time,
         urls.url,
         urls.title,
         CASE visits.visit_duration
@@ -139,110 +214,85 @@ def get_chrome(files_found, report_folder, seeker, wrap_text):
         Query2.url AS FromURL
         FROM visits
         LEFT JOIN urls ON visits.url = urls.id
-        LEFT JOIN (SELECT urls.url,urls.title,visits.visit_time,visits.id FROM visits LEFT JOIN urls ON visits.url = urls.id) Query2 ON visits.from_visit = Query2.id  
+        LEFT JOIN (SELECT urls.url,urls.title,visits.visit_time,visits.id FROM visits LEFT JOIN urls ON visits.url = urls.id) Query2 ON visits.from_visit = Query2.id
         ''')
+        rows = cursor.fetchall()
+        db.close()
 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport(f'{browser_name} - Web Visits')
-            #check for existing and get next name for report file, so report from another file does not get overwritten
-            report_path = os.path.join(report_folder, f'{browser_name} - Web Visits.temphtml')
-            report_path = get_next_unused_name(report_path)[:-9] # remove .temphtml
-            report.start_artifact_report(report_folder, os.path.basename(report_path))
-            report.add_script()
-            data_headers = ('Visit Timestamp','URL','Title','Duration','Transition Type','Qualifier(s)','From Visit URL')
-            data_list = []
-            for row in all_rows:
-                if wrap_text:
-                    data_list.append((row[0],textwrap.fill(row[1], width=100),row[2],row[3],row[4],row[5],row[6]))
-                else:
-                    data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'{browser_name} - Web Visits'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'{browser_name} - Web Visits'
-            timeline(report_folder, tlactivity, data_list, data_headers)
+        data_list = [(_webkit_to_utc(r[0]), r[1], r[2], r[3], r[4], r[5], r[6]) for r in rows]
+        if data_list:
+            _emit(report_folder, f'{browser_name} - Web Visits', data_headers, data_list, file_found,
+                  lava_data_headers, "get_chromeWebVisits")
+            all_data.extend([row + (browser_name,) for row in data_list])
         else:
             logfunc(f'No {browser_name} - Web Visits data available')
-            
-        #Web Search    
+
+    return all_data_headers, all_data, report_file
+
+
+@artifact_processor
+def get_chromeSearchTerms(files_found, report_folder, seeker, wrap_text):
+    all_data = []
+    data_headers = ['Last Visit Time', 'Search Term', 'URL', 'Title', 'Visit Count']
+    lava_data_headers = data_headers.copy()
+    lava_data_headers[0] = (lava_data_headers[0], 'datetime')
+    all_data_headers = lava_data_headers + ['Browser Name']
+    report_file = 'Unknown'
+
+    for file_found, browser_name in _history_files(files_found):
+        report_file = file_found if report_file == 'Unknown' else report_file + ', ' + file_found
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
         cursor.execute('''
-        SELECT
-            url,
-            title,
-            visit_count,
-            datetime(last_visit_time / 1000000 + (strftime('%s', '1601-01-01')), "unixepoch")
+        SELECT url, title, visit_count, last_visit_time
         FROM urls
         WHERE url like '%search?q=%'
         ''')
+        rows = cursor.fetchall()
+        db.close()
 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport(f'{browser_name} - Search Terms')
-            #check for existing and get next name for report file, so report from another file does not get overwritten
-            report_path = os.path.join(report_folder, f'{browser_name} - Search Terms.temphtml')
-            report_path = get_next_unused_name(report_path)[:-9] # remove .temphtml
-            report.start_artifact_report(report_folder, os.path.basename(report_path))
-            report.add_script()
-            data_headers = ('Last Visit Time','Search Term','URL', 'Title', 'Visit Count')
-            data_list = []
-            for row in all_rows:
-                search = row[0].split('search?q=')[1].split('&')[0]
-                search = urllib.parse.unquote(search).replace('+', ' ')
-                if wrap_text:
-                    data_list.append((row[3], search, (textwrap.fill(row[0], width=100)),row[1],row[2]))
-                else:
-                    data_list.append((row[3], search, row[0], row[1], row[2]))
+        data_list = []
+        for r in rows:
+            search = r[0].split('search?q=')[1].split('&')[0]
+            search = urllib.parse.unquote(search).replace('+', ' ')
+            data_list.append((_webkit_to_utc(r[3]), search, r[0], r[1], r[2]))
 
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'{browser_name} - Search Terms'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'{browser_name} - Search Terms'
-            timeline(report_folder, tlactivity, data_list, data_headers)
+        if data_list:
+            _emit(report_folder, f'{browser_name} - Search Terms', data_headers, data_list, file_found,
+                  lava_data_headers, "get_chromeSearchTerms")
+            all_data.extend([row + (browser_name,) for row in data_list])
         else:
             logfunc(f'No {browser_name} - Search Terms data available')
-            
-        #Downloads
-        # check for last_access_time column, an older version of chrome db (32) does not have it
-        if does_column_exist_in_db(file_found, 'downloads', 'last_access_time') == True:
-            last_access_time_query = '''
-            CASE last_access_time 
-                WHEN "0" 
-                THEN "" 
-                ELSE datetime(last_access_time / 1000000 + (strftime('%s', '1601-01-01')), "unixepoch")
-            END AS "Last Access Time"'''
-        else:
-            last_access_time_query = "'' as last_access_query"
 
-        # check for tab_url column, the older versions (pre-v65) does not have it
-        if does_column_exist_in_db(file_found, 'downloads', 'tab_url') == True:
-            tab_url_column = "tab_url"
-        else:
-            tab_url_column = "'' as tab_url"
+    return all_data_headers, all_data, report_file
 
+
+@artifact_processor
+def get_chromeDownloads(files_found, report_folder, seeker, wrap_text):
+    all_data = []
+    data_headers = ['Start Time', 'End Time', 'Last Access Time', 'URL', 'Target Path', 'State',
+                    'Danger Type', 'Interrupt Reason', 'Opened?', 'Received Bytes', 'Total Bytes']
+    lava_data_headers = data_headers.copy()
+    for i in (0, 1, 2):
+        lava_data_headers[i] = (lava_data_headers[i], 'datetime')
+    all_data_headers = lava_data_headers + ['Browser Name']
+    report_file = 'Unknown'
+
+    for file_found, browser_name in _history_files(files_found):
+        report_file = file_found if report_file == 'Unknown' else report_file + ', ' + file_found
+        # older chrome db (32) lacks last_access_time; pre-v65 lacks tab_url
+        last_access_sel = 'last_access_time' if does_column_exist_in_db(file_found, 'downloads', 'last_access_time') else "'' as last_access_time"
+        tab_url_sel = 'tab_url' if does_column_exist_in_db(file_found, 'downloads', 'tab_url') else "'' as tab_url"
+
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
         cursor.execute(f'''
-        SELECT 
-        CASE start_time  
-            WHEN "0" 
-            THEN "" 
-            ELSE datetime(start_time / 1000000 + (strftime('%s', '1601-01-01')), "unixepoch")
-        END AS "Start Time", 
-        CASE end_time 
-            WHEN "0" 
-            THEN "" 
-            ELSE datetime(end_time / 1000000 + (strftime('%s', '1601-01-01')), "unixepoch")
-        END AS "End Time", 
-        {last_access_time_query},
-        {tab_url_column}, 
-        target_path, 
+        SELECT
+        start_time,
+        end_time,
+        {last_access_sel},
+        {tab_url_sel},
+        target_path,
         CASE state
             WHEN "0" THEN "In Progress"
             WHEN "1" THEN "Complete"
@@ -308,79 +358,56 @@ def get_chrome(files_found, report_folder, seeker, wrap_text):
             WHEN "41" THEN "Browser Shutdown"
             WHEN "50" THEN "Browser Crashed"
         END,
-        CASE opened
-            WHEN 0 THEN ''
-            WHEN 1 THEN 'Yes'
-        END, 
-        received_bytes, 
+        CASE opened WHEN 0 THEN '' WHEN 1 THEN 'Yes' END,
+        received_bytes,
         total_bytes
         FROM downloads
         ''')
+        rows = cursor.fetchall()
+        db.close()
 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport(f'{browser_name} - Downloads')
-            #check for existing and get next name for report file, so report from another file does not get overwritten
-            report_path = os.path.join(report_folder, f'{browser_name} - Downloads.temphtml')
-            report_path = get_next_unused_name(report_path)[:-9] # remove .temphtml
-            report.start_artifact_report(report_folder, os.path.basename(report_path))
-            report.add_script()
-            data_headers = ('Start Time','End Time','Last Access Time','URL','Target Path','State','Danger Type','Interrupt Reason','Opened?','Received Bytes','Total Bytes')
-            data_list = []
-            for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10]))
+        data_list = []
+        for r in rows:
+            data_list.append((_webkit_to_utc(r[0]), _webkit_to_utc(r[1]), _webkit_to_utc(r[2]),
+                              r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10]))
 
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'{browser_name} - Downloads'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'{browser_name} - Downloads'
-            timeline(report_folder, tlactivity, data_list, data_headers)
+        if data_list:
+            _emit(report_folder, f'{browser_name} - Downloads', data_headers, data_list, file_found,
+                  lava_data_headers, "get_chromeDownloads")
+            all_data.extend([row + (browser_name,) for row in data_list])
         else:
             logfunc(f'No {browser_name} - Downloads data available')
-            
-        #Search Terms
+
+    return all_data_headers, all_data, report_file
+
+
+@artifact_processor
+def get_chromeKeywordSearchTerms(files_found, report_folder, seeker, wrap_text):
+    all_data = []
+    data_headers = ['Last Visit Time', 'Term', 'URL']
+    lava_data_headers = data_headers.copy()
+    lava_data_headers[0] = (lava_data_headers[0], 'datetime')
+    all_data_headers = lava_data_headers + ['Browser Name']
+    report_file = 'Unknown'
+
+    for file_found, browser_name in _history_files(files_found):
+        report_file = file_found if report_file == 'Unknown' else report_file + ', ' + file_found
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
         cursor.execute('''
-        SELECT
-            url_id,
-            term,
-            id,
-            url,
-            datetime(last_visit_time / 1000000 + (strftime('%s', '1601-01-01')), "unixepoch")
+        SELECT url_id, term, id, url, last_visit_time
         FROM keyword_search_terms, urls
         WHERE url_id = id
         ''')
+        rows = cursor.fetchall()
+        db.close()
 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport(f'{browser_name} - Keyword Search Terms')
-            #check for existing and get next name for report file, so report from another file does not get overwritten
-            report_path = os.path.join(report_folder, f'{browser_name} - Keyword Search Terms.temphtml')
-            report_path = get_next_unused_name(report_path)[:-9] # remove .temphtml
-            report.start_artifact_report(report_folder, os.path.basename(report_path))
-            report.add_script()
-            data_headers = ('Last Visit Time','Term','URL')
-            data_list = []
-            for row in all_rows:
-                if wrap_text:
-                    data_list.append((row[4], row[1],(textwrap.fill(row[3], width=100))))
-                else:
-                    data_list.append((row[4], row[1], row[3]))
-
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'{browser_name} - Keyword Search Terms'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'{browser_name} - Keyword Search Terms'
-            timeline(report_folder, tlactivity, data_list, data_headers)
+        data_list = [(_webkit_to_utc(r[4]), r[1], r[3]) for r in rows]
+        if data_list:
+            _emit(report_folder, f'{browser_name} - Keyword Search Terms', data_headers, data_list, file_found,
+                  lava_data_headers, "get_chromeKeywordSearchTerms")
+            all_data.extend([row + (browser_name,) for row in data_list])
         else:
             logfunc(f'No {browser_name} - Keyword Search Terms data available')
-        
-        
-        db.close()
+
+    return all_data_headers, all_data, report_file


### PR DESCRIPTION
Converts the core Chromium History parser to the LAVA `@artifact_processor` pattern, following the established multi-browser approach (per-browser HTML report + per-browser LAVA table + combined return with a `Browser Name` discriminator column).

Split the single old `get_chrome` into five decorated artifacts, one per report:
- **get_chrome** → Web History
- **get_chromeWebVisits** → Web Visits
- **get_chromeSearchTerms** → Search Terms
- **get_chromeDownloads** → Downloads (keeps the dynamic `last_access_time`/`tab_url` schema probes for older DB versions)
- **get_chromeKeywordSearchTerms** → Keyword Search Terms

Timestamps: replaced all in-SQL `datetime(col/1000000 + strftime('%s','1601-01-01'),'unixepoch')` WebKit conversions with raw column selection + a Python `_webkit_to_utc` helper returning tz-aware UTC datetimes (anchored 1601-01-01 UTC, 0/NULL → ''); the relevant timestamp columns are marked `datetime` in LAVA.

**`get_browser_name` is kept byte-for-byte identical** (verified for Brave/Edge/Opera/Chrome/webview/Unknown), and the modules that import it (chromeDIPS, chromeAutofill, chromeBookmarks, etc.) still load.

Verified: byte-compile, all 5 functions decorated with 4-arg signature, return 3-tuples, output_types valid, loader resolves all, get_browser_name behavior preserved + importers load, pylint clean.