### PR TITLE
Fix LAVA duplicate-name collisions (unique artifact names)

### DIFF
--- a/scripts/artifacts/blueskymessages.py
+++ b/scripts/artifacts/blueskymessages.py
@@ -1,7 +1,7 @@
 # pylint: disable=W0611,W0613,W0631,W0702,W1309
 __artifacts_v2__ = {
     "get_blueskymessages": {
-        "name": "Bluesky",
+        "name": "Bluesky - Messages",
         "description": "Bluesky Messages",
         "author": "Alexis Brignoni",
         "creation_date": "2024-11-19",

--- a/scripts/artifacts/blueskyposts.py
+++ b/scripts/artifacts/blueskyposts.py
@@ -1,7 +1,7 @@
 # pylint: disable=W0611,W0612,W0613,W0702,W1309
 __artifacts_v2__ = {
     "get_blueskyposts": {
-        "name": "Bluesky",
+        "name": "Bluesky - Posts",
         "description": "Bluesky Feed Posts",
         "author": "Alexis Brignoni",
         "creation_date": "2024-11-20",

--- a/scripts/artifacts/blueskysearches.py
+++ b/scripts/artifacts/blueskysearches.py
@@ -1,7 +1,7 @@
 # pylint: disable=W0613
 __artifacts_v2__ = {
     "get_blueskysearches": {
-        "name": "Bluesky",
+        "name": "Bluesky - Searches",
         "description": "User generated searches",
         "author": "DFIRcon 2025 Miami",
         "creation_date": "2024-11-15",

--- a/scripts/artifacts/burnerContacts.py
+++ b/scripts/artifacts/burnerContacts.py
@@ -1,7 +1,7 @@
 # pylint: disable=W0613
 __artifacts_v2__ = {
     "get_burnerContacts": {
-        "name": "Burner: Second Phone Number",
+        "name": "Burner - Contacts",
         "description": "Parses Burner Contacts",
         "author": "Heather Charpentier (With Tons of Help from Alexis Brignoni!)",
         "version": "0.0.1",

--- a/scripts/artifacts/burnerMessages.py
+++ b/scripts/artifacts/burnerMessages.py
@@ -1,7 +1,7 @@
 # pylint: disable=W0613
 __artifacts_v2__ = {
     "get_burnerMessages": {
-        "name": "Burner: Second Phone Number",
+        "name": "Burner - Messages",
         "description": "Parses Burner Messages",
         "author": "Heather Charpentier (With Tons of Help from Alexis Brignoni!)",
         "version": "0.0.1",

--- a/scripts/artifacts/burnerSubscription.py
+++ b/scripts/artifacts/burnerSubscription.py
@@ -1,7 +1,7 @@
 # pylint: disable=W0613
 __artifacts_v2__ = {
     "get_burnerSubscription": {
-        "name": "Burner: Second Phone Number",
+        "name": "Burner - Subscription",
         "description": "Parses Burner Subscription Information",
         "author": "Heather Charpentier (With Tons of Help from Alexis Brignoni!)",
         "version": "0.0.1",

--- a/scripts/artifacts/burnerUser.py
+++ b/scripts/artifacts/burnerUser.py
@@ -1,7 +1,7 @@
 # pylint: disable=W0613
 __artifacts_v2__ = {
     "get_burnerUser": {
-        "name": "Burner: Second Phone Number",
+        "name": "Burner - User",
         "description": "Parses Burner User Information",
         "author": "Heather Charpentier (With Tons of Help from Alexis Brignoni!)",
         "version": "0.0.1",

--- a/scripts/artifacts/chatgpt2.py
+++ b/scripts/artifacts/chatgpt2.py
@@ -1,7 +1,7 @@
 # pylint: disable=E0606,E1120,E1123,W0611,W0613,W0702,W0718
 __artifacts_v2__ = {
     "get_chatpgt2": {
-        "name": "ChatGPT",
+        "name": "ChatGPT - Conversations",
         "description": "Android ChatGPT conversations",
         "author": "Alexis Brignoni",
         "creation_date": "2025-07-08",

--- a/scripts/artifacts/chrome.py
+++ b/scripts/artifacts/chrome.py
@@ -1,7 +1,7 @@
 # pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_chrome": {
-        "name": "Chrome - Web History",
+        "name": "Web History",
         "description": "Parses Web History from Chromium based browsers",
         "author": "",
         "creation_date": "2020-03-19",
@@ -14,7 +14,7 @@ __artifacts_v2__ = {
         "artifact_icon": "globe",
     },
     "get_chromeWebVisits": {
-        "name": "Chrome - Web Visits",
+        "name": "Web Visits",
         "description": "Parses Web Visits from Chromium based browsers",
         "author": "",
         "creation_date": "2020-03-19",
@@ -27,7 +27,7 @@ __artifacts_v2__ = {
         "artifact_icon": "globe",
     },
     "get_chromeSearchTerms": {
-        "name": "Chrome - Search Terms",
+        "name": "Search Terms",
         "description": "Parses Search Terms from Chromium based browsers",
         "author": "",
         "creation_date": "2020-03-19",
@@ -40,7 +40,7 @@ __artifacts_v2__ = {
         "artifact_icon": "search",
     },
     "get_chromeDownloads": {
-        "name": "Chrome - Downloads",
+        "name": "Downloads",
         "description": "Parses Downloads from Chromium based browsers",
         "author": "",
         "creation_date": "2020-03-19",
@@ -53,7 +53,7 @@ __artifacts_v2__ = {
         "artifact_icon": "download",
     },
     "get_chromeKeywordSearchTerms": {
-        "name": "Chrome - Keyword Search Terms",
+        "name": "Keyword Search Terms",
         "description": "Parses Keyword Search Terms from Chromium based browsers",
         "author": "",
         "creation_date": "2020-03-19",


### PR DESCRIPTION
LAVA keys artifacts by display **name** and only shows the first when names collide; **category** only controls grouping. This makes the affected names unique while keeping categories intact for grouping.

**chrome.py (the reported case):** the multi-browser pattern emits a combined table (named by the artifact's `name`) plus per-browser tables (`{browser} - <type>`). With the combined artifacts named `Chrome - Web History` etc., they collided exactly with the Chrome browser's own per-browser table (e.g. two `Chrome - Web History` entries — 76 combined vs 34 Chrome-only). Renamed the 5 combined artifacts to report-type-only — `Web History`, `Web Visits`, `Search Terms`, `Downloads`, `Keyword Search Terms` — matching the existing `Bookmarks`/`Offline Pages` siblings. Combined names no longer equal any `{browser} - <type>` table.

**Burner (4 artifacts all named "Burner: Second Phone Number"):** → `Burner - Contacts / Messages / Subscription / User` (category stays `Burner`).

**Bluesky (3 named "Bluesky"):** → `Bluesky - Messages / Posts / Searches` (category stays `Bluesky`).

**ChatGPT (2 named "ChatGPT"):** kept the comprehensive `chatgpt.py` as `ChatGPT`; renamed the secondary `chatgpt2.py` → `ChatGPT - Conversations` (category stays `ChatGPT`).

Verified: byte-compile, a repo-wide scan shows no remaining cross-file duplicate names and no `Chrome - ` combined names, and the plugin loader builds (407 plugins).