### PR TITLE
Convert GarminWeight, GarminStressAPI, GarminDailiesAPI to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/GarminDailiesAPI.py
+++ b/scripts/artifacts/GarminDailiesAPI.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0631,W1309,W1514
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_dailies_api": {
         "name": "GarminDailiesAPI",
@@ -10,65 +10,82 @@ __artifacts_v2__ = {
         "category": "Garmin",
         "notes": "",
         "paths": ('*/garmin.api/daily*',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "activity",
-        "function": "get_dailies_api",
     }
 }
 
-# Get Information related to the Daily summaries from the Garmin API using the JSON file extracted
-# Requires to have extracted the information from the Garmin API using the script in the url: https://github.com/labcif/Garmin-Connect-API-Extractor
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-02-28
-# Version: 1.0
-# Requirements: Python 3.7 or higher, json
+# Requires extracting Garmin API data using https://github.com/labcif/Garmin-Connect-API-Extractor
 
 import json
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+# (field, header) pairs - duplicates from the original list removed so LAVA column names stay unique
+FIELDS = [
+    ('calendarDate', 'Calendar Date'),
+    ('totalKilocalories', 'Total Kilocalories'),
+    ('activeKilocalories', 'Active Kilocalories'),
+    ('bmrKilocalories', 'BMR Kilocalories'),
+    ('wellnessActiveKilocalories', 'Wellness Active Kilocalories'),
+    ('burnedKilocalories', 'Burned Kilocalories'),
+    ('consumedKilocalories', 'Consumed Kilocalories'),
+    ('remainingKilocalories', 'Remaining Kilocalories'),
+    ('totalSteps', 'Total Steps'),
+    ('totalDistanceMeters', 'Total Distance Meters'),
+    ('wellnessDistanceMeters', 'Wellness Distance Meters'),
+    ('highlyActiveSeconds', 'Highly Active Seconds'),
+    ('activeSeconds', 'Active Seconds'),
+    ('moderateIntensityMinutes', 'Moderate Intensity Minutes'),
+    ('floorsAscendedInMeters', 'Floors Ascended In Meters'),
+    ('floorsDescendedInMeters', 'Floors Descended In Meters'),
+    ('minHeartRate', 'Min Heart Rate'),
+    ('maxHeartRate', 'Max Heart Rate'),
+    ('restingHeartRate', 'Resting Heart Rate'),
+    ('lastSevenDaysAvgRestingHeartRate', 'Last Seven Days Avg Resting Heart Rate'),
+    ('averageStressLevel', 'Average Stress Level'),
+    ('maxStressLevel', 'Max Stress Level'),
+    ('stressDuration', 'Stress Duration'),
+    ('restStressDuration', 'Rest Stress Duration'),
+    ('activityStressDuration', 'Activity Stress Duration'),
+    ('uncategorizedStressDuration', 'Uncategorized Stress Duration'),
+    ('totalStressDuration', 'Total Stress Duration'),
+    ('lowStressDuration', 'Low Stress Duration'),
+    ('mediumStressDuration', 'Medium Stress Duration'),
+    ('highStressDuration', 'High Stress Duration'),
+    ('stressPercentage', 'Stress Percentage'),
+    ('restStressPercentage', 'Rest Stress Percentage'),
+    ('activityStressPercentage', 'Activity Stress Percentage'),
+    ('uncategorizedStressPercentage', 'Uncategorized Stress Percentage'),
+    ('lowStressPercentage', 'Low Stress Percentage'),
+    ('mediumStressPercentage', 'Medium Stress Percentage'),
+    ('highStressPercentage', 'High Stress Percentage'),
+    ('bodyBatteryChargedValue', 'Body Battery Charged Value'),
+    ('bodyBatteryDrainedValue', 'Body Battery Drained Value'),
+    ('bodyBatteryHighestValue', 'Body Battery Highest Value'),
+    ('bodyBatteryLowestValue', 'Body Battery Lowest Value'),
+    ('bodyBatteryMostRecentValue', 'Body Battery Most Recent Value'),
+    ('averageSpo2', 'Average Spo2'),
+    ('latestSpo2', 'Latest Spo2'),
+]
 
 
+@artifact_processor
 def get_dailies_api(files_found, report_folder, seeker, wrap_text):
-    fields = ['calendarDate', 'totalKilocalories', 'activeKilocalories', 'bmrKilocalories', 'wellnessActiveKilocalories', 'burnedKilocalories', 'consumedKilocalories', 'remainingKilocalories',
-                'totalSteps', 'totalDistanceMeters', 'wellnessDistanceMeters', 'highlyActiveSeconds', 'activeSeconds', 'moderateIntensityMinutes', 'floorsAscendedInMeters', 'floorsDescendedInMeters',
-                'floorsAscendedInMeters', 'floorsDescendedInMeters', 'minHeartRate', 'maxHeartRate', 'restingHeartRate', 'lastSevenDaysAvgRestingHeartRate', 'averageStressLevel', 'maxStressLevel',
-                'stressDuration', 'stressDuration', 'restStressDuration', 'activityStressDuration', 'uncategorizedStressDuration', 'totalStressDuration', 'lowStressDuration', 'mediumStressDuration',
-                'highStressDuration', 'stressPercentage', 'restStressPercentage', 'activityStressPercentage', 'uncategorizedStressPercentage', 'lowStressPercentage', 'mediumStressPercentage',
-                'highStressPercentage', 'bodyBatteryChargedValue', 'bodyBatteryDrainedValue', 'bodyBatteryHighestValue', 'bodyBatteryLowestValue', 'bodyBatteryMostRecentValue', 'averageSpo2', 'latestSpo2']
     logfunc("Processing data for Dailies API")
-    logfunc("Processing data for Dailies API")
-    report = ArtifactHtmlReport('Dailies API')
-    report.start_artifact_report(report_folder, 'Dailies API')
-    report.add_script()
-    data_headers = ('Calendar Date', 'Total Kilocalories', 'Active Kilocalories', 'BMR Kilocalories', 'Wellness Active Kilocalories', 'Burned Kilocalories', 'Consumed Kilocalories', 'Remaining Kilocalories',
-                        'Total Steps', 'Total Distance Meters', 'Wellness Distance Meters', 'Highly Active Seconds', 'Active Seconds', 'Moderate Intensity Minutes', 'Floors Ascended In Meters', 'Floors Descended In Meters',
-                        'Floors Ascended In Meters', 'Floors Descended In Meters', 'Min Heart Rate', 'Max Heart Rate', 'Resting Heart Rate', 'Last Seven Days Avg Resting Heart Rate', 'Average Stress Level', 'Max Stress Level',
-                        'Stress Duration', 'Stress Duration', 'Rest Stress Duration', 'Activity Stress Duration', 'Uncategorized Stress Duration', 'Total Stress Duration', 'Low Stress Duration', 'Medium Stress Duration',
-                        'High Stress Duration', 'Stress Percentage', 'Rest Stress Percentage', 'Activity Stress Percentage', 'Uncategorized Stress Percentage', 'Low Stress Percentage', 'Medium Stress Percentage',
-                        'High Stress Percentage', 'Body Battery Charged Value', 'Body Battery Drained Value', 'Body Battery Highest Value', 'Body Battery Lowest Value', 'Body Battery Most Recent Value',
-                        'Average Spo2', 'Latest Spo2')
     data_list = []
-    # file = str(files_found[0])
+    source_path = ''
     for file in files_found:
         file = str(file)
+        source_path = file
         logfunc("Processing file: " + file)
-        # Open JSON file
-        with open(file, "r") as f:
+        with open(file, "r", encoding='utf-8', errors='replace') as f:
             data = json.load(f)
 
         if len(data) > 0:
-            data_row = []
-            logfunc("Found Garmin Daily File")
-            # Get calendar date
-            for field in fields:
-                if data['UserDailySummary']['payload'][field] is not None:
-                    data_row.append(data['UserDailySummary']['payload'][field])
-                else:
-                    data_row.append('N/A')
-            data_list.append((row for row in data_row))
-    report.filter_by_date('GarminDailyAPI', 0)
-    report.write_artifact_data_table(data_headers, data_list, file, html_escape=False, table_id='GarminDailyAPI')
-    report.end_artifact_report()
-    tsvname = f'Garmin Log'
-    tsv(report_folder, data_headers, data_list, tsvname)
+            payload = data['UserDailySummary']['payload']
+            data_row = [payload[field] if payload.get(field) is not None else 'N/A' for field, _ in FIELDS]
+            data_list.append(tuple(data_row))
+
+    data_headers = tuple(header for _, header in FIELDS)
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/GarminStressAPI.py
+++ b/scripts/artifacts/GarminStressAPI.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0311,W0613,W0631,W1309,W1514
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_stress_api": {
         "name": "GarminStressAPI",
@@ -10,80 +10,43 @@ __artifacts_v2__ = {
         "category": "Garmin",
         "notes": "",
         "paths": ('*/garmin.api/stress*',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "activity",
-        "function": "get_stress_api",
     }
 }
 
-# Get Information from Garmin Stress API
-# Requires to have extracted the information from the Garmin API using the script in the url: https://github.com/labcif/Garmin-Connect-API-Extractor
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-02-24
-# Version: 1.0
-# Requirements: Python 3.7 or higher, json and datetime
+# Requires extracting Garmin API data using https://github.com/labcif/Garmin-Connect-API-Extractor
+
 import json
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv
+from scripts.ilapfuncs import artifact_processor, logfunc
 
 
+@artifact_processor
 def get_stress_api(files_found, report_folder, seeker, wrap_text):
-
     logfunc("Processing data for Stress API")
-    report = ArtifactHtmlReport('Stress API')
-    report.start_artifact_report(report_folder, 'Stress API')
-    report.add_script()
-    data_headers = ('Date', 'Stress Level', 'High Stress Duration', 'Medium Stress Duration', 'Low Stress Duration', 'Rest Stress Duration')
     data_list = []
-    stress = []
-    dates = []
-    #file = str(files_found[0])
+    source_path = ''
     for file in files_found:
         file = str(file)
+        source_path = file
         logfunc("Processing file: " + file)
-        #Open JSON file
-        with open(file, "r") as f:
+        with open(file, "r", encoding='utf-8', errors='replace') as f:
             data_file = json.load(f)
 
         if len(data_file) > 0:
-            logfunc("Found Garmin Stress API data")
             for data in data_file:
-                # Get calendar date
                 date = data['calendarDate']
-                dates.append(date)
-                # Get stress level
-                if data['values']['overallStressLevel'] == -1:
+                values = data['values']
+                if values['overallStressLevel'] == -1:
                     stress_level = 'N/A'
-                    stress.append(0)
                 else:
-                    stress_level = data['values']['overallStressLevel']
-                    stress.append(stress_level)
-                # Get max hearth rate if none set to 'N/A'
-                if data['values']['highStressDuration'] is not None:
-                    high_stress_duration = data['values']['highStressDuration']
-                else:
-                    high_stress_duration = 'N/A'
-                # Get min hearth rate
-                if data['values']['mediumStressDuration'] is not None:
-                    medium_stress_duration = data['values']['mediumStressDuration']
-                else:
-                    medium_stress_duration = 'N/A'
-                # Get resting hearth rate
-                if data['values']['lowStressDuration'] is not None:
-                    low_stress_duration = data['values']['lowStressDuration']
-                else:
-                   low_stress_duration = 'N/A'
-                # Get average hearth rate
-                if data['values']['restStressDuration'] is not None:
-                    rest_stress_duration = data['values']['restStressDuration']
-                else:
-                    rest_stress_duration = 'N/A'
+                    stress_level = values['overallStressLevel']
+                high_stress_duration = values['highStressDuration'] if values['highStressDuration'] is not None else 'N/A'
+                medium_stress_duration = values['mediumStressDuration'] if values['mediumStressDuration'] is not None else 'N/A'
+                low_stress_duration = values['lowStressDuration'] if values['lowStressDuration'] is not None else 'N/A'
+                rest_stress_duration = values['restStressDuration'] if values['restStressDuration'] is not None else 'N/A'
                 data_list.append((date, stress_level, high_stress_duration, medium_stress_duration, low_stress_duration, rest_stress_duration))
-    report.filter_by_date('GarminStressAPI', 0)
-    report.write_artifact_data_table(data_headers, data_list, file, html_escape=False, table_id='GarminStressAPI')
-    report.add_chart()
-    report.add_chart_script('myChart', 'line', stress, dates, 'Stress Level', 'Date', 'Stress Level')
-    report.end_artifact_report()
-    tsvname = f'Garmin Log'
-    tsv(report_folder, data_headers, data_list, tsvname)
+
+    data_headers = ('Date', 'Stress Level', 'High Stress Duration', 'Medium Stress Duration', 'Low Stress Duration', 'Rest Stress Duration')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/GarminWeight.py
+++ b/scripts/artifacts/GarminWeight.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_garmin_weight": {
         "name": "GarminWeight",
@@ -10,73 +10,35 @@ __artifacts_v2__ = {
         "category": "Garmin",
         "notes": "",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "activity",
-        "function": "get_garmin_weight",
     }
 }
 
-# Get Information relative to the weight data in the database cache-database from the table weight in the Garmin Connect app
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-02-24
-# Version: 1.0
-# Requirements: Python 3.7 or higher
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
 
+@artifact_processor
 def get_garmin_weight(files_found, report_folder, seeker, wrap_text):
     logfunc("Processing data for Garmin Weight")
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
-
-    #This query is retreiving the data from the table weight, which contains the weight data for the user
+    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     cursor.execute('''
-        Select
-        samplePk,
-        datetime("date"/1000,'unixepoch'),
-        weight
+        Select samplePk, "date", weight
         from weight
     ''')
-
     all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        logfunc(f"Found {usageentries} weight entries")
-        report = ArtifactHtmlReport('Weight')
-        report.start_artifact_report(report_folder, 'Weight')
-        report.add_script()
-        data_headers = ('samplePk', 'Date', 'Weight')
-        data_list = []
-        date = []
-        weight = []
-
-        for row in all_rows:
-            data_list.append((row[0], row[1], row[2]))
-            # get only the date from the datetime
-            date.append(row[1].split(' ')[0])
-            # convert weight in kg
-            weight.append(row[2] / 1000)
-
-
-
-        table_id = "GarminWeight"
-        report.filter_by_date(table_id, 1)
-        report.write_artifact_data_table(data_headers, data_list, file_found, table_id=table_id)
-        report.add_chart()
-        report.add_chart_script("myChart", "bar", weight, date, "Weight over time", "Weight (kg)", "Date")
-        report.end_artifact_report()
-
-        tsvname = f'Garmin - Weight'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = f'Garmin - Weight'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-
-    else:
-        logfunc('No Garmin Weight data available')
-
     db.close()
+    logfunc(f"Found {len(all_rows)} weight entries")
+
+    data_list = []
+    for row in all_rows:
+        date = datetime.datetime.fromtimestamp(int(row[1]) / 1000, datetime.timezone.utc) if row[1] else ''
+        data_list.append((row[0], date, row[2]))
+
+    data_headers = ('samplePk', ('Date', 'datetime'), 'Weight')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Starts converting the Garmin family (category already consolidated to `Garmin`). These used HTML-report-only chart helpers (`add_chart`/`add_chart_script`/`filter_by_date`) which don't apply to LAVA — dropped, underlying data tables preserved.

- **GarminWeight** — `date` raw → aware UTC `datetime` (replacing SQL `datetime(...,'unixepoch')`); dropped the weight bar-chart.
- **GarminStressAPI** — JSON daily stress table; `calendarDate` kept as the API's date string; dropped the stress line-chart; added `encoding` to `open()`.
- **GarminDailiesAPI** — JSON daily summary (44 fields). **Fixed a latent bug**: the original did `data_list.append((row for row in data_row))`, appending a generator object instead of the row. Also **de-duplicated the column list** (the original repeated `Floors Ascended/Descended In Meters` and `Stress Duration`), which matters because LAVA needs unique column names. Refactored field/header pairs into one `FIELDS` table.

Verified: byte-compile, decorated 4-arg signatures, return 3-tuples, output_types valid, GarminDailiesAPI headers unique (44 cols), loader builds (407 plugins), pylint clean.