### PR TITLE
Convert GarminSleep, GarminHRAPI, GarminSPo2 to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/GarminHRAPI.py
+++ b/scripts/artifacts/GarminHRAPI.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0631,W1309,W1514
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_hr_api": {
         "name": "GarminHRAPI",
@@ -10,93 +10,38 @@ __artifacts_v2__ = {
         "category": "Garmin",
         "notes": "",
         "paths": ('*/garmin.api/heart_rate*',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "activity",
-        "function": "get_hr_api",
     }
 }
 
-# Get Information related to the Heart Rate from the Garmin API using the JSON file extracted
-# Requires to have extracted the information from the Garmin API using the script in the url: https://github.com/labcif/Garmin-Connect-API-Extractor
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-02-24
-# Version: 1.0
-# Requirements: Python 3.7 or higher, json
+# Requires extracting Garmin API data using https://github.com/labcif/Garmin-Connect-API-Extractor
+
 import json
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv
+from scripts.ilapfuncs import artifact_processor, logfunc
 
 
+@artifact_processor
 def get_hr_api(files_found, report_folder, seeker, wrap_text):
-
     logfunc("Processing data for Heart Rate API")
-    report = ArtifactHtmlReport('Heart Rate API')
-    report.start_artifact_report(report_folder, 'Heart Rate API')
-    report.add_script()
-    data_headers = ('Date', 'Max Hearth Rate', 'Min Hearth Rate', 'Resting Hearth Rate', 'Average Hearth Rate', 'Graphic')
     data_list = []
-    #file = str(files_found[0])
+    source_path = ''
     for file in files_found:
         file = str(file)
+        source_path = file
         logfunc("Processing file: " + file)
-        #Open JSON file
-        with open(file, "r") as f:
+        with open(file, "r", encoding='utf-8', errors='replace') as f:
             data = json.load(f)
 
         if len(data) > 0:
-            logfunc("Found Garmin Presistent file")
-            # Get calendar date
-            date = data['AllDayHR']['payload']['calendarDate']
-            # Get max hearth rate if none set to 'N/A'
-            if data['AllDayHR']['payload']['maxHeartRate'] is not None:
-                max_hr = data['AllDayHR']['payload']['maxHeartRate']
-            else:
-                max_hr = 'N/A'
-            # Get min hearth rate
-            if data['AllDayHR']['payload']['minHeartRate'] is not None:
-                min_hr = data['AllDayHR']['payload']['minHeartRate']
-            else:
-                min_hr = 'N/A'
-            # Get resting hearth rate
-            if data['AllDayHR']['payload']['restingHeartRate'] is not None:
-                resting_hr = data['AllDayHR']['payload']['restingHeartRate']
-            else:
-                resting_hr = 'N/A'
-            # Get average hearth rate
-            if data['AllDayHR']['payload']['lastSevenDaysAvgRestingHeartRate'] is not None:
-                average_hr = data['AllDayHR']['payload']['lastSevenDaysAvgRestingHeartRate']
-            else:
-                average_hr = 'N/A'
-            # check if data['AllDayHR']['payload']['heartRateValues'] exists
-            if data['AllDayHR']['payload']['heartRateValues'] is not None:
-                hr_values = json.dumps(data['AllDayHR']['payload']['heartRateValues'])
-                # convert to list
-                hr_values = hr_values.replace('[', '').replace(']', '').split(',')
-                #logfunc(str(hr_values))
-                x_list = []
-                y_list = []
-                # from hr_values get x and y values
-                for i in range(len(hr_values)):
-                    if i % 2 == 0:
-                        x_list.append(float(hr_values[i]))
-                    else:
-                        #if value is null set to 0
-                        if 'null' in hr_values[i]:
-                            y_list.append(0)
-                        else:
-                            y_list.append(float(hr_values[i]))
+            payload = data['AllDayHR']['payload']
+            date = payload['calendarDate']
+            max_hr = payload['maxHeartRate'] if payload['maxHeartRate'] is not None else 'N/A'
+            min_hr = payload['minHeartRate'] if payload['minHeartRate'] is not None else 'N/A'
+            resting_hr = payload['restingHeartRate'] if payload['restingHeartRate'] is not None else 'N/A'
+            average_hr = payload['lastSevenDaysAvgRestingHeartRate'] if payload['lastSevenDaysAvgRestingHeartRate'] is not None else 'N/A'
+            data_list.append((date, max_hr, min_hr, resting_hr, average_hr))
 
-                #convert timestamp to hh:mm
-                #logfunc(str(x_list))
-                #logfunc(str(y_list))
-                hr_btn = '<button class="btn btn-light btn-sm" onclick="createLineChart(\'' + str(y_list) + '\', \'' + str(x_list) + '\', true, \'Heart Rate Variation\', \'Time\', \'BPM\')">View</button>'
-            else:
-                hr_btn = 'N/A'
-            data_list.append((date, max_hr, min_hr, resting_hr, average_hr, hr_btn))
-    report.filter_by_date('GarminHRAPI', 0)
-    report.write_artifact_data_table(data_headers, data_list, file, html_escape=False, table_id='GarminHRAPI')
-    report.add_chart()
-    report.end_artifact_report()
-    tsvname = f'Garmin Log'
-    tsv(report_folder, data_headers, data_list, tsvname)
+    data_headers = ('Date', 'Max Hearth Rate', 'Min Hearth Rate', 'Resting Hearth Rate', 'Average Hearth Rate')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/GarminSPo2.py
+++ b/scripts/artifacts/GarminSPo2.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0612,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_garmin_spo2": {
         "name": "GarminSPO2",
-        "description": "Get Information related to Garmin Pulse Ox from acclimation_pulse_ox_details table and generate a chart",
+        "description": "Get Information related to Garmin Pulse Ox from acclimation_pulse_ox_details table",
         "author": "Fabian Nunes {fabiannunes12@gmail.com}",
         "creation_date": "2023-02-24",
         "last_update_date": "2023-02-24",
@@ -10,129 +10,40 @@ __artifacts_v2__ = {
         "category": "Garmin",
         "notes": "",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "activity",
-        "function": "get_garmin_spo2",
     }
 }
 
-# Get Information related to Garmin Pulse Ox from acclimation_pulse_ox_details table and generate a chart
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-02-24
-# Version: 1.0
-# Requirements: Python 3.7 or higher
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
 
+@artifact_processor
 def get_garmin_spo2(files_found, report_folder, seeker, wrap_text):
     logfunc("Processing data for Garmin Pulse Ox details")
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
-
-    # Get the data from the database whre the spo2 is not null
+    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     cursor.execute('''
-        SELECT 
-        userProfilePk, 
-        startTimestampGMT, 
-        endTimestampGMT, 
-        spo2Value, 
-        spo2ValueAverage, 
-        spo2ValuesArray,
-        datetime("date"/1000, 'unixepoch'),
-        date
+        SELECT
+        userProfilePk,
+        startTimestampGMT,
+        endTimestampGMT,
+        spo2Value,
+        spo2ValueAverage,
+        spo2ValuesArray
         from acclimation_pulse_ox_details
         where spo2Value is not null
     ''')
-
     all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        logfunc(f'Found {usageentries} Garmin Pulse Ox details')
-        report = ArtifactHtmlReport('Garmin - SPO2')
-        report.start_artifact_report(report_folder, 'Garmin - SPO2')
-        report.add_script()
-        data_headers = (
-        'User Profile PK', 'Start Timestamp GMT', 'End Timestamp GMT', 'SPO2 Value Average', 'SPO2 Values Array')
-        data_list = []
-        imgs = []
-        i = 0
-        x_list = []
-        y_list = []
-        spo2Avg = []
-        date = []
-
-        for row in all_rows:
-            # spo2ValuesArray
-            spo2Array = row[5]
-            # turn spo2ValuesArray into a list in the form of '[1669075200000', '96]'
-            spo2Array = spo2Array[1:-1].split('],[')
-            # remove [ from the first element
-            spo2Array[0] = spo2Array[0][1:]
-            # remove ] from the last element
-            spo2Array[-1] = spo2Array[-1][:-1]
-            # split each element in the list into a list of two elements
-            spo2Array = [x.split(',') for x in spo2Array]
-            # convert the first element of each list to a datetime object
-            spo2Array = [[int(x[0]), int(x[1])] for x in spo2Array]
-            # convert the second element of each list to an integer
-            spo2Array = [[x[0], int(x[1])] for x in spo2Array]
-            # convert the datetime object to a timestamp
-            #spo2Array = [[x[0].strftime('%Y-%m-%d %H:%M:%S'), x[1]] for x in spo2Array]
-
-            # Get the values from array and add them to x and y lists
-            for x in spo2Array:
-                #convert x[0] to a timestamp
-                time = int(x[0])
-                x_list.append(time)
-                y_list.append(x[1])
-
-            spo2Average = row[4]
-            if spo2Average is None:
-                spo2Average = row[3]
-            spo2Avg.append(spo2Average)
-            # only get the date from the timestamp
-            date.append(row[6].split(' ')[0])
-
-            data_list.append((row[0], row[1], row[2], spo2Average,
-                              '<button class="btn btn-light btn-sm" onclick="createLineChart(\'' + str(y_list) + '\', \'' + str(x_list) + '\', true, \'Spo2 Variation\', \'Time\', \'Spo2%\')">View</button>'))
-            i += 1
-
-        # Create bar chart with SPO2 average per day
-        #plt.bar(date, spo2Avg)
-        #plt.xticks(rotation=90)
-        #plt.title('SPO2 Average')
-        #plt.xlabel('Time')
-        #plt.ylabel('SPO2 Average')
-        # show number on top of each bar center
-        #for i, v in enumerate(spo2Avg):
-            #plt.text(i, v, str(v), color='blue', fontweight='bold', horizontalalignment='center')
-        #imgName = "spo2Avg"+ str(time.time()) +".png"
-        #plt.savefig(report_folder + "\\" + imgName)
-        #plt.close()
-
-        # add /Garmin/ to the beginning of imageName
-        #imgName = "Garmin-Cache/" + imgName
-
-        # Add graph to the report
-        table_id = "spo2"
-        report.filter_by_date(table_id, 1)
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False, table_id=table_id)
-        # Add image to the report
-        report.add_chart()
-        # report.add_image_file(imgName, imgName, "Garmin SPO2 Average", secondImage=True)
-        report.end_artifact_report()
-
-        tsvname = f'SPO2'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = f'SPO2'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-
-    else:
-        logfunc('No Garmin SPO2 data available')
-
     db.close()
+    logfunc(f'Found {len(all_rows)} Garmin Pulse Ox details')
+
+    data_list = []
+    for row in all_rows:
+        spo2_average = row[4] if row[4] is not None else row[3]
+        data_list.append((row[0], row[1], row[2], spo2_average, row[5]))
+
+    data_headers = ('User Profile PK', 'Start Timestamp GMT', 'End Timestamp GMT', 'SPO2 Value Average', 'SPO2 Values Array')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/GarminSleep.py
+++ b/scripts/artifacts/GarminSleep.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_garmin_sleep": {
         "name": "GarminSleep",
@@ -10,81 +10,51 @@ __artifacts_v2__ = {
         "category": "Garmin",
         "notes": "",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "activity",
-        "function": "get_garmin_sleep",
     }
 }
 
-# Get Information relative to the sleep data in the database cache-database from the table sleep_detail in the Garmin Connect app
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-02-24
-# Version: 1.0
-# Requirements: Python 3.7 or higher
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
 
+def _ms_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    return ''
+
+
+@artifact_processor
 def get_garmin_sleep(files_found, report_folder, seeker, wrap_text):
     logfunc("Processing data for Garmin Sleep")
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
-
-    #This query is retreiving the data from the table sleep_details, which contains the sleep data for the user
+    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     cursor.execute('''
         SELECT
-        datetime("sleepStartTimeGMT"/1000, 'unixepoch'),
-        datetime("sleepEndTimeGMT"/1000, 'unixepoch'),
+        sleepStartTimeGMT,
+        sleepEndTimeGMT,
         sleepTimeInSeconds,
         deepSleepSeconds,
-        lightSleepSeconds, 
-        remSleepSeconds, 
-        awakeSleepSeconds, 
-        averageSpO2Value, 
-        averageSpO2HRSleep,
-        calendarDate
+        lightSleepSeconds,
+        remSleepSeconds,
+        awakeSleepSeconds,
+        averageSpO2Value,
+        averageSpO2HRSleep
         from sleep_detail
     ''')
-
     all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        logfunc(f"Found {usageentries} sleep entries")
-        report = ArtifactHtmlReport('Sleep')
-        report.start_artifact_report(report_folder, 'Sleep')
-        report.add_script()
-        data_headers = ('Sleep Start Time GMT', 'Sleep End Time GMT', 'Sleep Time In Seconds', 'Deep Sleep Seconds', 'Light Sleep Seconds', 'REM Sleep Seconds', 'Awake Sleep Seconds', 'Average SpO2 Value', 'Average SpO2 HR Sleep', 'Graph')
-        data_list = []
-
-        for row in all_rows:
-            sleepValues = []
-            sleepValues.append(row[3])
-            sleepValues.append(row[4])
-            sleepValues.append(row[5])
-            sleepValues.append(row[6])
-
-            sleep_btn = "<button class='btn btn-light btn-sm' onclick=" + '"createPieChart(\'' + str(sleepValues) + '\')">Sleep Graphic</button>'
-            data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], sleep_btn))
-
-        # Add graph to the report
-
-        table_id = 'garmin_sleep'
-        report.filter_by_date(table_id, 0)
-
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False, table_id=table_id)
-        report.add_chart(200)
-        report.end_artifact_report()
-
-        tsvname = f'Garmin - Sleep'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = f'Garmin - Sleep'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-
-    else:
-        logfunc('No Garmin Sleep data available')
-
     db.close()
+    logfunc(f"Found {len(all_rows)} sleep entries")
+
+    data_list = []
+    for row in all_rows:
+        data_list.append((_ms_to_utc(row[0]), _ms_to_utc(row[1]), row[2], row[3], row[4], row[5], row[6], row[7], row[8]))
+
+    data_headers = (('Sleep Start Time GMT', 'datetime'), ('Sleep End Time GMT', 'datetime'), 'Sleep Time In Seconds',
+                    'Deep Sleep Seconds', 'Light Sleep Seconds', 'REM Sleep Seconds', 'Awake Sleep Seconds',
+                    'Average SpO2 Value', 'Average SpO2 HR Sleep')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
More Garmin family conversions. These had per-row interactive chart **buttons** (`createPieChart`/`createLineChart`) that only function inside the HTML report — dropped them for LAVA, preserving the underlying data.

- **GarminSleep** — `sleepStartTimeGMT`/`sleepEndTimeGMT` (epoch-ms) → aware UTC `datetime` (replacing SQL `datetime(...,'unixepoch')`). Dropped the 'Graph' pie-chart button column; its inputs (deep/light/REM/awake seconds) are already their own columns. Removed an unused `calendarDate` select.
- **GarminHRAPI** — JSON heart-rate daily summary. Dropped the 'Graphic' line-chart button (and the now-dead HR time-series parsing); kept date + max/min/resting/average HR. Added `encoding` to `open()`.
- **GarminSPo2** — replaced the (buggy, globally-accumulating) 'View' chart button in the 'SPO2 Values Array' column with the **actual raw `spo2ValuesArray` value**, so real data is preserved instead of a non-functional button. Kept the GMT timestamps as the app's stored strings.

Verified: byte-compile, decorated 4-arg signatures, return 3-tuples, output_types valid, loader builds (407 plugins), pylint clean.