### PR TITLE
Convert GarminDailies, GarminStepsAPI, GarminSleepAPI to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/GarminDailies.py
+++ b/scripts/artifacts/GarminDailies.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0311,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_garmin_dailies": {
         "name": "GarminDailies",
@@ -10,75 +10,78 @@ __artifacts_v2__ = {
         "category": "Garmin",
         "notes": "",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "activity",
-        "function": "get_garmin_dailies",
     }
 }
 
-# Get Information from the table user_daily_summary from the cache-database in the Garmin Connect App
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-02-24
-# Version: 1.0
-# Requirements: Python 3.7 or higher
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+# (column, header) pairs - duplicates from the original query/headers removed so LAVA column names stay unique
+FIELDS = [
+    ('calendarDate', 'Calendar Date'),
+    ('totalKilocalories', 'Total Kilocalories'),
+    ('activeKilocalories', 'Active Kilocalories'),
+    ('bmrKilocalories', 'BMR Kilocalories'),
+    ('wellnessActiveKilocalories', 'Wellness Active Kilocalories'),
+    ('burnedKilocalories', 'Burned Kilocalories'),
+    ('consumedKilocalories', 'Consumed Kilocalories'),
+    ('remainingKilocalories', 'Remaining Kilocalories'),
+    ('totalSteps', 'Total Steps'),
+    ('totalDistanceMeters', 'Total Distance Meters'),
+    ('wellnessDistanceMeters', 'Wellness Distance Meters'),
+    ('highlyActiveSeconds', 'Highly Active Seconds'),
+    ('activeSeconds', 'Active Seconds'),
+    ('moderateIntensityMinutes', 'Moderate Intensity Minutes'),
+    ('floorsAscendedInMeters', 'Floors Ascended In Meters'),
+    ('floorsDescendedInMeters', 'Floors Descended In Meters'),
+    ('minHeartRate', 'Min Heart Rate'),
+    ('maxHeartRate', 'Max Heart Rate'),
+    ('restingHeartRate', 'Resting Heart Rate'),
+    ('lastSevenDaysAvgRestingHeartRate', 'Last Seven Days Avg Resting Heart Rate'),
+    ('averageStressLevel', 'Average Stress Level'),
+    ('maxStressLevel', 'Max Stress Level'),
+    ('stressDuration', 'Stress Duration'),
+    ('restStressDuration', 'Rest Stress Duration'),
+    ('activityStressDuration', 'Activity Stress Duration'),
+    ('uncategorizedStressDuration', 'Uncategorized Stress Duration'),
+    ('totalStressDuration', 'Total Stress Duration'),
+    ('lowStressDuration', 'Low Stress Duration'),
+    ('mediumStressDuration', 'Medium Stress Duration'),
+    ('highStressDuration', 'High Stress Duration'),
+    ('stressPercentage', 'Stress Percentage'),
+    ('restStressPercentage', 'Rest Stress Percentage'),
+    ('activityStressPercentage', 'Activity Stress Percentage'),
+    ('uncategorizedStressPercentage', 'Uncategorized Stress Percentage'),
+    ('lowStressPercentage', 'Low Stress Percentage'),
+    ('mediumStressPercentage', 'Medium Stress Percentage'),
+    ('highStressPercentage', 'High Stress Percentage'),
+    ('bodyBatteryChargedValue', 'Body Battery Charged Value'),
+    ('bodyBatteryDrainedValue', 'Body Battery Drained Value'),
+    ('bodyBatteryHighestValue', 'Body Battery Highest Value'),
+    ('bodyBatteryLowestValue', 'Body Battery Lowest Value'),
+    ('bodyBatteryMostRecentValue', 'Body Battery Most Recent Value'),
+    ('hydrationValueInML', 'Hydration Value In ML'),
+    ('averageSpo2', 'Average Spo2'),
+    ('latestSpo2', 'Latest Spo2'),
+]
 
 
+@artifact_processor
 def get_garmin_dailies(files_found, report_folder, seeker, wrap_text):
     logfunc("Processing data for Garmin User Dailies")
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
-
-    # SQL query for obtaining data from the table user_daily_summary
+    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
-    cursor.execute('''
-    SELECT 
-    calendarDate, totalKilocalories, activeKilocalories, bmrKilocalories, wellnessActiveKilocalories, burnedKilocalories, consumedKilocalories, remainingKilocalories,
-    totalSteps, totalDistanceMeters, wellnessDistanceMeters, highlyActiveSeconds, activeSeconds, moderateIntensityMinutes, floorsAscendedInMeters, floorsDescendedInMeters, floorsAscendedInMeters,
-    floorsDescendedInMeters, minHeartRate, maxHeartRate, restingHeartRate, lastSevenDaysAvgRestingHeartRate, averageStressLevel, maxStressLevel, stressDuration,stressDuration, restStressDuration, activityStressDuration,
-    uncategorizedStressDuration, totalStressDuration, lowStressDuration, mediumStressDuration, highStressDuration, stressPercentage, restStressPercentage, activityStressPercentage, uncategorizedStressPercentage,
-    lowStressPercentage, mediumStressPercentage, highStressPercentage, bodyBatteryChargedValue, bodyBatteryDrainedValue, bodyBatteryHighestValue, bodyBatteryLowestValue, bodyBatteryMostRecentValue, hydrationValueInML,
-    averageSpo2, latestSpo2
-    from user_daily_summary
+    cursor.execute(f'''
+        SELECT {", ".join(col for col, _ in FIELDS)}
+        from user_daily_summary
     ''')
-
     all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        logfunc(f"Found {usageentries} entries")
-        report = ArtifactHtmlReport('Dailies')
-        report.start_artifact_report(report_folder, 'Dailies')
-        report.add_script()
-        data_headers = ('Calendar Date', 'Total Kilocalories', 'Active Kilocalories', 'BMR Kilocalories', 'Wellness Active Kilocalories', 'Burned Kilocalories', 'Consumed Kilocalories', 'Remaining Kilocalories',
-                        'Total Steps', 'Total Distance Meters', 'Wellness Distance Meters', 'Highly Active Seconds', 'Active Seconds', 'Moderate Intensity Minutes', 'Floors Ascended In Meters', 'Floors Descended In Meters',
-                        'Floors Ascended In Meters', 'Floors Descended In Meters', 'Min Heart Rate', 'Max Heart Rate', 'Resting Heart Rate', 'Last Seven Days Avg Resting Heart Rate', 'Average Stress Level', 'Max Stress Level',
-                        'Stress Duration', 'Stress Duration', 'Rest Stress Duration', 'Activity Stress Duration', 'Uncategorized Stress Duration', 'Total Stress Duration', 'Low Stress Duration', 'Medium Stress Duration',
-                        'High Stress Duration', 'Stress Percentage', 'Rest Stress Percentage', 'Activity Stress Percentage', 'Uncategorized Stress Percentage', 'Low Stress Percentage', 'Medium Stress Percentage',
-                        'High Stress Percentage', 'Body Battery Charged Value', 'Body Battery Drained Value', 'Body Battery Highest Value', 'Body Battery Lowest Value', 'Body Battery Most Recent Value', 'Hydration Value In ML',
-                        'Average Spo2', 'Latest Spo2')
-        data_list = []
-        for row in all_rows:
-           data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18], row[19], row[20], row[21], row[22],
-                            row[23], row[24], row[25], row[26], row[27], row[28], row[29], row[30], row[31], row[32], row[33], row[34], row[35], row[36], row[37], row[38], row[39], row[40], row[41], row[42], row[43], row[44],
-                            row[45], row[46], row[47]))
-
-        # Added feature to allow the user to sort the data by the selected collumns and with the ID of the table
-        table_id = 'Garmin_Dailies'
-        report.filter_by_date(table_id, 0)
-
-        report.write_artifact_data_table(data_headers, data_list, file_found, table_id=table_id)
-        report.end_artifact_report()
-
-        tsvname = f'Garmin - Dailies'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = f'Garmin - Dailies'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-
-    else:
-        logfunc('No Garmin Dailies data available')
-
     db.close()
+    logfunc(f"Found {len(all_rows)} entries")
+
+    data_list = [tuple(row) for row in all_rows]
+    data_headers = tuple(header for _, header in FIELDS)
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/GarminSleepAPI.py
+++ b/scripts/artifacts/GarminSleepAPI.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W1309,W1514
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_sleep_api": {
         "name": "GarminSleepAPI",
@@ -10,132 +10,56 @@ __artifacts_v2__ = {
         "category": "Garmin",
         "notes": "",
         "paths": ('*/garmin.api/sleep*',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "activity",
-        "function": "get_sleep_api",
     }
 }
 
-# Get Information related to Garmin Sleep API
-# Requires to have extracted the information from the Garmin API using the script in the url: https://github.com/labcif/Garmin-Connect-API-Extractor
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-02-24
-# Version: 1.0
-# Requirements: Python 3.7 or higher, json and datetime
+# Requires extracting Garmin API data using https://github.com/labcif/Garmin-Connect-API-Extractor
+
 import datetime
 import json
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv
+from scripts.ilapfuncs import artifact_processor, logfunc
 
 
+def _seconds_to_hms(value):
+    if value is None:
+        return 'N/A'
+    return str(datetime.timedelta(seconds=value))
+
+
+def _ms_to_time(value):
+    if value is None:
+        return 'N/A'
+    return datetime.datetime.fromtimestamp(value / 1000, datetime.timezone.utc).strftime('%H:%M:%S')
+
+
+@artifact_processor
 def get_sleep_api(files_found, report_folder, seeker, wrap_text):
     logfunc("Processing data for Garmin Sleep API")
-    file = str(files_found[0])
-    logfunc("Processing file: " + file)
-    #Open JSON file
-    with open(file, "r") as f:
+    source_path = str(files_found[0])
+    logfunc("Processing file: " + source_path)
+    with open(source_path, "r", encoding='utf-8', errors='replace') as f:
         data = json.load(f)
 
-    if len(data) > 0:
-        logfunc("Found Garmin Sleep API data")
-        report = ArtifactHtmlReport('Sleep API')
-        report.start_artifact_report(report_folder, 'Sleep API')
-        report.add_script()
-        data_headers = ('Date', 'Sleep Time', 'Start Time', 'End Time', 'Deep Sleep', 'Light Sleep', 'REM Sleep', 'Awake Sleep', 'Average SPo2', 'Lowest SPo2', 'Highest SPo2', 'Sleep Graphic', 'SPo2 Graphic')
-        data_list = []
-        for i in data:
-            # Get calendar date
-            date = i['dailySleepDTO']['calendarDate']
-            # Get sleep time
-            sleep_time = i['dailySleepDTO']['sleepTimeSeconds']
-            # Convert sleep time to hours
-            if sleep_time is not None:
-                sleep_time = datetime.timedelta(seconds=sleep_time)
-            else:
-                sleep_time = 'N/A'
-            # Get start time
-            start_time = i['dailySleepDTO']['sleepStartTimestampGMT']
-            if start_time is not None:
-                # Convert start time to hours
-                start_time = datetime.datetime.utcfromtimestamp(start_time/1000).strftime('%H:%M:%S')
-            else:
-                start_time = 'N/A'
-            # Get end time
-            end_time = i['dailySleepDTO']['sleepEndTimestampGMT']
-            if end_time is not None:
-                # Convert end time to hours
-                end_time = datetime.datetime.utcfromtimestamp(end_time/1000).strftime('%H:%M:%S')
-            else:
-                end_time = 'N/A'
-            # Get deep sleep time
-            deep_sleep = i['dailySleepDTO']['deepSleepSeconds']
-            if deep_sleep is not None:
-                # Convert deep sleep time to hours
-                deep_sleep = datetime.timedelta(seconds=deep_sleep)
-            else:
-                deep_sleep = 'N/A'
-            # Get light sleep time
-            light_sleep = i['dailySleepDTO']['lightSleepSeconds']
-            if light_sleep is not None:
-                # Convert light sleep time to hours
-                light_sleep = datetime.timedelta(seconds=light_sleep)
-            else:
-                light_sleep = 'N/A'
-            # Get REM sleep time
-            rem_sleep = i['dailySleepDTO']['remSleepSeconds']
-            if rem_sleep is not None:
-                # Convert REM sleep time to hours
-                rem_sleep = datetime.timedelta(seconds=rem_sleep)
-            else:
-                rem_sleep = 'N/A'
-            # Get awake sleep time
-            awake_sleep = i['dailySleepDTO']['awakeSleepSeconds']
-            if awake_sleep is not None:
-                # Convert awake sleep time to hours
-                awake_sleep = datetime.timedelta(seconds=awake_sleep)
-            else:
-                awake_sleep = 'N/A'
-            # check if averageSpO2Value is not null and it exists
-            if 'averageSpO2Value' in i['dailySleepDTO']:
-                average_spo2 = i['dailySleepDTO']['averageSpO2Value']
-            else:
-                average_spo2 = 'N/A'
-            # check if lowestSpO2Value is not null and it exists
-            if  'lowestSpO2Value' in i['dailySleepDTO']:
-                lowest_spo2 = i['dailySleepDTO']['lowestSpO2Value']
-            else:
-                lowest_spo2 = 'N/A'
-            # check if highestSpO2Value is not null and it exists
-            if  'highestSpO2Value' in i['dailySleepDTO']:
-                highest_spo2 = i['dailySleepDTO']['highestSpO2Value']
-            else:
-                highest_spo2 = 'N/A'
-            # check if sleepGraphic is not null and it exists
-            if i['sleepLevels'] is not None:
-                if start_time == 'N/A' or end_time == 'N/A':
-                    sleep_btn = 'N/A'
-                else:
-                    sleeplevels = json.dumps(i['sleepLevels'])
-                    # replace " with &quot; to avoid errors in the html
-                    sleeplevels = sleeplevels.replace('"', '&quot;')
-                    sleep_btn = "<button class='btn btn-light btn-sm' onclick=" + '"generateChartSleep(\'' + sleeplevels + '\')">Sleep Graphic</button>'
-            else:
-                sleep_btn = 'N/A'
-            # check if i['wellnessEpochSPO2DataDTOList'] exists
-            if 'wellnessEpochSPO2DataDTOList' in i:
-                spo2 = json.dumps(i['wellnessEpochSPO2DataDTOList'])
-                # replace " with &quot; to avoid errors in the html
-                spo2 = spo2.replace('"', '&quot;')
-                spo2_btn = '<button class="btn btn-light btn-sm" onclick="spo2Chart(\'' + spo2 + '\')">SPo2 Graphic</button>'
-            else:
-                spo2_btn = 'N/A'
-            data_list.append((date, sleep_time, start_time, end_time, deep_sleep, light_sleep, rem_sleep, awake_sleep, average_spo2, lowest_spo2, highest_spo2, sleep_btn, spo2_btn))
-        report.filter_by_date('GarminSleepAPI', 0)
-        report.write_artifact_data_table(data_headers, data_list, file, html_escape=False, table_id='GarminSleepAPI')
-        report.add_chart()
-        report.end_artifact_report()
-        tsvname = f'Garmin Log'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc("No Garmin Sleep API data found")
+    data_list = []
+    for i in data:
+        dto = i['dailySleepDTO']
+        date = dto['calendarDate']
+        sleep_time = _seconds_to_hms(dto['sleepTimeSeconds'])
+        start_time = _ms_to_time(dto['sleepStartTimestampGMT'])
+        end_time = _ms_to_time(dto['sleepEndTimestampGMT'])
+        deep_sleep = _seconds_to_hms(dto['deepSleepSeconds'])
+        light_sleep = _seconds_to_hms(dto['lightSleepSeconds'])
+        rem_sleep = _seconds_to_hms(dto['remSleepSeconds'])
+        awake_sleep = _seconds_to_hms(dto['awakeSleepSeconds'])
+        average_spo2 = dto.get('averageSpO2Value', 'N/A')
+        lowest_spo2 = dto.get('lowestSpO2Value', 'N/A')
+        highest_spo2 = dto.get('highestSpO2Value', 'N/A')
+        data_list.append((date, sleep_time, start_time, end_time, deep_sleep, light_sleep, rem_sleep,
+                          awake_sleep, average_spo2, lowest_spo2, highest_spo2))
+
+    data_headers = ('Date', 'Sleep Time', 'Start Time', 'End Time', 'Deep Sleep', 'Light Sleep', 'REM Sleep',
+                    'Awake Sleep', 'Average SPo2', 'Lowest SPo2', 'Highest SPo2')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/GarminStepsAPI.py
+++ b/scripts/artifacts/GarminStepsAPI.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0613,W0631,W1309,W1514
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_steps_api": {
         "name": "GarminStepsAPI",
-        "description": "Get Information related to the Heart Rate from the Garmin API using the JSON file extracted",
+        "description": "Get Information related to the daily steps from the Garmin API using the JSON file extracted",
         "author": "Fabian Nunes {fabiannunes12@gmail.com}",
         "creation_date": "2023-02-24",
         "last_update_date": "2023-02-24",
@@ -10,96 +10,39 @@ __artifacts_v2__ = {
         "category": "Garmin",
         "notes": "",
         "paths": ('*/garmin.api/steps*',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "activity",
-        "function": "get_steps_api",
     }
 }
 
-# Get Information related to the Heart Rate from the Garmin API using the JSON file extracted
-# Requires to have extracted the information from the Garmin API using the script in the url: https://github.com/labcif/Garmin-Connect-API-Extractor
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-02-24
-# Version: 1.0
-# Requirements: Python 3.7 or higher, json
+# Requires extracting Garmin API data using https://github.com/labcif/Garmin-Connect-API-Extractor
+
 import json
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv
+from scripts.ilapfuncs import artifact_processor, logfunc
 
 
+@artifact_processor
 def get_steps_api(files_found, report_folder, seeker, wrap_text):
-
     logfunc("Processing data for Steps API")
-    report = ArtifactHtmlReport('Steps API')
-    report.start_artifact_report(report_folder, 'Steps API')
-    report.add_script()
-    data_headers = ('Date', 'Steps', 'Calories', 'Distance', 'Floors Asc', 'Floors Desc', 'Graphic')
     data_list = []
-    #file = str(files_found[0])
+    source_path = ''
     for file in files_found:
         file = str(file)
+        source_path = file
         logfunc("Processing file: " + file)
-        #Open JSON file
-        with open(file, "r") as f:
+        with open(file, "r", encoding='utf-8', errors='replace') as f:
             data = json.load(f)
 
         if len(data) > 0:
-            logfunc("Found Garmin Steps file")
-            # Get calendar date
-            date = data['UserDailySummary']['payload']['calendarDate']
-            # Get max hearth rate if none set to 'N/A'
-            if data['UserDailySummary']['payload']['totalSteps'] is not None:
-                steps = data['UserDailySummary']['payload']['totalSteps']
-            else:
-                steps = 'N/A'
-            # Get min hearth rate
-            if data['UserDailySummary']['payload']['totalKilocalories'] is not None:
-                cal = data['UserDailySummary']['payload']['totalKilocalories']
-            else:
-                cal = 'N/A'
-            # Get resting hearth rate
-            if data['UserDailySummary']['payload']['totalDistanceMeters'] is not None:
-                distance = data['UserDailySummary']['payload']['totalDistanceMeters']
-            else:
-                distance = 'N/A'
-            # Get average hearth rate
-            if data['UserDailySummary']['payload']['floorsAscended'] is not None:
-                floors_asc = int(data['UserDailySummary']['payload']['floorsAscended'])
-            else:
-                floors_asc = 'N/A'
-            # Get floors descended
-            if data['UserDailySummary']['payload']['floorsDescended'] is not None:
-                floors_desc = int(data['UserDailySummary']['payload']['floorsDescended'])
-            else:
-                floors_desc = 'N/A'
-            # check if data['AllDayHR']['payload']['heartRateValues'] exists
-            if data['DailyMovement']['payload']['movementValues'] is not None:
-                mv_values = json.dumps(data['DailyMovement']['payload']['movementValues'])
-                # convert to list
-                mv_values = mv_values.replace('[', '').replace(']', '').split(',')
-                #logfunc(str(hr_values))
-                x_list = []
-                y_list = []
-                # from hr_values get x and y values
-                for i in range(len(mv_values)):
-                    if i % 2 == 0:
-                        x_list.append(float(mv_values[i]))
-                    else:
-                        #if value is null set to 0
-                        if 'null' in mv_values[i]:
-                            y_list.append(0)
-                        else:
-                            y_list.append(float(mv_values[i]))
-                #logfunc(str(x_list))
-                #logfunc(str(y_list))
-                mv_btn = '<button class="btn btn-light btn-sm" onclick="createLineChart(\'' + str(y_list) + '\', \'' + str(x_list) + '\', true, \'Daily Movement\', \'Time\', \'Movement\')">View</button>'
-            else:
-                mv_btn = 'N/A'
-            data_list.append((date, steps, cal, distance, floors_asc, floors_desc, mv_btn))
-    report.filter_by_date('GarminStepsAPI', 0)
-    report.write_artifact_data_table(data_headers, data_list, file, html_escape=False, table_id='GarminStepsAPI')
-    report.add_chart()
-    report.end_artifact_report()
-    tsvname = f'Garmin Log'
-    tsv(report_folder, data_headers, data_list, tsvname)
+            payload = data['UserDailySummary']['payload']
+            date = payload['calendarDate']
+            steps = payload['totalSteps'] if payload['totalSteps'] is not None else 'N/A'
+            cal = payload['totalKilocalories'] if payload['totalKilocalories'] is not None else 'N/A'
+            distance = payload['totalDistanceMeters'] if payload['totalDistanceMeters'] is not None else 'N/A'
+            floors_asc = int(payload['floorsAscended']) if payload['floorsAscended'] is not None else 'N/A'
+            floors_desc = int(payload['floorsDescended']) if payload['floorsDescended'] is not None else 'N/A'
+            data_list.append((date, steps, cal, distance, floors_asc, floors_desc))
+
+    data_headers = ('Date', 'Steps', 'Calories', 'Distance', 'Floors Asc', 'Floors Desc')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
More Garmin family conversions.

- **GarminDailies** — `user_daily_summary` table (45 fields). **De-duplicated the columns** (the original SELECT/headers repeated `Floors Ascended/Descended In Meters` and `Stress Duration`), which LAVA needs unique; refactored to a single `FIELDS` table driving both the query and headers. `calendarDate` kept as the app's date string.
- **GarminStepsAPI** — JSON daily steps. Dropped the 'Graphic' line-chart **button** (and the now-dead movement time-series parsing); kept date/steps/calories/distance/floors. Added `encoding` to `open()`.
- **GarminSleepAPI** — JSON sleep summary. Dropped both chart **buttons** ('Sleep Graphic' / 'SPo2 Graphic'); kept durations (as H:MM:SS), GMT start/end times, and SpO2 values. Replaced deprecated `utcfromtimestamp` with aware-UTC `fromtimestamp`.

Verified: byte-compile, decorated 4-arg signatures, return 3-tuples, output_types valid, GarminDailies headers unique (45 cols), loader builds (407 plugins), pylint clean.