### PR TITLE
Convert GarminResponse, GarminJson, GarminGcmJsonActivities to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/GarminGcmJsonActivities.py
+++ b/scripts/artifacts/GarminGcmJsonActivities.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_garmin_gcm_json_activities": {
         "name": "GarminGcmJsonActivities",
@@ -10,96 +10,51 @@ __artifacts_v2__ = {
         "category": "Garmin",
         "notes": "",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/gcm_cache.db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "activity",
-        "function": "get_garmin_gcm_json_activities",
     }
 }
 
-# Get JSON information stored in the Garmin GCM database (json_activities table)
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-02-24
-# Version: 1.0
-# Requirements: Python 3.7 or higher and json module
+import datetime
 import json
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
 
+def _ms_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    return ''
+
+
+def _pretty_json(raw):
+    if not raw or raw == '[]':
+        return ''
+    try:
+        s = raw.replace('\\"', '"').replace('"{', '{').replace('}"', '}')
+        return json.dumps(json.loads(s), indent=4, sort_keys=True)
+    except (ValueError, TypeError):
+        return raw
+
+
+@artifact_processor
 def get_garmin_gcm_json_activities(files_found, report_folder, seeker, wrap_text):
-    logfunc("Processing data for Garmin Response")
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm') and not x.endswith('journal')]
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
-
+    logfunc("Processing data for Garmin GCM JSON Activities")
+    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm') and not str(x).endswith('journal')]
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     cursor.execute('''
-    SELECT  
-    _id, 
-    datetime("saved_timestamp"/1000, 'unixepoch'),
-    saved_timestamp,
-    concept_id,
-    data_type,
-    cached_val
-    from json_activities
+        SELECT _id, saved_timestamp, concept_id, data_type, cached_val
+        from json_activities
     ''')
-
     all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        logfunc(f"Found {usageentries} Garmin GCM JSON Activities")
-        report = ArtifactHtmlReport('JSON Activities')
-        report.start_artifact_report(report_folder, 'JSON Activities')
-        report.add_script()
-        data_headers = ('_id', 'saved_timestamp', 'concept_id', 'data_type', 'json')
-        data_list = []
-
-        for row in all_rows:
-            # ignore row that is [] (empty list)
-            if row[5] != '[]':
-                jsonData = row[5]
-                # convert to json
-                jsonData = jsonData.replace('\"', '"')
-                jsonData = jsonData.replace('"{', '{')
-                jsonData = jsonData.replace('}"', '}')
-                jsonData = json.loads(jsonData)
-                jsonData = json.dumps(jsonData, indent=4, sort_keys=True)
-                # replace " with &quot; to avoid breaking the html
-                jsonData = jsonData.replace('"', '&quot;')
-                data_list.append((row[0], row[1], row[3], row[4], '<button class="btn btn-light btn-sm" onclick="changeJSONHidden(this)" value="'+jsonData+'">View</button>'))
-            else:
-                data_list.append((row[0], row[1], row[3], row[4], ''))
-
-        table_id = "garmin_gcm_json_activities"
-        report.filter_by_date(table_id, 1)
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False, table_id=table_id)
-
-        # Insert pretty JSON into the report
-        i = 0
-        for row in all_rows:
-            # ignore row that is [] (empty list)
-            if row[5] != '[]' and i == 0:
-                jsonData = row[5]
-                #convert to json
-                jsonData = jsonData.replace('\"', '"')
-                jsonData = jsonData.replace('"{', '{')
-                jsonData = jsonData.replace('}"', '}')
-                jsonData = json.loads(jsonData)
-                jsonData = json.dumps(jsonData, indent=4, sort_keys=True)
-                if i == 0:
-                    report.add_json_to_artifact("Response", jsonData, False, row[0], True)
-                i += 1
-
-        report.end_artifact_report()
-
-        tsvname = f'Garmin - Response'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = f'Garmin - Response'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-
-    else:
-        logfunc('No Garmin GCM JSON data available')
-
     db.close()
+    logfunc(f"Found {len(all_rows)} Garmin GCM JSON Activities")
+
+    data_list = []
+    for row in all_rows:
+        data_list.append((row[0], _ms_to_utc(row[1]), row[2], row[3], _pretty_json(row[4])))
+
+    data_headers = ('_id', ('saved_timestamp', 'datetime'), 'concept_id', 'data_type', 'json')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/GarminJson.py
+++ b/scripts/artifacts/GarminJson.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_garmin_json": {
         "name": "GarminJson",
@@ -10,88 +10,51 @@ __artifacts_v2__ = {
         "category": "Garmin",
         "notes": "",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/gcm_cache*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "activity",
-        "function": "get_garmin_json",
     }
 }
 
-# Get JSON information from the Garmin GCM database
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-02-24
-# Version: 1.0
-# Requirements: Python 3.7 or higher and json module
+import datetime
 import json
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
 
+def _ms_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    return ''
+
+
+def _pretty_json(raw):
+    if not raw or raw == '[]':
+        return ''
+    try:
+        s = raw.replace('\\"', '"').replace('"{', '{').replace('}"', '}')
+        return json.dumps(json.loads(s), indent=4, sort_keys=True)
+    except (ValueError, TypeError):
+        return raw
+
+
+@artifact_processor
 def get_garmin_json(files_found, report_folder, seeker, wrap_text):
     logfunc("Processing data for Garmin JSON")
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm') and not x.endswith('journal')]
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
-
+    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm') and not str(x).endswith('journal')]
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     cursor.execute('''
-    SELECT  
-    _id, 
-    datetime("saved_timestamp"/1000, 'unixepoch'),
-    concept_name,
-    cached_val
-    from json
+        SELECT _id, saved_timestamp, concept_name, cached_val
+        from json
     ''')
-
     all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        logfunc(f"Found {usageentries} JSON entries")
-        report = ArtifactHtmlReport('JSON')
-        report.start_artifact_report(report_folder, 'JSON')
-        report.add_script()
-        data_headers = ('_id', 'saved_timestamp', 'concept_id', 'json')
-        data_list = []
-
-        for row in all_rows:
-            jsonData = row[3]
-            # convert to json
-            jsonData = jsonData.replace('\"', '"')
-            jsonData = jsonData.replace('"{', '{')
-            jsonData = jsonData.replace('}"', '}')
-            jsonData = json.loads(jsonData)
-            jsonData = json.dumps(jsonData, indent=4, sort_keys=True)
-            # replace " with &quot; to avoid breaking the html
-            jsonData = jsonData.replace('"', '&quot;')
-            data_list.append((row[0], row[1], row[2], '<button class="btn btn-light btn-sm" onclick="changeJSONHidden(this)" value="'+jsonData+'">View</button>'))
-
-        table_id = "garmin_json"
-        report.filter_by_date(table_id, 1)
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False, table_id=table_id)
-
-        # Insert pretty JSON into the report
-        i = 0
-        for row in all_rows:
-            jsonData = row[3]
-            #convert to json
-            jsonData = jsonData.replace('\"', '"')
-            jsonData = jsonData.replace('"{', '{')
-            jsonData = jsonData.replace('}"', '}')
-            jsonData = json.loads(jsonData)
-            jsonData = json.dumps(jsonData, indent=4, sort_keys=True)
-            if i == 0:
-                report.add_json_to_artifact("Response", jsonData, False, row[0], True)
-            i += 1
-
-        report.end_artifact_report()
-
-        tsvname = f'Garmin - JSON'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = f'Garmin - JSON'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-
-    else:
-        logfunc('No Garmin JSON data available')
-
     db.close()
+    logfunc(f"Found {len(all_rows)} JSON entries")
+
+    data_list = []
+    for row in all_rows:
+        data_list.append((row[0], _ms_to_utc(row[1]), row[2], _pretty_json(row[3])))
+
+    data_headers = ('_id', ('saved_timestamp', 'datetime'), 'concept_id', 'json')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/GarminResponse.py
+++ b/scripts/artifacts/GarminResponse.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_garmin_response": {
         "name": "GarminResponse",
@@ -10,81 +10,51 @@ __artifacts_v2__ = {
         "category": "Garmin",
         "notes": "",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "activity",
-        "function": "get_garmin_response",
     }
 }
 
-# Get Information related to the Garmin - Responses stored in the database cache
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-02-24
-# Version: 1.0
-# Requirements: Python 3.7 or higher and json
+import datetime
 import json
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
 
+def _ms_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    return ''
+
+
+def _pretty_json(raw):
+    if not raw or raw == '[]':
+        return ''
+    try:
+        s = raw.replace('\\"', '"').replace('"{', '{').replace('}"', '}')
+        return json.dumps(json.loads(s), indent=4, sort_keys=True)
+    except (ValueError, TypeError):
+        return raw
+
+
+@artifact_processor
 def get_garmin_response(files_found, report_folder, seeker, wrap_text):
     logfunc("Processing data for Garmin Response")
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
-
+    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     cursor.execute('''
-    SELECT  
-    requestUrl, 
-    response, 
-    datetime("lastUpdate"/1000, 'unixepoch'),
-    lastUpdate
-    from response_cache
+        SELECT requestUrl, response, lastUpdate
+        from response_cache
     ''')
-
     all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        logfunc(f"Found {usageentries} Garmin Response")
-        report = ArtifactHtmlReport('Response')
-        report.start_artifact_report(report_folder, 'Response')
-        report.add_script()
-        data_headers = ('Last Update', 'Request URL', 'Response')
-        data_list = []
-
-        for row in all_rows:
-            data_list.append((row[2], row[0], '<button class="btn btn-light btn-sm" onclick="changeJSON(' + str(row[3]) + ')">View</button>'))
-
-        table_id = 'garmin_response'
-        report.filter_by_date(table_id, 0)
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False, table_id=table_id)
-
-        # Insert pretty JSON into the report
-        i = 0
-        for row in all_rows:
-            jsonData = row[1]
-            #convert to json
-            jsonData = jsonData.replace('\"', '"')
-            jsonData = jsonData.replace('"{', '{')
-            jsonData = jsonData.replace('}"', '}')
-            jsonData = json.loads(jsonData)
-            jsonData = json.dumps(jsonData, indent=4, sort_keys=True)
-            if i == 0:
-                report.add_json_to_artifact("Response", jsonData, False, row[3])
-            else:
-                report.add_json_to_artifact("Response", jsonData, True, row[3])
-            i += 1
-        report.add_script('<script>hljs.highlightAll();</script>')
-        report.end_artifact_report()
-
-        tsvname = f'Garmin - Response'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = f'Garmin - Response'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-
-    else:
-        logfunc('No Garmin Response data available')
-
     db.close()
+    logfunc(f"Found {len(all_rows)} Garmin Response")
+
+    data_list = []
+    for row in all_rows:
+        data_list.append((_ms_to_utc(row[2]), row[0], _pretty_json(row[1])))
+
+    data_headers = (('Last Update', 'datetime'), 'Request URL', 'Response')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
The three Garmin JSON-cache 'viewer' artifacts. Originally each rendered a 'View' button + an embedded HTML JSON panel (`add_json_to_artifact`) — both HTML-report-only. For LAVA the actual JSON string is the data, so the button column now holds the **pretty-printed JSON itself**.

- **GarminResponse** — `response_cache`; `lastUpdate` raw → aware UTC `datetime`; `Response` column = the cached JSON (pretty-printed) instead of a button.
- **GarminJson** — `json` table; `saved_timestamp` raw → aware UTC `datetime`; `json` column = the cached value (pretty-printed).
- **GarminGcmJsonActivities** — `json_activities` table; `saved_timestamp` raw → aware UTC `datetime`; `json` column = the cached value (pretty-printed); empty `[]` rows yield ''.

Added a shared `_pretty_json` helper with a **guarded parse** (malformed JSON returns the raw string instead of crashing, which the original did not handle). Dropped `add_json_to_artifact`/`filter_by_date`/the buttons; the JSON cells are no longer `html_escape=False`, so content is safely escaped in the HTML report.

Verified: byte-compile, decorated 4-arg signatures, return 3-tuples, output_types valid, _pretty_json guard tested, loader builds (407 plugins), pylint clean.