### PR TITLE
Convert bluetoothConnections, permissions to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/bluetoothConnections.py
+++ b/scripts/artifacts/bluetoothConnections.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0612,W0613,W0702,W1309,W1514
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_bluetoothConnections": {
         "name": "Bluetooth Connections",
@@ -10,104 +10,79 @@ __artifacts_v2__ = {
         "category": "Bluetooth Connections",
         "notes": "",
         "paths": ('*/misc/bluedroid/bt_config.conf', '*/bt_config.conf'),
-        "output_types": None,
-        "artifact_icon": "wifi",
-        "function": "get_bluetoothConnections",
+        "output_types": "standard",
+        "artifact_icon": "bluetooth",
+    },
+    "get_bluetoothAdapter": {
+        "name": "Bluetooth Adapter Information",
+        "description": "",
+        "author": "",
+        "creation_date": "2021-06-23",
+        "last_update_date": "2021-06-23",
+        "requirements": "none",
+        "category": "Bluetooth Connections",
+        "notes": "",
+        "paths": ('*/misc/bluedroid/bt_config.conf', '*/bt_config.conf'),
+        "output_types": ['html', 'tsv', 'lava'],
+        "artifact_icon": "bluetooth",
     }
 }
 
-import csv
 import datetime
-import os
 import re
-import scripts.artifacts.artGlobals 
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, logdevinfo, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import artifact_processor
 
+MAC_RE = re.compile(r'(\[[0-9a-f]{2}(?::[0-9a-f]{2}){5}\])', re.IGNORECASE)
+
+
+@artifact_processor
 def get_bluetoothConnections(files_found, report_folder, seeker, wrap_text):
     data_list = []
-    file_found = str(files_found[0])
-    
-    name_value = ''
-    timestamp_value = ''
-    linkkey_value = ''
-    macaddrf = ''
+    source_path = str(files_found[0])
+
+    name_value = timestamp_value = linkkey_value = macaddrf = ''
     first_round = True
-    
-    with open(file_found, "r") as f:
-        for line in f: 
-            
-            p = re.compile(r'(\[[0-9a-f]{2}(?::[0-9a-f]{2}){5}\])', re.IGNORECASE)
-            macaddr = re.findall(p, line)
-            if macaddr:
-                try:
-                    if first_round == True:
-                        first_round = False
-                    else:
-                        data_list.append((timestamp_value, name_value, macaddrf, linkkey_value))
-                        name_value = ''
-                        timestamp_value = ''
-                        linkkey_value = ''
-                    macaddrf = macaddr[0].strip('[]')
-                    macaddrf = macaddrf.upper()
-                except:
-                    pass
-                
+    with open(source_path, "r", encoding='utf-8', errors='replace') as f:
+        for line in f:
+            if re.findall(MAC_RE, line):
+                if first_round:
+                    first_round = False
+                else:
+                    data_list.append((timestamp_value, name_value, macaddrf, linkkey_value))
+                    name_value = timestamp_value = linkkey_value = ''
+                macaddrf = re.findall(MAC_RE, line)[0].strip('[]').upper()
+
             splits = line.split(' = ')
-                
+            if len(splits) < 2:
+                continue
             if splits[0] == 'Name':
-                key = 'Name'
                 name_value = splits[1].strip()
-                
-            if splits[0] == 'Timestamp':
-                key = 'Timestamp'
-                timestamp_value = splits[1].strip()
-                timestamp_value = datetime.datetime.utcfromtimestamp(int(timestamp_value)).strftime('%Y-%m-%d %H:%M:%S')
-                
-            if splits[0] == 'LinkKey':
-                key = 'LinkKey'
+            elif splits[0] == 'Timestamp':
+                ts = splits[1].strip()
+                timestamp_value = datetime.datetime.fromtimestamp(int(ts), datetime.timezone.utc) if ts else ''
+            elif splits[0] == 'LinkKey':
                 linkkey_value = splits[1].strip()
-    
-    data_list.append((timestamp_value, name_value, macaddrf, linkkey_value))
-        
-    if len(data_list) > 0:
-        report = ArtifactHtmlReport('Bluetooth Connections')
-        report.start_artifact_report(report_folder, f'Bluetooth Connections')
-        report.add_script()
-        data_headers = ('First Connected Timestamp','Device Name','MAC Address','Link Key')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Bluetooth Connections'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Bluetooth Connections'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc(f'No Bluetooth Connections data available')
-   
+
+    if not first_round:  # at least one device was parsed
+        data_list.append((timestamp_value, name_value, macaddrf, linkkey_value))
+
+    data_headers = (('First Connected Timestamp', 'datetime'), 'Device Name', 'MAC Address', 'Link Key')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_bluetoothAdapter(files_found, report_folder, seeker, wrap_text):
     data_list = []
-    with open(file_found, "r") as f:
-        for line in f: 
-            
-            p = re.compile(r'(\[[0-9a-f]{2}(?::[0-9a-f]{2}){5}\])', re.IGNORECASE)
-            macaddr = re.findall(p, line)
-            if macaddr:
-                break
-            if '=' in line:
+    source_path = str(files_found[0])
+
+    with open(source_path, "r", encoding='utf-8', errors='replace') as f:
+        for line in f:
+            if re.findall(MAC_RE, line):
+                break  # adapter info is the block before the first device
+            if ' = ' in line:
                 splits = line.split(' = ')
                 data_list.append((splits[0], splits[1].strip()))
-                
-    if len(data_list) > 0:
-        report = ArtifactHtmlReport('Bluetooth Adapter Information')
-        report.start_artifact_report(report_folder, f'Bluetooth Adapter Information')
-        report.add_script()
-        data_headers = ('Key','Value')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Bluetooth Adapter Information'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc(f'No Bluetooth Adapter Information data available')
+
+    data_headers = ('Key', 'Value')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/permissions.py
+++ b/scripts/artifacts/permissions.py
@@ -1,7 +1,7 @@
-# pylint: disable=W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
-    "get_permissions": {
-        "name": "permissions",
+    "get_permissions_trees": {
+        "name": "Permission Trees",
         "description": "",
         "author": "",
         "creation_date": "2021-01-28",
@@ -10,101 +10,103 @@ __artifacts_v2__ = {
         "category": "Permissions",
         "notes": "",
         "paths": ('*/system/packages.xml',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "settings",
-        "function": "get_permissions",
+    },
+    "get_permissions_list": {
+        "name": "Permissions",
+        "description": "",
+        "author": "",
+        "creation_date": "2021-01-28",
+        "last_update_date": "2021-01-28",
+        "requirements": "none",
+        "category": "Permissions",
+        "notes": "",
+        "paths": ('*/system/packages.xml',),
+        "output_types": ['html', 'tsv', 'lava'],
+        "artifact_icon": "settings",
+    },
+    "get_permissions_packages": {
+        "name": "Package and Shared User",
+        "description": "",
+        "author": "",
+        "creation_date": "2021-01-28",
+        "last_update_date": "2021-01-28",
+        "requirements": "none",
+        "category": "Permissions",
+        "notes": "",
+        "paths": ('*/system/packages.xml',),
+        "output_types": ['html', 'tsv', 'lava'],
+        "artifact_icon": "settings",
     }
 }
 
-import xml.etree.ElementTree as ET 
+import xml.etree.ElementTree as ET
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, abxread, checkabx
+from scripts.ilapfuncs import artifact_processor, logfunc, is_platform_windows, abxread, checkabx
 
-def get_permissions(files_found, report_folder, seeker, wrap_text):
-    
-    slash = '\\' if is_platform_windows() else '/' 
-    
+
+def _iter_roots(files_found):
+    '''Yield (root, file_found) for each non-mirror packages.xml that parses.'''
+    slash = '\\' if is_platform_windows() else '/'
     for file_found in files_found:
         file_found = str(file_found)
-        
-        data_list_permission_trees = []
-        data_list_permissions = []
-        data_list_packages_su = []
-        err = 0
-        user = ''
-        
-        parts = file_found.split(slash)
-        if 'mirror' in parts:
-            user = 'mirror'
-        
-        if user == 'mirror':
+        if 'mirror' in file_found.split(slash):
             continue
-        else:
-            try:
-                if (checkabx(file_found)):
-                    multi_root = False
-                    tree = abxread(file_found, multi_root)
-                else:
-                    tree = ET.parse(file_found)
-                
-            except ET.ParseError:
-                logfunc('Parse error - Non XML file.') 
-                err = 1
-                
-            if err == 0:
-                root = tree.getroot()
-                
-                for elem in root:
-                    #print('TAG LVL 1 '+ elem.tag, elem.attrib)
-                    #role = elem.attrib['name']
-                    #print()
-                    if elem.tag == 'permission-trees':
-                        for subelem in elem:
-                            #print(elem.tag +' '+ subelem.tag, subelem.attrib)
-                            data_list_permission_trees.append((subelem.attrib.get('name', ''), subelem.attrib.get('package', '')))
-                    elif elem.tag == 'permissions':
-                        for subelem in elem:
-                            data_list_permissions.append((subelem.attrib.get('name', ''), subelem.attrib.get('package', ''), subelem.attrib.get('protection', '')))
-                            #print(elem.tag +' '+ subelem.tag, subelem.attrib)
-                    else:
-                        for subelem in elem:
-                            if subelem.tag == 'perms':
-                                for sub_subelem in subelem:
-                                    #print(elem.tag, elem.attrib['name'], sub_subelem.attrib['name'], sub_subelem.attrib['granted'] )
-                                    
-                                    
-                                    data_list_packages_su.append((elem.tag, elem.attrib.get('name', ''), sub_subelem.attrib.get('name', ''), sub_subelem.attrib.get('granted', '')))
-    
-                if len(data_list_permission_trees) > 0:
-                    report = ArtifactHtmlReport('Permission Trees')
-                    report.start_artifact_report(report_folder, f'Permission Trees')
-                    report.add_script()
-                    data_headers = ('Name', 'Package')
-                    report.write_artifact_data_table(data_headers, data_list_permission_trees, file_found)
-                    report.end_artifact_report()
-                    
-                    tsvname = f'Permission Trees'
-                    tsv(report_folder, data_headers, data_list_permission_trees, tsvname)
-                    
-                if len(data_list_permissions) > 0:
-                    report = ArtifactHtmlReport('Permissions')
-                    report.start_artifact_report(report_folder, f'Permissions')
-                    report.add_script()
-                    data_headers = ('Name', 'Package', 'Protection')
-                    report.write_artifact_data_table(data_headers, data_list_permissions, file_found)
-                    report.end_artifact_report()
-                    
-                    tsvname = f'Permissions'
-                    tsv(report_folder, data_headers, data_list_permissions, tsvname)
-                
-                if len(data_list_packages_su) > 0:
-                    report = ArtifactHtmlReport('Package and Shared User')
-                    report.start_artifact_report(report_folder, f'Package and Shared User')
-                    report.add_script()
-                    data_headers = ('Type', 'Package', 'Permission', 'Granted?')
-                    report.write_artifact_data_table(data_headers, data_list_packages_su, file_found)
-                    report.end_artifact_report()
-                    
-                    tsvname = f'Permissions - Packages and Shared User'
-                    tsv(report_folder, data_headers, data_list_packages_su, tsvname)
+        try:
+            if (checkabx(file_found)):
+                tree = abxread(file_found, False)
+            else:
+                tree = ET.parse(file_found)
+        except ET.ParseError:
+            logfunc('Parse error - Non XML file.')
+            continue
+        yield tree.getroot(), file_found
+
+
+@artifact_processor
+def get_permissions_trees(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for root, file_found in _iter_roots(files_found):
+        source_path = file_found
+        for elem in root:
+            if elem.tag == 'permission-trees':
+                for subelem in elem:
+                    data_list.append((subelem.attrib.get('name', ''), subelem.attrib.get('package', '')))
+
+    data_headers = ('Name', 'Package')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_permissions_list(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for root, file_found in _iter_roots(files_found):
+        source_path = file_found
+        for elem in root:
+            if elem.tag == 'permissions':
+                for subelem in elem:
+                    data_list.append((subelem.attrib.get('name', ''), subelem.attrib.get('package', ''), subelem.attrib.get('protection', '')))
+
+    data_headers = ('Name', 'Package', 'Protection')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_permissions_packages(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for root, file_found in _iter_roots(files_found):
+        source_path = file_found
+        for elem in root:
+            if elem.tag in ('permission-trees', 'permissions'):
+                continue
+            for subelem in elem:
+                if subelem.tag == 'perms':
+                    for sub_subelem in subelem:
+                        data_list.append((elem.tag, elem.attrib.get('name', ''), sub_subelem.attrib.get('name', ''), sub_subelem.attrib.get('granted', '')))
+
+    data_headers = ('Type', 'Package', 'Permission', 'Granted?')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Two multi-report system-config parsers, each split into separate decorated artifacts.

- **bluetoothConnections** → **Bluetooth Connections** (`Timestamp` raw → aware UTC `datetime`, replacing `utcfromtimestamp`; device name/MAC/link key) + **Bluetooth Adapter Information** (Key/Value block before the first device). Hoisted the MAC regex to a module constant; guarded the `split(' = ')` against malformed lines; dropped unused `csv`/`os`/`artGlobals` imports; only emits a connection row when a device was actually parsed (avoids a junk empty row).
- **permissions** → **Permission Trees** + **Permissions** + **Package and Shared User** (three decorated functions over `packages.xml`). Shared an `_iter_roots` helper that handles the ABX/XML parse and skips mirror copies; no timestamps.

Verified: byte-compile, all 5 functions decorated with 4-arg signature, return 3-tuples, output_types valid, loader builds (410 plugins), pylint clean.