### PR TITLE
Convert Xender, groupMe to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/Xender.py
+++ b/scripts/artifacts/Xender.py
@@ -1,7 +1,7 @@
-# pylint: disable=W0611,W0613,W0631,W0702,W1309
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_Xender": {
-        "name": "Xender",
+        "name": "Xender - Contacts",
         "description": "",
         "author": "",
         "creation_date": "2020-12-24",
@@ -10,100 +10,89 @@ __artifacts_v2__ = {
         "category": "File Transfer",
         "notes": "",
         "paths": ('*/cn.xender/databases/trans-history-db*',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
+        "artifact_icon": "users",
+    },
+    "get_Xender_messages": {
+        "name": "Xender - Messages",
+        "description": "",
+        "author": "",
+        "creation_date": "2020-12-24",
+        "last_update_date": "2020-12-24",
+        "requirements": "none",
+        "category": "File Transfer",
+        "notes": "",
+        "paths": ('*/cn.xender/databases/trans-history-db*',),
+        "output_types": "standard",
         "artifact_icon": "download",
-        "function": "get_Xender",
     }
 }
 
-import sqlite3
 import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
-def get_Xender(files_found, report_folder, seeker, wrap_text):
 
-    source_file = ''
-
+def _xender_db(files_found):
     for file_found in files_found:
         file_found = str(file_found)
-        
         if file_found.endswith('-db'):
-            source_file = file_found.replace(seeker.data_folder, '')
-            break
-        
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    try:
-        cursor.execute('''
-        SELECT device_id, nick_name FROM profile WHERE connect_times = 0
-        ''')
+            return file_found
+    return ''
 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-    except:
-        usageentries = 0
-        
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Xender file transfer - contacts')
-        report.start_artifact_report(report_folder, 'Xender file transfer - contacts')
-        report.add_script()
-        data_headers = ('device_id','nick_name') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = []
+
+@artifact_processor
+def get_Xender(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = _xender_db(files_found)
+    if source_path:
+        db = open_sqlite_db_readonly(source_path)
+        cursor = db.cursor()
+        try:
+            cursor.execute('SELECT device_id, nick_name FROM profile WHERE connect_times = 0')
+            all_rows = cursor.fetchall()
+        except Exception as e:
+            logfunc(str(e))
+            all_rows = []
+        db.close()
         for row in all_rows:
-            data_list.append((row[0],row[1]))
+            data_list.append((row[0], row[1]))
 
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Xender file transfer - contacts'
-        tsv(report_folder, data_headers, data_list, tsvname, source_file)
-        
-    else:
-        logfunc('No Xender Contacts found')
-        
-    try:        
-        cursor.execute('''
-        SELECT f_path, f_display_name, f_size_str, c_start_time/1000, c_direction, c_session_id, s_name, 
-               s_device_id, r_name, r_device_id
-          FROM new_history
-        ''')
-        
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-    except:
-        usageentries = 0
-        
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Xender file transfer - Messages')
-        report.start_artifact_report(report_folder, 'Xender file transfer - Messages')
-        report.add_script()
-        data_headers = ('file_path','file_display_name','file_size','timestamp','direction', 'to_id', 'from_id','session_id', 'sender_name', 'sender_device_id', 'recipient_name', 'recipient_device_id') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = []
+    data_headers = ('device_id', 'nick_name')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_Xender_messages(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = _xender_db(files_found)
+    if source_path:
+        db = open_sqlite_db_readonly(source_path)
+        cursor = db.cursor()
+        try:
+            cursor.execute('''
+                SELECT f_path, f_display_name, f_size_str, c_start_time, c_direction, c_session_id, s_name,
+                       s_device_id, r_name, r_device_id
+                FROM new_history
+            ''')
+            all_rows = cursor.fetchall()
+        except Exception as e:
+            logfunc(str(e))
+            all_rows = []
+        db.close()
+
         for row in all_rows:
             from_id = ''
             to_id = ''
-            if (row[4] == 1):
+            if row[4] == 1:
                 direction = 'Outgoing'
                 to_id = row[6]
             else:
                 direction = 'Incoming'
                 from_id = row[6]
-                
-            createtime = datetime.datetime.utcfromtimestamp(int(row[3])).strftime('%Y-%m-%d %H:%M:%S') 
-                        
+            createtime = datetime.datetime.fromtimestamp(int(row[3]) / 1000, datetime.timezone.utc) if row[3] else ''
             data_list.append((row[0], row[1], row[2], createtime, direction, to_id, from_id, row[5], row[6], row[7], row[8], row[9]))
-            
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Xender file transfer - Messages'
-        tsv(report_folder, data_headers, data_list, tsvname, source_file)
-        
-        tlactivity = f'Xender file transfer - Messages'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Xender file transfer messages data available')
 
-    db.close()
+    data_headers = ('file_path', 'file_display_name', 'file_size', ('timestamp', 'datetime'), 'direction', 'to_id',
+                    'from_id', 'session_id', 'sender_name', 'sender_device_id', 'recipient_name', 'recipient_device_id')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/groupMe.py
+++ b/scripts/artifacts/groupMe.py
@@ -1,136 +1,116 @@
-# pylint: disable=W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_groupMe": {
-        "name": "GroupMe",
-        "description": "GroupMe",
+        "name": "GroupMe - Group Information",
+        "description": "GroupMe group information",
         "author": "Josh Hickman (josh@thebinaryhick.blog)",
-        "creation_date": "2021-02-XX",
-        "last_update_date": "2021-02-XX",
+        "creation_date": "2021-02-01",
+        "last_update_date": "2021-02-01",
         "requirements": "None",
         "category": "GroupMe",
         "notes": "",
         "paths": ('*/com.groupme.android/databases/groupme.db',),
-        "output_types": None,
+        "output_types": "standard",
+        "artifact_icon": "users",
+    },
+    "get_groupMe_chat": {
+        "name": "GroupMe - Chat Information",
+        "description": "GroupMe chat information",
+        "author": "Josh Hickman (josh@thebinaryhick.blog)",
+        "creation_date": "2021-02-01",
+        "last_update_date": "2021-02-01",
+        "requirements": "None",
+        "category": "GroupMe",
+        "notes": "",
+        "paths": ('*/com.groupme.android/databases/groupme.db',),
+        "output_types": "standard",
         "artifact_icon": "message-square",
-        "function": "get_groupMe",
     }
 }
 
-# GroupMe
-# Author:  Josh Hickman (josh@thebinaryhick.blog)
-# Date 2021-02-XX
-# Version: 0.1
-# Requirements:  None
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+def _sec_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value), datetime.timezone.utc)
+    return ''
+
+
+@artifact_processor
 def get_groupMe(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        #if not file_found.endswith('burners.db'):
-            #continue # Skip all other files
-        
-        db = open_sqlite_db_readonly(file_found)
-        cursor = db.cursor()
-        cursor.execute('''
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
+    cursor = db.cursor()
+    cursor.execute('''
         SELECT
-        datetime(groups.created_at,'unixepoch') AS "Group Creation Time",
-        groups.name AS "Group Name",
-        groups.group_type AS "Group Type",
-        members.user_real_name AS "Group Creator",
-        members.role as "Creator Role",
-        groups.message_count AS "Total Message Count in Group",
-        groups.attachment_count AS "Total Attachment Count in Group",
-        datetime(groups.last_message_created_at,'unixepoch') AS "Time of Last Message in Group",
-        datetime(groups.updated_at,'unixepoch') AS "Time Group Last Updated"
-        FROM
-        groups
+        groups.created_at,
+        groups.name,
+        groups.group_type,
+        members.user_real_name,
+        members.role,
+        groups.message_count,
+        groups.attachment_count,
+        groups.last_message_created_at,
+        groups.updated_at
+        FROM groups
         JOIN members ON members.user_id=groups.creator_user_id
-        ORDER BY "Group Creation Time" ASC
-        ''')
+        ORDER BY groups.created_at ASC
+    ''')
+    all_rows = cursor.fetchall()
+    db.close()
 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Group Information')
-            report.start_artifact_report(report_folder, 'Group Information')
-            report.add_script()
-            data_headers = ('Group Creation Time','Group Name','Group Type','Group Creator','Creator Role','Total Message Count in Group','Total Attachment Count in Group','Time of Last Message in Group','Time Group Last Updated') 
-            data_list = []
-            for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8]))
+    data_list = []
+    for row in all_rows:
+        data_list.append((_sec_to_utc(row[0]), row[1], row[2], row[3], row[4], row[5], row[6],
+                          _sec_to_utc(row[7]), _sec_to_utc(row[8])))
 
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Group Information'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Group Information'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No GroupMe Group Information data available')
+    data_headers = (('Group Creation Time', 'datetime'), 'Group Name', 'Group Type', 'Group Creator', 'Creator Role',
+                    'Total Message Count in Group', 'Total Attachment Count in Group',
+                    ('Time of Last Message in Group', 'datetime'), ('Time Group Last Updated', 'datetime'))
+    return data_headers, data_list, source_path
 
-        cursor = db.cursor()
-        cursor.execute('''
+
+@artifact_processor
+def get_groupMe_chat(files_found, report_folder, seeker, wrap_text):
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
+    cursor = db.cursor()
+    cursor.execute('''
         SELECT
-        datetime(messages.created_at,'unixepoch') AS "Message Time",
-        groups.name as "Group Name",
-        messages.name AS "Message Sender",
-        messages.sender_type AS "Message Sender Type",
-        CASE
-        WHEN messages.is_system=0 THEN "No"
-        WHEN messages.is_system=1 THEN "Yes"
-        END AS "Is System Message",
-        CASE
-        WHEN messages.hidden=0 THEN "No"
-        WHEN messages.hidden=1 THEN "Yes"
-        END AS "Message Is Hidden",
-        CASE
-        WHEN messages.read=0 THEN "No"
-        WHEN messages.read=1 THEN "Yes"
-        END AS "Message Read",
-        messages.message_text AS "Message",
-        messages.photo_url AS "Picture URL",
-        messages.photo_uri AS "Picture Local Storage Location",
-        messages.photo_width as "Picture Width",
-        messages.photo_height AS "Picture Height",
-        CASE
-        WHEN messages.photo_is_gif=0 THEN "No"
-        WHEN messages.photo_is_gif=1 THEN "Yes"
-        END AS "Picture is GIF",
-        messages.video_url AS "Video URL",
-        messages.location_lat AS "Message Latitude",
-        messages.location_lng AS "Message Longitude",
-        messages.location_name AS "Location Name"
-        FROM
-        messages
+        messages.created_at,
+        groups.name,
+        messages.name,
+        messages.sender_type,
+        CASE WHEN messages.is_system=0 THEN "No" WHEN messages.is_system=1 THEN "Yes" END,
+        CASE WHEN messages.hidden=0 THEN "No" WHEN messages.hidden=1 THEN "Yes" END,
+        CASE WHEN messages.read=0 THEN "No" WHEN messages.read=1 THEN "Yes" END,
+        messages.message_text,
+        messages.photo_url,
+        messages.photo_uri,
+        messages.photo_width,
+        messages.photo_height,
+        CASE WHEN messages.photo_is_gif=0 THEN "No" WHEN messages.photo_is_gif=1 THEN "Yes" END,
+        messages.video_url,
+        messages.location_lat,
+        messages.location_lng,
+        messages.location_name
+        FROM messages
         LEFT JOIN groups ON groups.group_id=messages.conversation_id
-        ORDER BY "Message Time" ASC
-        ''')
+        ORDER BY messages.created_at ASC
+    ''')
+    all_rows = cursor.fetchall()
+    db.close()
 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Chat Information')
-            report.start_artifact_report(report_folder, 'Chat Information')
-            report.add_script()
-            data_headers = ('Message Time','Group Name','Message Sender','Message Sender Type','Is System Message','Message Is Hidden','Message Is Read','Message','Picture URL','Picture Local Storage Location','Picture Width','Picture Heigh','Picture Is GIF','Video URL','Message Latitude','Message Longitude','Location Name') 
-            data_list = []
-            for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11],row[12],row[13],row[14],row[15],row[16]))
+    data_list = []
+    for row in all_rows:
+        data_list.append((_sec_to_utc(row[0]), row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8],
+                          row[9], row[10], row[11], row[12], row[13], row[14], row[15], row[16]))
 
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Chat Information'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Chat Information'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No GroupMe Chat Information data available')
-                
-        db.close()
+    data_headers = (('Message Time', 'datetime'), 'Group Name', 'Message Sender', 'Message Sender Type',
+                    'Is System Message', 'Message Is Hidden', 'Message Is Read', 'Message', 'Picture URL',
+                    'Picture Local Storage Location', 'Picture Width', 'Picture Height', 'Picture Is GIF',
+                    'Video URL', 'Message Latitude', 'Message Longitude', 'Location Name')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Two more 2-report apps, each split into separate decorated artifacts (shared category, unique names).

- **Xender** (category `File Transfer`) → **Xender - Contacts** + **Xender - Messages** (`c_start_time` raw → aware UTC `datetime`; incoming/outgoing direction logic kept). Shared `_xender_db` helper; narrowed bare `except` to `Exception` + logfunc.
- **groupMe** (category `GroupMe`) → **GroupMe - Group Information** (`created_at`/`last_message_created_at`/`updated_at` → aware UTC `datetime`) + **GroupMe - Chat Information** (`created_at` → aware UTC `datetime`; keeps message/photo/video/location columns). Replaced all in-SQL `datetime(...,'unixepoch')` with raw selection + Python aware-UTC conversion; fixed the `2021-02-XX` placeholder dates.

Verified: byte-compile, all 4 functions decorated with 4-arg signature, return 3-tuples, output_types valid, unique names + shared categories, loader builds (412 plugins), pylint clean.