### PR TITLE
Convert tikTok, Oruxmaps to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/Oruxmaps.py
+++ b/scripts/artifacts/Oruxmaps.py
@@ -1,7 +1,7 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_Oruxmaps": {
-        "name": "Oruxmaps",
+        "name": "Oruxmaps - POI",
         "description": "",
         "author": "",
         "creation_date": "2021-03-11",
@@ -10,80 +10,68 @@ __artifacts_v2__ = {
         "category": "GEO Location",
         "notes": "",
         "paths": ('**/oruxmaps/tracklogs/oruxmapstracks.db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "map-pin",
-        "function": "get_Oruxmaps",
+    },
+    "get_Oruxmaps_tracks": {
+        "name": "Oruxmaps - Tracks",
+        "description": "",
+        "author": "",
+        "creation_date": "2021-03-11",
+        "last_update_date": "2021-03-11",
+        "requirements": "none",
+        "category": "GEO Location",
+        "notes": "",
+        "paths": ('**/oruxmaps/tracklogs/oruxmapstracks.db*',),
+        "output_types": "standard",
+        "artifact_icon": "map-pin",
     }
 }
 
-import sqlite3
 import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
+
+def _ms_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    return ''
+
+
+@artifact_processor
 def get_Oruxmaps(files_found, report_folder, seeker, wrap_text):
-    file_found = str(files_found[0])
-    source_file = file_found.replace(seeker.data_folder, '')
-    db = open_sqlite_db_readonly(file_found)
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
+    cursor = db.cursor()
+    cursor.execute('SELECT poilat, poilon, poialt, poitime, poiname FROM pois')
+    all_rows = cursor.fetchall()
+    db.close()
+
+    data_list = []
+    for row in all_rows:
+        data_list.append((row[0], row[1], row[2], _ms_to_utc(row[3]), row[4]))
+
+    data_headers = ('poilat', 'poilon', 'poialt', ('poitime', 'datetime'), 'poiname')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_Oruxmaps_tracks(files_found, report_folder, seeker, wrap_text):
+    source_path = str(files_found[0])
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     cursor.execute('''
-    SELECT poilat, poilon, poialt, poitime/1000, poiname FROM pois
+        SELECT tracks._id, trackname, trackciudad, segname, trkptlat, trkptlon, trkptalt, trkpttime
+        FROM tracks, segments, trackpoints
+        where tracks._id = segments.segtrack and segments._id = trackpoints.trkptseg
     ''')
-
     all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Oruxmaps POI')
-        report.start_artifact_report(report_folder, 'Oruxmaps POI')
-        report.add_script()
-        data_headers = ('poilat','poilon','poialt', 'poitime', 'poiname') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = []
-                        
-        for row in all_rows:
-            
-            timestamp = datetime.datetime.utcfromtimestamp(int(row[3])).strftime('%Y-%m-%d %H:%M:%S')
-            data_list.append((row[0], row[1], row[2], timestamp, row[4]))
-
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Oruxmaps POI'
-        tsv(report_folder, data_headers, data_list, tsvname, source_file)
-        
-        tlactivity = f'Oruxmaps POI'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Oruxmaps POI data available')
-    
-    cursor.execute('''
-            SELECT tracks._id, trackname, trackciudad, segname, trkptlat, trkptlon, trkptalt, trkpttime/1000 
-              FROM tracks, segments, trackpoints
-             where tracks._id = segments.segtrack and segments._id = trackpoints.trkptseg
-    ''')
-
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Oruxmaps Tracks')
-        report.start_artifact_report(report_folder, 'Oruxmaps Tracks')
-        report.add_script()
-        data_headers = ('track id','track name','track description', 'segment name', 'latitude', 'longitude', 'altimeter', 'datetime') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = []
-                        
-        for row in all_rows:
-            timestamp = datetime.datetime.utcfromtimestamp(int(row[7])).strftime('%Y-%m-%d %H:%M:%S')
-            data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], timestamp))
-
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Oruxmaps Tracks'
-        tsv(report_folder, data_headers, data_list, tsvname, source_file)
-        
-        tlactivity = f'Oruxmaps Tracks'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Oruxmaps Tracks data available')
-
     db.close()
+
+    data_list = []
+    for row in all_rows:
+        data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], _ms_to_utc(row[7])))
+
+    data_headers = ('track id', 'track name', 'track description', 'segment name', 'latitude', 'longitude', 'altimeter', ('datetime', 'datetime'))
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/tikTok.py
+++ b/scripts/artifacts/tikTok.py
@@ -1,7 +1,7 @@
-# pylint: disable=E0606,W0611,W0613,W0631
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_tikTok": {
-        "name": "tikTok",
+        "name": "TikTok - Messages",
         "description": "",
         "author": "",
         "creation_date": "2021-03-02",
@@ -10,104 +10,98 @@ __artifacts_v2__ = {
         "category": "TikTok",
         "notes": "",
         "paths": ('*_im.db*', '*db_im_xx*'),
-        "output_types": None,
+        "output_types": "standard",
+        "artifact_icon": "message-square",
+    },
+    "get_tikTok_contacts": {
+        "name": "TikTok - Contacts",
+        "description": "",
+        "author": "",
+        "creation_date": "2021-03-02",
+        "last_update_date": "2021-03-02",
+        "requirements": "none",
+        "category": "TikTok",
+        "notes": "",
+        "paths": ('*_im.db*', '*db_im_xx*'),
+        "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "users",
-        "function": "get_tikTok",
     }
 }
 
-from os.path import dirname, join
-import sqlite3
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
-def get_tikTok(files_found, report_folder, seeker, wrap_text):
-    data_list = []
-    data_list1 = []
-    
+def _tiktok_dbs(files_found):
+    maindb = attachdb = ''
     for file_found in files_found:
         file_found = str(file_found)
-
         if file_found.endswith('_im.db'):
             maindb = file_found
-        if file_found.endswith('db_im_xx'):
+        elif file_found.endswith('db_im_xx'):
             attachdb = file_found
+    return maindb, attachdb
 
-    db = open_sqlite_db_readonly(maindb)
-    cursor = db.cursor()
-    cursor.execute(f"ATTACH DATABASE '{attachdb}' as db_im_xx;")
-    cursor.execute('''
-        select
-        datetime(created_time/1000, 'unixepoch', 'localtime') as created_time,
-        UID,
-        UNIQUE_ID,
-        NICK_NAME,
-        json_extract(content, '$.text') as message,
-        json_extract(content,'$.display_name') as links_gifs_display_name,
-        json_extract(content, '$.url.url_list[0]') as links_gifs_urls,
-        read_status,
+
+@artifact_processor
+def get_tikTok(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    maindb, attachdb = _tiktok_dbs(files_found)
+    source_path = maindb
+    if maindb and attachdb:
+        db = open_sqlite_db_readonly(maindb)
+        cursor = db.cursor()
+        cursor.execute(f"ATTACH DATABASE '{attachdb}' as db_im_xx;")
+        cursor.execute('''
+            select
+            created_time,
+            UID,
+            UNIQUE_ID,
+            NICK_NAME,
+            json_extract(content, '$.text') as message,
+            json_extract(content,'$.display_name') as links_gifs_display_name,
+            json_extract(content, '$.url.url_list[0]') as links_gifs_urls,
+            read_status,
             case when read_status = 0 then 'Not read'
                 when read_status = 1 then 'Read'
                 else read_status
-            end
-        local_info
-        from db_im_xx.SIMPLE_USER, msg
-        where UID = sender and json_valid(content) = 1 order by created_time
+            end local_info
+            from db_im_xx.SIMPLE_USER, msg
+            where UID = sender and json_valid(content) = 1 order by created_time
         ''')
+        all_rows = cursor.fetchall()
+        db.close()
 
-    all_rows = cursor.fetchall()
-    
-    if len(all_rows) > 0:
         for row in all_rows:
+            timestamp = datetime.datetime.fromtimestamp(int(row[0]) / 1000, datetime.timezone.utc) if row[0] else ''
+            data_list.append((timestamp, row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8]))
 
-            data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8]))
+    data_headers = (('Timestamp', 'datetime'), 'UID', 'Unique ID', 'Nickname', 'Message', 'Link GIF Name',
+                    'Link GIF URL', 'Read?', 'Local Info')
+    return data_headers, data_list, source_path
 
-        report = ArtifactHtmlReport('TikTok Messages')
-        report.start_artifact_report(report_folder, 'TikTok - Messages')
-        report.add_script()
-        data_headers = ('Timestamp','UID','Unique ID','Nickname','Message','Link GIF Name','Link GIF URL','Read?','Local Info')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
 
-        tsvname = 'Tiktok Messages'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = 'TikTok Messages'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No TikTok messages available')
-
-    cursor.execute('''
-        select
-        UID,
-        NICK_NAME,
-        UNIQUE_ID,
-        INITIAL_LETTER,
-        json_extract(AVATAR_THUMB, '$.url_list[0]') as avatarURL,
-        FOLLOW_STATUS 
-        from SIMPLE_USER
+@artifact_processor
+def get_tikTok_contacts(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    maindb, attachdb = _tiktok_dbs(files_found)
+    source_path = maindb
+    if maindb and attachdb:
+        db = open_sqlite_db_readonly(maindb)
+        cursor = db.cursor()
+        cursor.execute(f"ATTACH DATABASE '{attachdb}' as db_im_xx;")
+        cursor.execute('''
+            select UID, NICK_NAME, UNIQUE_ID, INITIAL_LETTER,
+            json_extract(AVATAR_THUMB, '$.url_list[0]') as avatarURL,
+            FOLLOW_STATUS
+            from db_im_xx.SIMPLE_USER
         ''')
-    
-    all_rows1 = cursor.fetchall()
-    
-    if len(all_rows) > 0:
-        for row in all_rows1:
-            
-            data_list1.append((row[0], row[1], row[2], row[3], row[4], row[5]))
-            
-        report = ArtifactHtmlReport('TikTok Contacts')
-        report.start_artifact_report(report_folder, 'TikTok - Contacts')
-        report.add_script()
-        data_headers1 = ('UID','Nickname','Unique ID','Initial Letter','Avatar URL','Follow Status')
-        report.write_artifact_data_table(data_headers1, data_list1, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'TikTok Contacts'
-        tsv(report_folder, data_headers1, data_list1, tsvname)
-        
-    else:
-        logfunc('No TikTok Contacts available')
-    
-    db.close()
+        all_rows = cursor.fetchall()
+        db.close()
+
+        for row in all_rows:
+            data_list.append((row[0], row[1], row[2], row[3], row[4], row[5]))
+
+    data_headers = ('UID', 'Nickname', 'Unique ID', 'Initial Letter', 'Avatar URL', 'Follow Status')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Two more 2-report apps split into separate decorated artifacts (shared category, unique names).

- **tikTok** (category `TikTok`) → **TikTok - Messages** + **TikTok - Contacts**. Both `ATTACH` the `db_im_xx` database via a shared `_tiktok_dbs` helper. `created_time` now converted to **aware UTC** (the original used SQL `datetime(...,'unixepoch','localtime')`, i.e. machine-local time — replaced with proper UTC); `Timestamp` marked `datetime`. **Fixed a latent bug**: the contacts report was gated on the *messages* row count (`if len(all_rows)`), so contacts never showed when there were no messages — each table is now independent. Contacts query qualified as `db_im_xx.SIMPLE_USER`.
- **Oruxmaps** (category `GEO Location`) → **Oruxmaps - POI** + **Oruxmaps - Tracks**. `poitime`/`trkpttime` raw → aware UTC `datetime` (replacing `utcfromtimestamp`).

Verified: byte-compile, all 4 functions decorated with 4-arg signature, return 3-tuples, output_types valid, unique names + shared categories, loader builds (414 plugins), pylint clean.