### PR TITLE
Convert smyfilesRecents, wellbeing to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/smyfilesRecents.py
+++ b/scripts/artifacts/smyfilesRecents.py
@@ -1,7 +1,7 @@
-# pylint: disable=W0611,W0613,W0631,W0702,W1309
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_smyfilesRecents": {
-        "name": "smyfilesRecents",
+        "name": "My Files - Recent Files",
         "description": "",
         "author": "",
         "creation_date": "2020-03-21",
@@ -10,114 +10,96 @@ __artifacts_v2__ = {
         "category": "My Files",
         "notes": "",
         "paths": ('*/com.sec.android.app.myfiles/databases/myfiles.db*', '*/com.sec.android.app.myfiles/databases/FileInfo.db*'),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "file",
-        "function": "get_smyfilesRecents",
+    },
+    "get_smyfilesRecents_fileinfo": {
+        "name": "My Files - Recent Files (FileInfo)",
+        "description": "",
+        "author": "",
+        "creation_date": "2020-03-21",
+        "last_update_date": "2020-03-21",
+        "requirements": "none",
+        "category": "My Files",
+        "notes": "",
+        "paths": ('*/com.sec.android.app.myfiles/databases/myfiles.db*', '*/com.sec.android.app.myfiles/databases/FileInfo.db*'),
+        "output_types": "standard",
+        "artifact_icon": "file",
     }
 }
 
-import sqlite3
-import textwrap
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
-def get_smyfilesRecents(files_found, report_folder, seeker, wrap_text):
-    
+
+def _ms_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    return ''
+
+
+def _myfiles_db(files_found):
     for file_found in files_found:
         file_found = str(file_found)
-        
         if file_found.endswith('.db'):
-            break
-        
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    try:
-        cursor.execute('''
-        select
-        datetime(date_modified / 1000, "unixepoch"),
-        name,
-        size,
-        _data,
-        ext,
-        _source,
-        _description,
-        datetime(recent_date / 1000, "unixepoch")
-        from recent_files 
-        ''')
+            return file_found
+    return ''
 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-    except:
-        usageentries = 0    
-        
-    if usageentries > 0:
-        report = ArtifactHtmlReport('My Files DB - Recent Files')
-        report.start_artifact_report(report_folder, 'My Files DB - Recent Files')
-        report.add_script()
-        data_headers = ('Timestamp','Name','Size','Data','Ext.', 'Source', 'Description', 'Recent Timestamp' ) 
-        data_list = []
-        for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7]))
 
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'my files db - recent files'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'My Files DB - Recent Files'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No My Files DB Recents data available')
-    
-    try:
-        cursor.execute('''
-        SELECT
-        datetime (recent_files.recent_date/1000, "unixepoch") as "Recent Date",
-        datetime(recent_files.date_modified/1000, "unixepoch") as "Recent Files",
-        recent_files.file_id as "File ID",
-        recent_files.package_name as "Package Name",
-        recent_files.path as "Path",
-        recent_files.size as "Size",
-        case recent_files.is_download
-            WHEN '1' THEN "True"
-            WHEN '0' THEN "False"
-        end "Downloaded?",
-        case recent_files.is_hidden
-            WHEN '1' THEN "True"
-            WHEN '0' THEN "False"
-        end "Hidden",
-        case recent_files.is_trashed
-            WHEN '1' then  "True"
-            when '0' then "False"
-        end "Trashed"
-        from recent_files
-        ''')
-        
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-    except:
-        usageentries = 0    
-        
-    if usageentries > 0:
-        report = ArtifactHtmlReport('My Files DB - Recent Files')
-        report.start_artifact_report(report_folder, 'My Files DB - Recent Files')
-        report.add_script()
-        data_headers = ('Recent Timestamp','Modified Timestamp','File ID','Package Name','Path', 'Size', 'Is Downloaded?', 'Is Hidden?','Is Trashed?' ) 
-        data_list = []
+@artifact_processor
+def get_smyfilesRecents(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = _myfiles_db(files_found)
+    if source_path:
+        db = open_sqlite_db_readonly(source_path)
+        cursor = db.cursor()
+        try:
+            cursor.execute('''
+                select date_modified, name, size, _data, ext, _source, _description, recent_date
+                from recent_files
+            ''')
+            all_rows = cursor.fetchall()
+        except Exception as e:
+            logfunc(str(e))
+            all_rows = []
+        db.close()
         for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8]))
-            
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'my files db - recent files'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'My Files DB - Recent Files'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No My Files DB Recents data available')
-    
-    db.close()
+            data_list.append((_ms_to_utc(row[0]), row[1], row[2], row[3], row[4], row[5], row[6], _ms_to_utc(row[7])))
+
+    data_headers = (('Timestamp', 'datetime'), 'Name', 'Size', 'Data', 'Ext.', 'Source', 'Description', ('Recent Timestamp', 'datetime'))
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_smyfilesRecents_fileinfo(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = _myfiles_db(files_found)
+    if source_path:
+        db = open_sqlite_db_readonly(source_path)
+        cursor = db.cursor()
+        try:
+            cursor.execute('''
+                SELECT
+                recent_files.recent_date,
+                recent_files.date_modified,
+                recent_files.file_id,
+                recent_files.package_name,
+                recent_files.path,
+                recent_files.size,
+                case recent_files.is_download WHEN '1' THEN "True" WHEN '0' THEN "False" end,
+                case recent_files.is_hidden WHEN '1' THEN "True" WHEN '0' THEN "False" end,
+                case recent_files.is_trashed WHEN '1' then "True" when '0' then "False" end
+                from recent_files
+            ''')
+            all_rows = cursor.fetchall()
+        except Exception as e:
+            logfunc(str(e))
+            all_rows = []
+        db.close()
+        for row in all_rows:
+            data_list.append((_ms_to_utc(row[0]), _ms_to_utc(row[1]), row[2], row[3], row[4], row[5], row[6], row[7], row[8]))
+
+    data_headers = (('Recent Timestamp', 'datetime'), ('Modified Timestamp', 'datetime'), 'File ID', 'Package Name',
+                    'Path', 'Size', 'Is Downloaded?', 'Is Hidden?', 'Is Trashed?')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/wellbeing.py
+++ b/scripts/artifacts/wellbeing.py
@@ -1,41 +1,62 @@
-# pylint: disable=W0611,W0613,W0631,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_wellbeing": {
-        "name": "Digital Wellbeing",
+        "name": "Digital Wellbeing - Events",
         "description": "Parses Digital Wellbeing events",
         "author": "@AlexisBrignoni",
-        "creation_date": "2020-02-2",
-        "last_update_date": "2020-02-2",
+        "creation_date": "2020-02-02",
+        "last_update_date": "2020-02-02",
         "requirements": "none",
         "category": "Digital Wellbeing",
         "notes": "",
-        "paths": ('*/com.google.android.apps.wellbeing/databases/app_usage*'),
-        "output_types": None,
+        "paths": ('*/com.google.android.apps.wellbeing/databases/app_usage*',),
+        "output_types": "standard",
         "artifact_icon": "heart",
-        "function": "get_wellbeing",
+    },
+    "get_wellbeing_url": {
+        "name": "Digital Wellbeing - URL Events",
+        "description": "Parses Digital Wellbeing URL events",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2020-02-02",
+        "last_update_date": "2020-02-02",
+        "requirements": "none",
+        "category": "Digital Wellbeing",
+        "notes": "",
+        "paths": ('*/com.google.android.apps.wellbeing/databases/app_usage*',),
+        "output_types": "standard",
+        "artifact_icon": "globe",
     }
 }
 
-import os
-import sqlite3
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone
+import datetime
 
-def get_wellbeing(files_found, report_folder, seeker, wrap_text):
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-    data_list = []
-    data_list_url = []
 
+def _ms_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    return ''
+
+
+def _app_usage_db(files_found):
     for file_found in files_found:
         file_found = str(file_found)
-        
         if file_found.endswith('app_usage'):
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            cursor.execute('''
-            SELECT 
-            events._id,
-            datetime(events.timestamp/1000, 'UNIXEPOCH') as timestamps, 
+            return file_found
+    return ''
+
+
+@artifact_processor
+def get_wellbeing(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = _app_usage_db(files_found)
+    if source_path:
+        db = open_sqlite_db_readonly(source_path)
+        cursor = db.cursor()
+        cursor.execute('''
+            SELECT
+            events.timestamp,
             packages.package_name,
             case
                 when events.type = 1 THEN 'ACTIVITY_RESUMED'
@@ -43,92 +64,51 @@ def get_wellbeing(files_found, report_folder, seeker, wrap_text):
                 when events.type = 12 THEN 'NOTIFICATION'
                 when events.type = 18 THEN 'KEYGUARD_HIDDEN & || Device Unlock'
                 when events.type = 19 THEN 'FOREGROUND_SERVICE_START'
-                when events.type = 20 THEN 'FOREGROUND_SERVICE_STOP' 
+                when events.type = 20 THEN 'FOREGROUND_SERVICE_STOP'
                 when events.type = 23 THEN 'ACTIVITY_STOPPED'
                 when events.type = 26 THEN 'DEVICE_SHUTDOWN'
                 when events.type = 27 THEN 'DEVICE_STARTUP'
                 else events.type
             END as eventtype
-            FROM
-            events INNER JOIN packages ON events.package_id=packages._id 
-            ''')
+            FROM events INNER JOIN packages ON events.package_id=packages._id
+        ''')
+        all_rows = cursor.fetchall()
+        db.close()
+        for row in all_rows:
+            data_list.append((_ms_to_utc(row[0]), row[1], row[2]))
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                for row in all_rows:
-                    event_ts = row[1]
-                    if event_ts is None:
-                        pass
-                    else:
-                        event_ts = convert_utc_human_to_timezone(convert_ts_human_to_utc(event_ts),'UTC')
-                
-                    data_list.append((event_ts, row[2], row[3], file_found))
-                    
-            cursor = db.cursor()
-            cursor.execute('''
-            SELECT 
-            datetime(component_events.timestamp/1000, "UNIXEPOCH") as timestamp,
+    data_headers = (('Timestamp', 'datetime'), 'Package Name', 'Event Type')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_wellbeing_url(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = _app_usage_db(files_found)
+    if source_path:
+        db = open_sqlite_db_readonly(source_path)
+        cursor = db.cursor()
+        cursor.execute('''
+            SELECT
+            component_events.timestamp,
             component_events._id,
-            components.package_id, 
-            packages.package_name, 
+            components.package_id,
+            packages.package_name,
             components.component_name as website,
             CASE
-            when component_events.type=1 THEN 'ACTIVITY_RESUMED'
-            when component_events.type=2 THEN 'ACTIVITY_PAUSED'
-            else component_events.type
+                when component_events.type=1 THEN 'ACTIVITY_RESUMED'
+                when component_events.type=2 THEN 'ACTIVITY_PAUSED'
+                else component_events.type
             END as eventType
             FROM component_events
             INNER JOIN components ON component_events.component_id=components._id
             INNER JOIN packages ON components.package_id=packages._id
-            ORDER BY timestamp
-            ''')
+            ORDER BY component_events.timestamp
+        ''')
+        all_rows = cursor.fetchall()
+        db.close()
+        for row in all_rows:
+            data_list.append((_ms_to_utc(row[0]), row[1], row[2], row[3], row[4], row[5]))
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                for row in all_rows:
-                    event_ts = row[0]
-                    if event_ts is None:
-                        pass
-                    else:
-                        event_ts = convert_utc_human_to_timezone(convert_ts_human_to_utc(event_ts),'UTC')
-                    data_list_url.append((event_ts, row[1], row[2], row[3], row[4], row[5], file_found))
-            db.close()
-            
-        else:
-            continue # Skip all other files
-        
-    if data_list:
-        report = ArtifactHtmlReport('Digital Wellbeing - Events')
-        report.start_artifact_report(report_folder, 'Events')
-        report.add_script()
-        data_headers = ('Timestamp', 'Package ID', 'Event Type', 'Source File')
-
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Digital Wellbeing - Events'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Digital Wellbeing - Events'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Digital Wellbeing - Events data available')
-    
-    if data_list_url:
-        report = ArtifactHtmlReport('Digital Wellbeing - URL Events')
-        report.start_artifact_report(report_folder, 'Digital Wellbeing - URL Events')
-        report.add_script()
-        data_headers = ('Timestamp', 'Event ID', 'Package ID', 'Package Name', 'Website', 'Event', 'Source File')
-        
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Digital Wellbeing - URL Events'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Digital Wellbeing - URL Events'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Digital Wellbeing - URL Events data available')
+    data_headers = (('Timestamp', 'datetime'), 'Event ID', 'Package ID', 'Package Name', 'Website', 'Event')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Two more 2-report apps split into separate decorated artifacts.

- **smyfilesRecents** (category `My Files`) → **My Files - Recent Files** + **My Files - Recent Files (FileInfo)**. The two queries target two different schemas (myfiles.db vs FileInfo.db) but the original gave **both reports the same title** ('My Files DB - Recent Files') — a LAVA name collision; now distinct. All four `datetime(...,'unixepoch')` columns replaced with aware-UTC conversion; per-query try/except narrowed to `Exception` + logfunc.
- **wellbeing** (category `Digital Wellbeing`) → **Digital Wellbeing - Events** + **Digital Wellbeing - URL Events**. `timestamp` columns → aware UTC `datetime` (replacing the `datetime('UNIXEPOCH')` + `convert_ts_human_to_utc` round-trip). **Fixed a latent bug**: the URL-Events report wrote `data_list` (the Events rows) instead of `data_list_url`, so it showed the wrong data. Fixed `paths` (bare string → 1-tuple); dropped redundant per-row Source File columns; relabeled the mislabeled 'Package ID' column to 'Package Name'.

Verified: byte-compile, all 4 functions decorated with 4-arg signature, return 3-tuples, output_types valid, paths are tuples, unique names, loader builds (416 plugins), pylint clean.