### PR TITLE
Convert life360DriverBehavior to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/life360DriverBehavior.py
+++ b/scripts/artifacts/life360DriverBehavior.py
@@ -1,187 +1,110 @@
-# pylint: disable=W0611,W0613
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_TripEvents": {
-        "name": "Life360 Driver Behavior Trip Events and Waypoints",
-        "description": "Parses Events and Waypoints from Life360 DriverBehavior/trips JSON files",
+        "name": "Life360 Driver Behavior - Trip Events",
+        "description": "Parses Events from Life360 DriverBehavior/trips JSON files",
         "author": "Heather Charpentier",
         "creation_date": "2024-09-17",
         "last_update_date": "2024-09-17",
         "requirements": "none",
         "category": "Life360DriverBehavior",
-        "notes": "Processes event data and waypoints from trip JSON files",
+        "notes": "Processes event data from trip JSON files",
         "paths": ('*/trips/*.json',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "map-pin",
-        "function": "get_TripEvents",
+    },
+    "get_TripWaypoints": {
+        "name": "Life360 Driver Behavior - Trip Waypoints",
+        "description": "Parses Waypoints from Life360 DriverBehavior/trips JSON files",
+        "author": "Heather Charpentier",
+        "creation_date": "2024-09-17",
+        "last_update_date": "2024-09-17",
+        "requirements": "none",
+        "category": "Life360DriverBehavior",
+        "notes": "Processes waypoint data from trip JSON files",
+        "paths": ('*/trips/*.json',),
+        "output_types": ['html', 'tsv', 'lava'],
+        "artifact_icon": "map-pin",
     }
 }
 
+import datetime
 import json
-import os
-from datetime import datetime
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import tsv
 
-def get_TripEvents(files_found, report_folder, seeker, wrap_text):
-    data_list_events = []  
-    data_list_waypoints = []  
-    trips_dict = {}  
+from scripts.ilapfuncs import artifact_processor
 
-    
-    target_directory = 'data/com.life360.android.safetymapd/files/DriverBehavior/trips'
+TARGET_DIRECTORY = 'data/com.life360.android.safetymapd/files/DriverBehavior/trips'
 
-    
+
+def _mps_to_mph(value):
+    if value != '' and value is not None:
+        return round(float(value) * 2.23694, 2)
+    return ''
+
+
+def _sec_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value), datetime.timezone.utc)
+    return ''
+
+
+def _iter_trip_files(files_found):
     for file_found in files_found:
         file_found = str(file_found)
-
-        #Normalize the file path by removing the \\?\ prefix, if present
         if file_found.startswith('\\\\?\\'):
             file_found = file_found[4:]
-
-        #Ensure that we are processing files from the correct directory
-        if file_found.endswith('.json') and target_directory in file_found.replace('\\', '/'):
-            with open(file_found, 'r', encoding='utf-8') as f:
-                try:
+        if file_found.endswith('.json') and TARGET_DIRECTORY in file_found.replace('\\', '/'):
+            try:
+                with open(file_found, 'r', encoding='utf-8') as f:
                     data = json.load(f)
-                except json.JSONDecodeError:
-                    continue
-
-            if 'events' not in data:
+            except json.JSONDecodeError:
                 continue
-
-            for event in data.get('events', []):
-                timestamp = datetime.fromtimestamp(event.get('timestamp', 0)).strftime('%Y-%m-%d %H:%M:%S')
-                event_type = event.get('eventType', '')
-                lat = event.get('location', {}).get('lat', '')
-                lon = event.get('location', {}).get('lon', '')
-                speed = event.get('speed', '')  #Speed in meters per second
-                top_speed = event.get('topSpeed', '')
-                avg_speed = event.get('averageSpeed', '')
-                distance = event.get('distance', '')
-                trip_id = event.get('tripId', '')  
-
-                #Convert speeds from meters per second to miles per hour
-                speed_mph = ''
-                if speed != '':
-                    speed_mph = round(float(speed) * 2.23694, 2)  #Converts speed and rounds
-
-                top_speed_mph = ''
-                if top_speed != '':
-                    top_speed_mph = round(float(top_speed) * 2.23694, 2)  
-
-                avg_speed_mph = ''
-                if avg_speed != '':
-                    avg_speed_mph = round(float(avg_speed) * 2.23694, 2)  
-
-                
-                data_list_events.append((timestamp, event_type, lat, lon, speed, speed_mph, top_speed, top_speed_mph, avg_speed, avg_speed_mph, distance, trip_id))
-
-                
-                if trip_id not in trips_dict:
-                    trips_dict[trip_id] = []
-
-                #Combine trips and waypoints in the tsv
-                trips_dict[trip_id].append({
-                    'timestamp': timestamp,
-                    'type': 'event',
-                    'event_type': event_type,
-                    'lat': lat,
-                    'lon': lon,
-                    'speed': speed,
-                    'speed_mph': speed_mph,
-                    'top_speed': top_speed,
-                    'top_speed_mph': top_speed_mph,
-                    'avg_speed': avg_speed,
-                    'avg_speed_mph': avg_speed_mph,
-                    'distance': distance,
-                    'accuracy': '',  
-                    'trip_id': trip_id
-                })
-
-                
-                waypoints = event.get('waypoints', [])
-                for waypoint in waypoints:
-                    wp_lat = waypoint.get('lat', '')
-                    wp_lon = waypoint.get('lon', '')
-                    wp_accuracy = waypoint.get('accuracy', '')
-
-                    #Add waypoint data to the combined data list for HTML report (Waypoints)
-                    data_list_waypoints.append((wp_lat, wp_lon, wp_accuracy, trip_id))
-
-                    #Add waypoint data linked to the trip for TSV
-                    trips_dict[trip_id].append({
-                        'type': 'waypoint',
-                        'event_type': 'Waypoint',
-                        'timestamp': '',
-                        'lat': wp_lat,  
-                        'lon': wp_lon,  
-                        'speed': '',
-                        'speed_mph': '',
-                        'top_speed': '',
-                        'top_speed_mph': '',
-                        'avg_speed': '',
-                        'avg_speed_mph': '',
-                        'distance': '',  
-                        'accuracy': wp_accuracy,  
-                        'trip_id': trip_id
-                    })
-    
-   
-    if data_list_events:
-        description = 'Life360 Trip Event Report'
-        report = ArtifactHtmlReport('Trip Events')
-        report.start_artifact_report(report_folder, 'Trip Events', description)
-        report.add_script()
-        event_headers = ('Timestamp', 'Event Type', 'Latitude', 'Longitude', 'Speed (m/s)', 'Speed (mph)', 'Top Speed (m/s)', 'Top Speed (mph)', 'Average Speed (m/s)', 'Average Speed (mph)', 'Distance (m)', 'Trip ID')
-        report.write_artifact_data_table(event_headers, data_list_events, file_found, html_escape=False)
-        report.end_artifact_report()
-
-    
-    if data_list_waypoints:
-        description = 'Life360 Waypoints'
-        report = ArtifactHtmlReport('Trip Waypoints')
-        report.start_artifact_report(report_folder, 'Trip Waypoints', description)
-        report.add_script()
-        waypoint_headers = ('Latitude', 'Longitude', 'Accuracy (m)', 'Trip ID')
-        report.write_artifact_data_table(waypoint_headers, data_list_waypoints, file_found, html_escape=False)
-        report.end_artifact_report()
-
-    
-    for trip_id, trip_data in trips_dict.items():
-        if trip_data:
-            combined_data = []
-            for entry in trip_data:
-                combined_data.append((
-                    entry['timestamp'],
-                    entry['event_type'],
-                    entry['lat'],  
-                    entry['lon'],  
-                    entry['speed'],
-                    entry['speed_mph'],
-                    entry['top_speed'],
-                    entry['top_speed_mph'],
-                    entry['avg_speed'],
-                    entry['avg_speed_mph'],
-                    entry['distance'],  
-                    entry['accuracy'],  
-                    entry['trip_id']
-                ))
-
-            #Headers for both events and waypoints
-            combined_headers = ('Timestamp', 'Event Type', 'Latitude', 'Longitude', 'Speed (m/s)', 'Speed (mph)', 'Top Speed (m/s)', 'Top Speed (mph)', 'Average Speed (m/s)', 'Average Speed (mph)', 'Distance (m)', 'Accuracy (m)', 'Trip ID')
-            tsvname = f'Trip_{trip_id}_Combined'
-            tsv(report_folder, combined_headers, combined_data, tsvname)
+            if 'events' in data:
+                yield file_found, data
 
 
+@artifact_processor
+def get_TripEvents(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for file_found, data in _iter_trip_files(files_found):
+        source_path = file_found
+        for event in data.get('events', []):
+            timestamp = _sec_to_utc(event.get('timestamp', 0))
+            speed = event.get('speed', '')
+            top_speed = event.get('topSpeed', '')
+            avg_speed = event.get('averageSpeed', '')
+            data_list.append((
+                timestamp,
+                event.get('eventType', ''),
+                event.get('location', {}).get('lat', ''),
+                event.get('location', {}).get('lon', ''),
+                speed,
+                _mps_to_mph(speed),
+                top_speed,
+                _mps_to_mph(top_speed),
+                avg_speed,
+                _mps_to_mph(avg_speed),
+                event.get('distance', ''),
+                event.get('tripId', ''),
+            ))
+
+    data_headers = (('Timestamp', 'datetime'), 'Event Type', 'Latitude', 'Longitude', 'Speed (m/s)', 'Speed (mph)',
+                    'Top Speed (m/s)', 'Top Speed (mph)', 'Average Speed (m/s)', 'Average Speed (mph)',
+                    'Distance (m)', 'Trip ID')
+    return data_headers, data_list, source_path
 
 
+@artifact_processor
+def get_TripWaypoints(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for file_found, data in _iter_trip_files(files_found):
+        source_path = file_found
+        for event in data.get('events', []):
+            trip_id = event.get('tripId', '')
+            for waypoint in event.get('waypoints', []):
+                data_list.append((waypoint.get('lat', ''), waypoint.get('lon', ''), waypoint.get('accuracy', ''), trip_id))
 
-
-
-
-
-
-    
-
-
-
+    data_headers = ('Latitude', 'Longitude', 'Accuracy (m)', 'Trip ID')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Splits the Life360 DriverBehavior trips parser into two decorated artifacts (shared category `Life360DriverBehavior`):

- **Life360 Driver Behavior - Trip Events** — per-event row with location + speed metrics. **Fixed the timestamp**: the original used `datetime.fromtimestamp(...)` with no timezone (machine-local) and defaulted missing values to epoch 0 → now tz-aware UTC, blank when absent; `Timestamp` marked `datetime`. m/s→mph conversions kept (refactored into a `_mps_to_mph` helper).
- **Life360 Driver Behavior - Trip Waypoints** — lat/lon/accuracy per trip.

Dropped the per-trip combined `Trip_<id>_Combined` TSV side-output (a bespoke extra-file feature that doesn't map to the LAVA/table model); the framework still emits standard TSV per artifact. Shared file-iteration via `_iter_trip_files` (keeps the path normalization + JSON-decode guard).

Verified: byte-compile, both functions decorated with 4-arg signature, return 3-tuples, output_types valid, unique names + shared category, loader builds (417 plugins), pylint clean.