### PR TITLE
Harden XML parsing against invalid tokens (batch 1/4)

### DIFF
--- a/scripts/artifacts/atrackerdetect.py
+++ b/scripts/artifacts/atrackerdetect.py
@@ -15,9 +15,28 @@ __artifacts_v2__ = {
     }
 }
 
+import re
 import xml.etree.ElementTree as ET
 
-from scripts.ilapfuncs import artifact_processor
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+
+INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
+
+
+def _parse_xml(file_found):
+    """Parse XML, recovering from invalid tokens / unescaped ampersands; empty element if unparseable."""
+    try:
+        return ET.parse(file_found).getroot()
+    except ET.ParseError:
+        with open(file_found, encoding='utf-8', errors='replace') as f:
+            xml = BARE_AMPERSAND.sub('&amp;', INVALID_XML_CHARS.sub('', f.read()))
+        try:
+            return ET.fromstring(xml)
+        except ET.ParseError as ex:
+            logfunc(f'Skipping unparseable XML {file_found}: {ex}')
+            return ET.Element('empty')
 
 
 @artifact_processor
@@ -28,7 +47,7 @@ def get_atrackerdetect(files_found, report_folder, seeker, wrap_text):
     for file_found in files_found:
         file_found = str(file_found)
         source_path = file_found
-        root = ET.parse(file_found).getroot()
+        root = _parse_xml(file_found)
 
         for elem in root.iter():
             attribute = elem.attrib

--- a/scripts/artifacts/gmail.py
+++ b/scripts/artifacts/gmail.py
@@ -15,9 +15,28 @@ __artifacts_v2__ = {
     }
 }
 
+import re
 import xml.etree.ElementTree as ET
 
 from scripts.ilapfuncs import artifact_processor, logfunc
+
+
+INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
+
+
+def _parse_xml(file_found):
+    """Parse XML, recovering from invalid tokens / unescaped ampersands; empty element if unparseable."""
+    try:
+        return ET.parse(file_found).getroot()
+    except ET.ParseError:
+        with open(file_found, encoding='utf-8', errors='replace') as f:
+            xml = BARE_AMPERSAND.sub('&amp;', INVALID_XML_CHARS.sub('', f.read()))
+        try:
+            return ET.fromstring(xml)
+        except ET.ParseError as ex:
+            logfunc(f'Skipping unparseable XML {file_found}: {ex}')
+            return ET.Element('empty')
 
 
 @artifact_processor
@@ -25,7 +44,7 @@ def get_gmailActive(files_found, report_folder, seeker, wrap_text):
 
     data_list = []
     source_path = str(files_found[0])
-    root = ET.parse(source_path).getroot()
+    root = _parse_xml(source_path)
     for child in root:
         if child.attrib['name'] == "active-account":
             logfunc("Active gmail account found: " + child.text)

--- a/scripts/artifacts/kijijiLocalUserInfo.py
+++ b/scripts/artifacts/kijijiLocalUserInfo.py
@@ -15,6 +15,7 @@ __artifacts_v2__ = {
     }
 }
 
+import re
 import xml.etree.ElementTree as ET
 
 from scripts.ilapfuncs import artifact_processor, logfunc
@@ -34,12 +35,30 @@ def TryGetStringValue(root, xPathExpression):
     return GetFirstChild(elems)
 
 
+INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
+
+
+def _parse_xml(file_found):
+    """Parse XML, recovering from invalid tokens / unescaped ampersands; empty element if unparseable."""
+    try:
+        return ET.parse(file_found).getroot()
+    except ET.ParseError:
+        with open(file_found, encoding='utf-8', errors='replace') as f:
+            xml = BARE_AMPERSAND.sub('&amp;', INVALID_XML_CHARS.sub('', f.read()))
+        try:
+            return ET.fromstring(xml)
+        except ET.ParseError as ex:
+            logfunc(f'Skipping unparseable XML {file_found}: {ex}')
+            return ET.Element('empty')
+
+
 @artifact_processor
 def get_kijijiLocalUserInfo(files_found, report_folder, seeker, wrap_text):
     source_path = str(files_found[0])
     logfunc(f'XML file {source_path} is being interrogated...')
 
-    root = ET.parse(source_path).getroot()
+    root = _parse_xml(source_path)
     userEmailAddress = TryGetStringValue(root, userEmailXPath)  # May be available when logged-in/out.
     loggedInAsUser = TryGetStringValue(root, loggedInUserXPath)
     userDisplayName = TryGetStringValue(root, userDisplayNameXPath)

--- a/scripts/artifacts/setupWizardinfo.py
+++ b/scripts/artifacts/setupWizardinfo.py
@@ -16,9 +16,28 @@ __artifacts_v2__ = {
 }
 
 import datetime
+import re
 import xml.etree.ElementTree as ET
 
-from scripts.ilapfuncs import artifact_processor
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+
+INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
+
+
+def _parse_xml(file_found):
+    """Parse XML, recovering from invalid tokens / unescaped ampersands; empty element if unparseable."""
+    try:
+        return ET.parse(file_found).getroot()
+    except ET.ParseError:
+        with open(file_found, encoding='utf-8', errors='replace') as f:
+            xml = BARE_AMPERSAND.sub('&amp;', INVALID_XML_CHARS.sub('', f.read()))
+        try:
+            return ET.fromstring(xml)
+        except ET.ParseError as ex:
+            logfunc(f'Skipping unparseable XML {file_found}: {ex}')
+            return ET.Element('empty')
 
 
 @artifact_processor
@@ -32,7 +51,7 @@ def get_setupWizardinfo(files_found, report_folder, seeker, wrap_text):
             continue  # Skip all other files
 
         source_path = file_found
-        root = ET.parse(file_found).getroot()
+        root = _parse_xml(file_found)
         for elem in root:
             item = elem.attrib
             if item['name'] == 'suw_finished_time_ms':

--- a/scripts/artifacts/suggestions.py
+++ b/scripts/artifacts/suggestions.py
@@ -16,15 +16,34 @@ __artifacts_v2__ = {
 }
 
 import datetime
+import re
 import xml.etree.ElementTree as ET
 
-from scripts.ilapfuncs import artifact_processor
+from scripts.ilapfuncs import artifact_processor, logfunc
 
 SETUP_TIME_KEYS = (
     'com.android.settings.suggested.category.DEFERRED_SETUP_setup_time',
     'com.android.settings/com.android.settings.biometrics.fingerprint.FingerprintEnrollSuggestionActivity_setup_time',
     'com.google.android.setupwizard/com.google.android.setupwizard.deferred.DeferredSettingsSuggestionActivity_setup_time',
 )
+
+
+INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
+
+
+def _parse_xml(file_found):
+    """Parse XML, recovering from invalid tokens / unescaped ampersands; empty element if unparseable."""
+    try:
+        return ET.parse(file_found).getroot()
+    except ET.ParseError:
+        with open(file_found, encoding='utf-8', errors='replace') as f:
+            xml = BARE_AMPERSAND.sub('&amp;', INVALID_XML_CHARS.sub('', f.read()))
+        try:
+            return ET.fromstring(xml)
+        except ET.ParseError as ex:
+            logfunc(f'Skipping unparseable XML {file_found}: {ex}')
+            return ET.Element('empty')
 
 
 @artifact_processor
@@ -38,7 +57,7 @@ def get_suggestions(files_found, report_folder, seeker, wrap_text):
             continue  # Skip all other files
 
         source_path = file_found
-        root = ET.parse(file_found).getroot()
+        root = _parse_xml(file_found)
         for elem in root:
             item = elem.attrib
             if item['name'] in SETUP_TIME_KEYS:

--- a/scripts/artifacts/ulrUserprefs.py
+++ b/scripts/artifacts/ulrUserprefs.py
@@ -15,9 +15,28 @@ __artifacts_v2__ = {
     }
 }
 
+import re
 import xml.etree.ElementTree as ET
 
-from scripts.ilapfuncs import artifact_processor
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+
+INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
+
+
+def _parse_xml(file_found):
+    """Parse XML, recovering from invalid tokens / unescaped ampersands; empty element if unparseable."""
+    try:
+        return ET.parse(file_found).getroot()
+    except ET.ParseError:
+        with open(file_found, encoding='utf-8', errors='replace') as f:
+            xml = BARE_AMPERSAND.sub('&amp;', INVALID_XML_CHARS.sub('', f.read()))
+        try:
+            return ET.fromstring(xml)
+        except ET.ParseError as ex:
+            logfunc(f'Skipping unparseable XML {file_found}: {ex}')
+            return ET.Element('empty')
 
 
 @artifact_processor
@@ -31,7 +50,7 @@ def get_urluser(files_found, report_folder, seeker, wrap_text):
             continue
 
         source_path = file_found
-        root = ET.parse(file_found).getroot()
+        root = _parse_xml(file_found)
         for child in root:
             jsondata = child.attrib
             name = jsondata['name']

--- a/scripts/artifacts/usageHistory.py
+++ b/scripts/artifacts/usageHistory.py
@@ -16,9 +16,28 @@ __artifacts_v2__ = {
 }
 
 import datetime
+import re
 import xml.etree.ElementTree as ET
 
-from scripts.ilapfuncs import artifact_processor
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+
+INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
+
+
+def _parse_xml(file_found):
+    """Parse XML, recovering from invalid tokens / unescaped ampersands; empty element if unparseable."""
+    try:
+        return ET.parse(file_found).getroot()
+    except ET.ParseError:
+        with open(file_found, encoding='utf-8', errors='replace') as f:
+            xml = BARE_AMPERSAND.sub('&amp;', INVALID_XML_CHARS.sub('', f.read()))
+        try:
+            return ET.fromstring(xml)
+        except ET.ParseError as ex:
+            logfunc(f'Skipping unparseable XML {file_found}: {ex}')
+            return ET.Element('empty')
 
 
 @artifact_processor
@@ -33,7 +52,7 @@ def get_usageHistory(files_found, report_folder, seeker, wrap_text):
 
     data_list = []
     if source_path:
-        root = ET.parse(source_path).getroot()
+        root = _parse_xml(source_path)
         for elem in root:
             for subelem in elem:
                 pkg = elem.attrib['name']


### PR DESCRIPTION
Follow-up to the settingsSecure invalid-XML fix: applies the same recovery to other converted `ET.parse` artifacts so a malformed XML file (raw control characters, unescaped `&`) no longer errors the artifact.

Each file gains a local `_parse_xml(file_found)` helper that, on `ParseError`, strips XML-1.0-invalid control chars, escapes bare ampersands, and re-parses; if still unparseable it logs and returns an empty element (so the artifact yields no rows for that file instead of crashing).

**Batch 1 (7 prefs/settings XML parsers):** gmail, kijijiLocalUserInfo, usageHistory, atrackerdetect, ulrUserprefs, suggestions, setupWizardinfo.

Tested: each `_parse_xml` recovers a file containing a control char + bare ampersand (returns the real root), parses normal files unchanged, no recursion, loader builds (417), pylint clean. More batches to follow for the remaining ET.parse artifacts.