### PR TITLE
Harden XML parsing against invalid tokens (batch 2/4)

### DIFF
--- a/scripts/artifacts/GarminUser.py
+++ b/scripts/artifacts/GarminUser.py
@@ -20,6 +20,7 @@ __artifacts_v2__ = {
 # Date: 2023-02-24
 # Version: 1.0
 # Requirements: Python 3.7 or higher and ElementTree
+import re
 import xml.etree.ElementTree as ET
 
 from scripts.ilapfuncs import artifact_processor, logfunc
@@ -33,6 +34,24 @@ def remove_whitespace_from_xml_first_line(xml_file):
     lines[0] = '<?xml version=\'1.0\' encoding=\'utf-8\' standalone=\'yes\' ?>\n'
     with open(xml_file, 'w', encoding='utf-8') as f:
         f.writelines(lines)
+
+
+INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
+
+
+def _parse_xml(file_found):
+    """Parse XML, recovering from invalid tokens / unescaped ampersands; empty element if unparseable."""
+    try:
+        return ET.parse(file_found).getroot()
+    except ET.ParseError:
+        with open(file_found, encoding='utf-8', errors='replace') as f:
+            xml = BARE_AMPERSAND.sub('&amp;', INVALID_XML_CHARS.sub('', f.read()))
+        try:
+            return ET.fromstring(xml)
+        except ET.ParseError as ex:
+            logfunc(f'Skipping unparseable XML {file_found}: {ex}')
+            return ET.Element('empty')
 
 
 @artifact_processor
@@ -52,8 +71,7 @@ def get_garminUP(files_found, report_folder, seeker, wrap_text):
     logfunc("Processing file: " + source_path)
     # File is not well formatted, remove first element from first line
     remove_whitespace_from_xml_first_line(source_path)
-    tree = ET.parse(source_path)
-    root = tree.getroot()
+    root = _parse_xml(source_path)
     for child in root:
         for i in attribute:
             if child.attrib["name"] == i:

--- a/scripts/artifacts/LinkedIn.py
+++ b/scripts/artifacts/LinkedIn.py
@@ -46,9 +46,28 @@ __artifacts_v2__ = {
 
 # Requirements:  json, xml
 import json
+import re
 import xml.etree.ElementTree as ET
 
-from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records, logfunc
+
+INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
+
+
+def _parse_xml(file_found):
+    """Parse XML, recovering from invalid tokens / unescaped ampersands; empty element if unparseable."""
+    try:
+        return ET.parse(file_found).getroot()
+    except ET.ParseError:
+        with open(file_found, encoding='utf-8', errors='replace') as f:
+            xml = BARE_AMPERSAND.sub('&amp;', INVALID_XML_CHARS.sub('', f.read()))
+        try:
+            return ET.fromstring(xml)
+        except ET.ParseError as ex:
+            logfunc(f'Skipping unparseable XML {file_found}: {ex}')
+            return ET.Element('empty')
+
 
 @artifact_processor
 def linkedin_account(files_found, _report_folder, _seeker, _wrap_text):
@@ -56,8 +75,7 @@ def linkedin_account(files_found, _report_folder, _seeker, _wrap_text):
     # Get data from xml into a dict to work with
     xml_dict = {}
     with open(files_found[0], 'rb') as xml_file:
-        tree = ET.parse(xml_file)
-        root = tree.getroot()
+        root = _parse_xml(xml_file)
         for elem in root:
             name = elem.attrib.get('name')
 

--- a/scripts/artifacts/citymapper.py
+++ b/scripts/artifacts/citymapper.py
@@ -53,10 +53,29 @@ __artifacts_v2__ = {
 # Requirements: Python 3.7 or higher, folium
 import os
 import folium
+import re
 import xml.etree.ElementTree as ET
 
 from scripts.artifact_report import ArtifactHtmlReport
 from scripts.ilapfuncs import artifact_processor, logfunc, kmlgen, open_sqlite_db_readonly, convert_unix_ts_to_utc
+
+INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
+
+
+def _parse_xml(file_found):
+    """Parse XML, recovering from invalid tokens / unescaped ampersands; empty element if unparseable."""
+    try:
+        return ET.parse(file_found).getroot()
+    except ET.ParseError:
+        with open(file_found, encoding='utf-8', errors='replace') as f:
+            xml = BARE_AMPERSAND.sub('&amp;', INVALID_XML_CHARS.sub('', f.read()))
+        try:
+            return ET.fromstring(xml)
+        except ET.ParseError as ex:
+            logfunc(f'Skipping unparseable XML {file_found}: {ex}')
+            return ET.Element('empty')
+
 
 @artifact_processor
 def get_citymapperLocationHistory(files_found, report_folder, _seeker, _wrap_text):
@@ -372,8 +391,7 @@ def get_citymapperAppPreferences(files_found, report_folder, _seeker, _wrap_text
             source = file_found
 
         try:
-            tree = ET.parse(file_found)
-            root = tree.getroot()
+            root = _parse_xml(file_found)
             
             for child in root:
                 name = child.attrib.get('name', '')


### PR DESCRIPTION
Continues the invalid-XML hardening (see batch 1). Each artifact gains a local `_parse_xml` recovery helper: on `ParseError` it strips XML-1.0-invalid control chars, escapes bare ampersands, re-parses, and returns an empty element (logged) if still unparseable.

**Batch 2:** citymapper, LinkedIn, GarminUser — collapsed their `tree = ET.parse(); root = tree.getroot()` into `root = _parse_xml()`.

Note: OrnetBrowser, Grok and TorBrowser also use `ET.parse` but carry substantial *pre-existing* pylint W-level debt (bad indentation, unused args, broad excepts) that `lint-changed-files` would flag the moment they're touched — they need a separate lint cleanup and are intentionally excluded here.

Tested: each `_parse_xml` recovers a control-char + bare-ampersand file (returns real root), parses normal files unchanged, CI-style pylint (`--disable=C,R`) shows 0 W/E, loader builds (417).