### PR TITLE
Harden XML parsing against invalid tokens (batch 3/4)

### DIFF
--- a/scripts/artifacts/appopSetupWiz.py
+++ b/scripts/artifacts/appopSetupWiz.py
@@ -16,9 +16,28 @@ __artifacts_v2__ = {
 }
 
 import datetime
+import re
 import xml.etree.ElementTree as ET
 
-from scripts.ilapfuncs import artifact_processor, abxread, checkabx
+from scripts.ilapfuncs import artifact_processor, abxread, checkabx, logfunc
+
+
+INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
+
+
+def _parse_xml(file_found):
+    """Parse XML, recovering from invalid tokens / unescaped ampersands; empty element if unparseable."""
+    try:
+        return ET.parse(file_found).getroot()
+    except ET.ParseError:
+        with open(file_found, encoding='utf-8', errors='replace') as f:
+            xml = BARE_AMPERSAND.sub('&amp;', INVALID_XML_CHARS.sub('', f.read()))
+        try:
+            return ET.fromstring(xml)
+        except ET.ParseError as ex:
+            logfunc(f'Skipping unparseable XML {file_found}: {ex}')
+            return ET.Element('empty')
 
 
 @artifact_processor
@@ -35,10 +54,9 @@ def get_appopSetupWiz(files_found, report_folder, seeker, wrap_text):
         # check if file is abx
         if (checkabx(file_found)):
             multi_root = False
-            tree = abxread(file_found, multi_root)
+            root = abxread(file_found, multi_root).getroot()
         else:
-            tree = ET.parse(file_found)
-        root = tree.getroot()
+            root = _parse_xml(file_found)
 
         for elem in root.iter('pkg'):
             if elem.attrib['n'] == 'com.google.android.setupwizard':

--- a/scripts/artifacts/discreteNative.py
+++ b/scripts/artifacts/discreteNative.py
@@ -18,9 +18,10 @@ __artifacts_v2__ = {
 import datetime
 import os
 import pathlib
+import re
 import xml.etree.ElementTree as ET
 
-from scripts.ilapfuncs import artifact_processor, abxread, checkabx
+from scripts.ilapfuncs import artifact_processor, abxread, checkabx, logfunc
 
 
 def oplist(opvalue):
@@ -41,6 +42,24 @@ def timestampcalc(timevalue):
     return datetime.datetime.fromtimestamp(int(timevalue) / 1000, datetime.timezone.utc)
 
 
+INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
+
+
+def _parse_xml(file_found):
+    """Parse XML, recovering from invalid tokens / unescaped ampersands; empty element if unparseable."""
+    try:
+        return ET.parse(file_found).getroot()
+    except ET.ParseError:
+        with open(file_found, encoding='utf-8', errors='replace') as f:
+            xml = BARE_AMPERSAND.sub('&amp;', INVALID_XML_CHARS.sub('', f.read()))
+        try:
+            return ET.fromstring(xml)
+        except ET.ParseError as ex:
+            logfunc(f'Skipping unparseable XML {file_found}: {ex}')
+            return ET.Element('empty')
+
+
 @artifact_processor
 def get_discreteNative(files_found, report_folder, seeker, wrap_text):
     data_list = []
@@ -55,10 +74,9 @@ def get_discreteNative(files_found, report_folder, seeker, wrap_text):
         source_path = file_found
         if (checkabx(file_found)):
             multi_root = False
-            tree = abxread(file_found, multi_root)
+            root = abxread(file_found, multi_root).getroot()
         else:
-            tree = ET.parse(file_found)
-        root = tree.getroot()
+            root = _parse_xml(file_found)
 
         for elem in root:
             for subelem1 in elem:

--- a/scripts/artifacts/permissions.py
+++ b/scripts/artifacts/permissions.py
@@ -41,6 +41,7 @@ __artifacts_v2__ = {
     }
 }
 
+import re
 import xml.etree.ElementTree as ET
 
 from scripts.ilapfuncs import artifact_processor, logfunc, is_platform_windows, abxread, checkabx
@@ -53,15 +54,29 @@ def _iter_roots(files_found):
         file_found = str(file_found)
         if 'mirror' in file_found.split(slash):
             continue
+        if (checkabx(file_found)):
+            root = abxread(file_found, False).getroot()
+        else:
+            root = _parse_xml(file_found)
+        yield root, file_found
+
+
+INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
+
+
+def _parse_xml(file_found):
+    """Parse XML, recovering from invalid tokens / unescaped ampersands; empty element if unparseable."""
+    try:
+        return ET.parse(file_found).getroot()
+    except ET.ParseError:
+        with open(file_found, encoding='utf-8', errors='replace') as f:
+            xml = BARE_AMPERSAND.sub('&amp;', INVALID_XML_CHARS.sub('', f.read()))
         try:
-            if (checkabx(file_found)):
-                tree = abxread(file_found, False)
-            else:
-                tree = ET.parse(file_found)
-        except ET.ParseError:
-            logfunc('Parse error - Non XML file.')
-            continue
-        yield tree.getroot(), file_found
+            return ET.fromstring(xml)
+        except ET.ParseError as ex:
+            logfunc(f'Skipping unparseable XML {file_found}: {ex}')
+            return ET.Element('empty')
 
 
 @artifact_processor

--- a/scripts/artifacts/roles.py
+++ b/scripts/artifacts/roles.py
@@ -15,9 +15,28 @@ __artifacts_v2__ = {
     }
 }
 
+import re
 import xml.etree.ElementTree as ET
 
 from scripts.ilapfuncs import artifact_processor, logfunc, is_platform_windows
+
+
+INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
+
+
+def _parse_xml(file_found):
+    """Parse XML, recovering from invalid tokens / unescaped ampersands; empty element if unparseable."""
+    try:
+        return ET.parse(file_found).getroot()
+    except ET.ParseError:
+        with open(file_found, encoding='utf-8', errors='replace') as f:
+            xml = BARE_AMPERSAND.sub('&amp;', INVALID_XML_CHARS.sub('', f.read()))
+        try:
+            return ET.fromstring(xml)
+        except ET.ParseError as ex:
+            logfunc(f'Skipping unparseable XML {file_found}: {ex}')
+            return ET.Element('empty')
 
 
 @artifact_processor
@@ -43,14 +62,8 @@ def get_roles(files_found, report_folder, seeker, wrap_text):
         else:
             continue
 
-        try:
-            tree = ET.parse(file_found)
-        except ET.ParseError:
-            logfunc('Parse error - Non XML file.')
-            continue
-
         source_path = file_found
-        root = tree.getroot()
+        root = _parse_xml(file_found)
         for elem in root:
             holder = ''
             role = elem.attrib['name']

--- a/scripts/artifacts/runtimePerms.py
+++ b/scripts/artifacts/runtimePerms.py
@@ -15,9 +15,28 @@ __artifacts_v2__ = {
     }
 }
 
+import re
 import xml.etree.ElementTree as ET
 
 from scripts.ilapfuncs import artifact_processor, logfunc, is_platform_windows
+
+
+INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
+
+
+def _parse_xml(file_found):
+    """Parse XML, recovering from invalid tokens / unescaped ampersands; empty element if unparseable."""
+    try:
+        return ET.parse(file_found).getroot()
+    except ET.ParseError:
+        with open(file_found, encoding='utf-8', errors='replace') as f:
+            xml = BARE_AMPERSAND.sub('&amp;', INVALID_XML_CHARS.sub('', f.read()))
+        try:
+            return ET.fromstring(xml)
+        except ET.ParseError as ex:
+            logfunc(f'Skipping unparseable XML {file_found}: {ex}')
+            return ET.Element('empty')
 
 
 @artifact_processor
@@ -40,14 +59,8 @@ def get_runtimePerms(files_found, report_folder, seeker, wrap_text):
         else:
             continue
 
-        try:
-            tree = ET.parse(file_found)
-        except ET.ParseError:
-            logfunc('Parse error - Non XML file.')
-            continue
-
         source_path = file_found
-        root = tree.getroot()
+        root = _parse_xml(file_found)
         for elem in root:
             usagetype = elem.tag
             name = elem.attrib['name']


### PR DESCRIPTION
Continues the invalid-XML hardening for the **system XML** parsers (packages.xml, appops.xml, roles.xml, runtime-permissions.xml, appops/discrete) — the highest-risk files since their values contain arbitrary user/app data.

**Batch 3:** roles, runtimePerms, permissions, appopSetupWiz, discreteNative.

- Non-ABX paths now route through the `_parse_xml` recovery helper (strip invalid control chars / escape bare `&` / re-parse; empty element if still unparseable).
- ABX paths are unchanged (`abxread(...).getroot()`).
- roles/runtimePerms/permissions previously **skipped** a malformed file on `ParseError` (losing its data); they now **recover** it where possible. appopSetupWiz/discreteNative previously had no recovery and would error the artifact — now hardened.

Tested: each recovers a control-char + bare-ampersand file (returns real root), ABX branch intact, decorated 4-arg signatures, CI-style pylint (`--disable=C,R`) 0 W/E, loader builds (417).