### PR TITLE
Harden XML parsing against invalid tokens (batch 4/4)

### DIFF
--- a/scripts/artifacts/ChessComAccount.py
+++ b/scripts/artifacts/ChessComAccount.py
@@ -16,9 +16,28 @@ __artifacts_v2__ = {
 }
 
 import datetime
+import re
 import xml.etree.ElementTree as ET
 
-from scripts.ilapfuncs import artifact_processor
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+
+INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
+
+
+def _parse_xml(file_found):
+    """Parse XML, recovering from invalid tokens / unescaped ampersands; empty element if unparseable."""
+    try:
+        return ET.parse(file_found).getroot()
+    except ET.ParseError:
+        with open(file_found, encoding='utf-8', errors='replace') as f:
+            xml = BARE_AMPERSAND.sub('&amp;', INVALID_XML_CHARS.sub('', f.read()))
+        try:
+            return ET.fromstring(xml)
+        except ET.ParseError as ex:
+            logfunc(f'Skipping unparseable XML {file_found}: {ex}')
+            return ET.Element('empty')
 
 
 @artifact_processor
@@ -39,7 +58,7 @@ def get_ChessComAccount(files_found, report_folder, seeker, wrap_text):
     # Login credentials
     if credentials_file:
         source_path = credentials_file
-        cred_root = ET.parse(credentials_file).getroot()
+        cred_root = _parse_xml(credentials_file)
         for item in cred_root.findall("string"):
             key = item.attrib.get("name")
             value = item.text
@@ -50,7 +69,7 @@ def get_ChessComAccount(files_found, report_folder, seeker, wrap_text):
     if session_file:
         if not source_path:
             source_path = session_file
-        sesh_root = ET.parse(session_file).getroot()
+        sesh_root = _parse_xml(session_file)
         for item in sesh_root.findall("string"):
             key = item.attrib.get("name")
             value = item.text

--- a/scripts/artifacts/ChessComGames.py
+++ b/scripts/artifacts/ChessComGames.py
@@ -16,9 +16,28 @@ __artifacts_v2__ = {
 }
 
 import datetime
+import re
 import xml.etree.ElementTree as ET
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, logfunc
+
+
+INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
+
+
+def _parse_xml(file_found):
+    """Parse XML, recovering from invalid tokens / unescaped ampersands; empty element if unparseable."""
+    try:
+        return ET.parse(file_found).getroot()
+    except ET.ParseError:
+        with open(file_found, encoding='utf-8', errors='replace') as f:
+            xml = BARE_AMPERSAND.sub('&amp;', INVALID_XML_CHARS.sub('', f.read()))
+        try:
+            return ET.fromstring(xml)
+        except ET.ParseError as ex:
+            logfunc(f'Skipping unparseable XML {file_found}: {ex}')
+            return ET.Element('empty')
 
 
 @artifact_processor
@@ -28,7 +47,7 @@ def get_ChessComGames(files_found, report_folder, seeker, wrap_text):
     username = "None"
     session_files = [str(x) for x in files_found if str(x).endswith('.xml')]
     if session_files:
-        sesh_root = ET.parse(session_files[0]).getroot()
+        sesh_root = _parse_xml(session_files[0])
         for item in sesh_root.findall("string"):
             if item.attrib.get("name") == "pref_username":
                 username = item.text

--- a/scripts/artifacts/bittorrentClientpref.py
+++ b/scripts/artifacts/bittorrentClientpref.py
@@ -16,14 +16,33 @@ __artifacts_v2__ = {
 }
 
 import datetime
+import re
 import xml.etree.ElementTree as ET
 
-from scripts.ilapfuncs import artifact_processor, abxread, checkabx
+from scripts.ilapfuncs import artifact_processor, abxread, checkabx, logfunc
 
 
 def timestampcalc(timevalue):
     timestamp = (datetime.datetime.fromtimestamp(int(timevalue)/1000, datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S'))
     return timestamp
+
+
+INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
+
+
+def _parse_xml(file_found):
+    """Parse XML, recovering from invalid tokens / unescaped ampersands; empty element if unparseable."""
+    try:
+        return ET.parse(file_found).getroot()
+    except ET.ParseError:
+        with open(file_found, encoding='utf-8', errors='replace') as f:
+            xml = BARE_AMPERSAND.sub('&amp;', INVALID_XML_CHARS.sub('', f.read()))
+        try:
+            return ET.fromstring(xml)
+        except ET.ParseError as ex:
+            logfunc(f'Skipping unparseable XML {file_found}: {ex}')
+            return ET.Element('empty')
 
 
 @artifact_processor
@@ -37,11 +56,10 @@ def get_bittorrentClientpref(files_found, report_folder, seeker, wrap_text):
         # check if file is abx
         if (checkabx(file_found)):
             multi_root = False
-            tree = abxread(file_found, multi_root)
+            root = abxread(file_found, multi_root).getroot()
         else:
-            tree = ET.parse(file_found)
+            root = _parse_xml(file_found)
 
-        root = tree.getroot()
 
         for elem in root:
             key = elem.attrib['name']

--- a/scripts/artifacts/deviceHealthServices_AppUsage.py
+++ b/scripts/artifacts/deviceHealthServices_AppUsage.py
@@ -16,9 +16,28 @@ __artifacts_v2__ = {
 }
 
 import datetime
+import re
 import xml.etree.ElementTree as ET
 
-from scripts.ilapfuncs import artifact_processor
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+
+INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
+
+
+def _parse_xml(file_found):
+    """Parse XML, recovering from invalid tokens / unescaped ampersands; empty element if unparseable."""
+    try:
+        return ET.parse(file_found).getroot()
+    except ET.ParseError:
+        with open(file_found, encoding='utf-8', errors='replace') as f:
+            xml = BARE_AMPERSAND.sub('&amp;', INVALID_XML_CHARS.sub('', f.read()))
+        try:
+            return ET.fromstring(xml)
+        except ET.ParseError as ex:
+            logfunc(f'Skipping unparseable XML {file_found}: {ex}')
+            return ET.Element('empty')
 
 
 @artifact_processor
@@ -29,7 +48,7 @@ def get_Turbo_AppUsage(files_found, report_folder, seeker, wrap_text):
     for file_found in files_found:
         file_found = str(file_found)
         source_path = file_found
-        tree = ET.parse(file_found)
+        tree = _parse_xml(file_found)
 
         for elem in tree.iter(tag='string'):
             splits = elem.text.split('#')

--- a/scripts/artifacts/mewe.py
+++ b/scripts/artifacts/mewe.py
@@ -29,9 +29,10 @@ __artifacts_v2__ = {
 }
 
 import datetime
+import re
 import xml.etree.ElementTree as ET
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, logfunc
 
 # Module-level constants (kept for backwards-compatibility; snapchat.py imports APP_NAME)
 APP_NAME = 'MeWe'
@@ -53,6 +54,24 @@ CHAT_MESSAGES_QUERY = '''
     FROM CHAT_MESSAGE
     JOIN CHAT_THREAD ON threadId = CHAT_THREAD.id
 '''
+
+
+INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
+
+
+def _parse_xml(file_found):
+    """Parse XML, recovering from invalid tokens / unescaped ampersands; empty element if unparseable."""
+    try:
+        return ET.parse(file_found).getroot()
+    except ET.ParseError:
+        with open(file_found, encoding='utf-8', errors='replace') as f:
+            xml = BARE_AMPERSAND.sub('&amp;', INVALID_XML_CHARS.sub('', f.read()))
+        try:
+            return ET.fromstring(xml)
+        except ET.ParseError as ex:
+            logfunc(f'Skipping unparseable XML {file_found}: {ex}')
+            return ET.Element('empty')
 
 
 @artifact_processor
@@ -94,7 +113,7 @@ def get_mewe_session(files_found, report_folder, seeker, wrap_text):
             continue
 
         source_path = file_found
-        root = ET.parse(file_found).getroot()
+        root = _parse_xml(file_found)
         for node in root:
             if '.' in node.attrib['name']:
                 continue  # skip not relevant keys

--- a/scripts/artifacts/protonVPN.py
+++ b/scripts/artifacts/protonVPN.py
@@ -46,7 +46,25 @@ import socket
 import datetime
 import xml.etree.ElementTree as ET
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, device_info, checkabx, abxread, convert_human_ts_to_utc
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, device_info, checkabx, abxread, convert_human_ts_to_utc, logfunc
+
+
+INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
+
+
+def _parse_xml(file_found):
+    """Parse XML, recovering from invalid tokens / unescaped ampersands; empty element if unparseable."""
+    try:
+        return ET.parse(file_found).getroot()
+    except ET.ParseError:
+        with open(file_found, encoding='utf-8', errors='replace') as f:
+            xml = BARE_AMPERSAND.sub('&amp;', INVALID_XML_CHARS.sub('', f.read()))
+        try:
+            return ET.fromstring(xml)
+        except ET.ParseError as ex:
+            logfunc(f'Skipping unparseable XML {file_found}: {ex}')
+            return ET.Element('empty')
 
 
 @artifact_processor
@@ -60,11 +78,10 @@ def get_protonvpn_device_info(files_found, report_folder, seeker, wrap_text):
 
             if (checkabx(file_found)):
                 multi_root = False
-                tree = abxread(file_found, multi_root)
+                root = abxread(file_found, multi_root).getroot()
             else:
-                tree = ET.parse(file_found)
+                root = _parse_xml(file_found)
 
-            root = tree.getroot()
 
             for elem in root.iter():
                 if elem.attrib.get('name') is not None:

--- a/scripts/artifacts/rarlabPreferences.py
+++ b/scripts/artifacts/rarlabPreferences.py
@@ -17,9 +17,28 @@ __artifacts_v2__ = {
 }
 
 import json
+import re
 import xml.etree.ElementTree as ET
 
-from scripts.ilapfuncs import artifact_processor, abxread, checkabx
+from scripts.ilapfuncs import artifact_processor, abxread, checkabx, logfunc
+
+
+INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
+
+
+def _parse_xml(file_found):
+    """Parse XML, recovering from invalid tokens / unescaped ampersands; empty element if unparseable."""
+    try:
+        return ET.parse(file_found).getroot()
+    except ET.ParseError:
+        with open(file_found, encoding='utf-8', errors='replace') as f:
+            xml = BARE_AMPERSAND.sub('&amp;', INVALID_XML_CHARS.sub('', f.read()))
+        try:
+            return ET.fromstring(xml)
+        except ET.ParseError as ex:
+            logfunc(f'Skipping unparseable XML {file_found}: {ex}')
+            return ET.Element('empty')
 
 
 @artifact_processor
@@ -35,10 +54,9 @@ def get_rarlabPreferences(files_found, report_folder, seeker, wrap_text):
             # check if file is abx
             if (checkabx(file_found)):
                 multi_root = False
-                tree = abxread(file_found, multi_root)
+                root = abxread(file_found, multi_root).getroot()
             else:
-                tree = ET.parse(file_found)
-            root = tree.getroot()
+                root = _parse_xml(file_found)
 
             for elem in root.iter():
                 name = elem.attrib.get('name')


### PR DESCRIPTION
Final batch of the invalid-XML hardening — the remaining app-config XML parsers.

**Batch 4:** protonVPN, rarlabPreferences, bittorrentClientpref (ABX-aware), ChessComAccount, ChessComGames, mewe, deviceHealthServices_AppUsage.

Each routes its `ET.parse` through the `_parse_xml` recovery helper (strip invalid control chars / escape bare `&` / re-parse; empty element if still unparseable). ABX paths unchanged.

This completes the hardening across the converted `ET.parse` artifacts. **Excluded:** OrnetBrowser, Grok, TorBrowser — they use `ET.parse` too but carry substantial pre-existing pylint W-level debt (bad indentation, unused args, broad excepts) that `lint-changed-files` would flag the moment they're touched; they need a separate lint cleanup first.

Tested: each recovers a control-char + bare-ampersand file (returns real root), decorated 4-arg signatures, mewe's `APP_NAME` export (used by snapchat) intact, CI-style pylint (`--disable=C,R`) 0 W/E, loader builds (417).