### PR TITLE
Convert line (LINE messenger) to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/line.py
+++ b/scripts/artifacts/line.py
@@ -1,7 +1,7 @@
-# pylint: disable=W0104,W0311,W0611,W0613,W0631,W0702,W1309
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_line": {
-        "name": "line",
+        "name": "Line - Contacts",
         "description": "",
         "author": "",
         "creation_date": "2021-03-15",
@@ -10,190 +10,150 @@ __artifacts_v2__ = {
         "category": "Line",
         "notes": "",
         "paths": ('*/jp.naver.line.android/databases/**',),
-        "output_types": None,
+        "output_types": ['html', 'tsv', 'lava'],
+        "artifact_icon": "users",
+    },
+    "get_line_messages": {
+        "name": "Line - Messages",
+        "description": "",
+        "author": "",
+        "creation_date": "2021-03-15",
+        "last_update_date": "2021-03-15",
+        "requirements": "none",
+        "category": "Line",
+        "notes": "",
+        "paths": ('*/jp.naver.line.android/databases/**',),
+        "output_types": "standard",
         "artifact_icon": "message-square",
-        "function": "get_line",
+    },
+    "get_line_calls": {
+        "name": "Line - Call Logs",
+        "description": "",
+        "author": "",
+        "creation_date": "2021-03-15",
+        "last_update_date": "2021-03-15",
+        "requirements": "none",
+        "category": "Line",
+        "notes": "",
+        "paths": ('*/jp.naver.line.android/databases/**',),
+        "output_types": "standard",
+        "artifact_icon": "phone-call",
     }
 }
 
-import sqlite3
 import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
-def get_line(files_found, report_folder, seeker, wrap_text):
 
-    source_file_msg = ''
-    source_file_call = ''
-    line_call_db = ''
-    line_msg_db = ''
-    
+def _sec_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value), datetime.timezone.utc)
+    return ''
+
+
+def _line_dbs(files_found):
+    msg_db = call_db = ''
     for file_found in files_found:
-        
-        file_name = str(file_found)
-        if file_name.lower().endswith('naver_line'):
-           line_msg_db = str(file_found)
-           source_file_msg = file_found.replace(seeker.data_folder, '')
+        file_name = str(file_found).lower()
+        if file_name.endswith('naver_line'):
+            msg_db = str(file_found)
+        elif file_name.endswith('call_history'):
+            call_db = str(file_found)
+    return msg_db, call_db
 
-        if file_name.lower().endswith('call_history'):
-           line_call_db = str(file_found)
-           source_file_call = file_found.replace(seeker.data_folder, '')
 
-    db = open_sqlite_db_readonly(line_msg_db)
-    cursor = db.cursor()
-    try:
-        cursor.execute('''
-                   SELECT m_id, server_name FROM   contacts
-        ''')
+@artifact_processor
+def get_line(files_found, report_folder, seeker, wrap_text):
+    msg_db, _ = _line_dbs(files_found)
+    data_list = []
+    if msg_db:
+        db = open_sqlite_db_readonly(msg_db)
+        cursor = db.cursor()
+        try:
+            cursor.execute('SELECT m_id, server_name FROM contacts')
+            data_list = cursor.fetchall()
+        except Exception as e:
+            logfunc(str(e))
+        db.close()
 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-    except:
-        usageentries = 0
-        
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Line - Contacts')
-        report.start_artifact_report(report_folder, 'Line - Contacts')
-        report.add_script()
-        data_headers = ('user_id','user_name') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = []
+    data_headers = ('user_id', 'user_name')
+    return data_headers, data_list, msg_db
+
+
+@artifact_processor
+def get_line_messages(files_found, report_folder, seeker, wrap_text):
+    msg_db, _ = _line_dbs(files_found)
+    data_list = []
+    if msg_db:
+        db = open_sqlite_db_readonly(msg_db)
+        cursor = db.cursor()
+        try:
+            cursor.execute('''
+                SELECT contact_book_w_groups.id, contact_book_w_groups.members, messages.from_mid,
+                       messages.content, messages.created_time/1000, messages.attachement_type,
+                       messages.attachement_local_uri,
+                       case messages.status when 1 then "Incoming" else "Outgoing" end status
+                FROM   (SELECT id, Group_concat(M.m_id) AS members
+                        FROM   membership AS M GROUP BY id
+                        UNION
+                        SELECT m_id, NULL FROM contacts) AS contact_book_w_groups
+                       JOIN chat_history AS messages ON messages.chat_id = contact_book_w_groups.id
+                WHERE  attachement_type != 6
+            ''')
+            all_rows = cursor.fetchall()
+        except Exception as e:
+            logfunc(str(e))
+            all_rows = []
+        db.close()
+
         for row in all_rows:
-            data_list.append((row[0], row[1]))
-
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Line - Contacts'
-        tsv(report_folder, data_headers, data_list, tsvname, source_file_msg)
-        
-    else:
-        logfunc('No Line Contact Logs found')
-        
-    try:        
-        cursor.execute('''
-                    SELECT contact_book_w_groups.id, 
-                           contact_book_w_groups.members, 
-                           messages.from_mid, 
-                           messages.content, 
-                           messages.created_time/1000, 
-                           messages.attachement_type, 
-                           messages.attachement_local_uri, 
-                           case messages.status when 1 then "Incoming" 
-                           else "Outgoing" end status                           
-                    FROM   (SELECT id, 
-                                   Group_concat(M.m_id) AS members 
-                            FROM   membership AS M 
-                            GROUP  BY id 
-                            UNION 
-                            SELECT m_id, 
-                                   NULL 
-                            FROM   contacts) AS contact_book_w_groups 
-                           JOIN chat_history AS messages 
-                             ON messages.chat_id = contact_book_w_groups.id 
-                    WHERE  attachement_type != 6
-        ''')
-        
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-    except:
-        usageentries = 0
-        
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Line - Messages')
-        report.start_artifact_report(report_folder, 'Line - Messages')
-        report.add_script()
-        data_headers = ('Start Time','From ID', 'To ID', 'Direction', 'Thread ID', 'Message', 'Attachments') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = []
-        for row in all_rows:
-            thread_id = None
-            if row[1] == None:
-                thread_id = row[0]
+            thread_id = row[0] if row[1] is None else None
             to_id = None
-            if row[4] == "Outgoing":
-                if ',' in row[1]:
+            if row[7] == "Outgoing":
+                if row[1] and ',' in row[1]:
                     to_id = row[1]
                 else:
                     to_id = row[0]
             attachment = row[6]
-            if row[6] is None:
+            if attachment is None or 'content' in attachment:
                 attachment = None
-            elif 'content' in row[6]:
-                attachment = None
-            created_time = datetime.datetime.utcfromtimestamp(int(row[4])).strftime('%Y-%m-%d %H:%M:%S')
+            created_time = _sec_to_utc(row[4])
             data_list.append((created_time, row[2], to_id, row[7], thread_id, row[3], attachment))
-            
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Line - Messages'
-        tsv(report_folder, data_headers, data_list, tsvname, source_file_msg)
-        
-        tlactivity = f'Line - Messages'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-    else:
-        logfunc('No Line Messages available')
-            
 
-    db.close()
+    data_headers = (('Start Time', 'datetime'), 'From ID', 'To ID', 'Direction', 'Thread ID', 'Message', 'Attachments')
+    return data_headers, data_list, msg_db
 
-    db = open_sqlite_db_readonly(line_call_db)
-    cursor = db.cursor()
-    cursor.execute('''attach database "''' + line_msg_db + '''" as naver_line ''')
-    try:
-        cursor.execute('''
-                    SELECT case Substr(calls.call_type, -1) when "O" then "Outgoing"
-                           else "Incoming" end AS direction, 
-                           calls.start_time/1000              AS start_time, 
-                           calls.end_time/1000                AS end_time, 
-                           case when Substr(calls.call_type, -1) = "O" then contact_book_w_groups.members 
-                           else null end AS group_members,  
-                           calls.caller_mid, 
-                           case calls.voip_type when "V" then "Video" 
-                              when "A" then "Audio"
-                              when "G" then calls.voip_gc_media_type 
-                           end   AS call_type
-                    FROM   (SELECT id, 
-                                   Group_concat(M.m_id) AS members 
-                            FROM   membership AS M 
-                            GROUP  BY id 
-                            UNION 
-                            SELECT m_id, 
-                                   NULL 
-                            FROM   naver_line.contacts) AS contact_book_w_groups 
-                           JOIN call_history AS calls 
-                             ON calls.caller_mid = contact_book_w_groups.id
 
-        ''')
+@artifact_processor
+def get_line_calls(files_found, report_folder, seeker, wrap_text):
+    msg_db, call_db = _line_dbs(files_found)
+    data_list = []
+    if call_db and msg_db:
+        db = open_sqlite_db_readonly(call_db)
+        cursor = db.cursor()
+        cursor.execute('attach database "' + msg_db + '" as naver_line ')
+        try:
+            cursor.execute('''
+                SELECT case Substr(calls.call_type, -1) when "O" then "Outgoing" else "Incoming" end AS direction,
+                       calls.start_time/1000 AS start_time, calls.end_time/1000 AS end_time,
+                       case when Substr(calls.call_type, -1) = "O" then contact_book_w_groups.members else null end AS group_members,
+                       calls.caller_mid,
+                       case calls.voip_type when "V" then "Video" when "A" then "Audio" when "G" then calls.voip_gc_media_type end AS call_type
+                FROM   (SELECT id, Group_concat(M.m_id) AS members
+                        FROM   membership AS M GROUP BY id
+                        UNION
+                        SELECT m_id, NULL FROM naver_line.contacts) AS contact_book_w_groups
+                       JOIN call_history AS calls ON calls.caller_mid = contact_book_w_groups.id
+            ''')
+            all_rows = cursor.fetchall()
+        except Exception as e:
+            logfunc(str(e))
+            all_rows = []
+        db.close()
 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-    except:
-        usageentries = 0
-        
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Line - Call Logs')
-        report.start_artifact_report(report_folder, 'Line - Call Logs')
-        report.add_script()
-        data_headers = ('Start Time', 'End Time', 'To ID', 'From ID', 'Direction', 'Call Type') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = []
         for row in all_rows:
-            start_time = datetime.datetime.utcfromtimestamp(int(row[1])).strftime('%Y-%m-%d %H:%M:%S')
-            end_time = datetime.datetime.utcfromtimestamp(int(row[2])).strftime('%Y-%m-%d %H:%M:%S')
-            data_list.append((start_time, end_time, row[3], row[4], row[0], row[5]))
+            data_list.append((_sec_to_utc(row[1]), _sec_to_utc(row[2]), row[3], row[4], row[0], row[5]))
 
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Line - Call Logs'
-        tsv(report_folder, data_headers, data_list, tsvname, source_file_call)
-        
-        tlactivity = f'Line - Call Logs'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-
-    else:
-        logfunc('No Line Call Logs found')
-
-    db.close
-    
+    data_headers = (('Start Time', 'datetime'), ('End Time', 'datetime'), 'To ID', 'From ID', 'Direction', 'Call Type')
+    return data_headers, data_list, call_db


### PR DESCRIPTION
Splits the LINE parser into three decorated artifacts (category `Line`):

- **Line - Contacts** — contacts table (naver_line db); no timestamps.
- **Line - Messages** — chat_history join; `created_time` raw → aware UTC `datetime`. **Fixed a latent bug**: the to-id logic compared `row[4]` (the timestamp) against `"Outgoing"` instead of the direction column (`row[7]`), so it never fired; also guarded the `',' in members` check against NULL members (would have raised `TypeError` once the direction check worked).
- **Line - Call Logs** — call_history db with `naver_line` attached; `start_time`/`end_time` raw → aware UTC `datetime`.

Shared `_line_dbs` helper to locate the naver_line / call_history databases; bare `except:` narrowed to `Exception` + logfunc.

Verified: byte-compile, all 3 decorated 4-arg, return 3-tuples, no duplicate artifact names repo-wide, CI-style pylint 0 W/E, loader builds (423).