### PR TITLE
Convert Viber to LAVA @artifact_processor (multi-report)

### DIFF
--- a/scripts/artifacts/Viber.py
+++ b/scripts/artifacts/Viber.py
@@ -1,7 +1,7 @@
-# pylint: disable=E0606,W0104,W0311,W0611,W0613,W0702,W1309
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_Viber": {
-        "name": "Viber",
+        "name": "Viber - Call Logs",
         "description": "",
         "author": "",
         "creation_date": "2020-12-24",
@@ -10,221 +10,183 @@ __artifacts_v2__ = {
         "category": "Viber",
         "notes": "",
         "paths": ('*/com.viber.voip/databases/*',),
-        "output_types": None,
+        "output_types": "standard",
+        "artifact_icon": "phone-call",
+    },
+    "get_Viber_contacts": {
+        "name": "Viber - Contacts",
+        "description": "",
+        "author": "",
+        "creation_date": "2020-12-24",
+        "last_update_date": "2020-12-24",
+        "requirements": "none",
+        "category": "Viber",
+        "notes": "",
+        "paths": ('*/com.viber.voip/databases/*',),
+        "output_types": ['html', 'tsv', 'lava'],
+        "artifact_icon": "users",
+    },
+    "get_Viber_messages": {
+        "name": "Viber - Messages",
+        "description": "",
+        "author": "",
+        "creation_date": "2020-12-24",
+        "last_update_date": "2020-12-24",
+        "requirements": "none",
+        "category": "Viber",
+        "notes": "",
+        "paths": ('*/com.viber.voip/databases/*',),
+        "output_types": "standard",
         "artifact_icon": "message-square",
-        "function": "get_Viber",
+    },
+    "get_Viber_additional": {
+        "name": "Viber - Additional",
+        "description": "Hidden chat PIN (brute-forced from the stored hash)",
+        "author": "",
+        "creation_date": "2020-12-24",
+        "last_update_date": "2020-12-24",
+        "requirements": "none",
+        "category": "Viber",
+        "notes": "",
+        "paths": ('*/com.viber.voip/databases/*',),
+        "output_types": ['html', 'tsv', 'lava'],
+        "artifact_icon": "lock",
     }
 }
 
-import sqlite3
+import datetime
 from hashlib import sha256
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
-def get_Viber(files_found, report_folder, seeker, wrap_text):
 
-    source_file_messages = ''
-    source_file_data = ''
-    viber_data_db = ''
-    viber_messages_db = ''
-    
+def _ms_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    return ''
+
+
+def _viber_dbs(files_found):
+    data_db = messages_db = prefs_db = ''
     for file_found in files_found:
-        
+        file_found = str(file_found)
         if file_found.endswith('_messages'):
-           viber_messages_db = str(file_found)
-           source_file_messages = file_found.replace(seeker.data_folder, '')
+            messages_db = file_found
+        elif file_found.endswith('_data'):
+            data_db = file_found
+        elif file_found.endswith('viber_prefs'):
+            prefs_db = file_found
+    return data_db, messages_db, prefs_db
 
-        if file_found.endswith('_data'):
-           viber_data_db = str(file_found)
-           source_file_data = file_found.replace(seeker.data_folder, '')
 
-        if file_found.endswith('viber_prefs'):
-            viber_prefs_db = str(file_found)
-            viber_prefs_data = file_found.replace(seeker.data_folder, '') 
+@artifact_processor
+def get_Viber(files_found, report_folder, seeker, wrap_text):
+    data_db, _, _ = _viber_dbs(files_found)
+    data_list = []
+    if data_db:
+        db = open_sqlite_db_readonly(data_db)
+        cursor = db.cursor()
+        try:
+            cursor.execute('''
+                SELECT date, canonized_number,
+                case type when 2 then "Outgoing" else "Incoming" end AS direction,
+                duration,
+                case viber_call_type when 1 then "Audio Call" when 4 then "Video Call" else "Unknown" end AS viber_call_type
+                FROM calls
+            ''')
+            all_rows = cursor.fetchall()
+        except Exception as e:
+            logfunc(str(e))
+            all_rows = []
+        db.close()
+        for r in all_rows:
+            start = _ms_to_utc(r[0])
+            end = _ms_to_utc(int(r[0]) + int(r[3]) * 1000) if r[0] else ''
+            data_list.append((start, r[1], r[2], end, r[4]))
 
-    db = open_sqlite_db_readonly(viber_data_db)
-    cursor = db.cursor()
-    try:
-        cursor.execute('''
-        SELECT
-        datetime(date/1000, 'unixepoch') AS start_time,
-        canonized_number,
-        case type
-            when 2 then "Outgoing"
-            else "Incoming"
-        end AS direction,
-        datetime((date + (duration * 1000))/1000, 'unixepoch') as end_time,
-        case viber_call_type
-            when 1 then "Audio Call"
-            when 4 then "Video Call"
-            else "Unknown"
-        end AS viber_call_type
-        FROM calls
-        ''')
+    data_headers = (('Call Start Time', 'datetime'), ('Phone Number', 'phonenumber'), 'Call Direction', ('Call End Time', 'datetime'), 'Call Type')
+    return data_headers, data_list, data_db
 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-    except:
-        usageentries = 0
-        
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Viber - Call Logs')
-        report.start_artifact_report(report_folder, 'Viber - Call Logs')
-        report.add_script()
-        data_headers = ('Call Start Time', 'Phone Number','Call Direction', 'Call End Time', 'Call Type') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = []
-        for row in all_rows:
-            data_list.append((row[0], row[1], row[2], row[3], row[4]))
 
-        report.write_artifact_data_table(data_headers, data_list, viber_data_db)
-        report.end_artifact_report()
-        
-        tsvname = f'Viber - Call Logs'
-        tsv(report_folder, data_headers, data_list, tsvname, source_file_data)
+@artifact_processor
+def get_Viber_contacts(files_found, report_folder, seeker, wrap_text):
+    data_db, _, _ = _viber_dbs(files_found)
+    data_list = []
+    if data_db:
+        db = open_sqlite_db_readonly(data_db)
+        cursor = db.cursor()
+        try:
+            cursor.execute('''
+                SELECT C.display_name, coalesce(D.data2, D.data1, D.data3) as phone_number
+                FROM phonebookcontact AS C
+                JOIN phonebookdata AS D ON C._id = D.contact_id
+            ''')
+            data_list = cursor.fetchall()
+        except Exception as e:
+            logfunc(str(e))
+        db.close()
 
-        tlactivity = f'Viber - Call Logs'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-    else:
-        logfunc('No Viber Call Logs found')
-        
-    try:        
-        cursor.execute('''
-        SELECT
-        C.display_name,
-        coalesce(D.data2, D.data1, D.data3) as phone_number
-        FROM phonebookcontact AS C
-        JOIN phonebookdata AS D ON C._id = D.contact_id
-        ''')
-        
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-    except:
-        usageentries = 0
-        
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Viber - Contacts')
-        report.start_artifact_report(report_folder, 'Viber - Contacts')
-        report.add_script()
-        data_headers = ('Display Name','Phone Number') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = []
-        for row in all_rows:
-            data_list.append((row[0], row[1]))
-            
-        report.write_artifact_data_table(data_headers, data_list, viber_data_db)
-        report.end_artifact_report()
-        
-        tsvname = f'Viber - Contacts'
-        tsv(report_folder, data_headers, data_list, tsvname, source_file_messages)
-        
-    else:
-        logfunc('No Viber Contacts data available')
+    data_headers = ('Display Name', ('Phone Number', 'phonenumber'))
+    return data_headers, data_list, data_db
 
-    db.close()
 
-    db = open_sqlite_db_readonly(viber_messages_db)
-    cursor = db.cursor()
-    try:
-        cursor.execute('''
-        SELECT 
-        datetime(M.msg_date/1000, 'unixepoch') AS msg_date,
-        convo_participants.from_number AS from_number, 
-        convo_participants.recipients AS recipients, 
-        M.conversation_id AS thread_id, 
-        M.body AS msg_content, 
-        case M.send_type
-            when 1 then "Outgoing" 
-            else "Incoming"
-        end AS direction, 
-        M.unread read_status,
-        M.extra_uri AS file_attachment                            
-        FROM   (SELECT *, 
-                        group_concat(TO_RESULT.number) AS recipients 
-                 FROM   (SELECT P._id     AS FROM_ID, 
-                                P.conversation_id, 
-                                PI.number AS FROM_NUMBER 
-                         FROM   participants AS P 
-                                JOIN participants_info AS PI 
-                                  ON P.participant_info_id = PI._id) AS FROM_RESULT 
-                        JOIN (SELECT P._id AS TO_ID, 
-                                     P.conversation_id, 
-                                     PI.number 
-                              FROM   participants AS P 
-                                     JOIN participants_info AS PI 
-                                       ON P.participant_info_id = PI._id) AS TO_RESULT 
-                          ON FROM_RESULT.from_id != TO_RESULT.to_id 
-                             AND FROM_RESULT.conversation_id = TO_RESULT.conversation_id 
-                 GROUP  BY FROM_RESULT.from_id) AS convo_participants 
-                JOIN messages AS M 
-                  ON M.participant_id = convo_participants.from_id 
-                     AND M.conversation_id = convo_participants.conversation_id
-        ''')
+@artifact_processor
+def get_Viber_messages(files_found, report_folder, seeker, wrap_text):
+    _, messages_db, _ = _viber_dbs(files_found)
+    data_list = []
+    if messages_db:
+        db = open_sqlite_db_readonly(messages_db)
+        cursor = db.cursor()
+        try:
+            cursor.execute('''
+                SELECT M.msg_date, convo_participants.from_number AS from_number,
+                convo_participants.recipients AS recipients, M.conversation_id AS thread_id, M.body AS msg_content,
+                case M.send_type when 1 then "Outgoing" else "Incoming" end AS direction,
+                M.unread read_status, M.extra_uri AS file_attachment
+                FROM   (SELECT *, group_concat(TO_RESULT.number) AS recipients
+                        FROM   (SELECT P._id AS FROM_ID, P.conversation_id, PI.number AS FROM_NUMBER
+                                FROM   participants AS P JOIN participants_info AS PI ON P.participant_info_id = PI._id) AS FROM_RESULT
+                               JOIN (SELECT P._id AS TO_ID, P.conversation_id, PI.number
+                                     FROM   participants AS P JOIN participants_info AS PI ON P.participant_info_id = PI._id) AS TO_RESULT
+                                 ON FROM_RESULT.from_id != TO_RESULT.to_id AND FROM_RESULT.conversation_id = TO_RESULT.conversation_id
+                        GROUP  BY FROM_RESULT.from_id) AS convo_participants
+                       JOIN messages AS M ON M.participant_id = convo_participants.from_id AND M.conversation_id = convo_participants.conversation_id
+            ''')
+            all_rows = cursor.fetchall()
+        except Exception as e:
+            logfunc(str(e))
+            all_rows = []
+        db.close()
+        for r in all_rows:
+            data_list.append((_ms_to_utc(r[0]), r[1], r[2], r[3], r[4], r[5], r[6], r[7]))
 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-    except:
-        usageentries = 0
-        
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Viber - Messages')
-        report.start_artifact_report(report_folder, 'Viber - Messages')
-        report.add_script()
-        data_headers = ('Message Date', 'From Phone Number','Recipients', 'Thread ID', 'Message', 'Direction', 'Read Status', 'File Attachment') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = []
-        for row in all_rows:
-            data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7]))
+    data_headers = (('Message Date', 'datetime'), ('From Phone Number', 'phonenumber'), 'Recipients', 'Thread ID', 'Message', 'Direction', 'Read Status', 'File Attachment')
+    return data_headers, data_list, messages_db
 
-        report.write_artifact_data_table(data_headers, data_list, viber_messages_db)
-        report.end_artifact_report()
-        
-        tsvname = f'Viber - Messages'
-        tsv(report_folder, data_headers, data_list, tsvname, source_file_messages)
 
-        tlactivity = f'Viber - Messages'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-    else:
-        logfunc('No Viber Messages found')
+@artifact_processor
+def get_Viber_additional(files_found, report_folder, seeker, wrap_text):
+    _, _, prefs_db = _viber_dbs(files_found)
+    data_list = []
+    if prefs_db:
+        db = open_sqlite_db_readonly(prefs_db)
+        cursor = db.cursor()
+        try:
+            cursor.execute("SELECT key, value from kvdata WHERE key='key_hidden_chats_pin'")
+            all_rows = cursor.fetchall()
+        except Exception as e:
+            logfunc(str(e))
+            all_rows = []
+        db.close()
+        if all_rows:
+            userPINHash = all_rows[0][1]
+            currentPIN = 'Not recovered'
+            for i in range(0, 10000):
+                candidate = ('{0:04}'.format(i)).encode('utf-8')
+                if sha256(candidate + "Shawl9_Valid_Yeastv".encode("utf-8")).hexdigest() == userPINHash:
+                    currentPIN = candidate.decode("utf-8")
+                    break
+            data_list = [(userPINHash, currentPIN)]
 
-    db.close
-    
-    db = open_sqlite_db_readonly(viber_prefs_db)
-    cursor = db.cursor()
-    try:
-        cursor.execute('''
-        SELECT key, value from kvdata WHERE key='key_hidden_chats_pin'
-        ''')
-        
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-    except:
-        usageentries = 0
-
-    if usageentries > 0:
-        userPINHash = all_rows[0][1]
-        for i in range(0,10000):
-            currentPIN = ('{0:04}'.format(i)).encode('utf-8')
-            ## Section of code to try the hash process and print passcode if correct
-            ## Compare the current PIN SHA256 and the provided PIN hash
-            if sha256(currentPIN+"Shawl9_Valid_Yeastv".encode("utf-8")).hexdigest() == userPINHash:
-                currentPIN = currentPIN.decode("utf-8")
-                break
-        report = ArtifactHtmlReport('Viber - Additional')
-        report.start_artifact_report(report_folder, 'Viber - Additional')
-        report.add_script()
-        data_headers = ('User PIN Hash', 'User PIN',) # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-        data_list = [((userPINHash,currentPIN))]
-
-        report.write_artifact_data_table(data_headers, data_list, viber_prefs_db)
-        report.end_artifact_report()
-        
-        tsvname = f'Viber - Additional'
-        tsv(report_folder, data_headers, data_list, tsvname, viber_prefs_data)
-
-        tlactivity = f'Viber - Additional'
-        timeline(report_folder, tlactivity, data_list, data_headers)     
-    else:
-        logfunc('No Viber Hidden Chat PIN found')        
-
-    db.close()
+    data_headers = ('User PIN Hash', 'User PIN')
+    return data_headers, data_list, prefs_db


### PR DESCRIPTION
Splits the Viber parser into four decorated artifacts (category `Viber`):

- **Viber - Call Logs** — `date`/`date+duration` → aware UTC `datetime`; `Phone Number` marked `phonenumber`.
- **Viber - Contacts** — phonebook join; `Phone Number` marked `phonenumber`.
- **Viber - Messages** — participants/messages join; `msg_date` → aware UTC `datetime`; `From Phone Number` marked `phonenumber`.
- **Viber - Additional** — recovers the hidden-chat PIN by brute-forcing the stored salted SHA-256 hash (kept the logic; guarded the unbound `currentPIN` with a 'Not recovered' default).

All timestamps replaced SQL `datetime(...,'unixepoch')` with Python aware-UTC conversion. Shared `_viber_dbs` helper locates the `_data`/`_messages`/`viber_prefs` databases (fixes a latent unbound-var risk when `viber_prefs` is absent); bare `except:` narrowed to `Exception` + logfunc.

Verified: byte-compile, all 4 decorated 4-arg, return 3-tuples, no duplicate artifact names repo-wide, CI-style pylint 0 W/E, loader builds (426).