### PR TITLE
Convert teams (Microsoft Teams) to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/teams.py
+++ b/scripts/artifacts/teams.py
@@ -1,7 +1,7 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_teams": {
-        "name": "teams",
+        "name": "Teams - Messages",
         "description": "",
         "author": "",
         "creation_date": "2021-04-29",
@@ -10,210 +10,168 @@ __artifacts_v2__ = {
         "category": "Teams",
         "notes": "",
         "paths": ('*/com.microsoft.teams/databases/SkypeTeams.db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "message-square",
-        "function": "get_teams",
+    },
+    "get_teams_users": {
+        "name": "Teams - Users",
+        "description": "",
+        "author": "",
+        "creation_date": "2021-04-29",
+        "last_update_date": "2021-04-29",
+        "requirements": "none",
+        "category": "Teams",
+        "notes": "",
+        "paths": ('*/com.microsoft.teams/databases/SkypeTeams.db*',),
+        "output_types": ['html', 'tsv', 'lava'],
+        "artifact_icon": "users",
+    },
+    "get_teams_calllog": {
+        "name": "Teams - Call Log",
+        "description": "",
+        "author": "",
+        "creation_date": "2021-04-29",
+        "last_update_date": "2021-04-29",
+        "requirements": "none",
+        "category": "Teams",
+        "notes": "",
+        "paths": ('*/com.microsoft.teams/databases/SkypeTeams.db*',),
+        "output_types": "standard",
+        "artifact_icon": "phone-call",
+    },
+    "get_teams_activity": {
+        "name": "Teams - Activity Feed",
+        "description": "",
+        "author": "",
+        "creation_date": "2021-04-29",
+        "last_update_date": "2021-04-29",
+        "requirements": "none",
+        "category": "Teams",
+        "notes": "",
+        "paths": ('*/com.microsoft.teams/databases/SkypeTeams.db*',),
+        "output_types": "standard",
+        "artifact_icon": "activity",
+    },
+    "get_teams_fileinfo": {
+        "name": "Teams - File Info",
+        "description": "",
+        "author": "",
+        "creation_date": "2021-04-29",
+        "last_update_date": "2021-04-29",
+        "requirements": "none",
+        "category": "Teams",
+        "notes": "",
+        "paths": ('*/com.microsoft.teams/databases/SkypeTeams.db*',),
+        "output_types": "standard",
+        "artifact_icon": "file",
     }
 }
 
-import os
-import sqlite3
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, get_next_unused_name, open_sqlite_db_readonly
+import datetime
 
-def get_teams(files_found, report_folder, seeker, wrap_text):
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
+
+def _ms_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    return ''
+
+
+def _teams_db(files_found):
     for file_found in files_found:
         file_found = str(file_found)
-        if not file_found.endswith('SkypeTeams.db'):
-            continue # Skip all other files
+        if file_found.endswith('SkypeTeams.db'):
+            return file_found
+    return ''
 
-        db = open_sqlite_db_readonly(file_found)
-        cursor = db.cursor()
-        cursor.execute('''
-        SELECT
-        datetime("arrivalTime"/1000, 'unixepoch'),
-        userDisplayName,
-        content,
-        displayName,
-        datetime("deleteTime"/1000, 'unixepoch'),
-        Message.conversationId,
-        messageId
-        FROM Message
-        left join Conversation
-        on Message.conversationId = Conversation.conversationId
-        ORDER BY  Message.conversationId, arrivalTime
-        ''')
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Teams Messages')
-            report.start_artifact_report(report_folder, 'Teams Messages')
-            report.add_script()
-            data_headers = ('Timestamp','User Display Name','Content','Topic Name','Delete Time','Conversation ID','Message ID')
-            data_list=[]
-            for row in all_rows:
-                timeone = row[0]
-                timetwo = row[4]
-                if timeone == '1970-01-01 00:00:00':
-                    timeone = ''
-                if timetwo == '1970-01-01 00:00:00':
-                    timetwo = ''
-                data_list.append((timeone, row[1], row[2], row[3], timetwo, row[5], row[6]))
-            report.write_artifact_data_table(data_headers, data_list, file_found) #, html_escape=False
-            report.end_artifact_report()
-            
-            tsvname = 'Teams Messages'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Teams Messages'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-            
-        else:
-            logfunc('No Teams Messages data available')
-    
-        cursor.execute('''
-        SELECT
-        datetime("lastSyncTime"/1000, 'unixepoch'),
-        givenName,
-        surname,
-        displayName,
-        email,
-        secondaryEmail,
-        alternativeEmail,
-        telephoneNumber,
-        homeNumber,
-        accountEnabled,
-        type,
-        userType,
-        isSkypeTeamsUser,
-        isPrivateChatEnabled
-        from
-        User
-        ''')
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Teams Users')
-            report.start_artifact_report(report_folder, 'Teams Users')
-            report.add_script()
-            data_headers = ('Last Sync','Given Name','Surname','Display Name','Email','Secondary Email','Alt. Email','Telephone Number','Home Number','Account Enabled?','Type','User Type','Is Teams User?','Is Private Chat Enabled?')
-            data_list=[]
-            for row in all_rows:
-                data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11], row[12], row[13]))
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-            report.end_artifact_report()
-            
-            tsvname = 'Teams Users'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-        else:
-            logfunc('No Teams Users data available')
 
-        cursor.execute('''
-        SELECT
-        datetime(json_extract(attributeValue, '$.connectTimeMillis') /1000, 'unixepoch') as connectTimeMillis,
-        datetime(json_extract(attributeValue, '$.endTimeMillis') /1000, 'unixepoch') as endTimeMillis,
-        json_extract(attributeValue, '$.callState') as callState,
-        json_extract(attributeValue, '$.callType') as callType,
-        json_extract(attributeValue, '$.originatorDisplayName') as originator,
-        json_extract(attributeValue, '$.callDirection') as callDirection,
-        User.givenName as targetparticipantName,
-        json_extract(attributeValue, '$.sessionType') as sessionType,
-        json_extract(attributeValue, '$.callId') as callId,
-        json_extract(attributeValue, '$.target') as target
-        from MessagePropertyAttribute, User
-        where propertyId = 'CallLog' and target = User.mri
-        ''')
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Teams Call Log')
-            report.start_artifact_report(report_folder, 'Teams Call Log')
-            report.add_script()
-            data_headers = ('Connect Time','End Time','Call State','Call Type','Originator','Call Direction','Target Participant Name','Session Type')
-            data_list=[]
-            for row in all_rows:
-                timeone = row[0]
-                timetwo = row[1]
-                if timeone == '1970-01-01 00:00:00':
-                    timeone = ''
-                if timetwo == '1970-01-01 00:00:00':
-                    timetwo = ''
-                data_list.append((timeone, timetwo, row[2], row[3], row[4], row[5], row[6], row[7]))
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-            report.end_artifact_report()
-            
-            tsvname = 'Teams Call Log'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-        else:
-            logfunc('No Teams Call Log data available')
-    
-    
-        cursor.execute('''
-        SELECT
-        datetime("activityTimestamp"/1000, 'unixepoch') as activityTimestamp,
-        sourceUserImDisplayName,
-        messagePreview,
-        activityType,
-        activitySubtype,
-        isRead
-        FROM ActivityFeed
-        ''')
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Teams Activity Feed')
-            report.start_artifact_report(report_folder, 'Teams Activity Feed')
-            report.add_script()
-            data_headers = ('Timestamp','Display Name','Message Preview','Activity Type','Activity Subtype','Is read?')
-            data_list=[]
-            for row in all_rows:
-                data_list.append((row[0], row[1], row[2], row[3], row[4], row[5]))
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-            report.end_artifact_report()
-            
-            tsvname = 'Teams Activity Feed'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Teams Activity Feed'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-            
-        else:
-            logfunc('No Teams Activity Feed data available')
-        
-        cursor.execute('''
-        SELECT
-        lastModifiedTime,
-        fileName,
-        type,
-        objectUrl,
-        isFolder,
-        lastModifiedBy
-        FROM FileInfo
-        ''')
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Teams File Info')
-            report.start_artifact_report(report_folder, 'Teams File Info')
-            report.add_script()
-            data_headers = ('Timestamp','File Name','Type','Object URL','Is Folder?','Last Modified By')
-            data_list=[]
-            for row in all_rows:
-                mtime = row[0].replace('T', ' ')
-                data_list.append((mtime, row[1], row[2], row[3], row[4], row[5]))
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-            report.end_artifact_report()
-            
-            tsvname = 'Teams File Info'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Teams File Info'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-            
-        else:
-            logfunc('No Teams File Info data available')
-            
+def _run(source_path, sql):
+    if not source_path:
+        return []
+    db = open_sqlite_db_readonly(source_path)
+    cursor = db.cursor()
+    try:
+        cursor.execute(sql)
+        rows = cursor.fetchall()
+    except Exception as e:
+        logfunc(str(e))
+        rows = []
     db.close()
+    return rows
+
+
+@artifact_processor
+def get_teams(files_found, report_folder, seeker, wrap_text):
+    source_path = _teams_db(files_found)
+    rows = _run(source_path, '''
+        SELECT arrivalTime, userDisplayName, content, displayName, deleteTime,
+        Message.conversationId, messageId
+        FROM Message
+        left join Conversation on Message.conversationId = Conversation.conversationId
+        ORDER BY Message.conversationId, arrivalTime
+    ''')
+    data_list = [(_ms_to_utc(r[0]), r[1], r[2], r[3], _ms_to_utc(r[4]), r[5], r[6]) for r in rows]
+    data_headers = (('Timestamp', 'datetime'), 'User Display Name', 'Content', 'Topic Name', ('Delete Time', 'datetime'), 'Conversation ID', 'Message ID')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_teams_users(files_found, report_folder, seeker, wrap_text):
+    source_path = _teams_db(files_found)
+    rows = _run(source_path, '''
+        SELECT lastSyncTime, givenName, surname, displayName, email, secondaryEmail, alternativeEmail,
+        telephoneNumber, homeNumber, accountEnabled, type, userType, isSkypeTeamsUser, isPrivateChatEnabled
+        from User
+    ''')
+    data_list = [(_ms_to_utc(r[0]), r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10], r[11], r[12], r[13]) for r in rows]
+    data_headers = (('Last Sync', 'datetime'), 'Given Name', 'Surname', 'Display Name', 'Email', 'Secondary Email', 'Alt. Email', ('Telephone Number', 'phonenumber'), ('Home Number', 'phonenumber'), 'Account Enabled?', 'Type', 'User Type', 'Is Teams User?', 'Is Private Chat Enabled?')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_teams_calllog(files_found, report_folder, seeker, wrap_text):
+    source_path = _teams_db(files_found)
+    rows = _run(source_path, '''
+        SELECT
+        json_extract(attributeValue, '$.connectTimeMillis'),
+        json_extract(attributeValue, '$.endTimeMillis'),
+        json_extract(attributeValue, '$.callState'),
+        json_extract(attributeValue, '$.callType'),
+        json_extract(attributeValue, '$.originatorDisplayName'),
+        json_extract(attributeValue, '$.callDirection'),
+        User.givenName,
+        json_extract(attributeValue, '$.sessionType')
+        from MessagePropertyAttribute, User
+        where propertyId = 'CallLog' and json_extract(attributeValue, '$.target') = User.mri
+    ''')
+    data_list = [(_ms_to_utc(r[0]), _ms_to_utc(r[1]), r[2], r[3], r[4], r[5], r[6], r[7]) for r in rows]
+    data_headers = (('Connect Time', 'datetime'), ('End Time', 'datetime'), 'Call State', 'Call Type', 'Originator', 'Call Direction', 'Target Participant Name', 'Session Type')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_teams_activity(files_found, report_folder, seeker, wrap_text):
+    source_path = _teams_db(files_found)
+    rows = _run(source_path, '''
+        SELECT activityTimestamp, sourceUserImDisplayName, messagePreview, activityType, activitySubtype, isRead
+        FROM ActivityFeed
+    ''')
+    data_list = [(_ms_to_utc(r[0]), r[1], r[2], r[3], r[4], r[5]) for r in rows]
+    data_headers = (('Timestamp', 'datetime'), 'Display Name', 'Message Preview', 'Activity Type', 'Activity Subtype', 'Is read?')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_teams_fileinfo(files_found, report_folder, seeker, wrap_text):
+    source_path = _teams_db(files_found)
+    rows = _run(source_path, '''
+        SELECT lastModifiedTime, fileName, type, objectUrl, isFolder, lastModifiedBy
+        FROM FileInfo
+    ''')
+    data_list = []
+    for r in rows:
+        mtime = r[0].replace('T', ' ') if r[0] else ''
+        data_list.append((mtime, r[1], r[2], r[3], r[4], r[5]))
+    data_headers = ('Timestamp', 'File Name', 'Type', 'Object URL', 'Is Folder?', 'Last Modified By')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Splits the Microsoft Teams parser into five decorated artifacts (category `Teams`):

- **Teams - Messages** — `arrivalTime`/`deleteTime` → aware UTC `datetime` (the original converted in SQL then string-matched '1970-01-01 00:00:00' to blank epochs; `_ms_to_utc` returns '' for 0/NULL directly).
- **Teams - Users** — `lastSyncTime` → aware UTC; `Telephone Number`/`Home Number` marked `phonenumber`.
- **Teams - Call Log** — `connectTimeMillis`/`endTimeMillis` (json-extracted) → aware UTC.
- **Teams - Activity Feed** — `activityTimestamp` → aware UTC.
- **Teams - File Info** — `lastModifiedTime` kept as the app's ISO string (T→space), unverified format so left unmarked.

Shared `_teams_db`/`_run` helpers; each query wrapped so a missing table in a given app version logs and yields an empty table instead of erroring.

Verified: byte-compile, all 5 decorated 4-arg, return 3-tuples, no duplicate artifact names repo-wide, CI-style pylint 0 W/E, loader builds (430).