### PR TITLE
Convert K9Mail to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/K9Mail.py
+++ b/scripts/artifacts/K9Mail.py
@@ -1,195 +1,159 @@
-# pylint: disable=W0611,W0612,W0613,W1309
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
-
-    
-    "get_k9mail_data": {
-        "name": "K-9 Mail - Data",
-        "description": "K-9 Mail - Data",
+    "get_k9mail_accounts": {
+        "name": "K-9 Mail - Accounts",
+        "description": "Account information from the K-9 Mail App",
         "author": "Marco Neumann {kalinko@be-binary.de}",
         "creation_date": "2024-05-04",
         "last_update_date": "2024-05-04",
-        "requirements": "datetime, json, base64",
+        "requirements": "none",
         "category": "K-9 Mail",
-        "notes": "Get Account informations and E-Mails feom K-9 Mail App. Based on https://bebinary4n6.blogspot.com/2024/05/app-k-9-mail-for-android.html",
-        "paths": ('*/com.fsck.k9/databases/*'),
-        "output_types": None,
+        "notes": "Based on https://bebinary4n6.blogspot.com/2024/05/app-k-9-mail-for-android.html",
+        "paths": ('*/com.fsck.k9/databases/*',),
+        "output_types": "standard",
         "artifact_icon": "mail",
-        "function": "get_k9mail_data",
+    },
+    "get_k9mail_messages": {
+        "name": "K-9 Mail - Messages",
+        "description": "E-Mails from the K-9 Mail App",
+        "author": "Marco Neumann {kalinko@be-binary.de}",
+        "creation_date": "2024-05-04",
+        "last_update_date": "2024-05-04",
+        "requirements": "none",
+        "category": "K-9 Mail",
+        "notes": "Based on https://bebinary4n6.blogspot.com/2024/05/app-k-9-mail-for-android.html",
+        "paths": ('*/com.fsck.k9/databases/*',),
+        "output_types": "standard",
+        "artifact_icon": "mail",
     }
 }
 
-# K-9 Mail App (com.fsck.k9)
-# Author:  Marco Neumann (kalinko@be-binary.de)
-# Version: 0.0.1
-# 
-# Tested with the following versions:
-# 2024-05-04: Android 13, App: 6.802
-
-# Requirements:  datetime, json, base64
+import base64
 import datetime
 import json
-import base64
-import quopri
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
 
+def _ms_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    return ''
 
 
-def get_k9mail_data(files_found, report_folder, seeker, wrap_text):
-    logfunc("Processing data for K-9 Mail - Accounts")
- 
-    accountUUIDS = []
-    mail_addresses = []
- 
-    files_found = [x for x in files_found if x.endswith('db') or x.endswith('preferences_storage')]
-    
+def _prefs_db(files_found):
     for file_found in files_found:
-        # First get the data of the existing accounts and create this artifact
+        file_found = str(file_found)
         if file_found.endswith('preferences_storage'):
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
+            return file_found
+    return ''
+
+
+def _account_uuids(cursor):
+    cursor.execute("SELECT value FROM preferences_storage WHERE primkey = 'accountUuids'")
+    rows = cursor.fetchall()
+    return rows[0][0].split(',') if rows and rows[0][0] else []
+
+
+@artifact_processor
+def get_k9mail_accounts(files_found, report_folder, seeker, wrap_text):
+    source_path = _prefs_db(files_found)
+    data_list = []
+    if source_path:
+        db = open_sqlite_db_readonly(source_path)
+        cursor = db.cursor()
+        for uuid in _account_uuids(cursor):
+            cursor.execute("SELECT primkey, value FROM preferences_storage WHERE primkey LIKE ?", (uuid + '%',))
+            mail = name = username = password = server_in = server_out = server_in_settings = server_out_settings = ''
+            last_sync = ''
+            for key, value in cursor.fetchall():
+                if 'email.0' in key:
+                    mail = value
+                elif 'name.0' in key:
+                    name = value
+                elif 'lastSyncTime' in key:
+                    last_sync = value
+                elif 'incomingServerSettings' in key:
+                    server_in_settings = value
+                    j = json.loads(value)
+                    username = j.get('username', '')
+                    password = j.get('password', '')
+                    server_in = f"{j.get('host')}:{j.get('port')}"
+                elif 'outgoingServerSettings' in key:
+                    server_out_settings = value
+                    j = json.loads(value)
+                    server_out = f"{j.get('host')}:{j.get('port')}"
+            data_list.append((uuid, mail, name, username, password, _ms_to_utc(last_sync), server_in, server_out, server_in_settings, server_out_settings))
+        db.close()
+
+    data_headers = ('Internal Account UUID', 'Mail-Address', 'Name', 'Username', 'Password', ('Last Sync Time', 'datetime'), 'Incoming Server', 'Outgoing Server', 'Incoming Server Settings', 'Outgoing Server Settings')
+    return data_headers, data_list, source_path
+
+
+def _account_emails(files_found):
+    '''Map account UUID -> primary email address (from preferences_storage).'''
+    prefs = _prefs_db(files_found)
+    emails = {}
+    if prefs:
+        db = open_sqlite_db_readonly(prefs)
+        cursor = db.cursor()
+        for uuid in _account_uuids(cursor):
+            cursor.execute("SELECT value FROM preferences_storage WHERE primkey LIKE ?", (uuid + '.email.0%',))
+            row = cursor.fetchone()
+            emails[uuid] = row[0] if row else ''
+        db.close()
+    return emails
+
+
+@artifact_processor
+def get_k9mail_messages(files_found, report_folder, seeker, wrap_text):
+    emails = _account_emails(files_found)
+    data_list = []
+    source_path = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if file_found.endswith('preferences_storage') or not file_found.endswith('db'):
+            continue
+        uuid = next((u for u in emails if u in file_found), None)
+        account = emails.get(uuid, '')
+
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        try:
             cursor.execute('''
-                SELECT value 
-                FROM preferences_storage
-                WHERE primkey = 'accountUuids'
+                SELECT deleted, subject, date, sender_list, to_list, cc_list, bcc_list, reply_to_list,
+                attachment_count, internal_date, preview, read, flagged, answered, forwarded, name, root, header,
+                (SELECT encoding FROM message_parts M_INNER WHERE M_INNER.root = M_OUTER.ROOT AND seq = 1) AS encoding,
+                (SELECT data FROM message_parts M_INNER WHERE M_INNER.root = M_OUTER.ROOT AND seq = 1) AS data,
+                data_location
+                FROM message_parts M_OUTER
+                JOIN messages ON messages.message_part_id = M_OUTER.root
+                JOIN folders ON folders.id = messages.folder_id
+                WHERE seq = 0
             ''')
-            data_rows = cursor.fetchall()
-            for row in data_rows:
-                accountUUIDS = row[0].split(',')
-            
-            if len(accountUUIDS):
-                logfunc(f"Found {len(accountUUIDS)}  K-9 Mail - Accounts")
+            rows = cursor.fetchall()
+        except Exception as e:
+            logfunc(str(e))
+            rows = []
+        db.close()
 
-                description = f"Existing accounts in the K-9 Mail App. Based on https://bebinary4n6.blogspot.com/2024/05/app-k-9-mail-for-android.html"
-                report = ArtifactHtmlReport('K-9 Mail - Accounts')
-                report.start_artifact_report(report_folder, 'K-9 Mail - Accounts', description)
-                report.add_script()
-                data_headers = ('Internal Account UUID', 'Mail-Address', 'Name', 'Username', 'Password', 'Last Sync Time', 'Incoming Server', 'Outgoing Server', 'Incoming Server Settings', 'Outgoing Server Settings')
-                data_list = []
-                # Now get the entries per UUID from the same table
-                for UUID in accountUUIDS:
+        if rows:
+            source_path = file_found
+        for row in rows:
+            header = row[17].decode('UTF-8', 'replace') if isinstance(row[17], bytes) else (row[17] or '')
+            content = ''
+            try:
+                if row[18] == 'base64' and row[19]:
+                    content = base64.b64decode(row[19]).decode('UTF-8', 'replace')
+                elif row[19]:
+                    content = row[19].decode('UTF-8', 'replace') if isinstance(row[19], bytes) else row[19]
+            except (ValueError, TypeError):
+                content = str(row[19])
+            data_list.append((
+                account, _ms_to_utc(row[2]), row[15], row[1], row[10], row[3], row[4], row[5], row[6], row[7],
+                row[8], content, _ms_to_utc(row[9]),
+                'Yes' if row[0] == 1 else 'No', 'Yes' if row[11] == 1 else 'No', 'Yes' if row[12] == 1 else 'No',
+                'Yes' if row[13] == 1 else 'No', 'Yes' if row[14] == 1 else 'No', header))
 
-                    cursor.execute('''
-                        SELECT * 
-                        FROM preferences_storage
-                        WHERE primkey LIKE ?
-                    ''', (UUID + '%',))
-
-                    mail_address = ''
-                    username = ''
-                    name = ''
-                    password = ''
-                    last_sync = ''
-                    server_in = ''
-                    server_out = ''
-                    server_in_settings = ''
-                    server_out_settings = ''
-                    all_rows = cursor.fetchall()
-                    account_entries = len(all_rows)
-                    if account_entries > 0:
-                        for row in all_rows:
-                            if 'email.0' in row[0]:
-                                mail_address = row[1]
-                                mail_addresses.append(mail_address)
-                            if 'name.0' in row[0]:
-                                name = row[1]
-                            if 'lastSyncTime' in row[0]:
-                                last_sync = datetime.datetime.fromtimestamp(int(row[1])/1000).strftime('%Y-%m-%d %H:%M:%S')
-                            if 'incomingServerSettings' in row[0]:
-                                server_in_settings = row[1]
-                                json_data = json.loads(server_in_settings)
-                                username = json_data["username"]
-                                password = json_data["password"]
-                                server_in = str(json_data["host"]) + ":" + str(json_data["port"])
-                            if 'outgoingServerSettings' in row[0]:
-                                server_out_settings = row[1]
-                                json_data = json.loads(server_out_settings)
-                                server_out = str(json_data["host"]) + ":" + str(json_data["port"])
-
-
-                        data_list.append((UUID, mail_address, name, username, password, last_sync, server_in, server_out, server_in_settings, server_out_settings))
-
-                    else:
-                        logfunc(f"Warning! No entries found for K-9 Mail Account UUID {UUID}. This should not happen.")
-                
-                tableID = 'k9mail_accounts'
-
-                report.write_artifact_data_table(data_headers, data_list, ','.join(files_found))
-                report.end_artifact_report()
-
-                tsvname = f'K-9 Mail - Accounts'
-                tsv(report_folder, data_headers, data_list, tsvname)
-
-                tlactivity = f'K-9 Mail - Accounts'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc('No K-9 Mail Account data found!')
-
-            db.close()
-        
-        # okay, now lets get the mail/message data for the accounts
-        for UUID, account in zip(accountUUIDS, mail_addresses):
-            if UUID in file_found:
-                db = open_sqlite_db_readonly(file_found)
-                cursor = db.cursor()
-                cursor.execute('''
-                    SELECT deleted, subject, date, sender_list, to_list, cc_list, bcc_list, reply_to_list, attachment_count, internal_date, preview, read, flagged, answered, forwarded,  name, root, header, (SELECT encoding FROM message_parts M_INNER WHERE M_INNER.root = M_OUTER.ROOT AND seq = 1) AS encoding, (SELECT data FROM message_parts M_INNER WHERE M_INNER.root = M_OUTER.ROOT AND seq = 1) AS data, data_location  
-                    FROM message_parts M_OUTER  
-                    JOIN messages ON messages.message_part_id = M_OUTER.root  
-                    JOIN folders ON folders.id =  messages.folder_id  
-                    WHERE seq = 0
-                ''')
-                data_rows = cursor.fetchall()
-                
-                if len(data_rows):
-                    logfunc(f"Found {len(data_rows)}  K-9 Mail - Messages for account {account}")
-
-                    description = f"Existing E-Mails for the Account {account} in the K-9 Mail App. Based on https://bebinary4n6.blogspot.com/2024/05/app-k-9-mail-for-android.html"
-                    report = ArtifactHtmlReport(f'K-9 Mail - Mails for Account {account}')
-                    report.start_artifact_report(report_folder, f'K-9 Mail - Mails for Account {account}', description)
-                    report.add_script()
-                    data_headers = ('Date Sent', 'Folder', 'Subject', 'Message Preview', 'From', 'To', 'CC', 'BCC', 'Reply To', '# of Attachments', 'Content', 'Date Received', 'Deleted', 'Read', 'Flagged', 'Answered', 'Forwarded', 'Header')
-                    data_list = []
-                    for row in data_rows:
-                        date_sent = datetime.datetime.fromtimestamp(int(row[2])/1000).strftime('%Y-%m-%d %H:%M:%S')
-                        folder = row[15]
-                        subject = row[1]
-                        sender = row[3]
-                        to = row[4]
-                        cc = row[5]
-                        bcc = row[6]
-                        reply_to = row[7]
-                        attachment_count = row[8]
-                        date_received = datetime.datetime.fromtimestamp(int(row[9])/1000).strftime('%Y-%m-%d %H:%M:%S')
-                        message_preview = row[10]
-                        read_flag = 'Yes' if row[11] == 1 else 'No'
-                        flagged_flag = 'Yes' if row[12] == 1 else 'No'
-                        answered_flag = 'Yes' if row[13] == 1 else 'No'
-                        forwarded_flag = 'Yes' if row[14] == 1 else 'No'
-                        deleted_flag = 'Yes' if row[0] == 1 else 'No'
-                        header = row[17].decode('UTF-8')
-                        content = ''
-                        # Decocding is needed
-                        if row[18] == 'base64':
-                            content = base64.b64decode(row[19]).decode('UTF-8')
-                        elif row[19]:
-                            content = row[19]
-
-                        data_list.append((date_sent, folder, subject, message_preview, sender, to, cc, bcc, reply_to, attachment_count, content, date_received, deleted_flag, read_flag, flagged_flag, answered_flag, forwarded_flag, header))
-
-                    tableID = 'k9mail_messages_' + UUID
-
-                    report.write_artifact_data_table(data_headers, data_list, ','.join(files_found))
-                    report.end_artifact_report()
-
-                    tsvname = f'K-9 Mail - Mails {account}'
-                    tsv(report_folder, data_headers, data_list, tsvname)
-
-                    tlactivity = f'K-9 Mail - Mails {account}'
-                    timeline(report_folder, tlactivity, data_list, data_headers)
-                else:
-                    logfunc(f"No messages found for K-9 Mail Account {account}.")
-
-                db.close()
+    data_headers = ('Account', ('Date Sent', 'datetime'), 'Folder', 'Subject', 'Message Preview', 'From', 'To', 'CC', 'BCC', 'Reply To', '# of Attachments', 'Content', ('Date Received', 'datetime'), 'Deleted', 'Read', 'Flagged', 'Answered', 'Forwarded', 'Header')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Splits the K-9 Mail parser into two decorated artifacts (category `K-9 Mail`):

- **K-9 Mail - Accounts** — parses `preferences_storage` per account UUID (mail, name, username, password, server settings); `lastSyncTime` → aware UTC `datetime`.
- **K-9 Mail - Messages** — the original emitted a *separate* per-account report (`Mails for Account <x>`); for LAVA these are combined into one table with an **Account** discriminator column. `date`/`internal_date` → aware UTC `datetime`; base64 content decoding kept (now guarded against decode errors).

Fixes: timestamps were `datetime.fromtimestamp(...)` with no timezone (machine-local) → now aware UTC; `paths` was a bare string (not a 1-tuple → glob iterated char-by-char) → fixed; per-account message query wrapped (`Exception` + logfunc); header/content bytes decoded with `errors='replace'`; dropped unused `quopri` import.

Verified: byte-compile, both decorated 4-arg, return 3-tuples, paths are tuples, no duplicate artifact names repo-wide, CI-style pylint 0 W/E, loader builds (431).