### PR TITLE
Convert smsmmsBackup to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/smsmmsBackup.py
+++ b/scripts/artifacts/smsmmsBackup.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0631,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
-    "get_sms_mms_from_backup": {
-        "name": "sms_mms_backup",
-        "description": "Backup agent code defined here:",
+    "get_mms_from_backup": {
+        "name": "SMS & MMS Backup - MMS",
+        "description": "MMS messages recovered from backup.ab telephony backup files",
         "author": "",
         "creation_date": "2024-08-15",
         "last_update_date": "2024-08-15",
@@ -10,9 +10,21 @@ __artifacts_v2__ = {
         "category": "SMS & MMS from backup.ab",
         "notes": "",
         "paths": ('*/com.android.providers.telephony/d_f/*_backup',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "message-square",
-        "function": "get_sms_mms_from_backup",
+    },
+    "get_sms_from_backup": {
+        "name": "SMS & MMS Backup - SMS",
+        "description": "SMS messages recovered from backup.ab telephony backup files",
+        "author": "",
+        "creation_date": "2024-08-15",
+        "last_update_date": "2024-08-15",
+        "requirements": "none",
+        "category": "SMS & MMS from backup.ab",
+        "notes": "",
+        "paths": ('*/com.android.providers.telephony/d_f/*_backup',),
+        "output_types": "standard",
+        "artifact_icon": "message-square",
     }
 }
 
@@ -20,158 +32,103 @@ import datetime
 import json
 import zlib
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
+from scripts.ilapfuncs import artifact_processor, logfunc, is_platform_windows
 
 # Backup agent code defined here:
 # https://cs.android.com/android/platform/superproject/main/+/main:packages/providers/TelephonyProvider/src/com/android/providers/telephony/TelephonyBackupAgent.java
 
-is_windows = is_platform_windows()
-slash = '\\' if is_windows else '/' 
+slash = '\\' if is_platform_windows() else '/'
 
-def ReadUnixTimeMs(unix_time): # Unix timestamp is time epoch beginning 1970/1/1
-    '''Returns datetime object, or empty string upon error'''
+EPOCH = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
+
+MMS_BOX = {'0': 'All messages', '1': 'Inbox', '2': 'Sent', '3': 'Drafts', '4': 'Outbox', '5': 'Failed'}
+
+
+def ReadUnixTimeMs(unix_time):
+    '''Returns tz-aware UTC datetime from epoch milliseconds, or '' on error.'''
     if unix_time not in ('0', 0, None, ''):
         try:
-            if isinstance(unix_time, str):
-                unix_time = float(unix_time)
-            return datetime.datetime(1970, 1, 1) + datetime.timedelta(seconds=unix_time/1000)
+            return EPOCH + datetime.timedelta(seconds=float(unix_time) / 1000)
         except (ValueError, OverflowError, TypeError) as ex:
-            logfunc("ReadUnixTimeMs() Failed to convert timestamp from value " + str(unix_time) + " Error was: " + str(ex))
+            logfunc("ReadUnixTimeMs() Failed to convert " + str(unix_time) + " Error: " + str(ex))
     return ''
 
-def ReadUnixTime(unix_time): # Unix timestamp is time epoch beginning 1970/1/1
-    '''Returns datetime object, or empty string upon error'''
+
+def ReadUnixTime(unix_time):
+    '''Returns tz-aware UTC datetime from epoch seconds, or '' on error.'''
     if unix_time not in ('0', 0, None, ''):
         try:
-            if isinstance(unix_time, str):
-                unix_time = float(unix_time)
-            return datetime.datetime(1970, 1, 1) + datetime.timedelta(seconds=unix_time)
+            return EPOCH + datetime.timedelta(seconds=float(unix_time))
         except (ValueError, OverflowError, TypeError) as ex:
-            logfunc("ReadUnixTime() Failed to convert timestamp from value " + str(unix_time) + " Error was: " + str(ex))
+            logfunc("ReadUnixTime() Failed to convert " + str(unix_time) + " Error: " + str(ex))
     return ''
+
 
 def read_messages_from_backup(file_found):
     logfunc(f'Processing file {file_found}')
     with open(file_found, 'rb') as f:
         file_content = f.read()
-        if file_content[0:1] == b'\x78': # zlib compressed
-            try:
-                data = zlib.decompress(file_content)  
-            except zlib.error as ex:
-                logfunc(ex)
-                return []
-            data_str = data.decode('utf8', 'ignore')
-            try:
-                msg_data = json.loads(data_str)
-                return msg_data
-            except json.JSONDecodeError as ex:
-                logfunc(str(ex))
-        else:
-            logfunc('Not the right format!')
-    return []
+    if file_content[0:1] != b'\x78':  # not zlib compressed
+        logfunc('Not the right format!')
+        return []
+    try:
+        data = zlib.decompress(file_content)
+    except zlib.error as ex:
+        logfunc(str(ex))
+        return []
+    try:
+        return json.loads(data.decode('utf8', 'ignore'))
+    except json.JSONDecodeError as ex:
+        logfunc(str(ex))
+        return []
 
-def get_sms_mms_from_backup(files_found, report_folder, seeker, wrap_text):
-    sms_messages = []
-    mms_messages = []
 
+def _backup_files(files_found, suffix):
+    out = []
     for file_found in files_found:
         file_found = str(file_found)
         if file_found.find('{0}mirror{0}'.format(slash)) >= 0:
-            # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data
-            continue
-        
-        if file_found.endswith('sms_backup'):
-            messages = read_messages_from_backup(file_found)
-            sms_messages.extend(messages)
-        elif file_found.endswith('mms_backup'):
-            messages = read_messages_from_backup(file_found)
-            mms_messages.extend(messages)
-        else:
-            logfunc(f'unknown file found: {file_found}')
-            continue
+            continue  # Skip mirror, it should be duplicate data
+        if file_found.endswith(suffix):
+            out.append(file_found)
+    return out
 
-    if mms_messages:
-        report = ArtifactHtmlReport('MMS messages')
-        report.start_artifact_report(report_folder, 'MMS messages')
-        report.add_script()
-        data_headers = ('Date', 'Date sent', 'Content Location', 'Recipients', 'Subject',
-                        'Read', 'MMS Addresses', 'Transaction ID', 'MMS Version',
-                        'Body', 'Message Type', 'Message Box')
-        data_list = []
-        for mms in mms_messages:
-            mbox = mms.get('msg_box', '')
-            if mbox == '0':
-                mbox = 'All messages'
-            elif mbox == '1':
-                mbox = 'Inbox'
-            elif mbox == '2':
-                mbox = 'Sent'
-            elif mbox == '3':
-                mbox = 'Drafts'
-            elif mbox == '4':
-                mbox = 'Outbox'
-            elif mbox == '5':
-                mbox = 'Failed'
 
+@artifact_processor
+def get_mms_from_backup(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for file_found in _backup_files(files_found, 'mms_backup'):
+        source_path = file_found
+        for mms in read_messages_from_backup(file_found):
             body = mms.get('mms_body', '')
             if wrap_text:
                 body = body.replace("\n", "")
-                
-            data_list.append((ReadUnixTime(mms.get('date', 0)),
-                             ReadUnixTime(mms.get('date_sent', 0)),
-                             mms.get('ct_l', ''),
-                             ', '.join(mms.get('recipients', [])),
-                             mms.get('sub', ''),
-                             mms.get('read', ''),
-                             str(mms.get('mms_addresses', [])),
-                             mms.get('tr_id', ''),
-                             mms.get('v', ''),
-                             body,
-                             mms.get('m_type', ''),
-                             mbox
-                             ),)
-            
-        logfunc(f'Total mms messages = {len(mms_messages)}')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'mms messages'
-        tsv(report_folder, data_headers, data_list, tsvname, file_found.replace(seeker.data_folder, ''))
-        
-        tlactivity = f'MMS Messages'
-        timeline(report_folder, tlactivity, data_list, data_headers)
+            data_list.append((
+                ReadUnixTime(mms.get('date', 0)), ReadUnixTime(mms.get('date_sent', 0)),
+                mms.get('ct_l', ''), ', '.join(mms.get('recipients', [])), mms.get('sub', ''),
+                mms.get('read', ''), str(mms.get('mms_addresses', [])), mms.get('tr_id', ''),
+                mms.get('v', ''), body, mms.get('m_type', ''), MMS_BOX.get(mms.get('msg_box', ''), mms.get('msg_box', ''))))
 
-    if sms_messages:
-        report = ArtifactHtmlReport('SMS messages')
-        report.start_artifact_report(report_folder, 'SMS messages')
-        report.add_script()
-        data_headers = ('Date', 'Date sent', 'Read', 'Type', 'Body', 'recipients', 'Address', 'Status')
-        data_list = []
+    data_headers = (('Date', 'datetime'), ('Date sent', 'datetime'), 'Content Location', 'Recipients', 'Subject',
+                    'Read', 'MMS Addresses', 'Transaction ID', 'MMS Version', 'Body', 'Message Type', 'Message Box')
+    return data_headers, data_list, source_path
 
-        for sms in sms_messages:
+
+@artifact_processor
+def get_sms_from_backup(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for file_found in _backup_files(files_found, 'sms_backup'):
+        source_path = file_found
+        for sms in read_messages_from_backup(file_found):
             body = sms.get('body', '')
             if wrap_text:
                 body = body.replace("\n", "")
-            data_list.append((ReadUnixTimeMs(sms.get('date', 0)),
-                             ReadUnixTimeMs(sms.get('date_sent', 0)),
-                             sms.get('read', ''),
-                             sms.get('type', ''),
-                             body,
-                             ', '.join(sms.get('recipients', [])),
-                             sms.get('address', ''),
-                             sms.get('status', '')
-                            ),)
-        logfunc(f'Total sms messages = {len(sms_messages)}')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'sms messages'
-        tsv(report_folder, data_headers, data_list, tsvname, file_found.replace(seeker.data_folder, ''))
-        
-        tlactivity = f'SMS Messages'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No SMS or MMS messages found!')
-        return False
-    return True
+            data_list.append((
+                ReadUnixTimeMs(sms.get('date', 0)), ReadUnixTimeMs(sms.get('date_sent', 0)),
+                sms.get('read', ''), sms.get('type', ''), body,
+                ', '.join(sms.get('recipients', [])), sms.get('address', ''), sms.get('status', '')))
+
+    data_headers = (('Date', 'datetime'), ('Date sent', 'datetime'), 'Read', 'Type', 'Body', 'recipients', ('Address', 'phonenumber'), 'Status')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/smsmmsBackup.py
+++ b/scripts/artifacts/smsmmsBackup.py
@@ -1,7 +1,7 @@
 # pylint: disable=W0613
 __artifacts_v2__ = {
     "get_mms_from_backup": {
-        "name": "SMS & MMS Backup - MMS",
+        "name": "SMS and MMS Backup - MMS",
         "description": "MMS messages recovered from backup.ab telephony backup files",
         "author": "",
         "creation_date": "2024-08-15",
@@ -14,7 +14,7 @@ __artifacts_v2__ = {
         "artifact_icon": "message-square",
     },
     "get_sms_from_backup": {
-        "name": "SMS & MMS Backup - SMS",
+        "name": "SMS and MMS Backup - SMS",
         "description": "SMS messages recovered from backup.ab telephony backup files",
         "author": "",
         "creation_date": "2024-08-15",


### PR DESCRIPTION
Splits the telephony backup.ab parser into two decorated artifacts (category `SMS & MMS from backup.ab`):

- **SMS & MMS Backup - MMS** — MMS messages; `date`/`date_sent` → aware UTC `datetime`.
- **SMS & MMS Backup - SMS** — SMS messages; `date`/`date_sent` → aware UTC `datetime`; `Address` marked `phonenumber`.

The `ReadUnixTime`/`ReadUnixTimeMs` helpers previously anchored at a **naive** `datetime(1970,1,1)` (which would shift in LAVA); now anchored at tz-aware UTC. Message-box codes hoisted to an `MMS_BOX` lookup; shared `_backup_files` helper (skips mirror copies); zlib/JSON decode kept with its guards.

Verified: byte-compile, both decorated 4-arg, return 3-tuples, time helpers confirmed tz-aware UTC, no duplicate artifact names repo-wide, CI-style pylint 0 W/E, loader builds (433).