### PR TITLE
Convert mastodon to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/mastodon.py
+++ b/scripts/artifacts/mastodon.py
@@ -1,359 +1,276 @@
-# pylint: disable=E0606,W0311,W0611,W0612,W0613,W0631,W1309
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_mastodon": {
-        "name": "mastodon",
-        "description": "Module Description: Parses Mastodon timeline, notifications and searches",
+        "name": "Mastodon - Hashtag Searches",
+        "description": "Parses Mastodon hashtag searches",
         "author": "@KevinPagano3 (Twitter) / stark4n6@infosec.exchange (Mastodon)",
         "creation_date": "2022-12-07",
         "last_update_date": "2022-12-07",
         "requirements": "BeautifulSoup",
         "category": "Mastodon",
         "notes": "",
-        "paths": ('*/org.joinmastodon.android/databases/*.db*', '*/org.joinmastodon.android/files/*.json'),
-        "output_types": None,
+        "paths": ('*/org.joinmastodon.android/databases/*.db*',),
+        "output_types": "standard",
+        "artifact_icon": "search",
+    },
+    "get_mastodon_account_searches": {
+        "name": "Mastodon - Account Searches",
+        "description": "Parses Mastodon account searches",
+        "author": "@KevinPagano3 (Twitter) / stark4n6@infosec.exchange (Mastodon)",
+        "creation_date": "2022-12-07",
+        "last_update_date": "2022-12-07",
+        "requirements": "BeautifulSoup",
+        "category": "Mastodon",
+        "notes": "",
+        "paths": ('*/org.joinmastodon.android/databases/*.db*',),
+        "output_types": "standard",
+        "artifact_icon": "search",
+    },
+    "get_mastodon_notifications": {
+        "name": "Mastodon - Notifications",
+        "description": "Parses Mastodon notifications",
+        "author": "@KevinPagano3 (Twitter) / stark4n6@infosec.exchange (Mastodon)",
+        "creation_date": "2022-12-07",
+        "last_update_date": "2022-12-07",
+        "requirements": "BeautifulSoup",
+        "category": "Mastodon",
+        "notes": "",
+        "paths": ('*/org.joinmastodon.android/databases/*.db*',),
+        "output_types": "standard",
+        "artifact_icon": "bell",
+    },
+    "get_mastodon_timeline": {
+        "name": "Mastodon - Timeline",
+        "description": "Parses Mastodon timeline",
+        "author": "@KevinPagano3 (Twitter) / stark4n6@infosec.exchange (Mastodon)",
+        "creation_date": "2022-12-07",
+        "last_update_date": "2022-12-07",
+        "requirements": "BeautifulSoup",
+        "category": "Mastodon",
+        "notes": "",
+        "paths": ('*/org.joinmastodon.android/databases/*.db*',),
+        "output_types": "standard",
         "artifact_icon": "message-square",
-        "function": "get_mastodon",
+    },
+    "get_mastodon_accounts": {
+        "name": "Mastodon - Account Details",
+        "description": "Parses Mastodon account details",
+        "author": "@KevinPagano3 (Twitter) / stark4n6@infosec.exchange (Mastodon)",
+        "creation_date": "2022-12-07",
+        "last_update_date": "2022-12-07",
+        "requirements": "BeautifulSoup",
+        "category": "Mastodon",
+        "notes": "",
+        "paths": ('*/org.joinmastodon.android/files/accounts.json',),
+        "output_types": "standard",
+        "artifact_icon": "user",
+    },
+    "get_mastodon_instance": {
+        "name": "Mastodon - Instance Details",
+        "description": "Parses Mastodon instance details",
+        "author": "@KevinPagano3 (Twitter) / stark4n6@infosec.exchange (Mastodon)",
+        "creation_date": "2022-12-07",
+        "last_update_date": "2022-12-07",
+        "requirements": "BeautifulSoup",
+        "category": "Mastodon",
+        "notes": "",
+        "paths": ('*/org.joinmastodon.android/files/instance*.json',),
+        "output_types": "standard",
+        "artifact_icon": "server",
     }
 }
-
-# Module Description: Parses Mastodon timeline, notifications and searches
-# Author: @KevinPagano3 (Twitter) / stark4n6@infosec.exchange (Mastodon)
-# Date: 2022-12-07
-# Artifact version: 0.0.3
-# Requirements: BeautifulSoup
 
 import datetime
 import json
 import os
-import sqlite3
-import textwrap
+
 from bs4 import BeautifulSoup
 
-from packaging import version
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
-def get_mastodon(files_found, report_folder, seeker, wrap_text):
-    
-    account_db = ''
-    account_json = ''
-    source_file_account_db = ''
-    source_file_account_json = ''
-    
+
+def _sec_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value), datetime.timezone.utc)
+    return ''
+
+
+def _ms_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    return ''
+
+
+def _iso_to_utc(value):
+    if not value:
+        return ''
+    try:
+        dt = datetime.datetime.fromisoformat(value.replace('Z', '+00:00'))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=datetime.timezone.utc)
+        return dt.astimezone(datetime.timezone.utc)
+    except (ValueError, TypeError):
+        return value
+
+
+def _strip_html(value):
+    if not value:
+        return value
+    return BeautifulSoup(value, 'html.parser').get_text()
+
+
+def _mastodon_db(files_found):
     for file_found in files_found:
-        file_name = str(file_found)
-        
-        if file_name.lower().endswith('.db'):
-           accout_db = str(file_found)
-           source_file_account_db = file_found.replace(seeker.data_folder, '')
+        file_found = str(file_found)
+        if file_found.lower().endswith('.db'):
+            return file_found
+    return ''
 
-        if file_name.lower().endswith('accounts.json'):
-           account_json = str(file_found)
-           source_file_account_json = file_found.replace(seeker.data_folder, '')
-           
-        if file_name.lower().endswith('.json') and file_name.lower().startswith('instance'):
-           instance_json = str(file_found)
-           source_file_instance_json = file_found.replace(seeker.data_folder, '')
-           
-    db = open_sqlite_db_readonly(accout_db)
+
+def _query(source_path, sql):
+    if not source_path:
+        return []
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
-    
-    #Get Mastodon user search details for hashtags
-    cursor.execute('''
-    select
-    datetime(time,'unixepoch') as "Search Timestamp",
-    json_extract(recent_searches.json, '$.hashtag.name') as "Hashtag Name",
-    json_extract(recent_searches.json, '$.hashtag.url') as "Hashtag URL"
-    from recent_searches
-    where id like 'tag%'
-    ''')
-
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        description = 'Hashtag searches from the current user in Mastodon'
-        report = ArtifactHtmlReport('Mastodon - Hashtag Searches')
-        report.start_artifact_report(report_folder, 'Mastodon - Hashtag Searches')
-        report.add_script()
-        data_headers = ('Timestamp','Hashtag Name','Hashtag URL')
-        data_list = []
-        for row in all_rows:
-            data_list.append((row[0],row[1],row[2]))
-
-        report.write_artifact_data_table(data_headers, data_list, source_file_account_db)
-        report.end_artifact_report()
-        
-        tsvname = f'Mastodon - Hashtag Searches'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Mastodon - Hashtag Searches'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-    else:
-        logfunc('Mastodon - Hashtag Searches')
-
-    #Get Mastodon user search details for accounts
-    cursor = db.cursor()
-    cursor.execute('''
-    select
-    datetime(time,'unixepoch') as "Search Timestamp",
-    json_extract(recent_searches.json, '$.account.username') as "Username",
-    json_extract(recent_searches.json, '$.account.display_name') as "Display Name",
-    json_extract(recent_searches.json, '$.account.url') as "URL",
-    json_extract(recent_searches.json, '$.account.id') as "ID"
-    from recent_searches
-    where id like 'acc%'
-    ''')
-
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        description = 'Account searches from the current user in Mastodon'
-        report = ArtifactHtmlReport('Mastodon - Account Searches')
-        report.start_artifact_report(report_folder, 'Mastodon - Account Searches')
-        report.add_script()
-        data_headers = ('Timestamp','Username','Display Name','URL','ID')
-        data_list = []
-        for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4]))
-
-        report.write_artifact_data_table(data_headers, data_list, source_file_account_db)
-        report.end_artifact_report()
-        
-        tsvname = f'Mastodon - Account Searches'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Mastodon - Account Searches'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-    else:
-        logfunc('Mastodon - Account Searches')
-
-    #Get Mastodon user notification details
-    cursor = db.cursor()
-    cursor.execute('''
-    select 
-    json_extract(notifications_all.json, '$.created_at') as "Notification Created Timestamp",
-    json_extract(notifications_all.json, '$.account.acct') as "Notification From",
-    case type
-        when 0 then "Follow"
-        when 2 then "Mention"
-        when 3 then "Boost"
-        when 4 then "Favorite"
-    end as "Notification Type",
-    json_extract(notifications_all.json, '$.status.url') as "Reference URL",
-    json_extract(notifications_all.json, '$.status.content') as "Text Content",
-    json_extract(notifications_all.json, '$.status.visibility') as "Visibility",
-    json_extract(notifications_all.json, '$.status.created_at') as "Status Created Timestamp",
-    id
-    from notifications_all
-    ''')
-
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        description = 'Notification details for the current user in Mastodon'
-        report = ArtifactHtmlReport('Mastodon - Notifications')
-        report.start_artifact_report(report_folder, 'Mastodon - Notifications')
-        report.add_script()
-        data_headers = ('Notification Created Timestamp','Notification From','Notification Type','Reference URL','Text Content','Visibility','Status Created Timestamp','ID')
-        data_list = []
-        data_list_stripped = []
-        for row in all_rows:
-            
-            notification_timestamp = ''
-            status_timestamp = ''
-        
-            notification_timestamp = row[0].replace('T', ' ').replace('Z', '')
-            if row[6] != None:
-                status_timestamp = row[6].replace('T', ' ').replace('Z', '')
-            else:
-                status_timestamp = ''
-                
-            data_list.append((notification_timestamp,row[1],row[2],row[3],row[4],row[5],status_timestamp,row[7]))
-            
-            if row[4] != None:
-                soup = BeautifulSoup(row[4], 'html.parser').text
-                data_list_stripped.append((notification_timestamp,row[1],row[2],row[3],soup,row[5],status_timestamp,row[7]))
-            else:
-                data_list_stripped.append((notification_timestamp,row[1],row[2],row[3],row[4],row[5],status_timestamp,row[7]))
-                
-        report.write_artifact_data_table(data_headers, data_list, source_file_account_db, html_no_escape=['Text Content'])
-        report.end_artifact_report()
-        
-        tsvname = f'Mastodon - Notifications'
-        tsv(report_folder, data_headers, data_list_stripped, tsvname)
-        
-        tlactivity = f'Mastodon - Notifications'
-        timeline(report_folder, tlactivity, data_list_stripped, data_headers)
-        
-    else:
-        logfunc('Mastodon - Notifications data available')
-    
-    #Get Mastodon user timeline details
-    cursor = db.cursor()
-    cursor.execute('''
-    select
-    json_extract(home_timeline.json, '$.created_at') as "Created Timestamp",
-    json_extract(home_timeline.json, '$.account.acct') as "Account Name",
-    json_extract(home_timeline.json, '$.application.name') as "App Name",
-    json_extract(home_timeline.json, '$.content') as "Content",
-    json_extract(home_timeline.json, '$.url') as "URL",
-    json_extract(home_timeline.json, '$.reblog.account.acct') as "Boosted Account Name",
-    json_extract(home_timeline.json, '$.reblog.content') as "Boosted Content",
-    json_extract(home_timeline.json, '$.reblog.url') as "Boosted URL",
-    json_extract(home_timeline.json, '$.replies_count') as "Replies Count",
-    json_extract(home_timeline.json, '$.reblogs_count') as "Boosted Count",
-    json_extract(home_timeline.json, '$.favourites_count') as "Favorites Count",
-    json_extract(home_timeline.json, '$.visibility') as "Visibility",
-    id,
-    json
-    from home_timeline
-    ''')
-
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        description = 'Timeline details for the current users feed in Mastodon'
-        report = ArtifactHtmlReport('Mastodon - Timeline')
-        report.start_artifact_report(report_folder, 'Mastodon - Timeline')
-        report.add_script()
-        data_headers = ('Timestamp','Account Name','App Name','Text Content','Attachment URL','URL','Boosted Account Name','Boosted Content','Boosted URL','Replies Count','Boosted Count','Favorites Count','Visibility','ID')
-        data_list = []
-        data_list_stripped = []
-        for row in all_rows:
-            data = json.loads(row[13])
-            attachment_list = []
-            attachments = ''
-            for x in data['media_attachments']:
-                attachment_item = x.get('url','')
-                attachment_list.append(attachment_item)
-                if len(attachment_list) > 0:
-                    attachments = '\n'.join(map(str,attachment_list))
-                else:
-                    attachments = ''
-        
-            notification_timestamp = row[0].replace('T', ' ').replace('Z', '')
-        
-            data_list.append((notification_timestamp,row[1],row[2],row[3],attachments,row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11],row[12]))
-            
-            if row[3] and row[6] != None:
-                data_list_stripped.append((notification_timestamp,row[1],row[2],row[3],attachment_list,row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11],row[12]))
-                
-            else:
-                soup1 = ''
-                soup2 = ''
-                if str(row[3]).startswith('<p>'):
-                    soup1 = BeautifulSoup(row[3], 'html.parser').text
-                elif str(row[6]).startswith('<p>'):
-                    soup2 = BeautifulSoup(row[6], 'html.parser').text
-                    
-                data_list_stripped.append((notification_timestamp,row[1],row[2],soup1,attachment_list,row[4],soup2,row[6],row[7],row[8],row[9],row[10],row[11],row[12]))                      
-
-        report.write_artifact_data_table(data_headers, data_list, source_file_account_db, html_no_escape=['Text Content','Boosted Content'])
-        report.end_artifact_report()
-        
-        tsvname = f'Mastodon - Timeline'
-        tsv(report_folder, data_headers, data_list_stripped, tsvname)
-        
-        tlactivity = f'Mastodon - Timeline'
-        timeline(report_folder, tlactivity, data_list_stripped, data_headers)
-        
-    else:
-        logfunc('Mastodon - Timeline data available')   
-    
+    try:
+        cursor.execute(sql)
+        rows = cursor.fetchall()
+    except Exception as e:
+        logfunc(str(e))
+        rows = []
     db.close()
-    
-    #Get Mastodon account user details
-    with open(account_json, encoding = 'utf-8', mode = 'r') as f:
-        data = json.loads(f.read())
-    data_list_json = []
-    
-    for x in data['accounts']:
-        account_created_ts = str(x['b'].get('created_at','')).replace('T', ' ').replace('Z', '')
-        account_name = x['b'].get('acct','')
-        account_username = x['b'].get('username','')
-        account_display_name = x['b'].get('display_name','')
-        account_url = x['b'].get('url','')
-        account_id = x['b'].get('id','')
-        followers_count = x['b'].get('followers_count','')
-        following_count = x['b'].get('following_count','')
-        account_bio = x['b'].get('note','')
-        if str(account_bio).startswith('<p>'):
-            account_bio = BeautifulSoup(account_bio, 'html.parser').text
-            
-        account_avatar = x['b'].get('avatar','')
-        instance_name = x.get('c','')
-        
-        alert_favorite = str(x['j']['alerts'].get('favourite','')).title()
-        alert_follow = str(x['j']['alerts'].get('follow','')).title()
-        alert_mention = str(x['j']['alerts'].get('mention','')).title()
-        alert_poll = str(x['j']['alerts'].get('poll','')).title()
-        alert_reblog = str(x['j']['alerts'].get('reblog','')).title()
-        
-        flag_bot = str(x['b'].get('bot','')).title()
-        flag_discoverable = str(x['b'].get('discoverable','')).title()
-        flag_locked = str(x['b'].get('locked','')).title()
-        flag_suspended = str(x['b'].get('suspended','')).title()
-        
-        data_list_json.append((account_created_ts,account_name,account_username,account_display_name,account_url,account_id,followers_count,following_count,account_bio,account_avatar,instance_name,alert_favorite,alert_follow,alert_mention,alert_poll,alert_reblog,flag_bot,flag_discoverable,flag_locked,flag_suspended))
+    return rows
 
-    num_entries = len(data_list_json)
-    if num_entries > 0:
-        description = 'Account details for the current Mastodon user.'
-        report = ArtifactHtmlReport('Mastodon - Account Details')
-        report.start_artifact_report(report_folder, 'Mastodon - Account Details', description)
-        report.add_script()
-        data_headers = ('Created Timestamp','Name','User Name','Display Name','URL','ID','Followers Count','Following Count','Bio','Avatar URL','Instance Name','Favorite Alerts','Follow Alerts','Mention Alerts','Poll Alerts','Boost Alerts','Is Bot','Is Discoverable','Is Locked','Is Suspended')
 
-        report.write_artifact_data_table(data_headers, data_list_json, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Mastodon - Account Details'
-        tsv(report_folder, data_headers, data_list_json, tsvname)
-        
-        tlactivity = f'Mastodon - Account Details'
-        timeline(report_folder, tlactivity, data_list_json, data_headers)
-    else:
-        logfunc('No Mastodon - Account Details data available')
-        
-        
-    #Get Mastodon instance details    
-    with open(file_found, encoding = 'utf-8', mode = 'r') as f:
-        data = json.loads(f.read())
-    
-    data_list_instance_json = []
+@artifact_processor
+def get_mastodon(files_found, report_folder, seeker, wrap_text):
+    source_path = _mastodon_db(files_found)
+    rows = _query(source_path, '''
+        select time,
+        json_extract(recent_searches.json, '$.hashtag.name'),
+        json_extract(recent_searches.json, '$.hashtag.url')
+        from recent_searches where id like 'tag%'
+    ''')
+    data_list = [(_sec_to_utc(r[0]), r[1], r[2]) for r in rows]
+    data_headers = (('Timestamp', 'datetime'), 'Hashtag Name', 'Hashtag URL')
+    return data_headers, data_list, source_path
 
-    instance_updated_ts = datetime.datetime.utcfromtimestamp(int(data.get('last_updated',''))/1000).strftime('%Y-%m-%d %H:%M:%S')
-    instance_uri = data['instance'].get('uri','')
-    instance_title = data['instance'].get('title','')
-    instance_description = data['instance'].get('description','')
-    instance_version = data['instance'].get('version','')
-    instance_user_count = data['instance']['stats'].get('user_count','')
-    instance_status_count = data['instance']['stats'].get('status_count','')
-    instance_invites = str(data['instance'].get('invites_enabled','')).title()
-    instance_registrations = str(data['instance'].get('registrations','')).title()
-    instance_email = data['instance'].get('email','')
-    instance_contact = data['instance']['contact_account'].get('url','')
-    instance_thumbnail = data['instance'].get('thumbnail','')
 
-    data_list_instance_json.append((instance_updated_ts,instance_uri,instance_title,instance_description,instance_version,instance_user_count,instance_status_count,instance_invites,instance_registrations,instance_email,instance_contact,instance_thumbnail))
+@artifact_processor
+def get_mastodon_account_searches(files_found, report_folder, seeker, wrap_text):
+    source_path = _mastodon_db(files_found)
+    rows = _query(source_path, '''
+        select time,
+        json_extract(recent_searches.json, '$.account.username'),
+        json_extract(recent_searches.json, '$.account.display_name'),
+        json_extract(recent_searches.json, '$.account.url'),
+        json_extract(recent_searches.json, '$.account.id')
+        from recent_searches where id like 'acc%'
+    ''')
+    data_list = [(_sec_to_utc(r[0]), r[1], r[2], r[3], r[4]) for r in rows]
+    data_headers = (('Timestamp', 'datetime'), 'Username', 'Display Name', 'URL', 'ID')
+    return data_headers, data_list, source_path
 
-    num_entries = len(data_list_instance_json)
-    if num_entries > 0:
-        description = 'Details for the instance of Mastodon the user has joined.'
-        report = ArtifactHtmlReport('Mastodon - Instance Details')
-        report.start_artifact_report(report_folder, 'Mastodon - Instance Details', description)
-        report.add_script()
-        data_headers = ('Last Updated Timestamp','URI','Title','Description','Version','User Count','Status Count','Invites Enable','Registrations Enabled','Admin Contact Email','Owner','Thumbnail')
 
-        report.write_artifact_data_table(data_headers, data_list_instance_json, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Mastodon - Instance Details'
-        tsv(report_folder, data_headers, data_list_instance_json, tsvname)
-        
-        tlactivity = f'Mastodon - Instance Details'
-        timeline(report_folder, tlactivity, data_list_instance_json, data_headers)
-    else:
-        logfunc('No Mastodon - Instance Details data available')
+@artifact_processor
+def get_mastodon_notifications(files_found, report_folder, seeker, wrap_text):
+    source_path = _mastodon_db(files_found)
+    rows = _query(source_path, '''
+        select
+        json_extract(notifications_all.json, '$.created_at'),
+        json_extract(notifications_all.json, '$.account.acct'),
+        case type when 0 then "Follow" when 2 then "Mention" when 3 then "Boost" when 4 then "Favorite" end,
+        json_extract(notifications_all.json, '$.status.url'),
+        json_extract(notifications_all.json, '$.status.content'),
+        json_extract(notifications_all.json, '$.status.visibility'),
+        json_extract(notifications_all.json, '$.status.created_at'),
+        id
+        from notifications_all
+    ''')
+    data_list = [(_iso_to_utc(r[0]), r[1], r[2], r[3], _strip_html(r[4]), r[5], _iso_to_utc(r[6]), r[7]) for r in rows]
+    data_headers = (('Notification Created Timestamp', 'datetime'), 'Notification From', 'Notification Type', 'Reference URL', 'Text Content', 'Visibility', ('Status Created Timestamp', 'datetime'), 'ID')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_mastodon_timeline(files_found, report_folder, seeker, wrap_text):
+    source_path = _mastodon_db(files_found)
+    rows = _query(source_path, '''
+        select
+        json_extract(home_timeline.json, '$.created_at'),
+        json_extract(home_timeline.json, '$.account.acct'),
+        json_extract(home_timeline.json, '$.application.name'),
+        json_extract(home_timeline.json, '$.content'),
+        json_extract(home_timeline.json, '$.url'),
+        json_extract(home_timeline.json, '$.reblog.account.acct'),
+        json_extract(home_timeline.json, '$.reblog.content'),
+        json_extract(home_timeline.json, '$.reblog.url'),
+        json_extract(home_timeline.json, '$.replies_count'),
+        json_extract(home_timeline.json, '$.reblogs_count'),
+        json_extract(home_timeline.json, '$.favourites_count'),
+        json_extract(home_timeline.json, '$.visibility'),
+        id, json
+        from home_timeline
+    ''')
+    data_list = []
+    for r in rows:
+        attachments = ''
+        try:
+            attachments = '\n'.join(x.get('url', '') for x in json.loads(r[13]).get('media_attachments', []))
+        except (ValueError, TypeError):
+            pass
+        data_list.append((_iso_to_utc(r[0]), r[1], r[2], _strip_html(r[3]), attachments, r[4], r[5],
+                          _strip_html(r[6]), r[7], r[8], r[9], r[10], r[11], r[12]))
+    data_headers = (('Timestamp', 'datetime'), 'Account Name', 'App Name', 'Text Content', 'Attachment URL', 'URL', 'Boosted Account Name', 'Boosted Content', 'Boosted URL', 'Replies Count', 'Boosted Count', 'Favorites Count', 'Visibility', 'ID')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_mastodon_accounts(files_found, report_folder, seeker, wrap_text):
+    source_path = ''
+    data_list = []
+    for file_found in files_found:
+        file_found = str(file_found)
+        if not file_found.lower().endswith('accounts.json'):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as f:
+            data = json.loads(f.read())
+        for x in data.get('accounts', []):
+            b = x.get('b', {})
+            alerts = x.get('j', {}).get('alerts', {})
+            data_list.append((
+                _iso_to_utc(b.get('created_at', '')), b.get('acct', ''), b.get('username', ''), b.get('display_name', ''),
+                b.get('url', ''), b.get('id', ''), b.get('followers_count', ''), b.get('following_count', ''),
+                _strip_html(b.get('note', '')), b.get('avatar', ''), x.get('c', ''),
+                str(alerts.get('favourite', '')).title(), str(alerts.get('follow', '')).title(),
+                str(alerts.get('mention', '')).title(), str(alerts.get('poll', '')).title(), str(alerts.get('reblog', '')).title(),
+                str(b.get('bot', '')).title(), str(b.get('discoverable', '')).title(),
+                str(b.get('locked', '')).title(), str(b.get('suspended', '')).title()))
+
+    data_headers = (('Created Timestamp', 'datetime'), 'Name', 'User Name', 'Display Name', 'URL', 'ID', 'Followers Count', 'Following Count', 'Bio', 'Avatar URL', 'Instance Name', 'Favorite Alerts', 'Follow Alerts', 'Mention Alerts', 'Poll Alerts', 'Boost Alerts', 'Is Bot', 'Is Discoverable', 'Is Locked', 'Is Suspended')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_mastodon_instance(files_found, report_folder, seeker, wrap_text):
+    source_path = ''
+    data_list = []
+    for file_found in files_found:
+        file_found = str(file_found)
+        if not (file_found.lower().endswith('.json') and os.path.basename(file_found).lower().startswith('instance')):
+            continue
+        source_path = file_found
+        with open(file_found, encoding='utf-8') as f:
+            data = json.loads(f.read())
+        instance = data.get('instance', {})
+        stats = instance.get('stats', {})
+        data_list.append((
+            _ms_to_utc(data.get('last_updated', '')), instance.get('uri', ''), instance.get('title', ''),
+            instance.get('description', ''), instance.get('version', ''), stats.get('user_count', ''),
+            stats.get('status_count', ''), str(instance.get('invites_enabled', '')).title(),
+            str(instance.get('registrations', '')).title(), instance.get('email', ''),
+            instance.get('contact_account', {}).get('url', ''), instance.get('thumbnail', '')))
+
+    data_headers = (('Last Updated Timestamp', 'datetime'), 'URI', 'Title', 'Description', 'Version', 'User Count', 'Status Count', 'Invites Enable', 'Registrations Enabled', 'Admin Contact Email', 'Owner', 'Thumbnail')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Splits the Mastodon parser into six decorated artifacts (category `Mastodon`): **Hashtag Searches**, **Account Searches**, **Notifications**, **Timeline** (DB), plus **Account Details** and **Instance Details** (JSON). Each gets its own targeted `paths` (db vs accounts.json vs instance*.json).

- Search `time` (epoch sec) and instance `last_updated` (epoch ms) → aware UTC `datetime`.
- ISO8601 `created_at` timestamps now parsed to **aware UTC** via `_iso_to_utc` (the original just did `.replace('T',' ').replace('Z','')`, leaving a naive string that would shift in LAVA) and marked `datetime`.
- HTML post/bio content stripped to plain text via BeautifulSoup (`_strip_html`); timeline attachment URLs joined.
- Fixed the `accout_db` typo (the original mis-spelled the variable but worked by being consistently wrong).

Verified: byte-compile, all 6 decorated 4-arg, return 3-tuples, `_iso_to_utc`/`_strip_html` unit-tested, no duplicate names repo-wide, no '&' in names, CI-style pylint 0 W/E, loader builds (439).