### PR TITLE
Convert emulatedSmeta to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/emulatedSmeta.py
+++ b/scripts/artifacts/emulatedSmeta.py
@@ -89,9 +89,21 @@ YESNO = "case {0} when 0 then '' when 1 then 'Yes' end"
 
 
 def _sec_to_utc(value):
-    if value:
+    if not value:
+        return ''
+    try:
         return datetime.datetime.fromtimestamp(int(value), datetime.timezone.utc)
-    return ''
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
+
+
+def _ms_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
 
 
 def _keytime(date_added, date_modified):
@@ -135,7 +147,7 @@ def get_emulatedSmeta(files_found, report_folder, seeker, wrap_text):
     data_list = []
     for r in rows:
         xmp = str(r[15])[2:-1] if isinstance(r[15], bytes) else r[15]
-        data_list.append((_keytime(r[0], r[1]), _sec_to_utc(r[0]), _sec_to_utc(r[1]), _sec_to_utc(r[2]),
+        data_list.append((_keytime(r[0], r[1]), _sec_to_utc(r[0]), _sec_to_utc(r[1]), _ms_to_utc(r[2]),
                           r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10], r[11], r[12], r[13], r[14], xmp))
     data_headers = (('Key Timestamp', 'datetime'), ('Date Added', 'datetime'), ('Date Modified', 'datetime'), ('Date Taken', 'datetime'),
                     'Path', 'Title', 'Display Name', 'Size', 'Owner Package Name', 'Bucket Display Name', 'Referer URI', 'Download URI',
@@ -152,7 +164,7 @@ def get_emulatedSmeta_images(files_found, report_folder, seeker, wrap_text):
         {YESNO.format('is_download')}, {YESNO.format('is_favorite')}, {YESNO.format('is_trashed')}
         FROM images
     ''')
-    data_list = [(_keytime(r[0], r[1]), _sec_to_utc(r[0]), _sec_to_utc(r[1]), _sec_to_utc(r[2]),
+    data_list = [(_keytime(r[0], r[1]), _sec_to_utc(r[0]), _sec_to_utc(r[1]), _ms_to_utc(r[2]),
                   r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10], r[11], r[12], r[13], r[14], r[15]) for r in rows]
     data_headers = (('Key Timestamp', 'datetime'), ('Date Added', 'datetime'), ('Date Modified', 'datetime'), ('Date Taken', 'datetime'),
                     'Path', 'Title', 'Display Name', 'Size', 'Latitude', 'Longitude', 'Orientation', 'Owner Package Name',
@@ -169,7 +181,7 @@ def get_emulatedSmeta_files(files_found, report_folder, seeker, wrap_text):
         {YESNO.format('is_download')}, {YESNO.format('is_favorite')}, {YESNO.format('is_trashed')}
         FROM files
     ''')
-    data_list = [(_keytime(r[0], r[1]), _sec_to_utc(r[0]), _sec_to_utc(r[1]), _sec_to_utc(r[2]),
+    data_list = [(_keytime(r[0], r[1]), _sec_to_utc(r[0]), _sec_to_utc(r[1]), _ms_to_utc(r[2]),
                   r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10], r[11], r[12], r[13], r[14], r[15], r[16], r[17]) for r in rows]
     data_headers = (('Key Timestamp', 'datetime'), ('Date Added', 'datetime'), ('Date Modified', 'datetime'), ('Date Taken', 'datetime'),
                     'Path', 'Title', 'Display Name', 'Size', 'Latitude', 'Longitude', 'Orientation', 'Owner Package Name',
@@ -186,7 +198,7 @@ def get_emulatedSmeta_videos(files_found, report_folder, seeker, wrap_text):
         {YESNO.format('is_download')}, {YESNO.format('is_favorite')}, {YESNO.format('is_trashed')}
         FROM video
     ''')
-    data_list = [(_keytime(r[0], r[1]), _sec_to_utc(r[0]), _sec_to_utc(r[1]), _sec_to_utc(r[2]),
+    data_list = [(_keytime(r[0], r[1]), _sec_to_utc(r[0]), _sec_to_utc(r[1]), _ms_to_utc(r[2]),
                   r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10], r[11], r[12], r[13], r[14], r[15]) for r in rows]
     data_headers = (('Key Timestamp', 'datetime'), ('Date Added', 'datetime'), ('Date Modified', 'datetime'), ('Date Taken', 'datetime'),
                     'Path', 'Title', 'Display Name', 'Size', 'Latitude', 'Longitude', 'Orientation', 'Owner Package Name',
@@ -203,7 +215,7 @@ def get_emulatedSmeta_audio(files_found, report_folder, seeker, wrap_text):
         {YESNO.format('is_download')}, {YESNO.format('is_favorite')}, {YESNO.format('is_trashed')}
         FROM audio
     ''')
-    data_list = [(_keytime(r[0], r[1]), _sec_to_utc(r[0]), _sec_to_utc(r[1]), _sec_to_utc(r[2]),
+    data_list = [(_keytime(r[0], r[1]), _sec_to_utc(r[0]), _sec_to_utc(r[1]), _ms_to_utc(r[2]),
                   r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10], r[11], r[12]) for r in rows]
     data_headers = (('Key Timestamp', 'datetime'), ('Date Added', 'datetime'), ('Date Modified', 'datetime'), ('Date Taken', 'datetime'),
                     'Path', 'Title', 'Display Name', 'Size', 'Owner Package Name', 'Bucket Display Name', 'Relative Path',
@@ -219,7 +231,7 @@ def get_emulatedSmeta_files_legacy(files_found, report_folder, seeker, wrap_text
         {ORIENTATION}, bucket_display_name, width, height, _id
         FROM files
     ''')
-    data_list = [(_sec_to_utc(r[0]), _sec_to_utc(r[1]), _sec_to_utc(r[2]),
+    data_list = [(_sec_to_utc(r[0]), _sec_to_utc(r[1]), _ms_to_utc(r[2]),
                   r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10], r[11], r[12], r[13]) for r in rows]
     data_headers = (('Timestamp Added', 'datetime'), ('Timestamp Modified', 'datetime'), ('Timestamp Taken', 'datetime'),
                     'Path', 'Title', 'Display Name', 'Size', 'Latitude', 'Longitude', 'Orientation', 'Bucket Display Name',

--- a/scripts/artifacts/emulatedSmeta.py
+++ b/scripts/artifacts/emulatedSmeta.py
@@ -1,539 +1,227 @@
-# pylint: disable=W0611,W0613,W0631,W1309
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_emulatedSmeta": {
-        "name": "Emulated Storage Metadata",
-        "description": "Parses emulated storage metadata from external.db",
+        "name": "Emulated Storage Metadata - Downloads",
+        "description": "Parses media store metadata (downloads)",
         "author": "@AlexisBrignoni",
         "creation_date": "2020-10-19",
         "last_update_date": "2020-10-19",
         "requirements": "none",
         "category": "Emulated Storage Metadata",
-        "notes": "2023-02-10 - Updated by @KevinPagano3",
-        "paths": ('*/com.google.android.providers.media.module/databases/external.db*','*/com.android.providers.media/databases/external.db*'),
-        "output_types": None,
+        "notes": "",
+        "paths": ('*/com.google.android.providers.media.module/databases/external.db*', '*/com.android.providers.media/databases/external.db*'),
+        "output_types": "standard",
+        "artifact_icon": "download",
+    },
+    "get_emulatedSmeta_images": {
+        "name": "Emulated Storage Metadata - Images",
+        "description": "Parses media store metadata (images)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2020-10-19",
+        "last_update_date": "2020-10-19",
+        "requirements": "none",
+        "category": "Emulated Storage Metadata",
+        "notes": "",
+        "paths": ('*/com.google.android.providers.media.module/databases/external.db*', '*/com.android.providers.media/databases/external.db*'),
+        "output_types": "standard",
+        "artifact_icon": "image",
+    },
+    "get_emulatedSmeta_files": {
+        "name": "Emulated Storage Metadata - Files",
+        "description": "Parses media store metadata (files)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2020-10-19",
+        "last_update_date": "2020-10-19",
+        "requirements": "none",
+        "category": "Emulated Storage Metadata",
+        "notes": "",
+        "paths": ('*/com.google.android.providers.media.module/databases/external.db*', '*/com.android.providers.media/databases/external.db*'),
+        "output_types": "standard",
         "artifact_icon": "file",
-        "function": "get_emulatedSmeta",
+    },
+    "get_emulatedSmeta_videos": {
+        "name": "Emulated Storage Metadata - Videos",
+        "description": "Parses media store metadata (videos)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2020-10-19",
+        "last_update_date": "2020-10-19",
+        "requirements": "none",
+        "category": "Emulated Storage Metadata",
+        "notes": "",
+        "paths": ('*/com.google.android.providers.media.module/databases/external.db*', '*/com.android.providers.media/databases/external.db*'),
+        "output_types": "standard",
+        "artifact_icon": "video",
+    },
+    "get_emulatedSmeta_audio": {
+        "name": "Emulated Storage Metadata - Audio",
+        "description": "Parses media store metadata (audio)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2020-10-19",
+        "last_update_date": "2020-10-19",
+        "requirements": "none",
+        "category": "Emulated Storage Metadata",
+        "notes": "",
+        "paths": ('*/com.google.android.providers.media.module/databases/external.db*', '*/com.android.providers.media/databases/external.db*'),
+        "output_types": "standard",
+        "artifact_icon": "music",
+    },
+    "get_emulatedSmeta_files_legacy": {
+        "name": "Emulated Storage Metadata - Files (Legacy)",
+        "description": "Parses media store metadata (files, older schema)",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2020-10-19",
+        "last_update_date": "2020-10-19",
+        "requirements": "none",
+        "category": "Emulated Storage Metadata",
+        "notes": "",
+        "paths": ('*/com.google.android.providers.media.module/databases/external.db*', '*/com.android.providers.media/databases/external.db*'),
+        "output_types": "standard",
+        "artifact_icon": "file",
     }
 }
 
-import sqlite3
+import datetime
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
-def get_emulatedSmeta(files_found, report_folder, seeker, wrap_text):
+ORIENTATION = "case orientation when 0 then 'Horizontal' else 'Vertical' end"
+YESNO = "case {0} when 0 then '' when 1 then 'Yes' end"
 
-    data_list_downloads = []
-    data_list_images = []
-    data_list_files = []
-    data_list_videos = []    
-    data_list_audio = []
-    data_list = []
 
+def _sec_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value), datetime.timezone.utc)
+    return ''
+
+
+def _keytime(date_added, date_modified):
+    return _sec_to_utc(date_added if date_added else date_modified)
+
+
+def _external_db(files_found, media_module):
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('external.db'):
-            continue # Skip all other files
-            
-        if 'media.module' in file_found:
-            db = open_sqlite_db_readonly(file_found)
-            # Downloads
-            cursor = db.cursor()
-            cursor.execute('''
-            SELECT
-                datetime(date_added,  'unixepoch'),
-                datetime(date_modified, 'unixepoch'),
-                datetime(datetaken, 'unixepoch'),
-                _data,
-                title,
-                _display_name,
-                _size,
-                owner_package_name,
-                bucket_display_name,
-                referer_uri,
-                download_uri,
-                relative_path,
-                case is_download
-                    when 0 then ''
-                    when 1 then 'Yes'
-                end,
-                case is_favorite
-                    when 0 then ''
-                    when 1 then 'Yes'
-                end,
-                case is_trashed
-                    when 0 then ''
-                    when 1 then 'Yes'
-                end,
-                xmp
-            FROM downloads
-            ''')
+            continue
+        if media_module == ('media.module' in file_found):
+            return file_found
+    return ''
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                for row in all_rows:
-                    if bool(row[0]):
-                        keytime = row[0]
-                    else:
-                        keytime = row[1]
-                    if isinstance(row[15], bytes):
-                        xmp = str(row[15])[2:-1]
-                    else:
-                        xmp = row[15]
-                    
-                    if keytime is None:
-                        pass
-                    else:
-                        keytime = convert_utc_human_to_timezone(convert_ts_human_to_utc(keytime),'UTC')
-                        
-                    date_added = row[0]
-                    if date_added is None:
-                        pass
-                    else:
-                        date_added = convert_utc_human_to_timezone(convert_ts_human_to_utc(date_added),'UTC')
-                    
-                    date_modified = row[1]
-                    if date_modified is None:
-                        pass
-                    else:
-                        date_modified = convert_utc_human_to_timezone(convert_ts_human_to_utc(date_modified),'UTC')
-                        
-                    date_taken = row[2] 
-                    if date_taken is None:
-                        pass
-                    else:
-                        date_taken = convert_utc_human_to_timezone(convert_ts_human_to_utc(date_taken),'UTC')
-                    
-                    data_list_downloads.append((keytime, date_added, date_modified, date_taken, row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11], row[12], row[13], row[14], xmp, file_found))
-            
-            # Images
-            cursor.execute('''
-            SELECT
-            datetime(date_added,  'unixepoch'),
-            datetime(date_modified, 'unixepoch'),
-            datetime(datetaken, 'unixepoch'),
-            _data,
-            title,
-            _display_name,
-            _size,
-            latitude,
-            longitude,
-            case orientation
-                when 0 then 'Horizontal'
-                else 'Vertical'
-            end,
-            owner_package_name,
-            bucket_display_name,
-            relative_path,
-            case is_download
-                when 0 then ''
-                when 1 then 'Yes'
-            end,
-            case is_favorite
-                when 0 then ''
-                when 1 then 'Yes'
-            end,
-            case is_trashed
-                when 0 then ''
-                when 1 then 'Yes'
-            end
-            from images
-            ''')
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                for row in all_rows:
-                    if bool(row[0]):
-                        keytime = row[0]
-                    else:
-                        keytime = row[1]
-                        
-                    if keytime is None:
-                        pass
-                    else:
-                        keytime = convert_utc_human_to_timezone(convert_ts_human_to_utc(keytime),'UTC')
-                        
-                    date_added = row[0]
-                    if date_added is None:
-                        pass
-                    else:
-                        date_added = convert_utc_human_to_timezone(convert_ts_human_to_utc(date_added),'UTC')
-                    
-                    date_modified = row[1]
-                    if date_modified is None:
-                        pass
-                    else:
-                        date_modified = convert_utc_human_to_timezone(convert_ts_human_to_utc(date_modified),'UTC')
-                        
-                    date_taken = row[2] 
-                    if date_taken is None:
-                        pass
-                    else:
-                        date_taken = convert_utc_human_to_timezone(convert_ts_human_to_utc(date_taken),'UTC')
-                    
-                    data_list_images.append((keytime, date_added, date_modified, date_taken, row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11], row[12], row[13], row[14], row[15], file_found))
+def _run(source_path, sql):
+    if not source_path:
+        return []
+    db = open_sqlite_db_readonly(source_path)
+    cursor = db.cursor()
+    try:
+        cursor.execute(sql)
+        rows = cursor.fetchall()
+    except Exception as e:
+        logfunc(str(e))
+        rows = []
+    db.close()
+    return rows
 
-            # Files (newer version)
-            cursor.execute('''
-            SELECT
-            datetime(date_added,  'unixepoch'),
-            datetime(date_modified, 'unixepoch'),
-            datetime(datetaken, 'unixepoch'),
-            _data,
-            title,
-            _display_name,
-            _size,
-            latitude,
-            longitude,
-            case orientation
-                when 0 then 'Horizontal'
-                else 'Vertical'
-            end,
-            owner_package_name,
-            bucket_display_name,
-            referer_uri,
-            download_uri,
-            relative_path,
-            case is_download
-                when 0 then ''
-                when 1 then 'Yes'
-            end,
-            case is_favorite
-                when 0 then ''
-                when 1 then 'Yes'
-            end,
-            case is_trashed
-                when 0 then ''
-                when 1 then 'Yes'
-            end
-            from files
-            ''')
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                
-                for row in all_rows:
-                    if bool(row[0]):
-                        keytime = row[0]
-                    else:
-                        keytime = row[1]
-                        
-                    if keytime is None:
-                        pass
-                    else:
-                        keytime = convert_utc_human_to_timezone(convert_ts_human_to_utc(keytime),'UTC')
-                        
-                    date_added = row[0]
-                    if date_added is None:
-                        pass
-                    else:
-                        date_added = convert_utc_human_to_timezone(convert_ts_human_to_utc(date_added),'UTC')
-                    
-                    date_modified = row[1]
-                    if date_modified is None:
-                        pass
-                    else:
-                        date_modified = convert_utc_human_to_timezone(convert_ts_human_to_utc(date_modified),'UTC')
-                        
-                    date_taken = row[2] 
-                    if date_taken is None:
-                        pass
-                    else:
-                        date_taken = convert_utc_human_to_timezone(convert_ts_human_to_utc(date_taken),'UTC')
-                    
-                    data_list_files.append((keytime, date_added, date_modified, date_taken, row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], file_found))
+@artifact_processor
+def get_emulatedSmeta(files_found, report_folder, seeker, wrap_text):
+    source_path = _external_db(files_found, True)
+    rows = _run(source_path, f'''
+        SELECT date_added, date_modified, datetaken, _data, title, _display_name, _size,
+        owner_package_name, bucket_display_name, referer_uri, download_uri, relative_path,
+        {YESNO.format('is_download')}, {YESNO.format('is_favorite')}, {YESNO.format('is_trashed')}, xmp
+        FROM downloads
+    ''')
+    data_list = []
+    for r in rows:
+        xmp = str(r[15])[2:-1] if isinstance(r[15], bytes) else r[15]
+        data_list.append((_keytime(r[0], r[1]), _sec_to_utc(r[0]), _sec_to_utc(r[1]), _sec_to_utc(r[2]),
+                          r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10], r[11], r[12], r[13], r[14], xmp))
+    data_headers = (('Key Timestamp', 'datetime'), ('Date Added', 'datetime'), ('Date Modified', 'datetime'), ('Date Taken', 'datetime'),
+                    'Path', 'Title', 'Display Name', 'Size', 'Owner Package Name', 'Bucket Display Name', 'Referer URI', 'Download URI',
+                    'Relative Path', 'Is Downloaded?', 'Is Favorited?', 'Is Trashed?', 'XMP')
+    return data_headers, data_list, source_path
 
-            # Videos
-            cursor.execute('''
-            SELECT
-            datetime(date_added,  'unixepoch'),
-            datetime(date_modified, 'unixepoch'),
-            datetime(datetaken, 'unixepoch'),
-            _data,
-            title,
-            _display_name,
-            _size,
-            latitude,
-            longitude,
-            case orientation
-                when 0 then 'Horizontal'
-                else 'Vertical'
-            end,
-            owner_package_name,
-            bucket_display_name,
-            relative_path,
-            case is_download
-                when 0 then ''
-                when 1 then 'Yes'
-            end,
-            case is_favorite
-                when 0 then ''
-                when 1 then 'Yes'
-            end,
-            case is_trashed
-                when 0 then ''
-                when 1 then 'Yes'
-            end
-            from video
-            ''')
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                for row in all_rows:
-                    if bool(row[0]):
-                        keytime = row[0]
-                    else:
-                        keytime = row[1]
-                        
-                    if keytime is None:
-                        pass
-                    else:
-                        keytime = convert_utc_human_to_timezone(convert_ts_human_to_utc(keytime),'UTC')
-                        
-                    date_added = row[0]
-                    if date_added is None:
-                        pass
-                    else:
-                        date_added = convert_utc_human_to_timezone(convert_ts_human_to_utc(date_added),'UTC')
-                    
-                    date_modified = row[1]
-                    if date_modified is None:
-                        pass
-                    else:
-                        date_modified = convert_utc_human_to_timezone(convert_ts_human_to_utc(date_modified),'UTC')
-                        
-                    date_taken = row[2] 
-                    if date_taken is None:
-                        pass
-                    else:
-                        date_taken = convert_utc_human_to_timezone(convert_ts_human_to_utc(date_taken),'UTC')
-                    
-                    data_list_videos.append((keytime, date_added, date_modified, date_taken, row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11], row[12], row[13], row[14], row[15], file_found))
+@artifact_processor
+def get_emulatedSmeta_images(files_found, report_folder, seeker, wrap_text):
+    source_path = _external_db(files_found, True)
+    rows = _run(source_path, f'''
+        SELECT date_added, date_modified, datetaken, _data, title, _display_name, _size, latitude, longitude,
+        {ORIENTATION}, owner_package_name, bucket_display_name, relative_path,
+        {YESNO.format('is_download')}, {YESNO.format('is_favorite')}, {YESNO.format('is_trashed')}
+        FROM images
+    ''')
+    data_list = [(_keytime(r[0], r[1]), _sec_to_utc(r[0]), _sec_to_utc(r[1]), _sec_to_utc(r[2]),
+                  r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10], r[11], r[12], r[13], r[14], r[15]) for r in rows]
+    data_headers = (('Key Timestamp', 'datetime'), ('Date Added', 'datetime'), ('Date Modified', 'datetime'), ('Date Taken', 'datetime'),
+                    'Path', 'Title', 'Display Name', 'Size', 'Latitude', 'Longitude', 'Orientation', 'Owner Package Name',
+                    'Bucket Display Name', 'Relative Path', 'Is Downloaded?', 'Is Favorited?', 'Is Trashed?')
+    return data_headers, data_list, source_path
 
-            # Audio
-            cursor.execute('''
-            SELECT
-            datetime(date_added,  'unixepoch'),
-            datetime(date_modified, 'unixepoch'),
-            datetime(datetaken, 'unixepoch'),
-            _data,
-            title,
-            _display_name,
-            _size,
-            owner_package_name,
-            bucket_display_name,
-            relative_path,
-            case is_download
-                when 0 then ''
-                when 1 then 'Yes'
-            end,
-            case is_favorite
-                when 0 then ''
-                when 1 then 'Yes'
-            end,
-            case is_trashed
-                when 0 then ''
-                when 1 then 'Yes'
-            end
-            from audio
-            ''')
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                for row in all_rows:
-                    if bool(row[0]):
-                        keytime = row[0]
-                    else:
-                        keytime = row[1]
-                        
-                    if keytime is None:
-                        pass
-                    else:
-                        keytime = convert_utc_human_to_timezone(convert_ts_human_to_utc(keytime),'UTC')
-                        
-                    date_added = row[0]
-                    if date_added is None:
-                        pass
-                    else:
-                        date_added = convert_utc_human_to_timezone(convert_ts_human_to_utc(date_added),'UTC')
-                    
-                    date_modified = row[1]
-                    if date_modified is None:
-                        pass
-                    else:
-                        date_modified = convert_utc_human_to_timezone(convert_ts_human_to_utc(date_modified),'UTC')
-                        
-                    date_taken = row[2] 
-                    if date_taken is None:
-                        pass
-                    else:
-                        date_taken = convert_utc_human_to_timezone(convert_ts_human_to_utc(date_taken),'UTC')
-                    
-                    data_list_audio.append((keytime, date_added, date_modified, date_taken, row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11], row[12], file_found))
+@artifact_processor
+def get_emulatedSmeta_files(files_found, report_folder, seeker, wrap_text):
+    source_path = _external_db(files_found, True)
+    rows = _run(source_path, f'''
+        SELECT date_added, date_modified, datetaken, _data, title, _display_name, _size, latitude, longitude,
+        {ORIENTATION}, owner_package_name, bucket_display_name, referer_uri, download_uri, relative_path,
+        {YESNO.format('is_download')}, {YESNO.format('is_favorite')}, {YESNO.format('is_trashed')}
+        FROM files
+    ''')
+    data_list = [(_keytime(r[0], r[1]), _sec_to_utc(r[0]), _sec_to_utc(r[1]), _sec_to_utc(r[2]),
+                  r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10], r[11], r[12], r[13], r[14], r[15], r[16], r[17]) for r in rows]
+    data_headers = (('Key Timestamp', 'datetime'), ('Date Added', 'datetime'), ('Date Modified', 'datetime'), ('Date Taken', 'datetime'),
+                    'Path', 'Title', 'Display Name', 'Size', 'Latitude', 'Longitude', 'Orientation', 'Owner Package Name',
+                    'Bucket Display Name', 'Referer URI', 'Download URI', 'Relative Path', 'Is Downloaded?', 'Is Favorited?', 'Is Trashed?')
+    return data_headers, data_list, source_path
 
-            db.close()
-            
-        else:
-            # Files (older version)
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            cursor.execute('''
-            SELECT
-            datetime(date_added,  'unixepoch') as "Timestamp Added",
-            datetime(date_modified, 'unixepoch') as "Timestamp Modified",
-            datetime(datetaken, 'unixepoch') as "Timestamp Taken",
-            _data,
-            title,
-            _display_name,
-            _size,
-            latitude,
-            longitude,
-            case orientation
-                when 0 then 'Horizontal'
-                else 'Vertical'
-            end,
-            bucket_display_name,
-            width,
-            height,
-            _id
-            from files
-            ''')
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                for row in all_rows:
-                    date_added = row[0]
-                    if date_added is None:
-                        pass
-                    else:
-                        date_added = convert_utc_human_to_timezone(convert_ts_human_to_utc(date_added),'UTC')
-                    
-                    date_modified = row[1]
-                    if date_modified is None:
-                        pass
-                    else:
-                        date_modified = convert_utc_human_to_timezone(convert_ts_human_to_utc(date_modified),'UTC')
-                        
-                    date_taken = row[2] 
-                    if date_taken is None:
-                        pass
-                    else:
-                        date_taken = convert_utc_human_to_timezone(convert_ts_human_to_utc(date_taken),'UTC')
-                
-                    data_list.append((date_added, date_modified, date_taken, row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11], row[12], row[13], file_found))
+@artifact_processor
+def get_emulatedSmeta_videos(files_found, report_folder, seeker, wrap_text):
+    source_path = _external_db(files_found, True)
+    rows = _run(source_path, f'''
+        SELECT date_added, date_modified, datetaken, _data, title, _display_name, _size, latitude, longitude,
+        {ORIENTATION}, owner_package_name, bucket_display_name, relative_path,
+        {YESNO.format('is_download')}, {YESNO.format('is_favorite')}, {YESNO.format('is_trashed')}
+        FROM video
+    ''')
+    data_list = [(_keytime(r[0], r[1]), _sec_to_utc(r[0]), _sec_to_utc(r[1]), _sec_to_utc(r[2]),
+                  r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10], r[11], r[12], r[13], r[14], r[15]) for r in rows]
+    data_headers = (('Key Timestamp', 'datetime'), ('Date Added', 'datetime'), ('Date Modified', 'datetime'), ('Date Taken', 'datetime'),
+                    'Path', 'Title', 'Display Name', 'Size', 'Latitude', 'Longitude', 'Orientation', 'Owner Package Name',
+                    'Bucket Display Name', 'Relative Path', 'Is Downloaded?', 'Is Favorited?', 'Is Trashed?')
+    return data_headers, data_list, source_path
 
-            db.close()                
-                
-    # Downloads Report            
-    if data_list_downloads:
-        report = ArtifactHtmlReport('Emulated Storage Metadata - Downloads')
-        report.start_artifact_report(report_folder, 'Emulated Storage Metadata - Downloads')
-        report.add_script()
-        data_headers = ('Key Timestamp','Date Added','Date Modified','Date Taken','Path','Title','Display Name','Size','Owner Package Name','Bucket Display Name','Referer URI','Download URI','Relative Path','Is Downloaded?','Is Favorited?','Is Trashed?','XMP','Source')
-        
-        report.write_artifact_data_table(data_headers, data_list_downloads, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Emulated Storage Metadata - Downloads'
-        tsv(report_folder, data_headers, data_list_downloads, tsvname)
-        
-        tlactivity = f'Emulated Storage Metadata - Downloads'
-        timeline(report_folder, tlactivity, data_list_downloads, data_headers)
-    else:
-        logfunc('No Emulated Storage Metadata - Downloads data available')
-    
-    # Images Report    
-    if data_list_images:
-        report = ArtifactHtmlReport('Emulated Storage Metadata - Images')
-        report.start_artifact_report(report_folder, 'Emulated Storage Metadata - Images')
-        report.add_script()
-        data_headers = ('Key Timestamp','Date Added','Date Modified','Date Taken','Path','Title','Display Name','Size','Latitude','Longitude','Orientation','Owner Package Name','Bucket Display Name','Relative Path','Is Downloaded?','Is Favorited?','Is Trashed?','Source')
 
-        report.write_artifact_data_table(data_headers, data_list_images, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Emulated Storage Metadata - Images'
-        tsv(report_folder, data_headers, data_list_images, tsvname)
-        
-        tlactivity = f'Emulated Storage Metadata - Images'
-        timeline(report_folder, tlactivity, data_list_images, data_headers)
-    else:
-        logfunc('No Emulated Storage Metadata - Images data available')
-    
-    # Files (newer version) Report
-    if data_list_files:
-        report = ArtifactHtmlReport('Emulated Storage Metadata - Files')
-        report.start_artifact_report(report_folder, 'Emulated Storage Metadata - Files')
-        report.add_script()
-        data_headers = ('Key Timestamp','Date Added','Date Modified','Date Taken','Path','Title','Display Name','Size','Latitude','Longitude','Orientation','Owner Package Name','Bucket Display Name','Referer URI','Download URI','Relative Path','Is Downloaded?','Is Favorited?','Is Trashed?','Source')
+@artifact_processor
+def get_emulatedSmeta_audio(files_found, report_folder, seeker, wrap_text):
+    source_path = _external_db(files_found, True)
+    rows = _run(source_path, f'''
+        SELECT date_added, date_modified, datetaken, _data, title, _display_name, _size,
+        owner_package_name, bucket_display_name, relative_path,
+        {YESNO.format('is_download')}, {YESNO.format('is_favorite')}, {YESNO.format('is_trashed')}
+        FROM audio
+    ''')
+    data_list = [(_keytime(r[0], r[1]), _sec_to_utc(r[0]), _sec_to_utc(r[1]), _sec_to_utc(r[2]),
+                  r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10], r[11], r[12]) for r in rows]
+    data_headers = (('Key Timestamp', 'datetime'), ('Date Added', 'datetime'), ('Date Modified', 'datetime'), ('Date Taken', 'datetime'),
+                    'Path', 'Title', 'Display Name', 'Size', 'Owner Package Name', 'Bucket Display Name', 'Relative Path',
+                    'Is Downloaded?', 'Is Favorited?', 'Is Trashed?')
+    return data_headers, data_list, source_path
 
-        report.write_artifact_data_table(data_headers, data_list_files, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Emulated Storage Metadata - Files'
-        tsv(report_folder, data_headers, data_list_files, tsvname)
-        
-        tlactivity = f'Emulated Storage Metadata - Files'
-        timeline(report_folder, tlactivity, data_list_files, data_headers)
-    else:
-        logfunc('No Emulated Storage Metadata - Files data available')
-    
-    # Videos Report
-    if data_list_videos:  
-        report = ArtifactHtmlReport('Emulated Storage Metadata - Videos')
-        report.start_artifact_report(report_folder, 'Emulated Storage Metadata - Videos')
-        report.add_script()
-        data_headers = ('Key Timestamp','Date Added','Date Modified','Date Taken','Path','Title','Display Name','Size','Latitude','Longitude','Orientation','Owner Package Name','Bucket Display Name','Relative Path','Is Downloaded?','Is Favorited?','Is Trashed?','Source')
 
-        report.write_artifact_data_table(data_headers, data_list_videos, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Emulated Storage Metadata - Videos'
-        tsv(report_folder, data_headers, data_list_videos, tsvname)
-        
-        tlactivity = f'Emulated Storage Metadata - Videos'
-        timeline(report_folder, tlactivity, data_list_videos, data_headers)
-    else:
-        logfunc('No Emulated Storage Metadata - Videos data available')
-        
-    # Audio Report
-    if data_list_audio:
-        report = ArtifactHtmlReport('Emulated Storage Metadata - Audio')
-        report.start_artifact_report(report_folder, 'Emulated Storage Metadata - Audio')
-        report.add_script()
-        data_headers = ('Key Timestamp','Date Added','Date Modified','Date Taken','Path','Title','Display Name','Size','Owner Package Name','Bucket Display Name','Relative Path','Is Downloaded?','Is Favorited?','Is Trashed?','Source')
-
-        report.write_artifact_data_table(data_headers, data_list_audio, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Emulated Storage Metadata - Audio'
-        tsv(report_folder, data_headers, data_list_audio, tsvname)
-        
-        tlactivity = f'Emulated Storage Metadata - Audio'
-        timeline(report_folder, tlactivity, data_list_audio, data_headers)
-    else:
-        logfunc('No Emulated Storage Metadata - Audio data available')
-        
-    # Files (older version)
-    if data_list:
-        report = ArtifactHtmlReport('Emulated Storage Metadata - Files')
-        report.start_artifact_report(report_folder, 'Emulated Storage Metadata - Files')
-        report.add_script()
-        data_headers = ('Timestamp Added','Timestamp Modified','Timestamp Taken','Path','Title','Display Name','Size','Latitude','Longitude','Orientation','Bucket Display Name','Parent Path','Width','Height','ID')
-        
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Emulated Storage Metadata - Files'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Emulated Storage Metadata - Files'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Emulated Storage Metadata - Files data available')  
+@artifact_processor
+def get_emulatedSmeta_files_legacy(files_found, report_folder, seeker, wrap_text):
+    source_path = _external_db(files_found, False)
+    rows = _run(source_path, f'''
+        SELECT date_added, date_modified, datetaken, _data, title, _display_name, _size, latitude, longitude,
+        {ORIENTATION}, bucket_display_name, width, height, _id
+        FROM files
+    ''')
+    data_list = [(_sec_to_utc(r[0]), _sec_to_utc(r[1]), _sec_to_utc(r[2]),
+                  r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10], r[11], r[12], r[13]) for r in rows]
+    data_headers = (('Timestamp Added', 'datetime'), ('Timestamp Modified', 'datetime'), ('Timestamp Taken', 'datetime'),
+                    'Path', 'Title', 'Display Name', 'Size', 'Latitude', 'Longitude', 'Orientation', 'Bucket Display Name',
+                    'Width', 'Height', 'ID')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Splits the media-store metadata parser (external.db) into six decorated artifacts (category `Emulated Storage Metadata`):

- **Downloads**, **Images**, **Files**, **Videos**, **Audio** (modern `media.module` schema) and **Files (Legacy)** (older `com.android.providers.media` schema).

- Each query is gated to the correct DB via `_external_db(..., media_module)` (mirrors the original `'media.module' in path` branch) and wrapped (`Exception`+logfunc) so a table absent in a given schema yields an empty table.
- All `date_added`/`date_modified`/`datetaken` (+ the derived `Key Timestamp`) now converted from raw epoch seconds to aware UTC `datetime` (replacing the SQL `datetime(...)` → `convert_ts_human` round-trip).
- The original gave its two Files reports the **same title** ('Emulated Storage Metadata - Files') — now distinct (`Files` vs `Files (Legacy)`).
- **Fixed the legacy report's column misalignment**: it had a `Parent Path` header with no matching SELECT column (shifting Width/Height/ID and dropping Source); headers now match the data.
- XMP bytes handling preserved; dropped the redundant per-row `Source` column (framework records the source path). Original category/author/dates preserved.

Verified: byte-compile, all 6 decorated 4-arg, return 3-tuples, no duplicate names repo-wide, no '&' in names, CI-style pylint 0 W/E, loader builds (445).