### PR TITLE
Convert siminfo to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/siminfo.py
+++ b/scripts/artifacts/siminfo.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0311,W0611,W0612,W0613,W0702
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_siminfo": {
         "name": "siminfo",
-        "description": "Filter for path xxx/yyy/system_ce/0",
+        "description": "SIM card details (number, IMSI, ICCID, carrier) from the telephony provider database",
         "author": "",
         "creation_date": "2020-03-02",
         "last_update_date": "2020-03-02",
@@ -10,98 +10,65 @@ __artifacts_v2__ = {
         "category": "Device Information",
         "notes": "",
         "paths": ('*/user_de/*/com.android.providers.telephony/databases/telephony.db',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "info",
-        "function": "get_siminfo",
     }
 }
 
-import glob
-import json
-import os
-import shutil
 import sqlite3
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, logdevinfo, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logdevinfo, open_sqlite_db_readonly
 
+PRIMARY_SQL = '''
+    SELECT number, imsi, display_name, carrier_name, iso_country_code, carrier_id, icc_id
+    FROM siminfo
+'''
+
+FALLBACK_SQL = '''
+    SELECT number, card_id, display_name, carrier_name, carrier_name, carrier_name, icc_id
+    FROM siminfo
+'''
+
+
+@artifact_processor
 def get_siminfo(files_found, report_folder, seeker, wrap_text):
-
-    slash = '\\' if is_platform_windows() else '/' 
-    # Filter for path xxx/yyy/system_ce/0
+    data_list = []
+    source_paths = []
     for file_found in files_found:
-        file_found = str(file_found)
-        parts = file_found.split(slash)
-        uid = parts[-4]
+        file_found = str(file_found).replace('\\', '/')
+        # Skip mirrored copies (e.g. magisk mirror) which duplicate the data
+        if '/mirror/' in file_found:
+            continue
+        # Path layout: .../user_de/<uid>/com.android.providers.telephony/databases/telephony.db
+        parts = file_found.split('/')
         try:
-            uid_int = int(uid)
-            # Skip sbin/.magisk/mirror/data/system_de/0 , it should be duplicate data??
-            if file_found.find('{0}mirror{0}'.format(slash)) >= 0:
-                continue
-            process_siminfo(file_found, uid, report_folder)
-        except ValueError:
-                pass # uid was not a number
+            uid = parts[-4]
+            int(uid)  # uid must be numeric
+        except (IndexError, ValueError):
+            continue
 
-def process_siminfo(folder, uid, report_folder):
-    
-    #Query to create report
-    db = open_sqlite_db_readonly(folder)
-    cursor = db.cursor()
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        try:
+            cursor.execute(PRIMARY_SQL)
+        except sqlite3.Error:
+            cursor.execute(FALLBACK_SQL)
+        all_rows = cursor.fetchall()
+        db.close()
 
-    #Query to create report
-    try:
-        cursor.execute('''
-        SELECT
-            number,
-            imsi,
-            display_name,
-            carrier_name,
-            iso_country_code,
-            carrier_id,
-            icc_id
-        FROM
-            siminfo
-        ''')
-    except:
-        cursor.execute('''
-        SELECT
-            number,
-            card_id,
-            display_name,
-            carrier_name,
-            carrier_name,
-            carrier_name,
-            icc_id
-        FROM
-            siminfo
-        ''')
-
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Device Info')
-        report.start_artifact_report(report_folder, f'SIM_info_{uid}')
-        report.add_script()
-        data_headers = ('Number', 'IMSI', 'Display Name','Carrier Name', 'ISO Code', 'Carrier ID', 'ICC ID')
-        
-        data_list = []
         for row in all_rows:
+            # When the fallback schema is used, carrier_name fills the iso/carrier_id
+            # slots (row[3] == row[4]); blank those out so they aren't shown as data.
             if row[3] == row[4]:
-                row1 = ''
-                row4 = ''
-                row5 = ''
+                imsi, iso_code, carrier_id = '', '', ''
             else:
-                row1 = row[1]
-                row4 = row[4]
-                row5 = row[5]
-            data_list.append((row[0], row1, row[2], row[3], row4, row5, row[6]))
-            logdevinfo(f"<b>SIM Number & IMSI: </b>{row[0]} - {row1}")
+                imsi, iso_code, carrier_id = row[1], row[4], row[5]
+            data_list.append((uid, row[0], imsi, row[2], row[3], iso_code, carrier_id, row[6]))
+            logdevinfo(f"<b>SIM Number & IMSI: </b>{row[0]} - {imsi}")
             logdevinfo(f"<b>SIM Display Name: </b>{row[2]}")
-        report.write_artifact_data_table(data_headers, data_list, folder)
-        report.end_artifact_report()
-        
-        tsvname = f'Sim info {uid}'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc(f'No SIM_Info{uid} data available')    
-    db.close()
+        source_paths.append(file_found)
+
+    data_headers = (
+        'User ID', ('Number', 'phonenumber'), 'IMSI', 'Display Name',
+        'Carrier Name', 'ISO Code', 'Carrier ID', 'ICC ID')
+    return data_headers, data_list, ', '.join(source_paths)


### PR DESCRIPTION
Converts `siminfo.py` to the decorated `@artifact_processor` single-return pattern.

**Changes**
- Consolidates the previous per-uid HTML reports into one LAVA-compliant table with a `User ID` column.
- Marks `Number` as a `phonenumber` type for LAVA.
- Preserves the schema-fallback query (older DBs lacking `imsi`/`iso_country_code`/`carrier_id`) and the `logdevinfo` Device Information entries.
- Replaces the stale placeholder description with a real one; swaps the bare `except:` for `sqlite3.Error`.

Original `creation_date`/`last_update_date` (2020-03-02) preserved.