### PR TITLE
Convert usageapps to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/usageapps.py
+++ b/scripts/artifacts/usageapps.py
@@ -1,8 +1,9 @@
-# pylint: disable=E0606,W0611,W0612,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_usageapps": {
         "name": "usageapps",
-        "description": "",
+        "description": "App usage events from the Device Personalization Services "
+                       "reflection_gel_events database (includes deleted apps)",
         "author": "",
         "creation_date": "2020-04-11",
         "last_update_date": "2020-04-11",
@@ -10,128 +11,79 @@ __artifacts_v2__ = {
         "category": "App Interaction",
         "notes": "",
         "paths": ('*/com.google.android.as/databases/reflection_gel_events.db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "package",
-        "function": "get_usageapps",
     }
 }
 
+import datetime
+
 import blackboxprotobuf
-import json
-import sqlite3
-import time
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
 
-is_windows = is_platform_windows()
-slash = '\\' if is_windows else '/' 
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-def recursive_convert_bytes_to_str(obj):
-    '''Recursively convert bytes to strings if possible'''
-    ret = obj
+PROTO_TYPES = {
+    '1': {'type': 'bytes', 'name': ''},
+    '2': {'type': 'int', 'name': ''},
+    '5': {'type': 'message', 'message_typedef': {
+        '1': {'type': 'int', 'name': ''},
+        '6': {'type': 'fixed32', 'name': ''}}, 'name': ''},
+    '8': {'type': 'bytes', 'name': ''},
+}
+
+
+def _ms_to_utc(value):
+    if value:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    return ''
+
+
+def _to_str(obj):
+    '''Recursively decode bytes to str within decoded protobuf structures.'''
     if isinstance(obj, dict):
-        for k, v in obj.items():
-            obj[k] = recursive_convert_bytes_to_str(v)
-    elif isinstance(obj, list):
-        for index, v in enumerate(obj):
-            obj[index] = recursive_convert_bytes_to_str(v)
-    elif isinstance(obj, bytes):
-        # test for string
-        try:
-            ret = obj.decode('utf8', 'backslashreplace')
-        except UnicodeDecodeError:
-            ret = str(obj)
-    return ret
-
-def FilterInvalidValue(obj):
-    '''Return obj if it is valid, else empty string'''
-    # Remove any dictionary or list types
-    if isinstance(obj, dict) or isinstance(obj, list):
-        return ''
+        return {k: _to_str(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_to_str(v) for v in obj]
+    if isinstance(obj, bytes):
+        return obj.decode('utf8', 'backslashreplace')
     return obj
 
 
+def _scalar(obj):
+    '''Keep scalar values; drop nested dict/list structures.'''
+    return '' if isinstance(obj, (dict, list)) else obj
+
+
+@artifact_processor
 def get_usageapps(files_found, report_folder, seeker, wrap_text):
+    source_path = ''
+    data_list = []
     for file_found in files_found:
-        file_found = str(file_found)
-        
-        if file_found.find('{0}mirror{0}'.format(slash)) >= 0:
-            # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data
-            continue
-        elif not file_found.endswith('reflection_gel_events.db'):
-            continue # Skip all other files (-wal, -journal)
+        file_found = str(file_found).replace('\\', '/')
+        if '/mirror/' in file_found:
+            continue  # skip magisk mirror duplicates
+        if not file_found.endswith('reflection_gel_events.db'):
+            continue  # skip -wal/-journal
+        source_path = file_found
 
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
-        cursor.execute('''
-        SELECT
-        datetime(timestamp /1000, 'UNIXEPOCH') as timestamp,
-        id,
-        proto,
-        generated_from
-        FROM
-        reflection_event
-        ''')
+        cursor.execute('SELECT timestamp, id, proto, generated_from FROM reflection_event')
         all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-
-        if usageentries > 0:
-            description = 'This is data stored by the reflection_gel_events.db, which '\
-                        'shows data usage from apps to included deleted apps. '
-            report = ArtifactHtmlReport('Device Personalization Services')
-            report.start_artifact_report(report_folder, 'Personalization Services', description)
-            report.add_script()
-            
-            data_headers = ('Timestamp', 'Deleted?', 'BundleID', 'From', 'From in Proto', 'Proto Full')
-            data_list = []
-            types = (
-                    {'1': {'type': 'bytes', 'name': ''}, 
-                    '2': {'type': 'int', 'name': ''}, 
-                    '5': {'type': 'message', 'message_typedef': 
-                    {'1': {'type': 'int', 'name': ''}, 
-                    '6': {'type': 'fixed32', 'name': ''}}, 'name': ''}, 
-                    '8': {'type': 'bytes', 'name': ''}}
-                    )
-            for row in all_rows:
-                timestamp = row[0]
-                idb = row[1]
-                pb = row[2]
-                generated = row[3]
-                
-                if 'deleted_app' in idb:
-                    pass
-                else:
-                    idb = ''
-                
-                values, actual_types = blackboxprotobuf.decode_message(pb, types)
-                values = recursive_convert_bytes_to_str(values)
-
-                for key, val in values.items():
-                    #print(key, val)
-                    if key == '1':
-                        bundleid = val
-                    if key == '5':
-                        try:             timestamp = FilterInvalidValue(val['1'])
-                        except KeyError: timestamp = ''
-                        
-                        try:             usage = FilterInvalidValue(val['6'])
-                        except KeyError: usage = ''
-                    if key == '8':
-                        source = val
-                    else:
-                        source =''
-                    
-                data_list.append((row[0], idb, bundleid, row[3], usage, values))
-                
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'personalization services'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Personalization Services'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Usage Apps data available')
-        
         db.close()
+
+        for row in all_rows:
+            deleted = row[1] if row[1] and 'deleted_app' in row[1] else ''
+            bundleid, usage = '', ''
+            values, _ = blackboxprotobuf.decode_message(row[2], PROTO_TYPES)
+            values = _to_str(values)
+            for key, val in values.items():
+                if key == '1':
+                    bundleid = val
+                elif key == '5' and isinstance(val, dict):
+                    usage = _scalar(val.get('6', ''))
+            data_list.append((_ms_to_utc(row[0]), deleted, bundleid, row[3], usage, str(values)))
+
+    data_headers = (
+        ('Timestamp', 'datetime'), 'Deleted?', 'BundleID', 'From', 'From in Proto', 'Proto Full')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts `usageapps.py` (Device Personalization Services / `reflection_gel_events.db`) to the decorated `@artifact_processor` single-return pattern.

**Changes**
- Single LAVA-compliant table; `Timestamp` is now an aware UTC `datetime` (built from the raw epoch-ms column rather than a SQLite `datetime()` string).
- Initializes `bundleid`/`usage` before the proto-key loop so an absent key can't hit an unbound variable (the old code relied on `E0606` being disabled).
- Drops the dead `source` variable; guards the `'5'` branch with an `isinstance(dict)` check.
- Real description added. `blackboxprotobuf` decode types and column layout unchanged.

Original `creation_date`/`last_update_date` (2020-04-11) preserved.