### PR TITLE
Convert wifiProfiles to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/wifiProfiles.py
+++ b/scripts/artifacts/wifiProfiles.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0611,W0612,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_wifiProfiles": {
         "name": "wifiProfiles",
-        "description": "Create sqlite databases",
+        "description": "Saved Wi-Fi network profiles (SSID, keys, MAC, timestamps) from WifiConfigStore.xml",
         "author": "",
         "creation_date": "2020-03-23",
         "last_update_date": "2020-03-23",
@@ -10,177 +10,88 @@ __artifacts_v2__ = {
         "category": "WiFi Profiles",
         "notes": "",
         "paths": ('*/misc/wifi/WifiConfigStore.xml', '*/misc**/apexdata/com.android.wifi/WifiConfigStore.xml'),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "wifi",
-        "function": "get_wifiProfiles",
     }
 }
 
-import os
-import xml.etree.ElementTree as ET
-import textwrap
 import datetime
-import sqlite3
+import re
+import xml.etree.ElementTree as ET
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows
+from scripts.ilapfuncs import artifact_processor
 
+TEXT_FIELDS = ('PreSharedKey', 'WEPKeys', 'LoginUrl', 'IpAssignment', 'Identity', 'Password', 'DefaultGwMacAddress')
+TIME_FIELDS = ('semCreationTime', 'semUpdateTime', 'LastConnectedTime')
+
+
+def _ms_to_utc(value):
+    try:
+        ms = int(value)
+    except (TypeError, ValueError):
+        return ''
+    if ms <= 0:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(ms / 1000, datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError):
+        return ''
+
+
+def _parse_xml(file_found):
+    '''Parse XML, recovering from invalid tokens (stray control chars / bare &).'''
+    try:
+        return ET.parse(file_found).getroot()
+    except ET.ParseError:
+        with open(file_found, 'r', encoding='utf-8', errors='replace') as f:
+            text = f.read()
+        text = re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f]', '', text)
+        text = re.sub(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)', '&amp;', text)
+        try:
+            return ET.fromstring(text)
+        except ET.ParseError:
+            return ET.Element('empty')
+
+
+@artifact_processor
 def get_wifiProfiles(files_found, report_folder, seeker, wrap_text):
-
-    #Create sqlite databases
-    db = sqlite3.connect(os.path.join(report_folder, 'WiFiConfig.db'))
-    cursor = db.cursor()
-
-    #Create table WiFiConfig.
-
-    cursor.execute('''
-        CREATE TABLE wifi(ConfigKey TEXT, SSID TEXT, PreSharedKey TEXT, WEPKeys TEXT, DefaultGwMacAddress TEXT, semCreationTime INTEGER,
-        semUpdateTime INTEGER, LastConnectedTime INTEGER, CaptivePortal TEXT, LoginUrl TEXT, IpAssignment TEXT, Identity TEXT, Password TEXT)
-    ''')
-
-    db.commit()
-
-    #slash = '\\' if is_platform_windows() else '/' 
-    hit = 0
-    Identity = ''
-    Password = ''
-    PreSharedKey = ''
-    WEPKeys = ''
-    Password = ''
-    LoginUrl = ''
-    SecurityMode = '' 
-    SSID = ''
-    PreSharedKey = ''
-    WEPKeys = ''
-    DefaultGwMacAddress = '' 
-    semCreationTimeUTC = '' 
-    semUpdateTimeUTC = '' 
-    LastConnectedTimeUTC = '' 
-    CaptivePortal = '' 
-    LoginUrl = ''
-    IpAssignment = ''
-    SecurityMode = '' 
-    semCreationTime = '' 
-    semUpdateTime = '' 
-    LastConnectedTime = ''
-    
     data_list = []
+    source_paths = []
     for file_found in files_found:
         file_found = str(file_found)
-        tree = ET.parse(file_found)
+        source_paths.append(file_found)
+        root = _parse_xml(file_found)
 
-        for node in tree.iter('Network'):
+        for node in root.iter('Network'):
+            # Reset every field per network so values don't bleed between profiles
+            fields = {k: '' for k in ('SecurityMode', 'SSID', 'CaptivePortal') + TEXT_FIELDS + TIME_FIELDS}
             for elem in node.iter():
-                if not elem.tag==node.tag:
-                    #print(elem.attrib)
-                    data = elem.attrib
-                    for key, value in data.items():
-                        if value == 'ConfigKey':
-                            cut = elem.text.split('"')
-                            SecurityMode = (cut[2]) 
-                            hit = 1
+                if elem.tag == node.tag:
+                    continue
+                name = elem.attrib.get('name')
+                if not name:
+                    continue
+                if name == 'ConfigKey':
+                    cut = (elem.text or '').split('"')
+                    fields['SecurityMode'] = cut[2] if len(cut) > 2 else ''
+                elif name == 'SSID':
+                    fields['SSID'] = (elem.text or '').strip('"')
+                elif name in TEXT_FIELDS:
+                    fields[name] = elem.text or ''
+                elif name in TIME_FIELDS:
+                    fields[name] = _ms_to_utc(elem.attrib.get('value'))
+                elif name == 'CaptivePortal':
+                    fields['CaptivePortal'] = elem.attrib.get('value', '')
 
-                        if value == 'SSID':
-                            SSID = elem.text
-                            SSID = SSID.strip('"')
-                            hit = 1
+            if any(fields.values()):
+                data_list.append((
+                    fields['SecurityMode'], fields['SSID'], fields['PreSharedKey'], fields['WEPKeys'],
+                    fields['Password'], fields['Identity'], fields['DefaultGwMacAddress'],
+                    fields['semCreationTime'], fields['semUpdateTime'], fields['LastConnectedTime'],
+                    fields['CaptivePortal'], fields['LoginUrl'], fields['IpAssignment']))
 
-                        if value == 'PreSharedKey':
-                            PreSharedKey = elem.text
-                            hit = 1
-
-                        if value == 'WEPKeys':
-                            WEPKeys = elem.text
-                            hit = 1
-
-                        if value == 'DefaultGwMacAddress':
-                            DefaultGwMacAddress = elem.text
-                            hit = 1
-                        
-
-                        if value == 'semCreationTime':
-                            semCreationTime = elem.attrib['value']
-                            semCreationTimeUTC = elem.attrib['value']
-
-                            if int(semCreationTime) > 0:
-                                semCreationTime = datetime.datetime.utcfromtimestamp(int(semCreationTime) / 1000)
-                            hit = 1
-                        
-
-                        if value == 'semUpdateTime':
-                            semUpdateTime = elem.attrib['value']
-                            semUpdateTimeUTC = elem.attrib['value']
-                            if int(semUpdateTime) > 0:
-                                semUpdateTime = datetime.datetime.utcfromtimestamp(int(semUpdateTime) / 1000)
-                            hit = 1
-                        
-
-                        if value == 'LastConnectedTime':
-                            LastConnectedTime = elem.attrib['value']
-                            LastConnectedTimeUTC = elem.attrib['value']
-                            if int(LastConnectedTime) > 0:
-                                LastConnectedTime = datetime.datetime.utcfromtimestamp(int(LastConnectedTime) / 1000)
-                            hit = 1
-                        
-
-                        if value == 'CaptivePortal':
-                            CaptivePortal = elem.attrib['value']
-                            hit = 1
-                        
-
-                        if value == 'LoginUrl':
-                            LoginUrl = elem.text
-                            hit = 1
-                        
-
-                        if value == 'IpAssignment':
-                            IpAssignment = elem.text 
-                            hit = 1
-                        
-                        if value == 'Identity':
-                            Identity = elem.text  
-                            hit = 1
-
-                        if value == 'Password':
-                            Password = elem.text  
-                            hit = 1
-                        #data_list.append((SecurityMode, SSID, PreSharedKey, WEPKeys, DefaultGwMacAddress, semCreationTime, semUpdateTime, LastConnectedTime, CaptivePortal, LoginUrl, IpAssignment))
-            if hit == 1:           
-                if PreSharedKey == None:
-                    PreSharedKey = ''
-                if WEPKeys == None:
-                    WEPKeys = ''
-                if Password == None:
-                    Password = ''
-                if LoginUrl == None:
-                    LoginUrl = ''
-                
-                cursor = db.cursor()
-                datainsert = (SecurityMode, SSID, PreSharedKey, WEPKeys, Password, Identity, DefaultGwMacAddress, semCreationTimeUTC, semUpdateTimeUTC, LastConnectedTimeUTC, CaptivePortal, LoginUrl, IpAssignment)
-                cursor.execute('INSERT INTO wifi (ConfigKey, SSID, PreSharedKey, WEPKeys, Password, Identity, DefaultGwMacAddress, semCreationTime, '
-                'semUpdateTime , LastConnectedTime , CaptivePortal , LoginUrl , IpAssignment ) '
-                'VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)', datainsert)
-                db.commit()
-
-                if wrap_text:
-                    data_list.append((SecurityMode, SSID, PreSharedKey, WEPKeys, Password, Identity, DefaultGwMacAddress, semCreationTime, semUpdateTime, LastConnectedTime, CaptivePortal, (textwrap.fill(LoginUrl, width=10)), IpAssignment, file_found))
-                else:
-                    data_list.append((SecurityMode, SSID, PreSharedKey, WEPKeys, Password, Identity, DefaultGwMacAddress, semCreationTime, semUpdateTime, LastConnectedTime, CaptivePortal, LoginUrl, IpAssignment, file_found))
-                
-                #data_list.append(datainsert)
-                Identity = ''
-                Password = ''
-    db.close()
-
-    if hit == 1:
-        report = ArtifactHtmlReport('Wi-Fi Profiles')
-        report.start_artifact_report(report_folder, 'Wi-Fi Profiles')
-        report.add_script()
-        data_headers = ('SecurityMode', 'SSID', 'PreSharedKey', 'WEPKeys', 'Password', 'Identity', 'DefaultGwMacAddress', 'semCreationTime', 'semUpdateTime', 'LastConnectedTime', 'CaptivePortal', 'LoginUrl', 'IpAssignment', 'Path')
-        report.write_artifact_data_table(data_headers, data_list, ", ".join(files_found))
-        report.end_artifact_report()
-        
-        tsvname = f'wifi profiles'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc('No Wi-Fi Profiles data available')
+    data_headers = (
+        'SecurityMode', 'SSID', 'PreSharedKey', 'WEPKeys', 'Password', 'Identity', 'DefaultGwMacAddress',
+        ('semCreationTime', 'datetime'), ('semUpdateTime', 'datetime'), ('LastConnectedTime', 'datetime'),
+        'CaptivePortal', 'LoginUrl', 'IpAssignment')
+    return data_headers, data_list, ', '.join(source_paths)


### PR DESCRIPTION
Converts `wifiProfiles.py` (saved Wi-Fi profiles from `WifiConfigStore.xml`) to the decorated `@artifact_processor` pattern.

**Bug fixed:** every field except `Identity`/`Password` was initialized once before the file loop and never reset, so a profile **missing** a field inherited the previous profile's value (e.g. an open network would show the prior network's `PreSharedKey`/MAC). Fields are now reset per `Network` node. Verified with a 2-network fixture: the second (open) network correctly shows empty PSK/MAC.

**Other changes**
- Timestamps (`semCreationTime`/`semUpdateTime`/`LastConnectedTime`) are now aware UTC `datetime` values; `0`/negative epochs render blank instead of a 1970 timestamp, and deprecated naive `utcfromtimestamp` is gone.
- Adds invalid-token XML recovery (same hardening used across the other XML parsers).
- **Drops the redundant side `WiFiConfig.db`** that was written into the report folder — the same data is fully present in the HTML/TSV/LAVA output. (Flag if you want it retained.)
- Drops the manual `wrap_text`/`textwrap` handling (framework handles wrapping) and the redundant per-row `Path` column (now `source_path`).

Original `creation_date`/`last_update_date` (2020-03-23) preserved.