### PR TITLE
Convert offlinePages to LAVA @artifact_processor (+ media migration)

### DIFF
--- a/scripts/artifacts/offlinePages.py
+++ b/scripts/artifacts/offlinePages.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0401,W0611,W0613,W0614,W0621,W1309,W1514
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_offlinePages": {
-        "name": "pages",
-        "description": "fetch the timezone information",
+        "name": "Offline Pages (MHTML)",
+        "description": "Saved offline web pages (MHTML/MHT archives) with source URL, subject and capture time",
         "author": "",
         "creation_date": "2023-01-25",
         "last_update_date": "2023-01-25",
@@ -10,63 +10,36 @@ __artifacts_v2__ = {
         "category": "Offline Pages",
         "notes": "",
         "paths": ('*/*.mhtml', '*/*.mht'),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "message-square",
-        "function": "get_offlinePages",
     }
 }
 
-from datetime import *
+import datetime
 import email
 import os
-import pytz
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import timeline, logfunc, tsv, is_platform_windows, media_to_html
+from scripts.ilapfuncs import artifact_processor, check_in_media
 
-def convert_utc_int_to_timezone(utc_time, time_offset): 
-    #fetch the timezone information
-    timezone = pytz.timezone(time_offset)
-    
-    #convert utc to timezone
-    timezone_time = utc_time.astimezone(timezone)
-    
-    #return the converted value
-    return timezone_time
 
+@artifact_processor
 def get_offlinePages(files_found, report_folder, seeker, wrap_text):
-    
     data_list = []
-    
+    source_paths = []
     for file_found in files_found:
         file_found = str(file_found)
-        
-        modified_time = os.path.getmtime(file_found)
-        utc_modified_date = datetime.fromtimestamp(modified_time, tz=timezone.utc)
-        
-        timestamp = convert_utc_int_to_timezone(utc_modified_date, 'UTC')
-        
+        source_paths.append(file_found)
 
-        with open(file_found,'r', errors='replace') as fp:
+        timestamp = datetime.datetime.fromtimestamp(os.path.getmtime(file_found), tz=datetime.timezone.utc)
+        with open(file_found, 'r', errors='replace', encoding='utf-8') as fp:
             message = email.message_from_file(fp)
-            sourced = (message['Snapshot-Content-Location'])
-            subjectd = (message['Subject'])
-            dated = (message['Date'])
-            media = media_to_html(file_found, files_found, report_folder)
+            web_source = message['Snapshot-Content-Location']
+            subject = message['Subject']
+            mime_date = message['Date']
 
-        data_list.append((timestamp, media, sourced, subjectd, dated, file_found))
-        
-    if len(data_list) > 0:
-        note = 'Source location in extraction found in the report for each item.'
-        report = ArtifactHtmlReport('Offline Pages')
-        report.start_artifact_report(report_folder, f'Offline Pages')
-        report.add_script()
-        data_headers = ('Timestamp', 'File', 'Web Source', 'Subject', 'MIME Date', 'Source in Extraction')
-        report.write_artifact_data_table(data_headers, data_list, note, html_no_escape=['File'])
-        report.end_artifact_report()
-        
-        tsvname = f'Offline Pages'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = 'Offline Pages'
-        timeline(report_folder, tlactivity, data_list, data_headers)
+        media = check_in_media(file_found, os.path.basename(file_found))
+        data_list.append((timestamp, media, web_source, subject, mime_date, file_found))
+
+    data_headers = (
+        ('Timestamp', 'datetime'), ('File', 'media'), 'Web Source', 'Subject', 'MIME Date', 'Source in Extraction')
+    return data_headers, data_list, ', '.join(source_paths)


### PR DESCRIPTION
Converts `offlinePages.py` (MHTML/MHT saved offline pages) to the decorated `@artifact_processor` pattern.

**Changes**
- **Media migration:** the `File` column moves from legacy `media_to_html` to a proper `('File','media')` column backed by `check_in_media`, so each archive is registered in the LAVA media store (refs/dedupe; exports get a path instead of an HTML snippet). First of the `media_to_html` migrations tracked from the media discussion.
- `Timestamp` is now an aware UTC `datetime` (drops the no-op pytz UTC→UTC conversion).
- Renamed from the generic `pages` to **Offline Pages (MHTML)** — `Offline Pages` is already used by `chromeOfflinePages` (category Chromium); this one keeps category **Offline Pages**.
- Real description (was a stale "fetch the timezone information" note); `encoding=` added to `open()` for W1514.

Original `creation_date`/`last_update_date` (2023-01-25) preserved.