### PR TITLE
Convert vlcthumbsADB to LAVA @artifact_processor (2-way split + media migration)

### DIFF
--- a/scripts/artifacts/vlcthumbsADB.py
+++ b/scripts/artifacts/vlcthumbsADB.py
@@ -1,84 +1,78 @@
-# pylint: disable=W0404,W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_vlcthumbsADB": {
-        "name": "VLC Thumbs ADB",
-        "description": "",
+        "name": "VLC Thumbnails (ADB)",
+        "description": "VLC thumbnail cache from an ADB extraction (ef/medialib/thumbnails)",
         "author": "",
         "creation_date": "2022-08-23",
         "last_update_date": "2022-08-23",
         "requirements": "none",
-        "category": "VLC thumbs",
+        "category": "VLC",
         "notes": "",
-        "paths": ('*/org.videolan.vlc/ef/medialib/*.*', '*/org.videolan.vlc/ef/medialib/thumbnails/*.*'),
-        "output_types": None,
+        "paths": ('*/org.videolan.vlc/ef/medialib/thumbnails/*.*',),
+        "output_types": "standard",
         "artifact_icon": "image",
-        "function": "get_vlcthumbsADB",
+    },
+    "get_vlcthumbsADB_medialib": {
+        "name": "VLC Media Lib (ADB)",
+        "description": "VLC media library images from an ADB extraction (ef/medialib)",
+        "author": "",
+        "creation_date": "2022-08-23",
+        "last_update_date": "2022-08-23",
+        "requirements": "none",
+        "category": "VLC",
+        "notes": "",
+        "paths": ('*/org.videolan.vlc/ef/medialib/*.*',),
+        "output_types": "standard",
+        "artifact_icon": "image",
     }
 }
 
-import os
 import datetime
+import os
 from pathlib import Path
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import timeline, tsv, is_platform_windows, open_sqlite_db_readonly, is_platform_windows, media_to_html, logfunc
+from scripts.ilapfuncs import artifact_processor, check_in_media
 
 
+def _sec_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value), datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
+
+
+@artifact_processor
 def get_vlcthumbsADB(files_found, report_folder, seeker, wrap_text):
-    data_list_t = []
-    data_list_m = []
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
-        
-        filename = (Path(file_found).name)
-        filepath = str(Path(file_found).parents[1])
-        
-        modifiedtime = os.path.getmtime(file_found)
-        modifiedtime = (datetime.datetime.utcfromtimestamp(int(modifiedtime)).strftime('%Y-%m-%d %H:%M:%S'))
-        
-        thumb = media_to_html(filename, files_found, report_folder)
-        
-        platform = is_platform_windows()
-        if platform:
-            thumb = thumb.replace('?', '')
-        
-        if "thumbnails" in file_found:
-            data_list_t.append((modifiedtime, thumb, filename, file_found))
-        else:
-            data_list_m.append((modifiedtime, thumb, filename, file_found))
-    
-    if data_list_t:
-        description = 'VLC Thumbnails'
-        report = ArtifactHtmlReport('VLC Thumbnails')
-        report.start_artifact_report(report_folder, 'VLC Thumbnails', description)
-        report.add_script()
-        data_headers = ('Modified Timestamp','Thumbnail','Filename','Location' )
-        report.write_artifact_data_table(data_headers, data_list_t, filepath, html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = 'VLC Thumbnails'
-        tsv(report_folder, data_headers, data_list_t, tsvname)
-        
-        tlactivity = f'VLC Thumbnails'
-        timeline(report_folder, tlactivity, data_list_t, data_headers)
-    else:
-        logfunc('VLC Thumbnails data available')
-    
-    if data_list_m:
-        description = 'VLC Media Lib'
-        report = ArtifactHtmlReport('VLC Media Lib')
-        report.start_artifact_report(report_folder, 'VLC Media Lib', description)
-        report.add_script()
-        data_headers = ('Modified Timestamp','Thumbnail','Filename','Location')
-        report.write_artifact_data_table(data_headers, data_list_m, filepath, html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = 'VLC Media Lib'
-        tsv(report_folder, data_headers, data_list_m, tsvname)
-        
-        tlactivity = f'VLC Media Lib'
-        timeline(report_folder, tlactivity, data_list_m, data_headers)
-    else:
-        logfunc('VLC Media Lib data available')
-        
+        if 'thumbnails' not in file_found:
+            continue
+        filename = Path(file_found).name
+        source_path = str(Path(file_found).parents[1])
+        media = check_in_media(file_found, filename)
+        data_list.append((_sec_to_utc(os.path.getmtime(file_found)), media, filename, file_found))
+
+    data_headers = (('Modified Timestamp', 'datetime'), ('Thumbnail', 'media'), 'Filename', 'Location')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_vlcthumbsADB_medialib(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if 'thumbnails' in file_found:
+            continue
+        filename = Path(file_found).name
+        source_path = str(Path(file_found).parents[1])
+        media = check_in_media(file_found, filename)
+        data_list.append((_sec_to_utc(os.path.getmtime(file_found)), media, filename, file_found))
+
+    data_headers = (('Modified Timestamp', 'datetime'), ('Thumbnail', 'media'), 'Filename', 'Location')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts `vlcthumbsADB.py` (ADB-extraction VLC thumbnails) to the decorated `@artifact_processor` pattern, split into two artifacts (category **VLC**):

| Function | Name | Source |
|---|---|---|
| `get_vlcthumbsADB` | VLC Thumbnails (ADB) | `ef/medialib/thumbnails/*.*` |
| `get_vlcthumbsADB_medialib` | VLC Media Lib (ADB) | `ef/medialib/*.*` |

**Changes**
- **Media migration:** both image columns move from `media_to_html` to `('Thumbnail','media')` backed by `check_in_media` (drops the Windows `?`-strip hack that only existed to patch `media_to_html` output).
- `Modified Timestamp` is now an aware UTC `datetime` (was naive `utcfromtimestamp` string).
- **Name collision fixed:** the original report was also named "VLC Thumbnails", which now clashes with the filesystem-extraction artifact (PR #812). Renamed both with an `(ADB)` suffix.
- **Category consolidated** `VLC thumbs` → `VLC` so all VLC artifacts group together.

Original `creation_date`/`last_update_date` (2022-08-23) preserved.