### PR TITLE
Convert torThumbs to LAVA @artifact_processor (+ media migration)

### DIFF
--- a/scripts/artifacts/torThumbs.py
+++ b/scripts/artifacts/torThumbs.py
@@ -1,8 +1,8 @@
-# pylint: disable=E0602,W0404,W0611,W0612,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_torThumbs": {
-        "name": "torThumbs",
-        "description": "",
+        "name": "TOR Thumbnails",
+        "description": "Page thumbnails cached by the Tor Browser (mozac_browser_thumbnails)",
         "author": "",
         "creation_date": "2021-12-23",
         "last_update_date": "2021-12-23",
@@ -10,64 +10,51 @@ __artifacts_v2__ = {
         "category": "TOR",
         "notes": "",
         "paths": ('*/org.torproject.torbrowser/cache/mozac_browser_thumbnails/thumbnails/*.0',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "file",
-        "function": "get_torThumbs",
     }
 }
 
-import os
 import datetime
-from pathlib import Path
-from PIL import Image
+import io
+import os
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import timeline, tsv, is_platform_windows, open_sqlite_db_readonly, is_platform_windows, media_to_html
+from PIL import Image, UnidentifiedImageError
+
+from scripts.ilapfuncs import artifact_processor, logfunc, check_in_embedded_media
 
 
+def _sec_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value), datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
+
+
+@artifact_processor
 def get_torThumbs(files_found, report_folder, seeker, wrap_text):
     data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
-        data_file_real_path = file_found
-        modifiedtime = os.path.getmtime(file_found)
-        modifiedtime = (datetime.datetime.utcfromtimestamp(int(modifiedtime)).strftime('%Y-%m-%d %H:%M:%S'))
-        
         filename = os.path.basename(file_found)
         location = os.path.dirname(file_found)
-        newfilename = filename + '.png'
-        savepath = os.path.join(report_folder, newfilename)
-        
-        img = Image.open(file_found) 
-        img.save(savepath,'png')
-        
-        medialist = (savepath,)
-        thumb = media_to_html(savepath, medialist, report_folder)
-        #thumb = f'<img src="{savepath}"width="300"></img>'
-        
-        platform = is_platform_windows()
-        if platform:
-            thumb = thumb.replace('?', '')
-            
-        data_list.append((modifiedtime, thumb, filename, location))
-    
-    path_to_files = os.path.dirname(filename)
-    
-    if data_list:
-        description = 'TOR Thumbnails'
-        report = ArtifactHtmlReport('TOR Thumbnails')
-        report.start_artifact_report(report_folder, 'TOR Thumbnails', description)
-        report.add_script()
-        data_headers = ('Modified Time','Thumbnail','Filename','Location' )
-        report.write_artifact_data_table(data_headers, data_list, path_to_files, html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = 'TOR Thumbnails'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'TOR Thumbnails'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No TOR Thumbnails data available')
-        
+        source_path = location
+
+        # The .0 thumbnail files are image blobs without an extension; decode to
+        # PNG bytes and register them as embedded media for the LAVA media store.
+        try:
+            img = Image.open(file_found)
+            buf = io.BytesIO()
+            img.save(buf, format='PNG')
+        except (UnidentifiedImageError, OSError) as ex:
+            logfunc(f'Could not open TOR thumbnail as image: {file_found} ({ex})')
+            continue
+
+        media = check_in_embedded_media(file_found, buf.getvalue(), f'{filename}.png')
+        data_list.append((_sec_to_utc(os.path.getmtime(file_found)), media, filename, location))
+
+    data_headers = (('Modified Time', 'datetime'), ('Thumbnail', 'media'), 'Filename', 'Location')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts `torThumbs.py` (Tor Browser cached page thumbnails) to the decorated `@artifact_processor` pattern.

**Changes**
- **Media migration (embedded):** the `.0` thumbnail files are extensionless image blobs, so each is decoded to PNG bytes and registered via `check_in_embedded_media` into a `('Thumbnail','media')` column — same approach as SamsungHoneyboard. Replaces `media_to_html` + a loose PNG written into the report folder and the Windows `?`-strip hack.
- `Modified Time` is now an aware UTC `datetime`.
- `Image.open` is guarded — a non-image file is logged and skipped instead of crashing the artifact.
- Renamed `torThumbs` → **TOR Thumbnails**.

Original `creation_date`/`last_update_date` (2021-12-23) preserved.