### PR TITLE
Convert galleryTrash to LAVA @artifact_processor (+ media migration)

### DIFF
--- a/scripts/artifacts/galleryTrash.py
+++ b/scripts/artifacts/galleryTrash.py
@@ -1,86 +1,74 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_galleryTrash": {
         "name": "Gallery Trash",
-        "description": "",
+        "description": "Deleted media held in the Samsung Gallery trash (local.db trash table)",
         "author": "",
         "creation_date": "2023-04-25",
         "last_update_date": "2023-04-25",
         "requirements": "none",
         "category": "Gallery Trash",
         "notes": "",
-        "paths": ('*/data/com.sec.android.gallery3d/databases/local.db*', '*/data/com.sec.android.gallery3d/files/.Trash/**'),
-        "output_types": None,
+        "paths": ('*/data/com.sec.android.gallery3d/databases/local.db*',
+                  '*/data/com.sec.android.gallery3d/files/.Trash/**'),
+        "output_types": "all",
         "artifact_icon": "image",
-        "function": "get_galleryTrash",
     }
 }
 
-import sqlite3
-import json
 import datetime
-import textwrap
+import json
 import os
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, kmlgen, media_to_html
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, check_in_media
 
+
+def _ms_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
+
+
+@artifact_processor
 def get_galleryTrash(files_found, report_folder, seeker, wrap_text):
-    
+    # Map basename -> path for the trashed media files so each row can resolve its thumbnail
+    trash_files = {os.path.basename(str(f)): str(f) for f in files_found if '.Trash' in str(f)}
+
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        filename = os.path.basename(file_found)
-        
-        if filename.endswith('local.db'):
-            
-            db = open_sqlite_db_readonly(file_found)
-            
-            cursor = db.cursor()
-            cursor.execute('''
-            SELECT
-            datetime(__deleteTime/1000,'unixepoch'),
-            __Title,
-            __absPath,
-            __originTitle,
-            __originPath,
-            __expiredPeriod,
-            __restoreExtra
+        if not file_found.endswith('local.db'):
+            continue
+        source_path = file_found
+
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        cursor.execute('''
+            SELECT __deleteTime, __Title, __absPath, __originTitle, __originPath, __expiredPeriod, __restoreExtra
             FROM trash
-            ''')
-            
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            
-            if usageentries > 0:
-                data_list = []
-                for row in all_rows:
-                    extendeddata = row[6]
-                    extendeddata = json.loads(extendeddata)
-                    datetaken = (extendeddata['__dateTaken'])
-                    datetaken = (datetime.datetime.utcfromtimestamp(datetaken/1000).strftime('%Y-%m-%d %H:%M:%S'))
-                    latitude = (extendeddata.get('latitude', ''))
-                    longitude = (extendeddata.get('longitude', ''))
-                    
-                    thumb = media_to_html(row[1], files_found, report_folder)
-                    
-                    extendedout = ''
-                    for x, y in extendeddata.items():
-                        extendedout = extendedout + f'<br> {x}: {y}'
-                        
-                    data_list.append((datetaken, row[0], thumb, row[1], row[3], row[2], row[4], extendedout.strip(), latitude, longitude ))
-                
-                report = ArtifactHtmlReport('Gallery Trash Files')
-                report.start_artifact_report(report_folder, 'Gallery Trash Files')
-                report.add_script()
-                data_headers = ('Timestamp','Date Deleted','Deleted Media','Trash Title','Original Title','Trash Path','Orginal Path','Extra Data','Latitude','Longitude') 
-                report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-                report.end_artifact_report()
-                
-                tsvname = f'Gallery Trash Files'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-                tlactivity = f'Gallery Trash Files'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-                
-            else:
-                logfunc('No Gallery Trash Files data available')
+        ''')
+        for row in cursor.fetchall():
+            try:
+                extra = json.loads(row[6]) if row[6] else {}
+            except (ValueError, TypeError):
+                extra = {}
+            datetaken = _ms_to_utc(extra.get('__dateTaken'))
+            latitude = extra.get('latitude', '')
+            longitude = extra.get('longitude', '')
+            extra_str = '; '.join(f'{k}: {v}' for k, v in extra.items())
+
+            media_path = trash_files.get(row[1])
+            thumb = check_in_media(media_path, row[1]) if media_path else ''
+
+            data_list.append((datetaken, _ms_to_utc(row[0]), thumb, row[1], row[3], row[2], row[4],
+                              extra_str, latitude, longitude))
+        db.close()
+
+    data_headers = (
+        ('Timestamp', 'datetime'), ('Date Deleted', 'datetime'), ('Deleted Media', 'media'),
+        'Trash Title', 'Original Title', 'Trash Path', 'Original Path', 'Extra Data', 'Latitude', 'Longitude')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts `galleryTrash.py` (Samsung Gallery trash, `local.db` `trash` table) to the decorated `@artifact_processor` pattern.

**Changes**
- **Media migration:** deleted-media column moves from `media_to_html` to `('Deleted Media','media')` backed by `check_in_media`, resolved against the `.Trash/` files in the extraction.
- `Timestamp` (`__dateTaken`) and `Date Deleted` (`__deleteTime`) are now aware UTC `datetime` values from the raw epoch-ms.
- Hardened the `__restoreExtra` JSON parse (bad/missing JSON no longer raises).
- `Extra Data` is now a plain `'; '`-joined string instead of an HTML `<br>` dump (clean across HTML/TSV/LAVA).
- Fixed the `Orginal Path` header typo → `Original Path`.
- **Enabled KML** (`output_types: all`): the artifact has `Latitude`/`Longitude` and imported `kmlgen` but never called it.

Original `creation_date`/`last_update_date` (2023-04-25) preserved.