### PR TITLE
Convert playgroundVault to LAVA @artifact_processor (+ media migration)

### DIFF
--- a/scripts/artifacts/playgroundVault.py
+++ b/scripts/artifacts/playgroundVault.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0404,W0611,W0612,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_playgroundVault": {
-        "name": "playgroundVault",
-        "description": "",
+        "name": "Playground Vault",
+        "description": "Decrypts media hidden by the Playground AppLocker vault (AES-GCM)",
         "author": "",
         "creation_date": "2022-01-16",
         "last_update_date": "2022-01-16",
@@ -10,107 +10,87 @@ __artifacts_v2__ = {
         "category": "Encrypting Media Apps",
         "notes": "",
         "paths": ('*/playground.develop.applocker/shared_prefs/crypto.KEY_256.xml', '*/applocker/vault/*'),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "image",
-        "function": "get_playgroundVault",
     }
 }
 
-import sys
-import shutil
-import os
-import xml.etree.ElementTree as ET
 import base64
-import scripts.filetype as filetype
 import datetime
-from Crypto.Cipher import AES
-from Crypto.Util.Padding import unpad
+import os
+import re
+import xml.etree.ElementTree as ET
 from pathlib import Path
-from os.path import isfile, join, basename, dirname, getsize, abspath
-from pathlib import Path
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, media_to_html
 
+from Crypto.Cipher import AES
+
+import scripts.filetype as filetype
+from scripts.ilapfuncs import artifact_processor, logfunc, check_in_embedded_media
+
+
+def _ms_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
+
+
+def _find_key(files_found):
+    for file_found in files_found:
+        file_found = str(file_found)
+        if not os.path.basename(file_found).startswith('crypto.KEY_256.xml'):
+            continue
+        try:
+            root = ET.parse(file_found).getroot()
+            found = root.findall('./string[@name="cipher_key"]')
+            if found and found[0].text:
+                key = base64.b64decode(found[0].text)
+                logfunc('Playground Vault encryption key recovered')
+                return key
+        except (ET.ParseError, ValueError):
+            continue
+    return None
+
+
+@artifact_processor
 def get_playgroundVault(files_found, report_folder, seeker, wrap_text):
-    
+    key = _find_key(files_found)
     data_list = []
-    
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        #filesize = (getsize(file_found))
-        
-        if not isfile(file_found):
-            continue
-        filename = basename(file_found)
-        if filename.startswith('._'):
-            continue
-        if filename.startswith('crypto.KEY_256.xml'):
-            tree = ET.parse(file_found)
-            root = tree.getroot()
-            key = base64.b64decode(root.findall('./string[@name="cipher_key"]')[0].text)
-            logfunc(f'Encryption key found: {key}')
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        if not isfile(file_found):
-            continue
-        filename = basename(file_found)
-        if filename.startswith('._'):
-            continue
-        if filename.startswith('crypto.KEY_256.xml'):
-            continue
-        
-        with open (file_found, 'rb') as openFile:
-            #print('Atttempting to decrypt...')
-            fullFile = openFile.read()
-            ### IV is after the first 2 bytes
-            IV = fullFile[2:14]
-            ### Following IV encrypted data minus the GCM validation (16 bytes) at the end
-            encryptedData = fullFile[14:-16]
-            ### New encryption algo
-            cipher = AES.new((key), AES.MODE_GCM, (IV))
-            ### Decrypt the data
-            decryptedData = cipher.decrypt((encryptedData))
-            ### Determine the correct file extension
-            fileExtension = filetype.guess(decryptedData)
-            ### Open the new output file for writing
-            
-            with open (join(report_folder, basename(file_found)) , 'wb') as decryptedFile:
-                decryptedFile.write(decryptedData)
-                decryptedFile.close()
-                
-                tolink = []
-                pathdec = join(report_folder, basename(file_found))
-                tolink.append(pathdec)
-                thumb = media_to_html(pathdec, tolink, report_folder)
-                filename = basename(file_found)
-                
-                if 'EIF' in filename:
-                    utctime = filename.split('EIF')
-                    enctimestamp = datetime.datetime.utcfromtimestamp(int(utctime[1]) / 1000)
-                elif 'EVF' in filename:
-                    utctime = filename.split('EVF')
-                    enctimestamp = datetime.datetime.utcfromtimestamp(int(utctime[1]) / 1000)
-                else:
-                    enctimestamp = ''
-                    
-                data_list.append((thumb, filename, enctimestamp, file_found))
-    
-        if data_list:
-            report = ArtifactHtmlReport('Playground Vault')
-            report.start_artifact_report(report_folder, 'Playground Vault')
-            report.add_script()
-            data_headers = ('Media', 'Filename', 'Encrypted On Timestamp', 'Full Path')
-            maindirectory = str(Path(file_found).parents[1])
-            report.write_artifact_data_table(data_headers, data_list, maindirectory, html_no_escape=['Media'])
-            report.end_artifact_report()
-            
-            tsvname = f'Playground Vault'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            
-        else:
-            logfunc('No Playground Vault data available')
+    source_path = ''
+    if key:
+        for file_found in files_found:
+            file_found = str(file_found)
+            if not os.path.isfile(file_found):
+                continue
+            filename = os.path.basename(file_found)
+            if filename.startswith('._') or filename.startswith('crypto.KEY_256.xml'):
+                continue
+            source_path = str(Path(file_found).parents[1])
+
+            try:
+                with open(file_found, 'rb') as f:
+                    full = f.read()
+                if len(full) < 30:
+                    continue
+                # IV follows the first 2 bytes; the trailing 16 bytes are the GCM tag
+                cipher = AES.new(key, AES.MODE_GCM, full[2:14])
+                decrypted = cipher.decrypt(full[14:-16])
+            except (ValueError, OSError) as ex:
+                logfunc(f'Could not decrypt Playground Vault file {filename}: {ex}')
+                continue
+
+            kind = filetype.guess(decrypted)
+            if kind:
+                thumb = check_in_embedded_media(file_found, decrypted, f'{filename}.{kind.extension}',
+                                                force_type=kind.mime, force_extension=kind.extension)
+            else:
+                thumb = check_in_embedded_media(file_found, decrypted, filename)
+
+            match = re.search(r'(?:EIF|EVF)(\d+)', filename)
+            enctimestamp = _ms_to_utc(match.group(1)) if match else ''
+            data_list.append((thumb, filename, enctimestamp, file_found))
+
+    data_headers = (('Media', 'media'), 'Filename', ('Encrypted On Timestamp', 'datetime'), 'Full Path')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts `playgroundVault.py` (Playground AppLocker encrypting-media vault) to the decorated `@artifact_processor` pattern.

**Media migration (embedded/derived):** the vault files are AES-GCM encrypted. The decrypted bytes are registered directly via `check_in_embedded_media` into a `('Media','media')` column, with MIME/extension from `filetype.guess`. No more writing decrypted files into the report folder + `media_to_html`.

**Hardening**
- Key extraction is guarded — a missing `crypto.KEY_256.xml` previously left `key` undefined and raised `NameError` in the decrypt loop.
- Per-file decryption is wrapped: a corrupt/short file is logged and skipped instead of crashing the artifact.
- The `EIF`/`EVF` filename timestamp is parsed with a regex (tolerant of extensions/suffixes) into an aware UTC `datetime`.

Renamed `playgroundVault` → **Playground Vault**; real description added. Original dates (2022-01-16) preserved.