### PR TITLE
Convert NQ_Vault to LAVA @artifact_processor (2-way split + media migration)

### DIFF
--- a/scripts/artifacts/NQ_Vault.py
+++ b/scripts/artifacts/NQ_Vault.py
@@ -1,287 +1,170 @@
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_NQVault": {
-        "name": "NQVault",
-        "description": "",
+        "name": "NQ Vault Decrypted PINs",
+        "description": "Recovers NQ Vault (com.netqin.ps) PINs by reversing the stored Java hashcode",
         "author": "",
         "creation_date": "2023-05-19",
         "last_update_date": "2023-05-19",
         "requirements": "none",
-        "category": "Encrypting Media apps",
+        "category": "Encrypting Media Apps",
         "notes": "",
-        "paths": ('*/emulated/0/Android/data/com.netqin.ps/files/Documents/SystemAndroid/Data/322w465ay423xy11', '*/SystemAndroid/Data/**', '/media/0/SystemAndroid/Data/322w465ay423xy11'),
-        "output_types": None,
+        "paths": ('*/emulated/0/Android/data/com.netqin.ps/files/Documents/SystemAndroid/Data/322w465ay423xy11',
+                  '*/SystemAndroid/Data/**', '/media/0/SystemAndroid/Data/322w465ay423xy11'),
+        "output_types": "standard",
+        "artifact_icon": "key",
+    },
+    "get_NQVault_media": {
+        "name": "NQ Vault Decrypted Media",
+        "description": "Decrypts media hidden by NQ Vault (com.netqin.ps) using the recovered PIN XOR key",
+        "author": "",
+        "creation_date": "2023-05-19",
+        "last_update_date": "2023-05-19",
+        "requirements": "none",
+        "category": "Encrypting Media Apps",
+        "notes": "",
+        "paths": ('*/emulated/0/Android/data/com.netqin.ps/files/Documents/SystemAndroid/Data/322w465ay423xy11',
+                  '*/SystemAndroid/Data/**', '/media/0/SystemAndroid/Data/322w465ay423xy11'),
+        "output_types": "standard",
         "artifact_icon": "image",
-        "function": "get_NQVault",
     }
 }
 
+import datetime
+import functools
 import itertools
-import re
-import string
 import sqlite3
+import string
 from pathlib import Path
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, media_to_html, open_sqlite_db_readonly
+import scripts.filetype as filetype
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly, check_in_embedded_media
 
 
-def sanitize_output_filename(filename, default_name='recovered_file.bin'):
-    raw_name = str(filename or '')
-    normalized = raw_name.replace('\\', '/')
-    safe_name = Path(normalized).name
-    safe_name = re.sub(r'[\x00-\x1f<>:"/\\|?*]+', '_', safe_name)
-    safe_name = safe_name.strip().strip('.')
-    if not safe_name:
-        return default_name
-    return safe_name
-
-
-def build_safe_output_path(report_folder, original_filename):
-    report_root = Path(report_folder).resolve()
-    sanitized_name = sanitize_output_filename(original_filename)
-    output_path = (report_root / sanitized_name).resolve()
+def _ms_to_utc(value):
+    if not value:
+        return ''
     try:
-        output_path.relative_to(report_root)
-    except ValueError:
-        output_path = report_root / sanitize_output_filename(None)
-
-    if output_path.exists():
-        stem = output_path.stem
-        suffix = output_path.suffix
-        index = 1
-        while True:
-            candidate = report_root / f'{stem}_{index}{suffix}'
-            if not candidate.exists():
-                output_path = candidate
-                break
-            index += 1
-    return output_path
-
-
-def extract_data_from_db(file_found):
-    dict_of_dicts = {}
-    list_of_enc_pins = []
-    try:
-        connection = open_sqlite_db_readonly(file_found)
-        set_pointer = connection.cursor()
-        set_pointer.execute('''SELECT 
-       [file_path_from], 
-       [file_name_from], 
-       [file_path_new], 
-       DATETIME ([time] / 1000, 'unixepoch'), 
-       TIME ([viode_time] / 1000, 'unixepoch'), 
-       [resolution], 
-       [albums].[album_name], 
-       [albumstemp].[album_name_temp], 
-       [password_id]
-        FROM   [hideimagevideo]
-       LEFT OUTER JOIN [albums] ON [hideimagevideo].[album_id] = [albums].[_id]
-       LEFT OUTER JOIN [albumstemp] ON [hideimagevideo].[album_id] = [albumstemp].[album_temp_id];''')
-
-        db_data = set_pointer.fetchall()
-        connection.close()
-
-        for entry in db_data:
-            encrypted_filename = entry[2].split('/')[-1]
-            new_dict = {}
-            new_dict['old_filepath'] = entry[0]
-            new_dict['old_filename'] = entry[1]
-            new_dict['vault_filepath'] = entry[2]
-            new_dict['timestamp'] = entry[3]
-            new_dict['vid_length'] = entry[4]
-            new_dict['resolution'] = entry[5]
-            new_dict['alb_name'] = entry[6]
-            new_dict['prev_alb_name'] = entry[7]
-            new_dict['password_id'] = entry[8]
-
-            if entry[8] not in list_of_enc_pins:
-                list_of_enc_pins.append(entry[8])
-
-            dict_of_dicts[encrypted_filename] = new_dict
-
-        return dict_of_dicts, list_of_enc_pins, file_found
-    except (sqlite3.Error, OSError, ValueError, TypeError, AttributeError, IndexError, KeyError):
-        return None
-
-
-def brute_force_pin(encoded_PIN):
-    decoded_PIN = None
-
-    pin_len = 3
-    logfunc('PIN Hash Identified!\nAttempting PINs from 3 - 15 digits. If PIN len > 8/9 it could take some time.\n')
-    # earlier PINs that have been identified
-    if encoded_PIN == '1509442':
-        pin = 1234
-        return pin
-    elif encoded_PIN == '1477632':
-        pin = 0000
-        return pin
-    elif encoded_PIN == '-1867378635':
-        pin = 123456789
-        return pin
-    elif encoded_PIN == '-1812067894':
-        pin = 25101988
-        return pin
-    else:
-        while pin_len <= 15:
-            for numbers in itertools.product(string.digits, repeat=pin_len):
-
-                pin = ''.join(numbers)
-                decoded_test_value_string = str(java_string_hashcode(pin))
-
-                if decoded_test_value_string == encoded_PIN:
-                    #logfunc(f'Decrypted PIN is: {pin}')
-                    return pin
-            pin_len += 1
-
-        if decoded_PIN is None:
-            print('Sorry. No PIN found.')
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
 
 
 def java_string_hashcode(pin):
     hashcode_init = 0
-    for iters in pin:
-        hashcode_init = (31 * hashcode_init + ord(iters)) & 0xFFFFFFFF
+    for char in pin:
+        hashcode_init = (31 * hashcode_init + ord(char)) & 0xFFFFFFFF
     return ((hashcode_init + 0x80000000) & 0xFFFFFFFF) - 0x80000000
 
 
-def raw_pin_to_XOR_key(pin):
-    if not type(pin) == str:
-        pin = str(pin)
+@functools.lru_cache(maxsize=None)
+def brute_force_pin(encoded_pin):
+    # Previously identified PINs (instant)
+    known = {'1509442': 1234, '1477632': 0, '-1867378635': 123456789, '-1812067894': 25101988}
+    if encoded_pin in known:
+        return known[encoded_pin]
+    logfunc('PIN hash identified - brute forcing 3-15 digit PINs (long PINs can take a while).')
+    for pin_len in range(3, 16):
+        for numbers in itertools.product(string.digits, repeat=pin_len):
+            pin = ''.join(numbers)
+            if str(java_string_hashcode(pin)) == encoded_pin:
+                return pin
+    return None
 
-    hashed_pin = java_string_hashcode(pin)
 
-    int_XOR_key = hashed_pin & 0xFF
-    hex_XOR_key = hex(int_XOR_key)
+def raw_pin_to_xor_key(pin):
+    return hex(java_string_hashcode(str(pin)) & 0xFF)
 
-    return hex_XOR_key
 
-def file_decryption(files_found, dict_of_file_info, dict_of_pin_dicts, report_folder):
-    data_list = []
-    logfunc('Encrypted files found! File Decryption in progress...')
+def _extract_data_from_db(file_found):
+    try:
+        connection = open_sqlite_db_readonly(file_found)
+        cursor = connection.cursor()
+        cursor.execute('''
+            SELECT file_path_from, file_name_from, file_path_new, [time],
+                   TIME([viode_time] / 1000, 'unixepoch'), resolution,
+                   albums.album_name, albumstemp.album_name_temp, password_id
+            FROM hideimagevideo
+            LEFT OUTER JOIN albums ON hideimagevideo.album_id = albums._id
+            LEFT OUTER JOIN albumstemp ON hideimagevideo.album_id = albumstemp.album_temp_id
+        ''')
+        db_data = cursor.fetchall()
+        connection.close()
+    except (sqlite3.Error, OSError, ValueError, TypeError, AttributeError, IndexError, KeyError):
+        return {}, [], ''
 
+    dict_of_file_info = {}
+    enc_pins = []
+    for entry in db_data:
+        encrypted_filename = str(entry[2]).split('/')[-1]
+        dict_of_file_info[encrypted_filename] = {
+            'old_filepath': entry[0], 'old_filename': entry[1], 'vault_filepath': entry[2],
+            'timestamp': _ms_to_utc(entry[3]), 'vid_length': entry[4], 'resolution': entry[5],
+            'alb_name': entry[6], 'prev_alb_name': entry[7], 'password_id': entry[8],
+        }
+        if entry[8] not in enc_pins:
+            enc_pins.append(entry[8])
+    return dict_of_file_info, enc_pins, file_found
+
+
+def _load_db(files_found):
     for file_found in files_found:
         file_found = str(file_found)
-        # the parent folder of the files is base 64 encoded password hash
-        # could do further validation is required.
-        if file_found.endswith('.bin') and ('.image' in file_found or '.video' in file_found):
-
-            filename_without_ext = Path(file_found).stem
-            xor_key = ''
-            pin_code = None
-            for enc_filename, file_info in dict_of_file_info.items():
-                if enc_filename.split('.')[0] == filename_without_ext:
-                    file_enc_pin = file_info['password_id']
-
-                    # find xor pin from dictionary
-                    for encoded_pin, encoded_pin_info in dict_of_pin_dicts.items():
-                        if encoded_pin == file_enc_pin:
-                            xor_key = encoded_pin_info['xor_key']
-                            pin_code = encoded_pin_info['pin_for_XOR_key']
-
-                    if xor_key != 0:
-                        key_to_int = int(xor_key, 16)
-                        xor_list = []
-                        iter_through_initial_bytes = 0
-                        decrypted_file_name = file_info['old_filename']
-                        encrypted_file_name = Path(file_info['vault_filepath']).stem + '.bin'
-                        with open(file_found, 'rb') as file_to_decrypt:
-                            byte = file_to_decrypt.read(1)
-
-                            while byte:
-                                if iter_through_initial_bytes < 128:
-                                    xord_bytes = int(byte.hex(), 16) ^ key_to_int
-                                    xor_list.append(xord_bytes)
-                                else:
-                                    xor_list.append(int(byte.hex(), 16))
-
-                                iter_through_initial_bytes = iter_through_initial_bytes + 1
-                                byte = file_to_decrypt.read(1)
-
-                            xord_bytes_decrypted = bytes(xor_list)
-                            decrypted_output_path = build_safe_output_path(report_folder, decrypted_file_name)
-                            with open(decrypted_output_path, 'wb') as decryptedFile:
-                                decryptedFile.write(xord_bytes_decrypted)
-                                decryptedFile.close()
-
-                                tolink = []
-                                pathdec = str(decrypted_output_path)
-                                tolink.append(pathdec)
-                                thumb = media_to_html(pathdec, tolink, report_folder)
-
-                                data_list.append((thumb, file_info['old_filename'], file_info['old_filepath'],
-                                                  encrypted_file_name,file_found, file_info['timestamp'],
-                                                  file_info['vid_length'],file_info['resolution'],file_info['alb_name'],
-                                                  file_info['prev_alb_name'],pin_code, file_info['password_id']))
-                        logfunc(f'{encrypted_file_name} decrypted.')
-                        if data_list:
-                            report = ArtifactHtmlReport('NQ Vault Decrypted Media')
-                            report.start_artifact_report(report_folder, 'NQ Vault Decrypted Media')
-                            report.add_script()
-                            data_headers = ('Media', 'Original Filename', 'Original Filepath', 'Encrypted Filename',
-                                            'Full Path','Timestamp','Video Length','File Resolution','Album Name',
-                                            'Previous Album Name','Password','Password Hash')
-                            maindirectory = str(Path(file_found).parents[1])
-                            report.write_artifact_data_table(data_headers, data_list, maindirectory,
-                                                             html_no_escape=['Media'])
-                            report.end_artifact_report()
-
-                            tsvname = 'NQVault'
-                            tsv(report_folder, data_headers, data_list, tsvname)
-
-
-# MAIN #
-def get_NQVault(files_found, report_folder, seeker, wrap_text):
-    _ = seeker, wrap_text
-    data_list = []
-    list_of_enc_pins = []
-    dict_of_file_info = {}
-    dict_of_pin_dicts = {}
-    file_found_pin = ''
-    success = 0
-    # Get the "encrypted" PIN from DB
-    for file_found in files_found:
         if file_found.endswith('322w465ay423xy11'):
-            # multiple password hashes may be present, so these are stored as a list
-            extraction_result = extract_data_from_db(file_found)
-            if extraction_result:
-                dict_of_file_info, list_of_enc_pins, file_found_pin = extraction_result
-                success = 1
-    if success == 0:
-        logfunc('No Database DB Found or no hashed PIN present.')
-        return
+            dict_of_file_info, enc_pins, db_path = _extract_data_from_db(file_found)
+            if db_path:
+                return dict_of_file_info, enc_pins, db_path
+    return {}, [], ''
 
-    if len(list_of_enc_pins) > 0:
-        for encoded_pin in list_of_enc_pins:
-            pin_dict = {}
-            # Brute-force encrypted PIN
-            pin_for_XOR_key = brute_force_pin(encoded_pin)
-            # pin_for_XOR_key is decoded PIN
-            pin_dict['pin_for_XOR_key'] = pin_for_XOR_key
-            data_list.append((encoded_pin, pin_for_XOR_key))
 
-            # Use decrypted PIN to generate correct XOR key for media decryption (if media present).
-            xor_key = raw_pin_to_XOR_key(pin_for_XOR_key)
-            pin_dict['xor_key'] = xor_key
-            dict_of_pin_dicts[encoded_pin] = pin_dict
-            logfunc(f'XOR Key generated from encoded PIN of {encoded_pin}: {xor_key}.'
-                    f'\nDecrypted PIN: {pin_for_XOR_key}')
+@artifact_processor
+def get_NQVault(files_found, report_folder, seeker, wrap_text):
+    _, enc_pins, db_path = _load_db(files_found)
+    data_list = [(encoded_pin, brute_force_pin(encoded_pin)) for encoded_pin in enc_pins]
+    data_headers = ('Encrypted PIN', 'Decrypted PIN')
+    return data_headers, data_list, db_path
 
-        # Write encrypted/decrypted PIN info to report
-        report = ArtifactHtmlReport('NQ Vault Decrypted PIN')
-        report.start_artifact_report(report_folder, 'NQ Vault Decrypted PIN')
-        report.add_script()
-        data_headers = ('Encrypted PIN', 'Decrypted PIN')
 
-        report_source = file_found_pin if file_found_pin else 'NQ Vault Source DB'
-        report.write_artifact_data_table(data_headers, data_list, report_source, html_no_escape=['Media'])
-        report.end_artifact_report()
+@artifact_processor
+def get_NQVault_media(files_found, report_folder, seeker, wrap_text):
+    dict_of_file_info, enc_pins, db_path = _load_db(files_found)
+    pin_xor = {pin: (raw_pin_to_xor_key(brute_force_pin(pin)), brute_force_pin(pin)) for pin in enc_pins}
 
-        # Media decryption funct
-        if dict_of_file_info:
-            file_decryption(files_found, dict_of_file_info, dict_of_pin_dicts, report_folder)
-        else:
-            logfunc('No Encrypted Media Present in Database.')
-            return
-    else:
-        logfunc('No Database DB Found or no hashed PIN present.')
+    data_list = []
+    for file_found in files_found:
+        file_found = str(file_found)
+        if not (file_found.endswith('.bin') and ('.image' in file_found or '.video' in file_found)):
+            continue
+        stem = Path(file_found).stem
+        for enc_filename, info in dict_of_file_info.items():
+            if enc_filename.split('.')[0] != stem:
+                continue
+            pin_info = pin_xor.get(info['password_id'])
+            if not pin_info or not pin_info[0]:
+                continue
+            xor_key, pin_code = pin_info
+            key = int(xor_key, 16)
+
+            with open(file_found, 'rb') as f:
+                raw = f.read()
+            # Only the first 128 bytes are XOR-obfuscated
+            decrypted = bytes((b ^ key) if i < 128 else b for i, b in enumerate(raw))
+
+            kind = filetype.guess(decrypted)
+            name = info['old_filename'] or f'{stem}.bin'
+            if kind:
+                thumb = check_in_embedded_media(file_found, decrypted, name,
+                                                force_type=kind.mime, force_extension=kind.extension)
+            else:
+                thumb = check_in_embedded_media(file_found, decrypted, name)
+
+            encrypted_file_name = Path(info['vault_filepath']).stem + '.bin'
+            data_list.append((thumb, info['old_filename'], info['old_filepath'], encrypted_file_name,
+                              file_found, info['timestamp'], info['vid_length'], info['resolution'],
+                              info['alb_name'], info['prev_alb_name'], pin_code, info['password_id']))
+
+    data_headers = (
+        ('Media', 'media'), 'Original Filename', 'Original Filepath', 'Encrypted Filename', 'Full Path',
+        ('Timestamp', 'datetime'), 'Video Length', 'File Resolution', 'Album Name', 'Previous Album Name',
+        'Password', 'Password Hash')
+    return data_headers, data_list, db_path


### PR DESCRIPTION
Converts `NQ_Vault.py` (NQ Vault / com.netqin.ps) to the decorated `@artifact_processor` pattern, split into two artifacts under **Encrypting Media Apps** (was `Encrypting Media apps` — capitalization consolidated):

| Function | Name |
|---|---|
| `get_NQVault` | NQ Vault Decrypted PINs |
| `get_NQVault_media` | NQ Vault Decrypted Media |

**Changes**
- **PIN brute force memoized** with `functools.lru_cache` — the original ran it once; the two-function split would otherwise run it twice, so caching keeps the (potentially very slow) 3–15 digit brute force to a single pass per encoded PIN. Verified: `java_string_hashcode('1234') == 1509442`.
- **Media migration:** XOR-decrypted bytes go to `check_in_embedded_media` into a `('Media','media')` column. This **drops ~30 lines** of `sanitize_output_filename`/`build_safe_output_path`/file-writing — the LAVA media store handles storage and naming, so the path-traversal guards are no longer needed.
- `Timestamp` is now an aware UTC `datetime` (query selects raw epoch ms instead of a SQLite `DATETIME()` string).
- XOR decryption (first 128 bytes) rewritten as a single bytes comprehension.

Original dates (2023-05-19) preserved. Third of the encrypting-vault apps (after Playground #820, App Locker #821).