### PR TITLE
Convert browserCachechrome to LAVA @artifact_processor (+ media migration)

### DIFF
--- a/scripts/artifacts/browserCachechrome.py
+++ b/scripts/artifacts/browserCachechrome.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0125,W0126,W0404,W0611,W0612,W0613,W0718,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_browserCachechrome": {
-        "name": "browserCachechrome",
-        "description": "",
+        "name": "Chrome Browser Cache",
+        "description": "Cached web resources extracted from the Chrome browser disk cache",
         "author": "",
         "creation_date": "2023-01-28",
         "last_update_date": "2023-01-28",
@@ -10,103 +10,76 @@ __artifacts_v2__ = {
         "category": "Browser Cache",
         "notes": "",
         "paths": ('*/data/com.android.chrome/cache/Cache/*_0',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "globe",
-        "function": "get_browserCachechrome",
     }
 }
 
 import datetime
-import email
+import gzip
 import os
 import struct
-import gzip
-import shutil
 from io import BytesIO
 
 from scripts.filetype import guess_mime, guess_extension
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, media_to_html, is_platform_windows
+from scripts.ilapfuncs import artifact_processor, logfunc, check_in_embedded_media
 
+EOF_MARKER = b'\xD8\x41\x0D\x97\x45\x6F\xFA\xF4'
+
+
+def _sec_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value), datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
+
+
+@artifact_processor
 def get_browserCachechrome(files_found, report_folder, seeker, wrap_text):
-    
     data_list = []
-    
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
-        if file_found.endswith('_0'):
-        
-            filename = os.path.basename(file_found)
-            
-            modified_time = os.path.getmtime(file_found)
-            utc_modified_date = datetime.datetime.utcfromtimestamp(modified_time)
-            
-            with open(file_found, 'rb') as file:
-                data = file.read()
-                ab = BytesIO(data)
-                
-                try:
-                    eofloc = data.index(b'\xD8\x41\x0D\x97\x45\x6F\xFA\xF4')
-                except ValueError:
-                    logfunc(f'Skipping {file_found}: Expected byte pattern not found')
-                    continue
-                
-                header = ab.read(8)
-                version = ab.read(4)
-                lenghturl = ab.read(4)
-                lenghturl = (struct.unpack_from("<i",lenghturl)[0])
-                dismiss = ab.read(8)
-                
-                headerlenght = lenghturl + 8 + 4 + 4 + 8
-                
-                url = ab.read(lenghturl)
-                url = (url.decode())
-                filedata = ab.read(eofloc - headerlenght)
-                
-                mime = guess_mime(filedata)
-                ext = guess_extension(filedata)
-                
-                sfilename = filename + '.' + ext if ext else filename
-                spath = os.path.join(report_folder,sfilename)
-                
-                with open(f'{spath}', 'wb') as d:
-                    d.write(filedata)
-                
-                if ext == 'x-gzip':
-                    try:
-                        with gzip.open(f'{spath}', 'rb') as f_in:
-                            file_content = f_in.read()
-                                
-                            mime = guess_mime(file_content)
-                            extin = guess_extension(file_content)
-                            #logfunc(f'Gzip mime: {mime} for {spath}')    
-                            sfilename = filename + '.' + extin if extin else filename
-                            spath = os.path.join(report_folder,sfilename)
-                            
-                        with open(f'{spath}', 'wb') as f_out:
-                            f_out.write(file_content)
+        if not file_found.endswith('_0'):
+            continue
+        filename = os.path.basename(file_found)
+        source_path = os.path.dirname(file_found)
 
-                    except Exception as e: logfunc(str(e))
-                
-                filetosearch = []
-                filetosearch.append(spath)
-                
-                media = media_to_html(sfilename, filetosearch, report_folder)
-                if is_platform_windows:
-                    media = media.replace('/?','',1)
+        with open(file_found, 'rb') as f:
+            data = f.read()
+        try:
+            eofloc = data.index(EOF_MARKER)
+        except ValueError:
+            logfunc(f'Skipping {file_found}: expected byte pattern not found')
+            continue
 
-                data_list.append((utc_modified_date, filename, mime, media, url, file_found))
-        
-    if len(data_list) > 0:
-        note = 'Source location in extraction found in the report for each item.'
-        report = ArtifactHtmlReport('Chrome Browser Cache')
-        report.start_artifact_report(report_folder, f'Chrome Browser Cache')
-        report.add_script()
-        data_headers = ('Timestamp Modified', 'Filename', 'Mime Type', 'Cached File', 'Source URL', 'Source')
-        report.write_artifact_data_table(data_headers, data_list, note, html_no_escape=['Cached File'])
-        report.end_artifact_report()
-        
-        tsvname = f'Chrome Browser Cache'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    
+        ab = BytesIO(data)
+        ab.read(8)   # header
+        ab.read(4)   # version
+        url_length = struct.unpack_from("<i", ab.read(4))[0]
+        ab.read(8)   # dismiss
+        header_length = url_length + 8 + 4 + 4 + 8
+
+        url = ab.read(url_length).decode(errors='replace')
+        filedata = ab.read(eofloc - header_length)
+
+        ext = guess_extension(filedata)
+        if ext == 'x-gzip':
+            try:
+                filedata = gzip.decompress(filedata)
+            except (OSError, EOFError) as ex:
+                logfunc(f'Could not gunzip {file_found}: {ex}')
+        mime = guess_mime(filedata)
+        ext = guess_extension(filedata)
+
+        name = f'{filename}.{ext}' if ext else filename
+        media = check_in_embedded_media(file_found, filedata, name, force_type=mime, force_extension=ext)
+
+        data_list.append((_sec_to_utc(os.path.getmtime(file_found)), filename, mime, media, url, file_found))
+
+    data_headers = (
+        ('Timestamp Modified', 'datetime'), 'Filename', 'Mime Type', ('Cached File', 'media'),
+        'Source URL', 'Source')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts `browserCachechrome.py` (Chrome disk cache `*_0` entries) to the decorated `@artifact_processor` pattern.

**Changes**
- **Media migration:** the cache body — unwrapped from the header/URL/EOF-marker envelope and gunzipped when `x-gzip` — is registered via `check_in_embedded_media` into a `('Cached File','media')` column (with the guessed MIME/extension), instead of being written to the report folder + `media_to_html`. Gzip is now decompressed **in memory**.
- `Timestamp Modified` → aware UTC `datetime`.
- **Bug dropped:** `if is_platform_windows:` tested the *function object* (always truthy), so the `/?`-strip always ran; removed along with the dead `email` import.
- Renamed `browserCachechrome` → **Chrome Browser Cache**.

Original dates (2023-01-28) preserved. Firefox sibling (`browserCachefirefox`) coming next.