### PR TITLE
Convert browserCachefirefox to LAVA @artifact_processor (+ media migration)

### DIFF
--- a/scripts/artifacts/browserCachefirefox.py
+++ b/scripts/artifacts/browserCachefirefox.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0125,W0126,W0404,W0611,W0613,W0702,W0718,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_browserCachefirefox": {
-        "name": "browserCachefirefox",
-        "description": "",
+        "name": "Firefox Browser Cache",
+        "description": "Cached web resources extracted from the Firefox browser disk cache (cache2)",
         "author": "",
         "creation_date": "2023-01-30",
         "last_update_date": "2023-01-30",
@@ -10,93 +10,71 @@ __artifacts_v2__ = {
         "category": "Browser Cache",
         "notes": "",
         "paths": ('*/data/org.mozilla.firefox/cache/*/cache2/entries/**',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "globe",
-        "function": "get_browserCachefirefox",
     }
 }
 
 import datetime
-import email
-import os
-import struct
 import gzip
-import shutil
+import os
 from io import BytesIO
 
 from scripts.filetype import guess_mime, guess_extension
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, media_to_html, is_platform_windows
+from scripts.ilapfuncs import artifact_processor, logfunc, check_in_media, check_in_embedded_media
 
+
+def _sec_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value), datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
+
+
+@artifact_processor
 def get_browserCachefirefox(files_found, report_folder, seeker, wrap_text):
-    
     data_list = []
-    
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
+        if os.path.isdir(file_found):
+            continue
         filename = os.path.basename(file_found)
-        
-        modified_time = os.path.getmtime(file_found)
-        utc_modified_date = datetime.datetime.utcfromtimestamp(modified_time)
-        
-        with open(file_found, 'rb') as file:
-            data = file.read()
-            
-            ab = BytesIO(data)
-            try:
-                indexone = data.index(b'partitionKey=%28') + 16
-                indextwo = data.index(b'necko') - 1
-                urltoread = indextwo - indexone
-                ab.read(indexone)
-                url = ab.read(urltoread)
-                url = (url.decode())
-            except:
-                url = ''
-            
-            mime = guess_mime(file_found)
-            ext = guess_extension(file_found)
-            
-            sfilename = filename + '.' + ext if ext else filename
-            spath = os.path.join(report_folder,sfilename)
-            shutil.copy2(file_found, spath)
-            
-            if ext == 'x-gzip':
-                try:
-                    with gzip.open(f'{spath}', 'rb') as f_in:
-                        file_content = f_in.read()
-                        
-                        mime = guess_mime(file_content)
-                        extin = guess_extension(file_content)
-                        #logfunc(f'Gzip mime: {mime} for {spath}')
-                        sfilename = filename + '.' + extin if extin else filename
-                        spath = os.path.join(report_folder,sfilename)
-                        
-                    with open(f'{spath}', 'wb') as f_out:
-                        f_out.write(file_content)
-                        
-                except Exception as e: logfunc(str(e))
-                
-            
-            filetosearch = []
-            filetosearch.append(spath)
-            
-            media = media_to_html(sfilename, filetosearch, report_folder)
-            if is_platform_windows:
-                media = media.replace('/?','',1)
-                
-            data_list.append((utc_modified_date, filename, mime, media, url, file_found))
-        
-    if len(data_list) > 0:
-        note = 'Source location in extraction found in the report for each item.'
-        report = ArtifactHtmlReport('Firefox Browser Cache')
-        report.start_artifact_report(report_folder, f'Firefox  Browser Cache')
-        report.add_script()
-        data_headers = ('Timestamp Modified', 'Filename', 'Mime Type', 'Cached File', 'Source URL', 'Source')
-        report.write_artifact_data_table(data_headers, data_list, note, html_no_escape=['Cached File'])
-        report.end_artifact_report()
-        
-        tsvname = f'Firefox Browser Cache'
-        tsv(report_folder, data_headers, data_list, tsvname)
+        source_path = os.path.dirname(file_found)
+        with open(file_found, 'rb') as f:
+            data = f.read()
 
-            
+        # The source URL sits between the partitionKey marker and 'necko'
+        try:
+            start = data.index(b'partitionKey=%28') + 16
+            end = data.index(b'necko') - 1
+            url = data[start:end].decode(errors='replace')
+        except ValueError:
+            url = ''
+
+        ext = guess_extension(file_found)
+        if ext == 'x-gzip':
+            try:
+                with gzip.GzipFile(fileobj=BytesIO(data)) as gz:
+                    body = gz.read()
+                mime = guess_mime(body)
+                ext = guess_extension(body)
+                name = f'{filename}.{ext}' if ext else filename
+                media = check_in_embedded_media(file_found, body, name, force_type=mime, force_extension=ext)
+            except (OSError, EOFError) as ex:
+                logfunc(f'Could not gunzip {file_found}: {ex}')
+                mime = guess_mime(file_found)
+                media = check_in_media(file_found, filename)
+        else:
+            mime = guess_mime(file_found)
+            name = f'{filename}.{ext}' if ext else filename
+            media = check_in_media(file_found, name)
+
+        data_list.append((_sec_to_utc(os.path.getmtime(file_found)), filename, mime, media, url, file_found))
+
+    data_headers = (
+        ('Timestamp Modified', 'datetime'), 'Filename', 'Mime Type', ('Cached File', 'media'),
+        'Source URL', 'Source')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts `browserCachefirefox.py` (Firefox `cache2/entries`) to the decorated `@artifact_processor` pattern — sibling of #824.

**Changes**
- **Media migration:** non-gzip entries (real files in the extraction) use `check_in_media`; `x-gzip` entries are gunzipped **in memory** and use `check_in_embedded_media` — both feeding a `('Cached File','media')` column, replacing the `shutil.copy2` + `media_to_html`.
- `Timestamp Modified` → aware UTC `datetime`.
- Directories matched by the `**` glob are skipped.
- Dropped the no-op `if is_platform_windows:` bug (tested the function object) and dead imports (`struct`, `email`, `shutil`).
- Renamed `browserCachefirefox` → **Firefox Browser Cache**.

Original dates (2023-01-30) preserved.