### PR TITLE
Convert googlemapaudio + googlemapaudioTemp to LAVA @artifact_processor (+ media migration)

### DIFF
--- a/scripts/artifacts/googlemapaudio.py
+++ b/scripts/artifacts/googlemapaudio.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_googlemapaudio": {
-        "name": "Googlemapaudio",
-        "description": "",
+        "name": "Google Maps Voice Guidance",
+        "description": "Google Maps text-to-speech voice guidance audio (app_tts-cache)",
         "author": "",
         "creation_date": "2021-12-27",
         "last_update_date": "2021-12-27",
@@ -10,78 +10,49 @@ __artifacts_v2__ = {
         "category": "Google Maps Voice Guidance",
         "notes": "",
         "paths": ('*/com.google.android.apps.maps/app_tts-cache/*_*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "map-pin",
-        "function": "get_googlemapaudio",
     }
 }
 
-from re import fullmatch
-from datetime import datetime
+import datetime
+import os
+import re
 from pathlib import Path
-from os.path import getsize
+
+from scripts.ilapfuncs import artifact_processor, check_in_media
+
+NAME_PATTERN = re.compile(r"-?\d+_\d+")
 
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, media_to_html
+def _ms_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
 
-def convertGeo(s):
-    length = len(s)
-    if length > 6:
-        return (s[0 : length-6] + "." + s[length-6 : length])
-    else:
-        return (s)
 
+@artifact_processor
 def get_googlemapaudio(files_found, report_folder, seeker, wrap_text):
-
-    files_found = list(filter(lambda x: "sbin" not in x, files_found))
-
-    data_headers = ("Timestamp", "Filename", "Audio", "Size")
-    audio_info = []
-    source_dir = ""
-
-    pattern = r"-?\d+_\d+"
-
+    data_list = []
+    source_path = ''
     for file_found in files_found:
-
+        file_found = str(file_found)
+        if 'sbin' in file_found:
+            continue
         name = Path(file_found).name
+        if not NAME_PATTERN.fullmatch(name):
+            continue
+        file_size = os.path.getsize(file_found)
+        if file_size == 0:
+            continue
+        source_path = os.path.dirname(file_found)
+        # filename is <geo>_<timestamp_ms>
+        timestamp = _ms_to_utc(name.split('_')[1])
+        media = check_in_media(file_found, name)
+        data_list.append((timestamp, media, name, file_size))
 
-        match = fullmatch(pattern, name)
-        file_size = getsize(file_found)
-        has_data = file_size > 0
-
-        if match and has_data:
-
-            # Timestamp
-            timestamp = Path(file_found).name.split("_")[1]
-            timestamp_datetime = datetime.utcfromtimestamp(int(timestamp) / 1000)
-            timestamp_str = timestamp_datetime.isoformat(timespec="seconds", sep=" ")
-            
-            # Audio
-            audio = media_to_html(name, files_found, report_folder)
-            
-            # Size
-            file_size_kb = f"{round(file_size / 1024, 2)} kb"
-
-            # Artefacts
-            info = (timestamp_str, name, audio, file_size_kb)
-            audio_info.append(info)
-
-
-    if audio_info:
-
-        source_dir = str(Path(files_found[0]).parent)
-
-        report = ArtifactHtmlReport('Google Maps Voice Guidance')
-        report.start_artifact_report(report_folder, 'Google Maps Voice Guidance')
-        report.add_script()
-
-        report.write_artifact_data_table(data_headers, audio_info, source_dir, html_escape=False)
-        report.end_artifact_report()
-            
-        tsvname = f'Google Map Audio'
-        tsv(report_folder, data_headers, audio_info, tsvname, source_dir)
-            
-    else:
-        logfunc('No Google Audio Locations found')
-            
+    data_headers = (('Timestamp', 'datetime'), ('Audio', 'media'), 'Filename', 'File Size')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/googlemapaudioTemp.py
+++ b/scripts/artifacts/googlemapaudioTemp.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0611,W0612,W0613,W0631,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_googlemapaudioTemp": {
-        "name": "GooglemapaudioT",
-        "description": "",
+        "name": "Google Maps Voice Guidance (Temp)",
+        "description": "Google Maps text-to-speech voice guidance audio (app_tts-temp)",
         "author": "",
         "creation_date": "2023-04-27",
         "last_update_date": "2023-04-27",
@@ -10,64 +10,42 @@ __artifacts_v2__ = {
         "category": "Google Maps Voice Guidance",
         "notes": "",
         "paths": ('*/com.google.android.apps.maps/app_tts-temp/**',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "map-pin",
-        "function": "get_googlemapaudioTemp",
     }
 }
 
-from re import fullmatch
-from datetime import datetime
-from pathlib import Path
-from os.path import getsize
+import datetime
 import os
+from pathlib import Path
+
+from scripts.ilapfuncs import artifact_processor, check_in_media
 
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, media_to_html
+def _sec_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value), datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
 
+
+@artifact_processor
 def get_googlemapaudioTemp(files_found, report_folder, seeker, wrap_text):
-
     data_list = []
-    
+    source_path = ''
     for file_found in files_found:
-
+        file_found = str(file_found)
+        if os.path.isdir(file_found):
+            continue
+        file_size = os.path.getsize(file_found)
+        if file_size == 0:
+            continue
         name = Path(file_found).name
-        modified_time = os.path.getmtime(file_found)
-        file_size = getsize(file_found)
-        has_data = file_size > 0
+        source_path = os.path.dirname(file_found)
+        media = check_in_media(file_found, name)
+        data_list.append((_sec_to_utc(os.path.getmtime(file_found)), media, name, file_size))
 
-        if  os.path.isdir(file_found) is False:
-            
-            if has_data :
-                
-                # Timestamp
-                utc_modified_date = datetime.utcfromtimestamp(modified_time)
-                
-                # Audio
-                audio = media_to_html(file_found, files_found, report_folder)
-                
-                # Size
-                file_size_kb = f"{round(file_size / 1024, 2)} kb"
-    
-                # Artefacts
-                data_list.append((utc_modified_date,audio,name,file_size))
-
-
-    if len(data_list) > 0:
-
-        source_dir = str(Path(file_found).parent)
-
-        report = ArtifactHtmlReport('Google Maps Temp Voice Guidance')
-        report.start_artifact_report(report_folder, 'Google Maps Temp Voice Guidance')
-        report.add_script()
-        data_headers = ('Timestamp Modified', 'Audio', 'Name', 'File Size')
-        report.write_artifact_data_table(data_headers, data_list, source_dir, html_escape=False)
-        report.end_artifact_report()
-            
-        tsvname = f'Google Maps Temp Voice Guidance'
-        tsv(report_folder, data_headers, data_list, tsvname, source_dir)
-            
-    else:
-        logfunc('No Google Maps Temp Voice Guidance found')
-            
+    data_headers = (('Timestamp Modified', 'datetime'), ('Audio', 'media'), 'Filename', 'File Size')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts the Google Maps voice-guidance TTS audio pair to the decorated `@artifact_processor` pattern, both under category **Google Maps Voice Guidance**:

| Function | Name | Source |
|---|---|---|
| `get_googlemapaudio` | Google Maps Voice Guidance | `app_tts-cache/*_*` |
| `get_googlemapaudioTemp` | Google Maps Voice Guidance (Temp) | `app_tts-temp/**` |

**Changes**
- **Media migration:** the audio files move from `media_to_html` to an `('Audio','media')` column backed by `check_in_media`.
- Timestamps are now aware UTC `datetime` values — `googlemapaudio` from the `<geo>_<ms>` filename, the Temp variant from file mtime.
- `File Size` is raw bytes for both (was a `"X kb"` string in one); columns unified.
- Dropped the dead `convertGeo` helper. Renamed from `Googlemapaudio`/`GooglemapaudioT` to descriptive names.

Original dates preserved (2021-12-27 / 2023-04-27).