### PR TITLE
Convert chatgpt to LAVA @artifact_processor (9-way split + media migration)

### DIFF
--- a/scripts/artifacts/chatgpt.py
+++ b/scripts/artifacts/chatgpt.py
@@ -14,8 +14,8 @@ __artifacts_v2__ = {
         "artifact_icon": "message-circle",
     },
     "get_chatgpt_conversations": {
-        "name": "ChatGPT - Messages",
-        "description": "User messages with ChatGPT (older DBMessage.messageNode schema; see chatgpt2 for the newer DBMessageChunk schema)",
+        "name": "ChatGPT - Messages (Legacy)",
+        "description": "User messages with ChatGPT, older DBMessage.messageNode schema (see ChatGPT - Conversations / chatgpt2 for the newer DBMessageChunk schema)",
         "author": "Evangelos Dragonas (@theAtropos4n6)",
         "creation_date": "2024-07-09",
         "last_update_date": "2024-07-09",

--- a/scripts/artifacts/chatgpt.py
+++ b/scripts/artifacts/chatgpt.py
@@ -1,440 +1,408 @@
-# pylint: disable=W0311,W0401,W0612,W0613,W0614,W0622,W0702,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_chatgpt": {
-        "name": "ChatGPT",
-        "description": "Get user's ChatGPT conversations, settings and media files. This parser is based on a research project. Parser is validated up to the app's 1.2024.177 version",
+        "name": "ChatGPT - Conversations Metadata",
+        "description": "Metadata related to the user's ChatGPT conversations. Validated up to app 1.2024.177.",
         "author": "Evangelos Dragonas (@theAtropos4n6)",
         "creation_date": "2024-07-09",
         "last_update_date": "2024-07-09",
         "requirements": "",
         "category": "ChatGPT",
-        "paths": (
-            '**/com.openai.chatgpt/databases/*.*',
-            '**/com.openai.chatgpt/files/datastore/*.*',
-            '**/com.openai.chatgpt/shared_prefs/*',
-            '**/com.openai.chatgpt/cache/files/*',
-        ),
-        "output_types": None,
-        "function": "get_chatgpt",
+        "notes": "",
+        "paths": ('**/com.openai.chatgpt/databases/*_conversations.db*',),
+        "output_types": "standard",
+        "artifact_icon": "message-circle",
+    },
+    "get_chatgpt_conversations": {
+        "name": "ChatGPT - Messages",
+        "description": "User messages with ChatGPT (older DBMessage.messageNode schema; see chatgpt2 for the newer DBMessageChunk schema)",
+        "author": "Evangelos Dragonas (@theAtropos4n6)",
+        "creation_date": "2024-07-09",
+        "last_update_date": "2024-07-09",
+        "requirements": "",
+        "category": "ChatGPT",
+        "notes": "",
+        "paths": ('**/com.openai.chatgpt/databases/*_conversations.db*',),
+        "output_types": "standard",
+        "artifact_icon": "message-circle",
+    },
+    "get_chatgpt_user": {
+        "name": "ChatGPT - User",
+        "description": "ChatGPT user preferences (user.preferences_pb)",
+        "author": "Evangelos Dragonas (@theAtropos4n6)",
+        "creation_date": "2024-07-09",
+        "last_update_date": "2024-07-09",
+        "requirements": "",
+        "category": "ChatGPT",
+        "notes": "",
+        "paths": ('**/com.openai.chatgpt/files/datastore/*_user.preferences_pb',),
+        "output_types": "standard",
+        "artifact_icon": "user",
+    },
+    "get_chatgpt_accountstatus": {
+        "name": "ChatGPT - Account Status",
+        "description": "ChatGPT account status preferences (accountstatus.preferences_pb)",
+        "author": "Evangelos Dragonas (@theAtropos4n6)",
+        "creation_date": "2024-07-09",
+        "last_update_date": "2024-07-09",
+        "requirements": "",
+        "category": "ChatGPT",
+        "notes": "",
+        "paths": ('**/com.openai.chatgpt/files/datastore/*_accountstatus.preferences_pb',),
+        "output_types": "standard",
+        "artifact_icon": "user-check",
+    },
+    "get_chatgpt_accountuserstate": {
+        "name": "ChatGPT - Account User State",
+        "description": "ChatGPT account user state preferences (accountuser_state.preferences_pb)",
+        "author": "Evangelos Dragonas (@theAtropos4n6)",
+        "creation_date": "2024-07-09",
+        "last_update_date": "2024-07-09",
+        "requirements": "",
+        "category": "ChatGPT",
+        "notes": "",
+        "paths": ('**/com.openai.chatgpt/files/datastore/*_accountuser_state.preferences_pb',),
+        "output_types": "standard",
+        "artifact_icon": "users",
+    },
+    "get_chatgpt_custominstructions": {
+        "name": "ChatGPT - Custom Instructions",
+        "description": "User-provided custom instructions for ChatGPT (custom_instructions.preferences_pb)",
+        "author": "Evangelos Dragonas (@theAtropos4n6)",
+        "creation_date": "2024-07-09",
+        "last_update_date": "2024-07-09",
+        "requirements": "",
+        "category": "ChatGPT",
+        "notes": "",
+        "paths": ('**/com.openai.chatgpt/files/datastore/*_custom_instructions.preferences_pb',),
+        "output_types": "standard",
+        "artifact_icon": "edit",
+    },
+    "get_chatgpt_usersettings": {
+        "name": "ChatGPT - User Settings",
+        "description": "ChatGPT user settings (user_settings.preferences_pb)",
+        "author": "Evangelos Dragonas (@theAtropos4n6)",
+        "creation_date": "2024-07-09",
+        "last_update_date": "2024-07-09",
+        "requirements": "",
+        "category": "ChatGPT",
+        "notes": "",
+        "paths": ('**/com.openai.chatgpt/files/datastore/*_user_settings.preferences_pb',),
+        "output_types": "standard",
+        "artifact_icon": "settings",
+    },
+    "get_chatgpt_analytics": {
+        "name": "ChatGPT - User Analytics",
+        "description": "ChatGPT analytics user/device traits (analytics-android-oai.xml)",
+        "author": "Evangelos Dragonas (@theAtropos4n6)",
+        "creation_date": "2024-07-09",
+        "last_update_date": "2024-07-09",
+        "requirements": "",
+        "category": "ChatGPT",
+        "notes": "",
+        "paths": ('**/com.openai.chatgpt/shared_prefs/analytics-android-oai.xml',),
+        "output_types": "standard",
+        "artifact_icon": "bar-chart-2",
+    },
+    "get_chatgpt_media": {
+        "name": "ChatGPT - Media Uploads",
+        "description": "Images uploaded to / cached by ChatGPT",
+        "author": "Evangelos Dragonas (@theAtropos4n6)",
+        "creation_date": "2024-07-09",
+        "last_update_date": "2024-07-09",
+        "requirements": "",
+        "category": "ChatGPT",
+        "notes": "",
+        "paths": ('**/com.openai.chatgpt/cache/files/*',),
+        "output_types": "standard",
+        "artifact_icon": "image",
     }
 }
 
-import xml.etree.ElementTree as ET
-from datetime import *
-import os
-import blackboxprotobuf
+import datetime
 import json
+import os
+import re
+import xml.etree.ElementTree as ET
 from pathlib import Path
-from PIL import Image
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, timeline, open_sqlite_db_readonly, media_to_html,convert_utc_human_to_timezone
+import blackboxprotobuf
+from PIL import Image, UnidentifiedImageError
 
-def is_image(file_path):
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly, check_in_media
+
+
+def _iso_to_utc(value):
+    if not value:
+        return ''
     try:
-        with Image.open(file_path) as img:
+        return datetime.datetime.fromisoformat(value.replace('Z', '+00:00')).astimezone(datetime.timezone.utc)
+    except (ValueError, TypeError, AttributeError):
+        return ''
+
+
+def _sec_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value), datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
+
+
+def _account(file_name, suffix):
+    return file_name[:-len(suffix)] if file_name.endswith(suffix) else file_name
+
+
+def _pb_json(file_found):
+    '''Decode a *.preferences_pb file and return the embedded JSON dict (or None).'''
+    try:
+        with open(file_found, 'rb') as f:
+            values, _ = blackboxprotobuf.decode_message(f.read())
+        if isinstance(values, dict):
+            pb = values.get('1', {}).get('2', {}).get('5', b'{}')
+            return json.loads(pb.decode('utf-8'))
+    except (ValueError, KeyError, TypeError, AttributeError, UnicodeDecodeError) as ex:
+        logfunc(f'ChatGPT: error parsing {os.path.basename(file_found)} protobuf: {ex}')
+    return None
+
+
+def _is_image(file_path):
+    try:
+        with Image.open(file_path):
             return True
-    except IOError:
+    except (UnidentifiedImageError, OSError):
         return False
 
+
+@artifact_processor
 def get_chatgpt(files_found, report_folder, seeker, wrap_text):
-    counter=1
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        file_name = os.path.basename(file_found)
-        if file_name.endswith('_conversations.db'):
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            #Conversations Metadata
-            cursor.execute('''
-                    select 
-                        id,
-                        json_extract(conversation, '$.id') AS id,
-                        json_extract(conversation, '$.remote_id') AS remote_id,
-                        json_extract(conversation, '$.creation_date') AS creation_date,
-                        json_extract(conversation, '$.modification_date') AS modification_date,
-                        json_extract(conversation, '$.title') AS title,
-                        json_extract(conversation, '$.moderation_results') AS moderation_results,
-                        json_extract(conversation, '$.gizmo_id') AS gizmo_id,
-                        CASE
-                        when json_extract(conversation, '$.has_title') = true then 'Yes' 
-                        else 'No'
-                        end has_title
-                    from DBConversation
-                 ''')
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                description = 'Metadata related to the user conversations'
-                report = ArtifactHtmlReport(f"ChatGPT - Conversations Metadata - Account: {file_name[:-17]}") # webpage title
-                #multiple accounts.db may exist. counter keeps track of their number
-                if counter == 1:
-                    report.start_artifact_report(report_folder, f"Conversations Metadata", description) # html + artifact title
-                else:
-                    report.start_artifact_report(report_folder, f"Conversations Metadata {counter}", description) # html + artifact title
-                report.add_script()
-                #data_headers = ('Conversation ID','Remote ID','Title','Creation Date','Modification Date','Custom Instructions', 'Model') 
-                data_headers = ('Creation Date','Modification Date','Title','Custom Instructions', 'Model','ID','Conversation ID','Remote ID') 
-                data_list = []
-                for row in all_rows:
-                    cdate_without_z = row[3].rstrip('Z')
-                    mdate_without_z = row[4].rstrip('Z')
-                    cdatetime_obj = datetime.fromisoformat(cdate_without_z).replace(tzinfo=timezone.utc)
-                    cdatetime_obj_no_microseconds = cdatetime_obj.replace(microsecond=0)
-                    mdatetime_obj = datetime.fromisoformat(mdate_without_z).replace(tzinfo=timezone.utc)
-                    mdatetime_obj_no_microseconds = mdatetime_obj.replace(microsecond=0)
-                    conv_cdate = convert_utc_human_to_timezone(cdatetime_obj_no_microseconds, 'UTC')
-                    conv_mdate = convert_utc_human_to_timezone(mdatetime_obj_no_microseconds, 'UTC')
-                    data_list.append((conv_cdate,conv_mdate,row[5],row[6],row[7],row[0],row[1],row[2]))
+        if not file_found.endswith('_conversations.db'):
+            continue
+        source_path = file_found
+        account = _account(os.path.basename(file_found), '_conversations.db')
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        cursor.execute('''
+            SELECT id, json_extract(conversation, '$.id'), json_extract(conversation, '$.remote_id'),
+            json_extract(conversation, '$.creation_date'), json_extract(conversation, '$.modification_date'),
+            json_extract(conversation, '$.title'), json_extract(conversation, '$.moderation_results'),
+            json_extract(conversation, '$.gizmo_id'),
+            CASE WHEN json_extract(conversation, '$.has_title') = true THEN 'Yes' ELSE 'No' END
+            FROM DBConversation
+        ''')
+        for row in cursor.fetchall():
+            data_list.append((account, _iso_to_utc(row[3]), _iso_to_utc(row[4]), row[5], row[6], row[7],
+                              row[0], row[1], row[2]))
+        db.close()
 
-                report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-                report.end_artifact_report()
-                
-                tsvname = f"ChatGPT - Conversations Metadata - {file_name[:-17]}"
-                tsv(report_folder, data_headers, data_list, tsvname)
+    data_headers = ('Account', ('Creation Date', 'datetime'), ('Modification Date', 'datetime'), 'Title',
+                    'Custom Instructions', 'Model', 'ID', 'Conversation ID', 'Remote ID')
+    return data_headers, data_list, source_path
 
-                tlactivity = f'ChatGPT - Conversations Metadata - {file_name[:-17]}'
-                timeline(report_folder, tlactivity, data_list, data_headers)
 
-            else:
-                logfunc(f'No ChatGPT - Conversations Metadata available within {file_name}')
+@artifact_processor
+def get_chatgpt_conversations(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if not file_found.endswith('_conversations.db'):
+            continue
+        source_path = file_found
+        account = _account(os.path.basename(file_found), '_conversations.db')
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        cursor.execute('''
+            SELECT DBMessage.id, DBMessage.conversationId,
+            json_extract(DBConversation.conversation, '$.title'),
+            json_extract(DBMessage.messageNode, '$.content.role'),
+            json_extract(DBMessage.messageNode, '$.content.content.content'),
+            json_extract(DBMessage.messageNode, '$.content.date'),
+            json_extract(DBMessage.messageNode, '$.content.role_name'),
+            json_extract(DBMessage.messageNode, '$.content.attachments'),
+            json_extract(DBMessage.messageNode, '$.content.model'),
+            CASE WHEN json_extract(DBMessage.messageNode, '$.content.is_complete') = true THEN 'Yes' ELSE 'No' END,
+            CASE WHEN json_extract(DBMessage.messageNode, '$.content.is_blocked') = true THEN 'Yes' ELSE 'No' END,
+            CASE WHEN json_extract(DBMessage.messageNode, '$.content.is_flagged') = true THEN 'Yes' ELSE 'No' END,
+            CASE WHEN json_extract(DBMessage.messageNode, '$.content.is_interrupted') = true THEN 'Yes' ELSE 'No' END,
+            CASE WHEN json_extract(DBMessage.messageNode, '$.content.is_user_system_message') = true THEN 'Yes' ELSE 'No' END,
+            CASE WHEN json_extract(DBMessage.messageNode, '$.content.is_voice_message') = true THEN 'Yes' ELSE 'No' END
+            FROM DBMessage JOIN DBConversation ON DBMessage.conversationId = DBConversation.id
+        ''')
+        for row in cursor.fetchall():
+            data_list.append((account, _iso_to_utc(row[5]), row[0], row[1], row[2], row[3], row[4], row[6],
+                              row[7], row[8], row[9], row[10], row[11], row[12], row[13], row[14]))
+        db.close()
 
-            #Conversations 
-            cursor.execute('''
-                    select 
-                        DBMessage.id as message_id,
-                        DBMessage.conversationId as conversationId_id,
-                        json_extract(DBConversation.conversation, '$.title') AS conversation,
-                        json_extract(DBMessage.messageNode, '$.content.role') AS role,
-                        json_extract(DBMessage.messageNode, '$.content.content.content') AS content,
-                        json_extract(DBMessage.messageNode, '$.content.date') AS date,
-                        json_extract(DBMessage.messageNode, '$.content.role_name') AS role_name,
-                        json_extract(DBMessage.messageNode, '$.content.attachments') AS attachments,
-                        json_extract(DBMessage.messageNode, '$.content.model') AS model,
-                        CASE
-                            when json_extract(DBMessage.messageNode, '$.content.is_complete') = true then 'Yes' 
-                        else 'No'
-                            end is_complete,
-                        CASE
-                            when json_extract(DBMessage.messageNode, '$.content.is_blocked') = true then 'Yes' 
-                        else 'No'
-                            end is_blocked,
-                        CASE
-                            when json_extract(DBMessage.messageNode, '$.content.is_flagged') = true then 'Yes' 
-                        else 'No'
-                            end is_flagged,
-                        CASE
-                            when json_extract(DBMessage.messageNode, '$.content.is_interrupted') = true then 'Yes' 
-                        else 'No'
-                            end is_interrupted,
-                        CASE
-                            when json_extract(DBMessage.messageNode, '$.content.is_user_system_message') = true then 'Yes' 
-                        else 'No'
-                            end is_user_system_message,
-                        CASE
-                            when json_extract(DBMessage.messageNode, '$.content.is_voice_message') = true then 'Yes' 
-                        else 'No'
-                            end is_voice_message
-                    from DBMessage
-                    join DBConversation on DBMessage.conversationId = DBConversation.id
-            ''')
+    data_headers = ('Account', ('Message Date', 'datetime'), 'Message ID', 'Conversation ID', 'Title', 'Role',
+                    'Content', 'Role Name', 'Attachments', 'Model', 'Complete', 'Blocked', 'Flagged',
+                    'Interrupted', 'User System Message', 'Voice Message')
+    return data_headers, data_list, source_path
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                description = f'User:{file_name[:-17]} conversations with ChatGPT'
-                report = ArtifactHtmlReport(f"ChatGPT - Conversations - Account: {file_name[:-17]}")
-                if counter == 1:
-                    report.start_artifact_report(report_folder, f"Conversations", description)
-                else:
-                    report.start_artifact_report(report_folder, f"Conversations {counter}", description)
-                report.add_script()
-                data_headers = ('Date','Message ID','Conversation ID','Title','Role','Content','Role Name','Attachments','Model','Complete','Blocked','Flagged','Interrupted','User System Message','Voice Message') 
-                data_list = []
-                for row in all_rows:
-                    #Date sanitization => changing the ISO format of the date to more aleapp friendly format
-                    if row[5] is not None and row[5].endswith("Z"):
-                        date_without_z = row[5].rstrip('Z')
-                        datetime_obj = datetime.fromisoformat(date_without_z).replace(tzinfo=timezone.utc)
-                        message_date = convert_utc_human_to_timezone(datetime_obj, 'UTC')
-                        data_list.append((message_date,row[0],row[1],row[2],row[3],row[4],row[6],row[7],row[8],row[9],row[10],row[11],row[12],row[13],row[14]))
-                    else:
-                        data_list.append((row[5],row[0],row[1],row[2],row[3],row[4],row[6],row[7],row[8],row[9],row[10],row[11],row[12],row[13],row[14]))
-                report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-                report.end_artifact_report()
-                
-                tsvname = f"ChatGPT - Conversations - {file_name[:-17]}"
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-            else:
-                logfunc(f'No ChatGPT - Conversations data available within {file_name}')
-            counter+=1
-            db.close()
 
-            #parsing protobuf files
-        if file_name.endswith('.preferences_pb'):
-            #parse user-ID__user.preferences_pb
-            if file_name.endswith("_user.preferences_pb"):
-                with open(file_found, 'rb') as file:
-                    data = file.read()
-                    values, types = blackboxprotobuf.decode_message(data)
-                    data_list = []
-                    if isinstance(values, dict):
-                        try:
-                            pb = values.get('1', {}).get('2', {}).get('5', b'{}')
-                            info = pb.decode('utf-8')
-                            userinfo = json.loads(info)
-                            id = userinfo.get('id', None)
-                            email = userinfo.get('email', '')
-                            name = userinfo.get('name', '')
-                            picture = userinfo.get('picture', '')
-                            created_timestamp = int(userinfo.get('created', 0))
-                            created = datetime.fromtimestamp(created_timestamp, tz=timezone.utc)
-                            createdts = convert_utc_human_to_timezone(created, 'UTC')
-                            data_list.append((id,email,name,createdts,picture))
-                        except:
-                            logfunc(f'Error parsing ChatGPT - error occured when parsing {file_name} protobuf')
-                        
-                    if len(data_list) > 0:
-                        description = f'User preferences'
-                        report = ArtifactHtmlReport('ChatGPT - User')
-                        report.start_artifact_report(report_folder, f'User', description)
-                        report.add_script()
-                        data_headers = ('User-ID', 'Email','Name','Account Creation Time','Picture')
-                        report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-                        report.end_artifact_report()
-                        
-                        tsvname = f'ChatGPT - User'
-                        tsv(report_folder, data_headers, data_list, tsvname)
-                        
-                    else:
-                        logfunc(f'No ChatGPT - User available')
+@artifact_processor
+def get_chatgpt_user(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if not file_found.endswith('_user.preferences_pb'):
+            continue
+        source_path = file_found
+        info = _pb_json(file_found)
+        if info:
+            data_list.append((info.get('id'), info.get('email', ''), info.get('name', ''),
+                              _sec_to_utc(info.get('created', 0)), info.get('picture', '')))
 
-                            #parse user-ID_accountstatus.preferences_pb
-            if file_name.endswith("_accountstatus.preferences_pb"):
-                with open(file_found, 'rb') as file:
-                    data = file.read()
-                    values, types = blackboxprotobuf.decode_message(data)
-                    data_list = []
-                    if isinstance(values, dict):
-                        try:
-                            pb = values.get('1', {}).get('2', {}).get('5', b'{}')
-                            info = pb.decode('utf-8')
-                            accstatus = json.loads(info)
-                            if 'accounts' in accstatus:  
-                                for k in accstatus['accounts'].keys():
-                                    account = accstatus['accounts'][k]
-                                    account_id = account.get('account_id', None)
-                                    account_user_id = account.get('account_user_id', None)
-                                    subscription = account.get('subscription', {})
-                                    subscription_plan = subscription.get('plan', '')
-                                    plan_type = account.get('plan_type', '')
-                                    subscription_purchase_origin = subscription.get('purchase_origin', '')
-                                    subscription_will_renew = subscription.get('will_renew', False)
-                                    structure = account.get('structure', '')
-                                    is_deactivated = account.get('is_deactivated', False)
-                                    data_list.append((k,account_id,account_user_id,subscription_plan,plan_type,subscription_purchase_origin,subscription_will_renew,structure,is_deactivated))
-                        except:
-                            logfunc(f'Error parsing ChatGPT - error occured when parsing {file_name} protobuf')
-                        
-                    if len(data_list) > 0:
-                        description = f'ChatGPT account status prefs'
-                        report = ArtifactHtmlReport('ChatGPT - Account Status')
-                        report.start_artifact_report(report_folder, f'Account Status', description)
-                        report.add_script()
-                        data_headers = ('Account','Account-ID', 'Account-User-ID','Subscription Plan','Plan Type','Subscription Purchase Origin','Subscription Will Renew','Structure','Is Deactivated')
-                        report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-                        report.end_artifact_report()
-                        
-                        tsvname = f'ChatGPT - Account Status'
-                        tsv(report_folder, data_headers, data_list, tsvname)
-                        
-                    else:
-                        logfunc(f'No ChatGPT - Account Status available')
-            #parse  _accountuser_state protobuf
-            if file_name.endswith("_accountuser_state.preferences_pb"):
-                with open(file_found, 'rb') as file:
-                    data = file.read()
-                    values, types = blackboxprotobuf.decode_message(data)
-                    data_list = []
-                    if isinstance(values, dict):
-                        try:
-                            pb = values.get('1', {}).get('2', {}).get('5', b'{}')
-                            info = pb.decode('utf-8')
-                            accuserstate = json.loads(info)
-                            active_account_id = accuserstate.get('active_account_id', None)
-                            for i in accuserstate.get('available_account_users', []):
-                                account = i.get('account', {})
-                                user = i.get('user', {})
-                                account_id = account.get('account_id', None)
-                                user_id = user.get('id', None)
-                                account_user_id = account.get('account_user_id', None)
-                                email = user.get('email', '')
-                                name = user.get('name', '')
-                                created = datetime.fromtimestamp(int(user.get('created', 0)), tz=timezone.utc)
-                                createdts = convert_utc_human_to_timezone(created, 'UTC')
+    data_headers = ('User-ID', 'Email', 'Name', ('Account Creation Time', 'datetime'), 'Picture')
+    return data_headers, data_list, source_path
 
-                                subscription = account.get('subscription', {})
-                                subscription_plan = subscription.get('plan', '')
-                                plan_type = account.get('plan_type', '')
-                                subscription_purchase_origin = subscription.get('purchase_origin', '')
-                                subscription_will_renew = subscription.get('will_renew', False)
-                                expiration_date = subscription.get('expiration_date', '')
-                                structure = account.get('structure', '')
-                                is_deactivated = account.get('is_deactivated', False)
-                                picture = user.get('picture', '')
-                                is_active_account = 'Yes' if active_account_id == account_id else 'No'
-                                data_list.append((is_active_account,account_id,user_id,account_user_id,email,name,createdts,subscription_plan,plan_type,subscription_purchase_origin,subscription_will_renew,expiration_date,structure,is_deactivated,picture))
-                        except:
-                            logfunc(f'Error parsing ChatGPT - error occured when parsing {file_name} protobuf')
-                    
-                    if len(data_list) > 0:
-                        description = f'Account user state preferences'
-                        report = ArtifactHtmlReport('ChatGPT - Account User State')
-                        report.start_artifact_report(report_folder, f'Account User State', description)
-                        report.add_script()
-                        data_headers = ('Is Active Account','Account-ID', 'User-ID','Account-User-ID','Email','Name','Account Creation Time','Subscription Plan','Plan Type','Subscription Purchase Origin','Subscription Will Renew','Plan Expiration Date','Structure','Is Deactivated','Picture')
-                        report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-                        report.end_artifact_report()
-                        
-                        tsvname = f'ChatGPT - Account User State'
-                        tsv(report_folder, data_headers, data_list, tsvname)
-                        
-                    else:
-                        logfunc(f'No ChatGPT - Account User State available')
-                #parse custom instructions protobuf
-            if file_name.endswith("_custom_instructions.preferences_pb"):
-                with open(file_found, 'rb') as file:
-                    data = file.read()
-                    values, types = blackboxprotobuf.decode_message(data)
-                    data_list = []
-                    if isinstance(values, dict):
-                        try:
-                            pb = values.get('1', {}).get('2', {}).get('5', b'{}')
-                            info = pb.decode('utf-8')
-                            custominst = json.loads(info)
-                            is_enabled = custominst.get('enabled', False)
-                            about_user_message = custominst.get('about_user_message', '')
-                            about_model_message = custominst.get('about_model_message', '')
-                            data_list.append((is_enabled,about_user_message,about_model_message))
-                        except:
-                            logfunc(f'Error parsing ChatGPT - error occured when parsing {file_name} protobuf')
-                    
-                    if len(data_list) > 0:
-                        description = f'User provided custom instructions to ChatGPT'
-                        report = ArtifactHtmlReport('ChatGPT - Custom Instructions')
-                        report.start_artifact_report(report_folder, f'Custom Instructions', description)
-                        report.add_script()
-                        data_headers = ('Are Enabled','About User Message', 'About Model Message')
-                        report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-                        report.end_artifact_report()
-                        
-                        tsvname = f'ChatGPT - Custom Instructions'
-                        tsv(report_folder, data_headers, data_list, tsvname)
-                        
-                    else:
-                        logfunc(f'No ChatGPT - Custom Instructions available')
-                #parse history sync status from user settings protobuf
-            if file_name.endswith("_user_settings.preferences_pb"):
-                with open(file_found, 'rb') as file:
-                    data = file.read()
-                    values, types = blackboxprotobuf.decode_message(data)
-                    data_list = []
-                    if isinstance(values, dict):
-                        try:
-                            pb = values.get('1', {}).get('2', {}).get('5', b'{}')
-                            info = pb.decode('utf-8')
-                            usersets = json.loads(info)
-                            history_disabled = usersets.get('history_disabled', False)
-                            seen_custom_instructions_introduction = usersets.get('seen_custom_instructions_introduction', False) 
-                            has_seen_voice_intro = usersets.get('has_seen_voice_intro', False)
-                            has_seen_voice_selection = usersets.get('has_seen_voice_selection', False)
-                            data_list.append((history_disabled,seen_custom_instructions_introduction,has_seen_voice_intro,has_seen_voice_selection,))
-                        except:
-                            logfunc(f'Error parsing ChatGPT - error occured when parsing {file_name} protobuf')
-                    
-                    if len(data_list) > 0:
-                        description = f'User settings'
-                        report = ArtifactHtmlReport('ChatGPT - User Settings')
-                        report.start_artifact_report(report_folder, f'User Settings', description)
-                        report.add_script()
-                        data_headers = ('Chat History Disabled','Seen Custom Instructions Intro', 'Seen Voice Intro','Seen Voice Selection')
-                        report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-                        report.end_artifact_report()
-                        
-                        tsvname = f'ChatGPT - User Settings'
-                        tsv(report_folder, data_headers, data_list, tsvname)
-                        
-                    else:
-                        logfunc(f'No ChatGPT - User Settings available')
-               
-        #parse analytics-android-oai.xml
-        if file_name == 'analytics-android-oai.xml':
-            tree = ET.parse(file_found)
-            root = tree.getroot()
-            data_list = []
-            data_dict = {}
-            for elem in root.findall('string'):
-                key = elem.get('name')
-                value = elem.text
-                data_dict[key] = value
+
+@artifact_processor
+def get_chatgpt_accountstatus(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if not file_found.endswith('_accountstatus.preferences_pb'):
+            continue
+        source_path = file_found
+        info = _pb_json(file_found)
+        for key, account in (info or {}).get('accounts', {}).items():
+            subscription = account.get('subscription', {})
+            data_list.append((key, account.get('account_id'), account.get('account_user_id'),
+                              subscription.get('plan', ''), account.get('plan_type', ''),
+                              subscription.get('purchase_origin', ''), subscription.get('will_renew', False),
+                              account.get('structure', ''), account.get('is_deactivated', False)))
+
+    data_headers = ('Account', 'Account-ID', 'Account-User-ID', 'Subscription Plan', 'Plan Type',
+                    'Subscription Purchase Origin', 'Subscription Will Renew', 'Structure', 'Is Deactivated')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_chatgpt_accountuserstate(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if not file_found.endswith('_accountuser_state.preferences_pb'):
+            continue
+        source_path = file_found
+        info = _pb_json(file_found)
+        if not info:
+            continue
+        active_account_id = info.get('active_account_id')
+        for entry in info.get('available_account_users', []):
+            account = entry.get('account', {})
+            user = entry.get('user', {})
+            subscription = account.get('subscription', {})
+            data_list.append((
+                'Yes' if active_account_id == account.get('account_id') else 'No',
+                account.get('account_id'), user.get('id'), account.get('account_user_id'),
+                user.get('email', ''), user.get('name', ''), _sec_to_utc(user.get('created', 0)),
+                subscription.get('plan', ''), account.get('plan_type', ''),
+                subscription.get('purchase_origin', ''), subscription.get('will_renew', False),
+                subscription.get('expiration_date', ''), account.get('structure', ''),
+                account.get('is_deactivated', False), user.get('picture', '')))
+
+    data_headers = ('Is Active Account', 'Account-ID', 'User-ID', 'Account-User-ID', 'Email', 'Name',
+                    ('Account Creation Time', 'datetime'), 'Subscription Plan', 'Plan Type',
+                    'Subscription Purchase Origin', 'Subscription Will Renew', 'Plan Expiration Date',
+                    'Structure', 'Is Deactivated', 'Picture')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_chatgpt_custominstructions(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if not file_found.endswith('_custom_instructions.preferences_pb'):
+            continue
+        source_path = file_found
+        info = _pb_json(file_found)
+        if info:
+            data_list.append((info.get('enabled', False), info.get('about_user_message', ''),
+                              info.get('about_model_message', '')))
+
+    data_headers = ('Are Enabled', 'About User Message', 'About Model Message')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_chatgpt_usersettings(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if not file_found.endswith('_user_settings.preferences_pb'):
+            continue
+        source_path = file_found
+        info = _pb_json(file_found)
+        if info:
+            data_list.append((info.get('history_disabled', False),
+                              info.get('seen_custom_instructions_introduction', False),
+                              info.get('has_seen_voice_intro', False),
+                              info.get('has_seen_voice_selection', False)))
+
+    data_headers = ('Chat History Disabled', 'Seen Custom Instructions Intro', 'Seen Voice Intro',
+                    'Seen Voice Selection')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_chatgpt_analytics(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if os.path.basename(file_found) != 'analytics-android-oai.xml':
+            continue
+        source_path = file_found
+        try:
+            root = ET.parse(file_found).getroot()
+        except ET.ParseError:
+            with open(file_found, 'r', encoding='utf-8', errors='replace') as f:
+                text = re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f]', '', f.read())
             try:
-                segment_traits = json.loads(data_dict['segment.traits'])
-                anonymousId = data_dict['segment.anonymousId']
-                userId = data_dict['segment.userId']
-                device_id = data_dict['segment.device.id']
-                app_ver = data_dict['segment.app.version']
-                email = segment_traits['email']
-                workspace_id = segment_traits['workspace_id']
-                account_has_plus = segment_traits['account_has_plus']
-                has_active_subscription = segment_traits['has_active_subscription']
-                plan_type = segment_traits['plan_type']
-                data_list.append((userId,anonymousId,email,device_id,workspace_id,account_has_plus,plan_type,has_active_subscription,app_ver))
-            except:
-                 logfunc(f'Error parsing ChatGPT - error occured when parsing {file_name} XML')
-            
-            if len(data_list) > 0:
-                description = f'User settings'
-                report = ArtifactHtmlReport('ChatGPT - User Analytics')
-                report.start_artifact_report(report_folder, f'User Analytics', description)
-                report.add_script()
-                data_headers = ('User-ID','Anonymous-ID', 'Email','Device-ID','Workspace-ID','Account Has Plus','Plan Type','Has Active Subscription','App Version')
-                report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-                report.end_artifact_report()
-                
-                tsvname = f'ChatGPT - User Analytics'
-                tsv(report_folder, data_headers, data_list, tsvname)
-                
-            else:
-                logfunc(f'No ChatGPT - User Analytics available')
-             
-             #parse media files
-        if "cache" in file_found and "files" in file_found and os.path.isfile(file_found):
-            is_file_image = is_image(file_found)
-            data_list = []
-            if is_file_image:
-                filename = (Path(file_found).name)
-                filepath = str(Path(file_found).parents[1])
-                    
-                thumb = media_to_html(filename, files_found, report_folder)
-                
-                platform = is_platform_windows()
-                if platform:
-                    thumb = thumb.replace('?', '')
-                    
-                data_list.append((thumb, filename, file_found))
-                if len(data_list) > 0:
-                    description = 'ChatGPT - Media Uploads'
-                    report = ArtifactHtmlReport('ChatGPT - Media Uploads')
-                    report.start_artifact_report(report_folder, 'Media Uploads', description)
-                    report.add_script()
-                    data_headers = ('Thumbnail','Filename','Location' )
-                    report.write_artifact_data_table(data_headers, data_list, filepath, html_escape=False)
-                    report.end_artifact_report()
-                    
-                    tsvname = 'ChatGPT - Media Uploads'
-                    tsv(report_folder, data_headers, data_list, tsvname)
-                    
-                else:
-                    logfunc('No ChatGPT - Media Uploads available')   
-                            
+                root = ET.fromstring(text)
+            except ET.ParseError:
+                continue
+        prefs = {elem.get('name'): elem.text for elem in root.findall('string')}
+        try:
+            traits = json.loads(prefs['segment.traits'])
+            data_list.append((prefs.get('segment.userId'), prefs.get('segment.anonymousId'),
+                              traits.get('email'), prefs.get('segment.device.id'), traits.get('workspace_id'),
+                              traits.get('account_has_plus'), traits.get('plan_type'),
+                              traits.get('has_active_subscription'), prefs.get('segment.app.version')))
+        except (KeyError, ValueError, TypeError) as ex:
+            logfunc(f'ChatGPT: error parsing analytics XML: {ex}')
+
+    data_headers = ('User-ID', 'Anonymous-ID', 'Email', 'Device-ID', 'Workspace-ID', 'Account Has Plus',
+                    'Plan Type', 'Has Active Subscription', 'App Version')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_chatgpt_media(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source_path = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if not os.path.isfile(file_found) or not ('cache' in file_found and 'files' in file_found):
+            continue
+        if not _is_image(file_found):
+            continue
+        name = os.path.basename(file_found)
+        source_path = str(Path(file_found).parents[1])
+        data_list.append((check_in_media(file_found, name), name, file_found))
+
+    data_headers = (('Thumbnail', 'media'), 'Filename', 'Location')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts `chatgpt.py` (440 lines, 9 reports) to the decorated `@artifact_processor` pattern — nine artifacts (category **ChatGPT**): Conversations Metadata, Messages, User, Account Status, Account User State, Custom Instructions, User Settings, User Analytics, Media Uploads.

**Changes**
- **Per-account dynamic report names** (`Account: {name}`, `counter`) → an `Account` column on the conversation tables.
- The shared `*.preferences_pb` **protobuf→JSON** extraction (`values['1']['2']['5']` → `json.loads`) is factored into one `_pb_json` helper.
- ISO conversation dates and epoch account-creation times → aware UTC `datetime`.
- **Media uploads** migrate from `media_to_html` to `('Thumbnail','media')` via `check_in_media`.
- Light invalid-token recovery added to the analytics XML parse.

**⚠️ Overlap with your `chatgpt2.py`:** the old messages report and your `chatgpt2.py` both target `conversations.db`, but they parse **different schemas** — `chatgpt2.py` (yours, 2025) reads the newer `DBMessageChunk` table; this one reads the older `DBMessage.messageNode`. To avoid the name collision I renamed this one **"ChatGPT - Messages"** (yours keeps "ChatGPT - Conversations"). Both are kept for schema coverage — **say the word if you'd rather I drop the legacy messages report** since you have the newer parser.

Reserved-word audit clean. Original author (Evangelos Dragonas @theAtropos4n6) and dates (2024-07-09) preserved.