### PR TITLE
Migrate 4 artifacts off legacy media_to_html to check_in_media

### DIFF
--- a/scripts/artifacts/FairEmail.py
+++ b/scripts/artifacts/FairEmail.py
@@ -54,7 +54,7 @@ __artifacts_v2__ = {
 # Requirements: os
 import os
 
-from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records, media_to_html
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records, check_in_media
 
 
 @artifact_processor
@@ -126,7 +126,7 @@ def get_fair_mail_contacts(files_found, _report_folder, _seeker, _wrap_text):
     return data_headers, data_list, files_found[0]
 
 @artifact_processor
-def get_fair_mail_messages(files_found, report_folder, _seeker, _wrap_text):
+def get_fair_mail_messages(files_found, _report_folder, _seeker, _wrap_text):
     
     # Get the different files found and store their pathes in corresponding lists to work with them
     main_db = ''
@@ -220,18 +220,18 @@ def get_fair_mail_messages(files_found, report_folder, _seeker, _wrap_text):
             for att_path in attachments:
                 for att_id in row[19].split(','):
                     if str(att_id) in os.path.basename(att_path):
-                        attachment.append(media_to_html(os.path.basename(att_path), attachments, report_folder))
+                        attachment.append(check_in_media(att_path, os.path.basename(att_path)))
         infrastructure = row[18]
         for path in messages:
             try:
                 if int(os.path.basename(path)) == message_id:
-                    content = media_to_html(str(message_id), messages, report_folder)
+                    content = check_in_media(path, os.path.basename(path))
                     
             except ValueError:
                 continue
 
         data_list.append((received, sent, stored, account, folder, address_from, name_from, address_to, name_to, address_cc, name_cc, address_bcc, name_bcc, return_path, subject, preview, content, seen, attachment, infrastructure))
 
-    data_headers = ('Date Received', 'Date Sent', 'Date Stored', 'Mail Account', 'Folder', 'Sender Address', 'Sender Name', 'Recipient Address', 'Recipient Name', 'CC Address', 'CC Name', 'BCC Address', 'BCC Name', 'Return Path', 'Subject', 'Preview', 'Content', 'Seen', 'Attachments', 'Infrastructure')
+    data_headers = ('Date Received', 'Date Sent', 'Date Stored', 'Mail Account', 'Folder', 'Sender Address', 'Sender Name', 'Recipient Address', 'Recipient Name', 'CC Address', 'CC Name', 'BCC Address', 'BCC Name', 'Return Path', 'Subject', 'Preview', ('Content', 'media'), 'Seen', ('Attachments', 'media'), 'Infrastructure')
 
     return data_headers, data_list, main_db

--- a/scripts/artifacts/RandoChat.py
+++ b/scripts/artifacts/RandoChat.py
@@ -60,10 +60,10 @@ __artifacts_v2__ = {
 
 import os
 
-from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records, media_to_html
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records, check_in_media
 
 @artifact_processor
-def randochat_messages(files_found, report_folder, _seeker, _wrap_text):
+def randochat_messages(files_found, _report_folder, _seeker, _wrap_text):
     files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]   
 
 
@@ -113,7 +113,7 @@ def randochat_messages(files_found, report_folder, _seeker, _wrap_text):
             attachment = ''
             for att_path in attachments:
                 if os.path.basename(media_file) in os.path.basename(att_path):
-                    attachment = media_to_html(os.path.basename(att_path), attachments, report_folder)
+                    attachment = check_in_media(att_path, os.path.basename(att_path))
 
         data_list.append((timestamp, content, contact_name, direction, attachment, conv_id, message_id))
     
@@ -121,8 +121,8 @@ def randochat_messages(files_found, report_folder, _seeker, _wrap_text):
                         ('Timestamp', 'datetime'),
                         'Content', 
                         'Contact Username',
-                        'Sent?', 
-                        'Media File',
+                        'Sent?',
+                        ('Media File', 'media'),
                         'Conversation ID',
                         'Message ID'
                     )

--- a/scripts/artifacts/SamsungNotes.py
+++ b/scripts/artifacts/SamsungNotes.py
@@ -10,7 +10,6 @@ __artifacts_v2__ = {
         "category": "Notes",
         "notes": "",
         "output_types": ["standard"],
-        "html_columns": ["Media"],
         "paths": (  '*/com.samsung.android.app.notes/databases/sdoc.db*',
                     '*/user/*/com.samsung.android.app.notes/SDocData/*/media/*'),
         "artifact_icon": "edit"
@@ -22,10 +21,10 @@ __artifacts_v2__ = {
 # Author:  Marco Neumann (kalinko@be-binary.de)
 # Tested Version: 4.4.30.91
 import os
-from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records, media_to_html
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records, check_in_media
 
 @artifact_processor
-def snotes(files_found, report_folder, _seeker, _wrap_text):
+def snotes(files_found, _report_folder, _seeker, _wrap_text):
 
     main_db = ''
     medias = []
@@ -74,7 +73,7 @@ def snotes(files_found, report_folder, _seeker, _wrap_text):
         media = []
         for media_path in medias:
             if os.path.basename(file_path) in media_path:
-                media.append(media_to_html(os.path.basename(media_path), medias, report_folder))
+                media.append(check_in_media(media_path, os.path.basename(media_path)))
 
         data_list.append((  created,
                             last_modified,
@@ -98,7 +97,7 @@ def snotes(files_found, report_folder, _seeker, _wrap_text):
                         ('First Opened Time', 'datetime'),
                         ('Second Opened Time', 'datetime'),
                         ('Last Opened Time', 'datetime'),
-                        'Media'
+                        ('Media', 'media')
                     )
 
     return data_headers, data_list, files_found[0]

--- a/scripts/artifacts/gmailIMAPEmails.py
+++ b/scripts/artifacts/gmailIMAPEmails.py
@@ -31,10 +31,10 @@ __artifacts_v2__ = {
 import os
 import urllib.parse
 
-from scripts.ilapfuncs import open_sqlite_db_readonly, artifact_processor, convert_unix_ts_to_utc, logfunc, media_to_html
+from scripts.ilapfuncs import open_sqlite_db_readonly, artifact_processor, convert_unix_ts_to_utc, logfunc, check_in_media
 
 @artifact_processor
-def gmailIMAPEmails(files_found, report_folder, _seeker, _wrap_text):
+def gmailIMAPEmails(files_found, _report_folder, _seeker, _wrap_text):
     emailProviderDB = ''    
     emailProviderDB_found = []
 
@@ -122,7 +122,7 @@ def gmailIMAPEmails(files_found, report_folder, _seeker, _wrap_text):
                         # Received Attachment */data/com.google.android.gm/databases/*.db_att/*.*
                         for rAttach in attachRecv_list:
                             if (((os.path.basename(rAttach)) == f'{attachmentID}') and ((os.path.basename(os.path.dirname(rAttach))) == f'{accountID}.db_att')):
-                                AttachmentPaths.append([row_a[2], media_to_html(rAttach, files_found, report_folder)])
+                                AttachmentPaths.append(check_in_media(rAttach, row_a[2]))
                     else:
                         # Sent Attachment /data/com.google.android.gm/cache/*.attachment
                         uri = row_a[4]
@@ -138,11 +138,11 @@ def gmailIMAPEmails(files_found, report_folder, _seeker, _wrap_text):
                             
                             for sAttach in attachSent_list:
                                 if ((os.path.basename(sAttach)) == fileName):
-                                    AttachmentPaths.append([row_a[2], media_to_html(sAttach, files_found, report_folder)])
+                                    AttachmentPaths.append(check_in_media(sAttach, row_a[2]))
                            
             data_list.append((row[0], row[1], row[2], tBody, hBody, row[3], row[4], row[5], row[6], row[7], row[8], row[9], AttachmentPaths, row[11], emailProviderDB))
 
-    data_headers = (('Timestamp','datetime'),'_id','Snippet', 'Body(TXT)', 'Body(HTML)', 'Recipient','Reply To','Subject Line','Mailed By','Signed by', 'Read', 'AttachmentFlag', 'Attachments', 'Mailbox Folder', 'Source File')
+    data_headers = (('Timestamp','datetime'),'_id','Snippet', 'Body(TXT)', 'Body(HTML)', 'Recipient','Reply To','Subject Line','Mailed By','Signed by', 'Read', 'AttachmentFlag', ('Attachments', 'media'), 'Mailbox Folder', 'Source File')
     return data_headers, data_list, 'See source file(s) below:'
     
 @artifact_processor


### PR DESCRIPTION
Four artifacts were already `@artifact_processor`-decorated but still rendered media through the legacy `media_to_html` helper, which stores raw HTML in the LAVA cell (bypassing the media store). This swaps each to a proper `('media')` column backed by `check_in_media`:

| Artifact | Media column(s) |
|---|---|
| `SamsungNotes` | note `Media` (also drops the manual `html_columns`) |
| `FairEmail` | `Attachments` (list) + `Content` (message body) |
| `RandoChat` | `Media File` |
| `gmailIMAPEmails` | `Attachments` — flat list of refs, with each attachment's filename preserved as the media name |

The now-unused `report_folder` parameters are underscored to avoid `W0613`. All four are lint-clean and reserved-word-audited.

This completes the clean part of the media migration. Remaining `media_to_html` users are either dead imports in files with heavy pre-existing lint debt (DuckDuckGo, ProtonDrive, gmailEmails — left alone) or the polymorphic `clipBoard` Data column (needs a column redesign).