### PR TITLE
Shorten 'Android Notification History - Snoozed' name (Windows path length)

### DIFF
--- a/scripts/artifacts/notificationHistory.py
+++ b/scripts/artifacts/notificationHistory.py
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
         "artifact_icon": "toggle-right",
     },
     "get_notificationHistory_snoozed": {
-        "name": "Android Notification History - Snoozed Notifications",
+        "name": "Android Notification History - Snoozed",
         "description": "Notifications the user chose to snooze for a specific time interval (notification_policy.xml).",
         "author": "Evangelos Dragonas (@theAtropos4n6)",
         "creation_date": "2024-07-02",


### PR DESCRIPTION
The framework writes each artifact's HTML using its `name` as the filename, so long names can contribute to Windows `MAX_PATH` (260) overflow on deep output paths (see the FCM Dump report-generation crash).

This shortens `Android Notification History - Snoozed Notifications` (52 chars) → `Android Notification History - Snoozed` (38), staying consistent with the sibling `… - Status` report. Description unchanged. No behaviour change.