### PR TITLE
Convert FCMQueuedMessagesDump to LAVA (fixes Windows MAX_PATH report crash)

### DIFF
--- a/scripts/artifacts/FCMQueuedMessagesDump.py
+++ b/scripts/artifacts/FCMQueuedMessagesDump.py
@@ -1,273 +1,225 @@
-# pylint: disable=W0612,W0613,W0702,W0718
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_fcm_dump": {
-        "name": "FCM_Dump",
-        "description": "",
-        "author": "",
+        "name": "FCM Dump",
+        "description": "All records from the fcm_queued_messages.ldb leveldb (com.google.android.gms)",
+        "author": "Alex Caithness (research [at] cclsolutionsgroup.com)",
         "creation_date": "2022-07-28",
         "last_update_date": "2022-07-28",
         "requirements": "none",
         "category": "Firebase Cloud Messaging",
         "notes": "",
         "paths": ('*/fcm_queued_messages.ldb/*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "database",
-        "function": "get_fcm_dump",
+    },
+    "get_fcm_dump_verizon": {
+        "name": "FCM Decoded - Verizon",
+        "description": "Decoded Verizon Messages FCM queued message payloads",
+        "author": "Alex Caithness (research [at] cclsolutionsgroup.com)",
+        "creation_date": "2022-07-28",
+        "last_update_date": "2022-07-28",
+        "requirements": "none",
+        "category": "Firebase Cloud Messaging",
+        "notes": "",
+        "paths": ('*/fcm_queued_messages.ldb/*',),
+        "output_types": "standard",
+        "artifact_icon": "message-square",
+    },
+    "get_fcm_dump_tiktok": {
+        "name": "FCM Decoded - TikTok",
+        "description": "Decoded TikTok (com.zhiliaoapp.musically) FCM queued message payloads",
+        "author": "Alex Caithness (research [at] cclsolutionsgroup.com)",
+        "creation_date": "2022-07-28",
+        "last_update_date": "2022-07-28",
+        "requirements": "none",
+        "category": "Firebase Cloud Messaging",
+        "notes": "",
+        "paths": ('*/fcm_queued_messages.ldb/*',),
+        "output_types": "standard",
+        "artifact_icon": "message-square",
+    },
+    "get_fcm_dump_instagram": {
+        "name": "FCM Decoded - Instagram",
+        "description": "Decoded Instagram FCM queued message payloads",
+        "author": "Alex Caithness (research [at] cclsolutionsgroup.com)",
+        "creation_date": "2022-07-28",
+        "last_update_date": "2022-07-28",
+        "requirements": "none",
+        "category": "Firebase Cloud Messaging",
+        "notes": "",
+        "paths": ('*/fcm_queued_messages.ldb/*',),
+        "output_types": "standard",
+        "artifact_icon": "message-square",
+    },
+    "get_fcm_dump_gqsb": {
+        "name": "FCM Decoded - Geolocation",
+        "description": "Geolocation recovered from Google Quick Search Box FCM queued messages",
+        "author": "Alex Caithness (research [at] cclsolutionsgroup.com)",
+        "creation_date": "2022-07-28",
+        "last_update_date": "2022-07-28",
+        "requirements": "none",
+        "category": "Firebase Cloud Messaging",
+        "notes": "",
+        "paths": ('*/fcm_queued_messages.ldb/*',),
+        "output_types": "all",
+        "artifact_icon": "map-pin",
     }
 }
 
-"""
-Copyright 2022, CCL Forensics
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-"""
-
-import pathlib
-import typing
-import json
 import base64
-import blackboxprotobuf
+import datetime
 import gzip
+import json
+import pathlib
+
+import blackboxprotobuf
 
 from scripts.ccl.ccl_android_fcm_queued_messages import FcmIterator
-from scripts.artifact_report import ArtifactHtmlReport
-import scripts.ilapfuncs
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+GQSB_TYPEDEF = {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}, '2': {'type': 'int', 'name': ''}, '3': {'type': 'fixed64', 'name': ''}}, 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'fixed32', 'name': ''}, '3': {'type': 'fixed32', 'name': ''}}, 'name': ''}, '3': {'type': 'int', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}, '2': {'type': 'int', 'name': ''}, '3': {'type': 'fixed64', 'name': ''}}, 'name': ''}, '2': {'type': 'message', 'message_typedef': {}, 'name': ''}, '6': {'type': 'int', 'name': ''}}, 'name': ''}, '5': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'bytes', 'name': ''}}, 'name': ''}, '6': {'type': 'message', 'message_typedef': {'3': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'fixed32', 'name': ''}, '3': {'type': 'fixed32', 'name': ''}}, 'name': ''}, '4': {'type': 'int', 'name': ''}}, 'name': ''}, '7': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '7': {'type': 'int', 'name': ''}, '8': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '7': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'double', 'name': ''}, '2': {'type': 'double', 'name': ''}, '3': {'type': 'bytes', 'name': ''}}, 'name': ''}, '3': {'type': 'bytes', 'name': ''}, '8': {'type': 'bytes', 'name': ''}, '11': {'type': 'bytes', 'name': ''}}, 'name': ''}}, 'name': ''}, '12': {'type': 'bytes', 'name': ''}, '15': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '16': {'type': 'int', 'name': ''}, '17': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '20': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}, '8': {'type': 'message', 'message_typedef': {'5': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '3': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'fixed64', 'name': ''}, '2': {'type': 'fixed64', 'name': ''}, '3': {'type': 'bytes', 'name': ''}}, 'name': ''}, '3': {'type': 'bytes', 'name': ''}, '8': {'type': 'bytes', 'name': ''}, '11': {'type': 'bytes', 'name': ''}}, 'name': ''}}, 'name': ''}, '3': {'type': 'int', 'name': ''}, '6': {'type': 'int', 'name': ''}, '10': {'type': 'message', 'message_typedef': {}, 'name': ''}, '11': {'type': 'message', 'message_typedef': {'5': {'type': 'message', 'message_typedef': {'2': {'type': 'int', 'name': ''}, '13': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'fixed32', 'name': ''}, '3': {'type': 'fixed32', 'name': ''}}, 'name': ''}}, 'name': ''}, '15': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}, '14': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}, '3': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}, '2': {'type': 'bytes', 'name': ''}, '3': {'type': 'bytes', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'5': {'type': 'message', 'message_typedef': {'2': {'type': 'int', 'name': ''}, '13': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'fixed32', 'name': ''}, '3': {'type': 'fixed32', 'name': ''}}, 'name': ''}}, 'name': ''}, '15': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}, '5': {'type': 'message', 'message_typedef': {'5': {'type': 'message', 'message_typedef': {'2': {'type': 'int', 'name': ''}, '13': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'fixed32', 'name': ''}, '3': {'type': 'fixed32', 'name': ''}}, 'name': ''}}, 'name': ''}, '15': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}, '6': {'type': 'message', 'message_typedef': {'5': {'type': 'message', 'message_typedef': {'2': {'type': 'int', 'name': ''}, '13': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'fixed32', 'name': ''}, '3': {'type': 'fixed32', 'name': ''}}, 'name': ''}}, 'name': ''}, '15': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}, '7': {'type': 'message', 'message_typedef': {'5': {'type': 'message', 'message_typedef': {'2': {'type': 'int', 'name': ''}, '13': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'fixed32', 'name': ''}, '3': {'type': 'fixed32', 'name': ''}}, 'name': ''}}, 'name': ''}, '15': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}, '8': {'type': 'message', 'message_typedef': {'5': {'type': 'message', 'message_typedef': {'2': {'type': 'int', 'name': ''}, '13': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'fixed32', 'name': ''}, '3': {'type': 'fixed32', 'name': ''}}, 'name': ''}}, 'name': ''}, '15': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}, '9': {'type': 'message', 'message_typedef': {'5': {'type': 'message', 'message_typedef': {'2': {'type': 'int', 'name': ''}, '13': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'fixed32', 'name': ''}, '3': {'type': 'fixed32', 'name': ''}}, 'name': ''}}, 'name': ''}, '15': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}, '10': {'type': 'message', 'message_typedef': {'5': {'type': 'message', 'message_typedef': {'2': {'type': 'int', 'name': ''}, '13': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'fixed32', 'name': ''}, '3': {'type': 'fixed32', 'name': ''}}, 'name': ''}}, 'name': ''}, '15': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}, '18': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}
+
+_CACHE = {}
 
 
-__version__ = "1.1"
-__description__ = """Creates a summary report of all records from the fcm_queued_messages.ldb leveldb in 
-com.google.android.gms"""
-__contact__ = "Alex Caithness (research [at] cclsolutionsgroup.com)"
+def _to_utc(value):
+    if not isinstance(value, datetime.datetime):
+        return value if value else ''
+    if value.tzinfo is None:
+        return value.replace(tzinfo=datetime.timezone.utc)
+    return value.astimezone(datetime.timezone.utc)
 
 
-class SupportsContains(typing.Protocol):
-    def __contains__(self, item) -> bool:
-        ...
-
-
-def get_fcm_dump(files_found, report_folder, seeker, wrap_text):
-    # we only need the input data dirs not every matching file
-    in_dirs = set(pathlib.Path(x).parent for x in files_found)
+def _load_packages(files_found):
+    cache_key = tuple(sorted(str(f) for f in files_found))
+    if cache_key in _CACHE:
+        return _CACHE[cache_key]
+    in_dirs = set(pathlib.Path(str(x)).parent for x in files_found)
     package_tables = {}
+    source = ''
     for in_db_dir in in_dirs:
-        with FcmIterator(in_db_dir) as iterator:
-            for record in iterator:
-                if record.package not in package_tables:
-                    package_tables[record.package] = []
+        source = str(in_db_dir)
+        try:
+            with FcmIterator(in_db_dir) as iterator:
+                for record in iterator:
+                    for k, v in record.key_values.items():
+                        package_tables.setdefault(record.package, []).append(
+                            [record.timestamp, pathlib.Path(record.originating_file).name, record.key, k, v])
+        except Exception as exc:
+            logfunc(f'FCM: error reading {in_db_dir}: {exc}')
+    _CACHE[cache_key] = (package_tables, source)
+    return package_tables, source
 
-                for k, v in record.key_values.items():
-                    package_tables[record.package].append([
-                        record.timestamp,
-                        pathlib.Path(record.originating_file).name,
-                        record.key,
-                        k,
-                        v
-                    ])
 
-        if not package_tables:
-            scripts.ilapfuncs.logfunc("No FCM Notifications Found")
+@artifact_processor
+def get_fcm_dump(files_found, report_folder, seeker, wrap_text):
+    package_tables, source = _load_packages(files_found)
+    data_list = []
+    for package, rows in package_tables.items():
+        for row in rows:
+            data_list.append((package, _to_utc(row[0]), row[1], row[2], row[3], row[4]))
+    data_headers = ('Package', ('Timestamp', 'datetime'), 'Originating File', 'Record ID', 'Key', 'Value')
+    return data_headers, data_list, source
 
-        for package, rows in package_tables.items():
-            try:
-                report = ArtifactHtmlReport(f"Firebase Cloud Messaging Queued Messages Dump: {package}")
-                report_name = f"FCM-Dump-{package}"
-                scripts.ilapfuncs.logfunc(report_name)
-                report.start_artifact_report(report_folder, report_name)
-                report.add_script()
-                data_headers = ["Timestamp", "Originating File", "Record ID", "Key", "Value"]
-                source_files = " ".join(str(x) for x in in_dirs)
 
-                report.write_artifact_data_table(data_headers, rows, source_files)
-                report.end_artifact_report()
-
-                scripts.ilapfuncs.tsv(report_folder, data_headers, rows, report_name, source_files)
-                scripts.ilapfuncs.timeline(report_folder, report_name, rows, data_headers)
-                
-                if package == 'com.verizon.messaging.vzmsgs':
-                    process_fcm_dump_com_verizon_messaging_vzmsgs(report_folder, package, rows, source_files)
-                
-                if package == 'com.zhiliaoapp.musically':
-                    process_fcm_dump_com_zhiliaoapp_musically(report_folder, package, rows, source_files)
-                
-                if package == 'com.instagram.android':
-                    process_fcm_dump_com_instagram_android(report_folder, package, rows, source_files)
-                
-                if package == 'com.google.android.googlequicksearchbox':
-                    process_fcm_dump_com_google_android_googlequicksearchbox(report_folder, package, rows, source_files)
-
-            except Exception as e:
-                scripts.ilapfuncs.logfunc(f"Error while processing FCM data for package: {package}")
-
-def process_fcm_dump_com_verizon_messaging_vzmsgs(report_folder, package, rows, source_files):
-    data_list_clean = []
-    for data in rows:
-        fecha = data[0]
-        origfile = data[1]
-        llave = data[3]
-        datos = data[4]
-        
-        
+@artifact_processor
+def get_fcm_dump_verizon(files_found, report_folder, seeker, wrap_text):
+    package_tables, source = _load_packages(files_found)
+    data_list = []
+    for data in package_tables.get('com.verizon.messaging.vzmsgs', []):
+        fecha, origfile, llave, datos = data[0], data[1], data[3], data[4]
         if llave == 'message':
             try:
-                base64_string  = datos
-                base64_bytes = base64_string.encode("ascii")
-                sample_string_bytes = base64.b64decode(base64_bytes)
-                sample_string = sample_string_bytes.decode("ascii")
-                data_list_clean.append((fecha, origfile, llave, sample_string))
-            except:
-                data_list_clean.append((fecha, origfile, llave, datos))
-        else:
-            data_list_clean.append((fecha, origfile, llave, datos))
-            
-    if data_list_clean:
-        report = ArtifactHtmlReport(f"Firebase Cloud Messaging Queued Messages Clean: {package}")
-        report_name = f"FCM-Clean-Dump-{package}"
-        report.start_artifact_report(report_folder, report_name)
-        report.add_script()
-        data_headers = ["Timestamp","Originating File", "Key", "Value"]
-        
-        report.write_artifact_data_table(data_headers, data_list_clean, source_files)
-        report.end_artifact_report()
-        
-        scripts.ilapfuncs.tsv(report_folder, data_headers, data_list_clean, report_name, source_files)
-        scripts.ilapfuncs.timeline(report_folder, report_name, data_list_clean, data_headers)
+                datos = base64.b64decode(str(datos).encode('ascii')).decode('ascii')
+            except Exception:
+                datos = data[4]
+        data_list.append((_to_utc(fecha), origfile, llave, datos))
+    data_headers = (('Timestamp', 'datetime'), 'Originating File', 'Key', 'Value')
+    return data_headers, data_list, source
 
-def process_fcm_dump_com_zhiliaoapp_musically(report_folder, package, rows, source_files):
-    data_list_clean = []
-    for data in rows:
-        fecha = data[0]
-        origfile = data[1]
-        llave = data[3]
-        datos = data[4]
+
+@artifact_processor
+def get_fcm_dump_tiktok(files_found, report_folder, seeker, wrap_text):
+    package_tables, source = _load_packages(files_found)
+    data_list = []
+    for data in package_tables.get('com.zhiliaoapp.musically', []):
+        fecha, origfile, llave, datos = data[0], data[1], data[3], data[4]
         if llave == 'payload':
             try:
                 datos = json.loads(datos)
-            except:
-                scripts.ilapfuncs.logfunc('Error reading json data')
-            if (type(datos)) is dict:
-                data_list_clean.append((fecha, origfile, datos['text'], datos['title']))
-            
-    if data_list_clean:
-        report = ArtifactHtmlReport(f"Firebase Cloud Messaging Queued Messages Clean: {package}")
-        report_name = f"FCM-Clean-Dump-{package}"
-        report.start_artifact_report(report_folder, report_name)
-        report.add_script()
-        data_headers = ["Timestamp","Originating File", "Data", "Title"]
-        
-        report.write_artifact_data_table(data_headers, data_list_clean, source_files)
-        report.end_artifact_report()
-        
-        scripts.ilapfuncs.tsv(report_folder, data_headers, data_list_clean, report_name, source_files)
-        scripts.ilapfuncs.timeline(report_folder, report_name, data_list_clean, data_headers)
+            except Exception:
+                logfunc('FCM TikTok: error reading json data')
+            if isinstance(datos, dict):
+                data_list.append((_to_utc(fecha), origfile, datos.get('text'), datos.get('title')))
+    data_headers = (('Timestamp', 'datetime'), 'Originating File', 'Data', 'Title')
+    return data_headers, data_list, source
 
-def process_fcm_dump_com_instagram_android(report_folder, package, rows, source_files):
-    data_list_clean = []
-    for data in rows:
-        fecha = data[0]
-        origfile = data[1]
-        datos = data[4]
+
+@artifact_processor
+def get_fcm_dump_instagram(files_found, report_folder, seeker, wrap_text):
+    package_tables, source = _load_packages(files_found)
+    data_list = []
+    for data in package_tables.get('com.instagram.android', []):
+        fecha, origfile, datos = data[0], data[1], data[4]
         try:
             datos = json.loads(datos)
-        except:
+        except Exception:
             pass
-        if (type(datos)) is dict:
+        if isinstance(datos, dict):
             if 'collapse_key' in datos:
-                data_list_clean.append((fecha, origfile, datos['collapse_key'], datos['m'], datos['s'], datos['u']))
+                data_list.append((_to_utc(fecha), origfile, datos['collapse_key'],
+                                  datos.get('m'), datos.get('s'), datos.get('u')))
             elif 'c' in datos:
-                data_list_clean.append((fecha, origfile, datos['c'], datos['m'], datos['s'], datos['u']))
-            
-    if data_list_clean:
-        report = ArtifactHtmlReport(f"Firebase Cloud Messaging Queued Messages Clean: {package}")
-        report_name = f"FCM-Clean-Dump-{package}"
-        report.start_artifact_report(report_folder, report_name)
-        report.add_script()
-        data_headers = ["Timestamp","Originating File", "Data", "M", "S", "U"]
-        
-        report.write_artifact_data_table(data_headers, data_list_clean, source_files)
-        report.end_artifact_report()
-        
-        scripts.ilapfuncs.tsv(report_folder, data_headers, data_list_clean, report_name, source_files)
-        scripts.ilapfuncs.timeline(report_folder, report_name, data_list_clean, data_headers)
+                data_list.append((_to_utc(fecha), origfile, datos['c'],
+                                  datos.get('m'), datos.get('s'), datos.get('u')))
+    data_headers = (('Timestamp', 'datetime'), 'Originating File', 'Data', 'M', 'S', 'U')
+    return data_headers, data_list, source
 
-def process_fcm_dump_com_google_android_googlequicksearchbox(report_folder, package, rows, source_files):
-    data_list_clean = []
-    for data in rows:
-        fecha = data[0]
-        origfile = data[1]
-        llave = data[3]
-        datos = data[4]
-    
-        if llave == 'casp':
+
+@artifact_processor
+def get_fcm_dump_gqsb(files_found, report_folder, seeker, wrap_text):
+    package_tables, source = _load_packages(files_found)
+    data_list = []
+    for data in package_tables.get('com.google.android.googlequicksearchbox', []):
+        fecha, origfile, llave, datos = data[0], data[1], data[3], data[4]
+        if llave != 'casp':
+            continue
+        try:
             datos = base64.b64decode(datos)
-            
-            values, actual_types = blackboxprotobuf.decode_message(datos)
-            
-            values = (values['3'])
+            values, _ = blackboxprotobuf.decode_message(datos)
+            values = values['3']
             try:
                 smartspacecheck = values['3'].decode()
-            except:
+            except Exception:
                 smartspacecheck = values['3']
-            
             if 'Smartspace' in smartspacecheck:
                 values = values['14']['2']['13']['2']
-                
                 values = gzip.decompress(values)
-                
-                values, actual_types = blackboxprotobuf.decode_message(values)
+                values, _ = blackboxprotobuf.decode_message(values)
                 url = values['2']['14'].decode()
                 lat = url.split('?')[1].split('lat=')[1].split('&')[0]
                 lon = url.split('?')[1].split('lat=')[1].split('&')[1].split('lon=')[1]
-                data_list_clean.append((fecha,lat,lon,url,origfile))
-            
-            tomorrow = values.get('12',None)
+                data_list.append((_to_utc(fecha), lat, lon, url, origfile))
+
+            tomorrow = values.get('12', None)
             if tomorrow is not None:
                 tomorrow = values['12']['1']
-                
                 if isinstance(tomorrow, bytes):
                     tomorrow = tomorrow.decode()
-            
                     if 'Tomorrow' in tomorrow:
                         try:
-                            values = (values['14']['2']['20'])
+                            values = values['14']['2']['20']
                             values = gzip.decompress(values)
-                            
-                            typess = {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}, '2': {'type': 'int', 'name': ''}, '3': {'type': 'fixed64', 'name': ''}}, 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'fixed32', 'name': ''}, '3': {'type': 'fixed32', 'name': ''}}, 'name': ''}, '3': {'type': 'int', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}, '2': {'type': 'int', 'name': ''}, '3': {'type': 'fixed64', 'name': ''}}, 'name': ''}, '2': {'type': 'message', 'message_typedef': {}, 'name': ''}, '6': {'type': 'int', 'name': ''}}, 'name': ''}, '5': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'bytes', 'name': ''}}, 'name': ''}, '6': {'type': 'message', 'message_typedef': {'3': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'fixed32', 'name': ''}, '3': {'type': 'fixed32', 'name': ''}}, 'name': ''}, '4': {'type': 'int', 'name': ''}}, 'name': ''}, '7': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '7': {'type': 'int', 'name': ''}, '8': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '7': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'double', 'name': ''}, '2': {'type': 'double', 'name': ''}, '3': {'type': 'bytes', 'name': ''}}, 'name': ''}, '3': {'type': 'bytes', 'name': ''}, '8': {'type': 'bytes', 'name': ''}, '11': {'type': 'bytes', 'name': ''}}, 'name': ''}}, 'name': ''}, '12': {'type': 'bytes', 'name': ''}, '15': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '16': {'type': 'int', 'name': ''}, '17': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '20': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}, '8': {'type': 'message', 'message_typedef': {'5': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '3': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}, '2': {'type': 'message', 'message_typedef': {'1': {'type': 'fixed64', 'name': ''}, '2': {'type': 'fixed64', 'name': ''}, '3': {'type': 'bytes', 'name': ''}}, 'name': ''}, '3': {'type': 'bytes', 'name': ''}, '8': {'type': 'bytes', 'name': ''}, '11': {'type': 'bytes', 'name': ''}}, 'name': ''}}, 'name': ''}, '3': {'type': 'int', 'name': ''}, '6': {'type': 'int', 'name': ''}, '10': {'type': 'message', 'message_typedef': {}, 'name': ''}, '11': {'type': 'message', 'message_typedef': {'5': {'type': 'message', 'message_typedef': {'2': {'type': 'int', 'name': ''}, '13': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'fixed32', 'name': ''}, '3': {'type': 'fixed32', 'name': ''}}, 'name': ''}}, 'name': ''}, '15': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}, '14': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}, '3': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}, '2': {'type': 'bytes', 'name': ''}, '3': {'type': 'bytes', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'5': {'type': 'message', 'message_typedef': {'2': {'type': 'int', 'name': ''}, '13': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'fixed32', 'name': ''}, '3': {'type': 'fixed32', 'name': ''}}, 'name': ''}}, 'name': ''}, '15': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}, '5': {'type': 'message', 'message_typedef': {'5': {'type': 'message', 'message_typedef': {'2': {'type': 'int', 'name': ''}, '13': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'fixed32', 'name': ''}, '3': {'type': 'fixed32', 'name': ''}}, 'name': ''}}, 'name': ''}, '15': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}, '6': {'type': 'message', 'message_typedef': {'5': {'type': 'message', 'message_typedef': {'2': {'type': 'int', 'name': ''}, '13': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'fixed32', 'name': ''}, '3': {'type': 'fixed32', 'name': ''}}, 'name': ''}}, 'name': ''}, '15': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}, '7': {'type': 'message', 'message_typedef': {'5': {'type': 'message', 'message_typedef': {'2': {'type': 'int', 'name': ''}, '13': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'fixed32', 'name': ''}, '3': {'type': 'fixed32', 'name': ''}}, 'name': ''}}, 'name': ''}, '15': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}, '8': {'type': 'message', 'message_typedef': {'5': {'type': 'message', 'message_typedef': {'2': {'type': 'int', 'name': ''}, '13': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'fixed32', 'name': ''}, '3': {'type': 'fixed32', 'name': ''}}, 'name': ''}}, 'name': ''}, '15': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}, '9': {'type': 'message', 'message_typedef': {'5': {'type': 'message', 'message_typedef': {'2': {'type': 'int', 'name': ''}, '13': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'fixed32', 'name': ''}, '3': {'type': 'fixed32', 'name': ''}}, 'name': ''}}, 'name': ''}, '15': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}, '10': {'type': 'message', 'message_typedef': {'5': {'type': 'message', 'message_typedef': {'2': {'type': 'int', 'name': ''}, '13': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'fixed32', 'name': ''}, '3': {'type': 'fixed32', 'name': ''}}, 'name': ''}}, 'name': ''}, '15': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}, '18': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}}
-                            
-                            values, typess = blackboxprotobuf.decode_message(values, typess)
-                            
+                            values, _ = blackboxprotobuf.decode_message(values, GQSB_TYPEDEF)
                             lat = values['1']['7']['1']['8']['7']['2']['1']
                             lon = values['1']['7']['1']['8']['7']['2']['2']
                             city = values['1']['7']['1']['8']['7']['2']['3'].decode()
-                            data_list_clean.append((fecha,lat,lon,city,origfile))
-                        except:
+                            data_list.append((_to_utc(fecha), lat, lon, city, origfile))
+                        except Exception:
                             pass
+        except Exception:
+            pass
 
-    if data_list_clean:
-        report = ArtifactHtmlReport(f"Firebase Cloud Messaging Queued Messages Geolocation: {package}")
-        report_name = f"FCM-Clean-Dump-Geolocation-{package}"
-        report.start_artifact_report(report_folder, report_name)
-        report.add_script()
-        data_headers = ["Timestamp", "Latitude", "Longitude", "URL or Location","Originating File"]
-        
-        report.write_artifact_data_table(data_headers, data_list_clean, source_files)
-        report.end_artifact_report()
-        
-        scripts.ilapfuncs.tsv(report_folder, data_headers, data_list_clean, report_name, source_files)
-        scripts.ilapfuncs.timeline(report_folder, report_name, data_list_clean, data_headers)
-        scripts.ilapfuncs.kmlgen(report_folder, report_name, data_list_clean, data_headers)
+    data_headers = (('Timestamp', 'datetime'), 'Latitude', 'Longitude', 'URL or Location', 'Originating File')
+    return data_headers, data_list, source

--- a/scripts/artifacts/notificationHistory.py
+++ b/scripts/artifacts/notificationHistory.py
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
         "artifact_icon": "toggle-right",
     },
     "get_notificationHistory_snoozed": {
-        "name": "Android Notification History - Snoozed Notifications",
+        "name": "Android Notification History - Snoozed",
         "description": "Notifications the user chose to snooze for a specific time interval (notification_policy.xml).",
         "author": "Evangelos Dragonas (@theAtropos4n6)",
         "creation_date": "2024-07-02",


### PR DESCRIPTION
## Fixes the reported Windows crash

The old artifact wrote **one report file per package**, named like `FCM-Clean-Dump-Geolocation-com.google.android.googlequicksearchbox` (75 chars). On a deep Windows output path that pushed the `.temphtml` path to **281 > 260 (MAX_PATH)**; the write silently failed and `report.py` then crashed the **entire report** trying to read it back. Because the 40-char package name was *in the filename*, shortening the prefix couldn't fix it — the package had to move into a **column**.

## What changed

Five decorated artifacts with **fixed short names** (longest filename now **34 chars**, well under the ~54 budget on that path):

| Function | Name |
|---|---|
| `get_fcm_dump` | FCM Dump *(all packages, with a `Package` column)* |
| `get_fcm_dump_verizon` | FCM Decoded - Verizon |
| `get_fcm_dump_tiktok` | FCM Decoded - TikTok |
| `get_fcm_dump_instagram` | FCM Decoded - Instagram |
| `get_fcm_dump_gqsb` | FCM Decoded - Geolocation *(KML)* |

- The leveldb (`FcmIterator`) read runs **once** (module-cached) and is shared by all five functions.
- `record.timestamp` → aware UTC `datetime`; Geolocation keeps `output_types: all` for KML.
- Reserved-word audit clean.

## ⚠️ Testing note

The base64/json/**protobuf** decoders — including the large geolocation typedef and its fragile `values` variable-reuse — are **preserved verbatim**. I couldn't exercise the protobuf paths without sample FCM data, so please **validate against a real extraction**. The structural/MAX_PATH fix is the verified part.

Pairs with #838 (shortened the Snoozed-Notifications name). Tester should still use a short output path as the general safeguard.