### PR TITLE
Convert appSemloc to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/appSemloc.py
+++ b/scripts/artifacts/appSemloc.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0401,W0611,W0612,W0613,W0614,W0631
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_appSemloc": {
         "name": "App Semantic Locations",
@@ -8,84 +8,62 @@ __artifacts_v2__ = {
         "last_update_date": "2024/06/21",
         "requirements": "",
         "category": "App Semantic Locations",
-        "notes": "Thanks to Alex Caithness for the ccc_leveldb libraries",
-        "paths": (
-            '*/com.google.android.gms/app_semanticlocation_rawsignal_db/*',
-        ),
-        "output_types": None,
-        "function": "get_appSemloc",
+        "notes": "Thanks to Alex Caithness for the ccl_leveldb libraries",
+        "paths": ('*/com.google.android.gms/app_semanticlocation_rawsignal_db/*',),
+        "output_types": "all",
+        "artifact_icon": "map-pin",
     }
 }
 
+import datetime
 import pathlib
-import json
+
 import blackboxprotobuf
-from datetime import *
+
 from scripts.ccl import ccl_leveldb
+from scripts.ilapfuncs import artifact_processor
 
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, timeline, kmlgen 
+def _ms_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
 
+
+@artifact_processor
 def get_appSemloc(files_found, report_folder, seeker, wrap_text):
-    
     data_list = []
-    in_dirs = set(pathlib.Path(x).parent for x in files_found)
+    source_path = ''
+    in_dirs = set(pathlib.Path(str(x)).parent for x in files_found)
     for in_db_dir in in_dirs:
-        leveldb_records = ccl_leveldb.RawLevelDb(in_db_dir)
-        
+        source_path = str(in_db_dir)
+        try:
+            leveldb_records = ccl_leveldb.RawLevelDb(in_db_dir)
+        except (ValueError, OSError):
+            continue
         for record in leveldb_records.iterate_records_raw():
-            #print(record.seq, record.user_key, record.value)
-            record_sequence = record.seq
-            record_key = record.user_key
-            record_value = record.value
+            try:
+                value, _ = blackboxprotobuf.decode_message(record.value)
+            except Exception:
+                continue
+            outer = value.get('1') if isinstance(value, dict) else None
+            latlongrecord = outer.get('1') if isinstance(outer, dict) else None
+            if not isinstance(latlongrecord, dict):
+                continue
+            try:
+                timestamp = _ms_to_utc(latlongrecord['6'])
+                latitude = latlongrecord['1'] / 1e7
+                longitude = latlongrecord['2'] / 1e7
+                accuracy = latlongrecord['3'] / 1000
+            except (KeyError, TypeError):
+                continue
             origin = str(record.origin_file)
-            
-            p = str(pathlib.Path(origin).parent.name)
-            f = str(pathlib.Path(origin).name)
-            pf = f'{p}/{f}'
-            
-            value = record_value
-            value, types = blackboxprotobuf.decode_message(value)
-            
-            check = value.get('1')
-            if check is not None:
-                
-                latlongrecord = value['1'].get('1')
-                if latlongrecord is not None:
-                    #print(record_key)
-                    #print(latlongrecord)
-                    #timestamp = value['2']
-                    timestamp2 = latlongrecord['6']
-                    #timestamp = datetime.fromtimestamp(timestamp/1000, tz=timezone.utc)
-                    timestamp2 = datetime.fromtimestamp(timestamp2/1000, tz=timezone.utc)
-                    
-                    latitude = latlongrecord['1']/1e7
-                    longitude = latlongrecord['2']/1e7
-                    accuracy = latlongrecord['3']/1000
-                    
-                    data_list.append((timestamp2,record_sequence,latitude,longitude,accuracy,pf))
-        
-    if len(data_list) > 0:
-        maindirectory = str(pathlib.Path(in_db_dir).parent)
-        description = ''
-        report = ArtifactHtmlReport('App Semantic Location')
-        report.start_artifact_report(report_folder, 'App Semantic Location', description)
-        report.add_script()
-        data_headers = ('Timestamp','Rec. Sequence','Latitude','Longitude','Horizontal Acc.','Origin')
-        report.write_artifact_data_table(data_headers, data_list, maindirectory)
-        report.end_artifact_report()
-            
-        tsvname = 'App Semantic Location'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = 'App Semantic Location'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-        kmlactivity = 'App Semantic Location'
-        kmlgen(report_folder, kmlactivity, data_list, data_headers)    
-    else:
-        logfunc('No App Semantic Location Data available')
-                        
-                
-    
+            origin_pf = f'{pathlib.Path(origin).parent.name}/{pathlib.Path(origin).name}'
+            data_list.append((timestamp, record.seq, latitude, longitude, accuracy, origin_pf))
+
+    data_headers = (('Timestamp', 'datetime'), 'Rec. Sequence', 'Latitude', 'Longitude',
+                    'Horizontal Acc.', 'Origin')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts `appSemloc.py` (App Semantic Locations — `com.google.android.gms` leveldb + protobuf geolocation) to the decorated `@artifact_processor` pattern.

- `Timestamp` remains an aware UTC `datetime`; **KML retained** via `output_types: all` (lat/long).
- Guards the leveldb open, protobuf decode, and lat/long/timestamp key access so a malformed record is skipped instead of crashing the artifact.
- Drops dead imports (`json`, `is_platform_windows`, report helpers).

Own artifact; author and dates (2024/06/21) preserved.