### PR TITLE
Convert googleKeepNotes to LAVA @artifact_processor (2-way split)

### DIFF
--- a/scripts/artifacts/googleKeepNotes.py
+++ b/scripts/artifacts/googleKeepNotes.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0611,W0613
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_googleKeepNotes": {
-        "name": "GoogleKeepNotes",
-        "description": "",
+        "name": "Google Keep - Notes",
+        "description": "Google Keep notes",
         "author": "",
         "creation_date": "2021-05-17",
         "last_update_date": "2021-05-17",
@@ -10,145 +10,93 @@ __artifacts_v2__ = {
         "category": "Google Keep",
         "notes": "",
         "paths": ('*/com.google.android.keep/databases/keep.db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "file-text",
-        "function": "get_googleKeepNotes",
+    },
+    "get_googleKeepNotes_sharing": {
+        "name": "Google Keep - Notes Sharing",
+        "description": "Google Keep note sharing",
+        "author": "",
+        "creation_date": "2021-05-17",
+        "last_update_date": "2021-05-17",
+        "requirements": "none",
+        "category": "Google Keep",
+        "notes": "",
+        "paths": ('*/com.google.android.keep/databases/keep.db*',),
+        "output_types": "standard",
+        "artifact_icon": "share-2",
     }
 }
 
+import datetime
 import os
 import sqlite3
-import textwrap
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, kmlgen
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-is_windows = is_platform_windows()
-slash = '\\' if is_windows else '/' 
 
-def get_googleKeepNotes(files_found, report_folder, seeker, wrap_text):
+def _ms_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
+
+
+def _keep_db(files_found):
     for file_found in files_found:
         file_found = str(file_found)
-        if not os.path.basename(file_found) == 'keep.db': # skip -journal and other files
-            continue
-        
-        db = open_sqlite_db_readonly(file_found)
-        cursor = db.cursor()
-        
-        cursor.execute('''
-            Select
-            CASE
-                list_item.time_created
-                WHEN
-                    "0"
-                THEN
-                    ""
-                ELSE
-                    datetime(list_item.time_created / 1000, "unixepoch")
-            END AS time_created,
-            CASE
-                list_item.time_last_updated
-                WHEN
-                    "0"
-                THEN
-                    ""
-                ELSE
-                    datetime(list_item.time_last_updated / 1000, "unixepoch")
-            END AS time_last_updated,
-            list_parent_id,
-            name AS creator_email,
-            title,
-            text,
-            synced_text,
-            list_item.is_deleted,
-            last_modifier_email
-            FROM
-            account
-            INNER JOIN
-            list_item
-            ON
-            account._id == list_item.account_id
-            INNER JOIN
-            tree_entity
-            ON
-            tree_entity._id == list_item._id
-        ''')
+        if os.path.basename(file_found) == 'keep.db':
+            return file_found
+    return ''
 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if(usageentries > 0):
-            report = ArtifactHtmlReport('Google Keep - Notes')
-            report.start_artifact_report(report_folder,"Google Keep - Notes")
-            report.add_script()
-            data_headers = ('Notes Creation Time','Notes Last Modified Time', 'List Parent ID', 'Creator Email', 'Title', 'Text', 'Synced Text', 'Is deleted', 'Last Modifier Email')
-            data_list = []
-            for row in all_rows:
-                data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], 'True' if row[7]==1 else 'False', row[8]))
 
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-            report.end_artifact_report()
+def _run(source_path, sql):
+    if not source_path:
+        return []
+    db = open_sqlite_db_readonly(source_path)
+    cursor = db.cursor()
+    try:
+        cursor.execute(sql)
+        rows = cursor.fetchall()
+    except sqlite3.Error:
+        rows = []
+    db.close()
+    return rows
 
-            tsvname = "Google Keep - Notes"
-            tsv(report_folder, data_headers, data_list, tsvname)
 
-            tlactivity = "Google Keep - Notes"
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc("No Google Keep - Notes data found")
+@artifact_processor
+def get_googleKeepNotes(files_found, report_folder, seeker, wrap_text):
+    source_path = _keep_db(files_found)
+    rows = _run(source_path, '''
+        SELECT list_item.time_created, list_item.time_last_updated, list_parent_id, name, title, text,
+        synced_text, list_item.is_deleted, last_modifier_email
+        FROM account
+        INNER JOIN list_item ON account._id == list_item.account_id
+        INNER JOIN tree_entity ON tree_entity._id == list_item._id
+    ''')
+    data_list = [(_ms_to_utc(r[0]), _ms_to_utc(r[1]), r[2], r[3], r[4], r[5], r[6],
+                  'True' if r[7] == 1 else 'False', r[8]) for r in rows]
+    data_headers = (('Notes Creation Time', 'datetime'), ('Notes Last Modified Time', 'datetime'),
+                    'List Parent ID', 'Creator Email', 'Title', 'Text', 'Synced Text', 'Is deleted',
+                    'Last Modifier Email')
+    return data_headers, data_list, source_path
 
-        cursor.execute('''
-            SELECT 
-            CASE
-                shared_timestamp
-                WHEN
-                    "0"
-                THEN
-                    ""
-                ELSE
-                    coalesce(datetime(tree_entity.shared_timestamp /1000, "unixepoch"), "Unknown")
-            END AS shared_timestamp,
-            list_item.list_parent_id,
-            account.name as creator_Email, 
-            sharing.email AS Shared_email, 
-            title,
-            text,
-            sync_status, 
-            sharing.is_deleted
-            FROM 
-            account 
-            INNER JOIN
-            list_item 
-            ON 
-            list_item.account_id == account._id 
-            INNER JOIN 
-            tree_entity 
-            ON 
-            tree_entity._id == list_item._id 
-            INNER JOIN 
-            sharing 
-            ON list_item._id == sharing.tree_entity_id
-        ''')
 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if(usageentries > 0):
-            report = ArtifactHtmlReport('Google Keep - Notes Sharing')
-            report.start_artifact_report(report_folder,"Google Keep - Notes Sharing")
-            report.add_script()
-            data_headers = ('Notes Shared Timestamp', 'List Parent ID', 'Creator Email', 'Shared Email', 'Title', 'Text', 'Sync Status','Is deleted')
-            data_list = []
-            for row in all_rows:
-                data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], 'Synced' if row[6]==1 else 'Not Synced', 'True' if row[7] == 1 else 'False'))
-
-            report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-            report.end_artifact_report()
-
-            tsvname = "Google Keep - Notes Sharing"
-            tsv(report_folder, data_headers, data_list, tsvname)
-
-            tlactivity = "Google Keep - Notes Sharing"
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc("No Google Keep - Notes Sharing data found")
-        db.close()
-        
+@artifact_processor
+def get_googleKeepNotes_sharing(files_found, report_folder, seeker, wrap_text):
+    source_path = _keep_db(files_found)
+    rows = _run(source_path, '''
+        SELECT tree_entity.shared_timestamp, list_item.list_parent_id, account.name, sharing.email,
+        title, text, sync_status, sharing.is_deleted
+        FROM account
+        INNER JOIN list_item ON list_item.account_id == account._id
+        INNER JOIN tree_entity ON tree_entity._id == list_item._id
+        INNER JOIN sharing ON list_item._id == sharing.tree_entity_id
+    ''')
+    data_list = [(_ms_to_utc(r[0]), r[1], r[2], r[3], r[4], r[5],
+                  'Synced' if r[6] == 1 else 'Not Synced', 'True' if r[7] == 1 else 'False') for r in rows]
+    data_headers = (('Notes Shared Timestamp', 'datetime'), 'List Parent ID', 'Creator Email', 'Shared Email',
+                    'Title', 'Text', 'Sync Status', 'Is deleted')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts `googleKeepNotes.py` (Google Keep) to the decorated `@artifact_processor` pattern, split into **Google Keep - Notes** and **Google Keep - Notes Sharing**.

- Timestamps (created / last modified / shared) are now aware UTC `datetime` values, built from the raw epoch-ms columns instead of SQLite `datetime()` strings.
- Renamed from the generic `GoogleKeepNotes` to the report titles. Reserved-word audit clean.

Original `creation_date`/`last_update_date` (2021-05-17) preserved.