### PR TITLE
Convert googleMapsSearches to LAVA @artifact_processor (+ bug fix)

### DIFF
--- a/scripts/artifacts/googleMapsSearches.py
+++ b/scripts/artifacts/googleMapsSearches.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0401,W0611,W0612,W0613,W0614,W1309
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_googleMapsSearches": {
-        "name": "googleMapsSearches",
-        "description": "",
+        "name": "Google Maps Searches",
+        "description": "Recent Google Maps search history (new_recent_history_cache_search.cs)",
         "author": "",
         "creation_date": "2023-10-15",
         "last_update_date": "2023-10-15",
@@ -10,113 +10,72 @@ __artifacts_v2__ = {
         "category": "GEO Location",
         "notes": "",
         "paths": ('*/com.google.android.apps.maps/files/new_recent_history_cache_search.cs',),
-        "output_types": None,
+        "output_types": "all",
         "artifact_icon": "map-pin",
-        "function": "get_googleMapsSearches",
     }
 }
 
-import blackboxprotobuf
-from datetime import *
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, convert_utc_human_to_timezone, kmlgen, timeline
+import datetime
 
+import blackboxprotobuf
+
+from scripts.ilapfuncs import artifact_processor
+
+TYPEDEF = {'1': {'type': 'message', 'message_typedef': {'2': {'type': 'int', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}, '2': {'type': 'bytes', 'name': ''}, '3': {'type': 'bytes', 'name': ''}, '4': {'type': 'bytes', 'name': ''}, '5': {'type': 'message', 'message_typedef': {'3': {'type': 'double', 'name': ''}, '4': {'type': 'double', 'name': ''}}, 'name': ''}, '10': {'type': 'int', 'name': ''}, '11': {'type': 'bytes', 'name': ''}, '12': {'type': 'int', 'name': ''}, '13': {'type': 'int', 'name': ''}, '14': {'type': 'int', 'name': ''}, '17': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}, '3': {'type': 'bytes', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'3': {'type': 'fixed64', 'name': ''}, '4': {'type': 'fixed64', 'name': ''}}, 'name': ''}, '5': {'type': 'bytes', 'name': ''}, '6': {'type': 'bytes', 'name': ''}, '8': {'type': 'fixed32', 'name': ''}, '9': {'type': 'int', 'name': ''}, '10': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}, '2': {'type': 'bytes', 'name': ''}}, 'name': ''}, '11': {'type': 'int', 'name': ''}, '13': {'type': 'message', 'message_typedef': {'4': {'type': 'bytes', 'name': ''}, '5': {'type': 'message', 'message_typedef': {'3': {'type': 'int', 'name': ''}, '4': {'type': 'int', 'name': ''}, '5': {'type': 'int', 'name': ''}, '6': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}, '14': {'type': 'bytes', 'name': ''}, '16': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {}, 'name': ''}}, 'name': ''}, '21': {'type': 'bytes', 'name': ''}, '24': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}, '4': {'type': 'bytes', 'name': ''}, '5': {'type': 'bytes', 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}, '6': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'double', 'name': ''}, '2': {'type': 'double', 'name': ''}, '3': {'type': 'double', 'name': ''}}, 'name': ''}, '3': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '4': {'type': 'fixed32', 'name': ''}}, 'name': ''}, '16': {'type': 'int', 'name': ''}}, 'name': ''}, '9': {'type': 'int', 'name': ''}, '1': {'type': 'bytes', 'name': ''}, '11': {'type': 'bytes', 'name': ''}}, 'name': ''}, '2': {'type': 'bytes', 'name': ''}}
+
+
+def _us_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value) / 1000000, datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
+
+
+def _extract_search(item):
+    timeofsearch = item['2']
+    place = item.get('4', '')
+    latitude = ''
+    longitude = ''
+    if place != '':
+        if item['4'].get('5', '') != '':
+            latitude = item['4']['5']['3']
+            longitude = item['4']['5']['4']
+        elif item['4'].get('6', '') != '':
+            latitude = item['4']['6']['1']['3']
+            longitude = item['4']['6']['1']['2']
+    url = item.get('11', 'No URL')
+    place = place if isinstance(place, str) else place['1'].decode()
+    url = url if isinstance(url, str) else url.decode()
+    return (_us_to_utc(timeofsearch), place, latitude, longitude, url)
+
+
+@artifact_processor
 def get_googleMapsSearches(files_found, report_folder, seeker, wrap_text):
     data_list = []
-    
-    typess = {'1': {'type': 'message', 'message_typedef': {'2': {'type': 'int', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}, '2': {'type': 'bytes', 'name': ''}, '3': {'type': 'bytes', 'name': ''}, '4': {'type': 'bytes', 'name': ''}, '5': {'type': 'message', 'message_typedef': {'3': {'type': 'double', 'name': ''}, '4': {'type': 'double', 'name': ''}}, 'name': ''}, '10': {'type': 'int', 'name': ''}, '11': {'type': 'bytes', 'name': ''}, '12': {'type': 'int', 'name': ''}, '13': {'type': 'int', 'name': ''}, '14': {'type': 'int', 'name': ''}, '17': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}, '3': {'type': 'bytes', 'name': ''}, '4': {'type': 'message', 'message_typedef': {'3': {'type': 'fixed64', 'name': ''}, '4': {'type': 'fixed64', 'name': ''}}, 'name': ''}, '5': {'type': 'bytes', 'name': ''}, '6': {'type': 'bytes', 'name': ''}, '8': {'type': 'fixed32', 'name': ''}, '9': {'type': 'int', 'name': ''}, '10': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}, '2': {'type': 'bytes', 'name': ''}}, 'name': ''}, '11': {'type': 'int', 'name': ''}, '13': {'type': 'message', 'message_typedef': {'4': {'type': 'bytes', 'name': ''}, '5': {'type': 'message', 'message_typedef': {'3': {'type': 'int', 'name': ''}, '4': {'type': 'int', 'name': ''}, '5': {'type': 'int', 'name': ''}, '6': {'type': 'int', 'name': ''}}, 'name': ''}}, 'name': ''}, '14': {'type': 'bytes', 'name': ''}, '16': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {}, 'name': ''}}, 'name': ''}, '21': {'type': 'bytes', 'name': ''}, '24': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'bytes', 'name': ''}, '4': {'type': 'bytes', 'name': ''}, '5': {'type': 'bytes', 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}}, 'name': ''}, '6': {'type': 'message', 'message_typedef': {'1': {'type': 'message', 'message_typedef': {'1': {'type': 'double', 'name': ''}, '2': {'type': 'double', 'name': ''}, '3': {'type': 'double', 'name': ''}}, 'name': ''}, '3': {'type': 'message', 'message_typedef': {'1': {'type': 'int', 'name': ''}, '2': {'type': 'int', 'name': ''}}, 'name': ''}, '4': {'type': 'fixed32', 'name': ''}}, 'name': ''}, '16': {'type': 'int', 'name': ''}}, 'name': ''}, '9': {'type': 'int', 'name': ''}, '1': {'type': 'bytes', 'name': ''}, '11': {'type': 'bytes', 'name': ''}}, 'name': ''}, '2': {'type': 'bytes', 'name': ''}}
-    counter = 0
+    source_path = ''
     for file_found in files_found:
-        counter = counter + 1
-        with open(file_found, 'rb') as f:
-            data = f.read()
-            arreglo = (data)
-            pb = arreglo[8:]
-            values, types = blackboxprotobuf.decode_message(pb, typess)
-        latitude = ''
-        longitude = ''
-        for x, y in values.items():
-            if x == '1':
-                if isinstance(y, list):
-                    for things in y:
-                        timeofsearch = things['2']
-                        place = things.get('4','')
-                        if place != '':
-                            if things['4'].get('5', '') != '':
-                                latitude = (things['4']['5']['3'])
-                                longitude = (things['4']['5']['4'])
-                            elif things['4'].get('6','') != '':	
-                                latitude = (things['4']['6']['1']['3'])
-                                longitude = (things['4']['6']['1']['2'])
-                            else:
-                                latitude = ''
-                                longitude = ''
-                                
-                        url = things.get('11', 'No URL')
-                        timeofsearch = datetime.fromtimestamp(timeofsearch/1000000, tz=timezone.utc)
-                        timeofsearch = convert_utc_human_to_timezone(timeofsearch, 'UTC')
-                        if isinstance(place, str):
-                            pass
-                        else:
-                            place = (place['1'].decode())
-                        
-                        if isinstance(url, str):
-                            pass
-                        else:
-                            url = url.decode()
-                        
-                        data_list.append((timeofsearch,place,latitude,longitude,url))
-                        latitude = ''
-                        longitude = ''
-                elif isinstance(y, dict):
-                    timeofsearch = y['2']
-                    place = y.get('4','')
-                    if place != '':
-                        if y['4'].get('5', '') != '':
-                            latitude = (y['4']['5']['3'])
-                            longitude = (y['4']['5']['4'])
-                        elif things['4'].get('6','') != '':	
-                            latitude = (y['4']['6']['1']['3'])
-                            longitude = (y['4']['6']['1']['2'])
-                        else:
-                            latitude = ''
-                            longitude = ''
-                            
-                    url = y.get('11', 'No URL')
-                    timeofsearch = datetime.fromtimestamp(timeofsearch/1000000, tz=timezone.utc)
-                    timeofsearch = convert_utc_human_to_timezone(timeofsearch, 'UTC')
-                    if isinstance(place, str):
-                        pass
-                    else:
-                        place = (place['1'].decode())
-                        
-                    if isinstance(url, str):
-                        pass
-                    else:
-                        url = url.decode()
-                        
-                    data_list.append((timeofsearch,place,latitude,longitude,url))
-                    latitude = ''
-                    longitude = ''
-                        
-                        
-                        
-        if len(data_list) > 0:
-            report = ArtifactHtmlReport('Google Maps Searches')
-            report.start_artifact_report(report_folder, f'Google Maps Searches - {counter}')
-            report.add_script()
-            data_headers = ('Timestamp', 'Place','Latitude','Longitude','URL')
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Google Maps Searches - {counter}'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Google Maps Searches - {counter}'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-            
-            kmlactivity = f'Google Maps Searches - {counter}'
-            kmlgen(report_folder, kmlactivity, data_list, data_headers)
-            
+        file_found = str(file_found)
+        source_path = file_found
+        try:
+            with open(file_found, 'rb') as f:
+                data = f.read()
+            values, _ = blackboxprotobuf.decode_message(data[8:], TYPEDEF)
+        except Exception:
+            continue
+        entry = values.get('1')
+        if isinstance(entry, list):
+            items = entry
+        elif isinstance(entry, dict):
+            items = [entry]
         else:
-            logfunc(f'No Google Maps Searches available')
+            items = []
+        for item in items:
+            try:
+                data_list.append(_extract_search(item))
+            except (KeyError, TypeError, AttributeError):
+                continue
+
+    data_headers = (('Timestamp', 'datetime'), 'Place', 'Latitude', 'Longitude', 'URL')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts `googleMapsSearches.py` (Google Maps recent-search protobuf cache) to the decorated `@artifact_processor` pattern.

**Changes**
- Consolidates the per-file dynamically-named (`- {counter}`) reports into one fixed-name **Google Maps Searches** table; **KML retained** (`output_types: all`) — Latitude/Longitude/Timestamp columns confirmed present.
- **Bug fix:** the duplicated list/dict extraction is refactored into one `_extract_search` helper, fixing a latent `NameError` where the dict branch referenced `things` (the *list* branch's loop variable, undefined if only a single dict entry existed).
- Microsecond search timestamp → aware UTC `datetime`.
- Protobuf typedef preserved verbatim; the decode is wrapped so a malformed cache is skipped instead of crashing.

Original dates (2023-10-15) preserved.