### PR TITLE
Convert Todoist to LAVA @artifact_processor (3-way split)

### DIFF
--- a/scripts/artifacts/Todoist.py
+++ b/scripts/artifacts/Todoist.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0611,W0613,W0631,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_Todoist": {
-        "name": "Todoist",
-        "description": "Todoist - Parses items, notes and projects",
+        "name": "Todoist - Items",
+        "description": "Todoist - Parses task items",
         "author": "Kevin Pagano (https://startme.stark4n6.com)",
         "creation_date": "2023-04-26",
         "last_update_date": "2023-04-26",
@@ -10,165 +10,123 @@ __artifacts_v2__ = {
         "category": "Todoist",
         "notes": "",
         "paths": ('*/com.todoist/databases/database.db*',),
-        "output_types": None,
+        "output_types": "standard",
+        "artifact_icon": "check-square",
+    },
+    "get_Todoist_notes": {
+        "name": "Todoist - Notes",
+        "description": "Todoist - Parses notes and attachments",
+        "author": "Kevin Pagano (https://startme.stark4n6.com)",
+        "creation_date": "2023-04-26",
+        "last_update_date": "2023-04-26",
+        "requirements": "None",
+        "category": "Todoist",
+        "notes": "",
+        "paths": ('*/com.todoist/databases/database.db*',),
+        "output_types": "standard",
         "artifact_icon": "file-text",
-        "function": "get_Todoist",
+    },
+    "get_Todoist_projects": {
+        "name": "Todoist - Projects",
+        "description": "Todoist - Parses projects",
+        "author": "Kevin Pagano (https://startme.stark4n6.com)",
+        "creation_date": "2023-04-26",
+        "last_update_date": "2023-04-26",
+        "requirements": "None",
+        "category": "Todoist",
+        "notes": "",
+        "paths": ('*/com.todoist/databases/database.db*',),
+        "output_types": "standard",
+        "artifact_icon": "folder",
     }
 }
 
-# Todoist - Parses items, notes and projects
-# Author:  Kevin Pagano (https://startme.stark4n6.com)
-# Date 2023-04-26
-# Version: 0.1
-# Requirements:  None
-
+import datetime
 import sqlite3
-import textwrap
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, kmlgen
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-def get_Todoist(files_found, report_folder, seeker, wrap_text):
-    
+
+def _ms_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
+
+
+def _todoist_db(files_found):
     for file_found in files_found:
-        file_found = str(file_found)  
+        file_found = str(file_found)
         if file_found.endswith('database.db'):
-            break
-        else:
-            continue # Skip all other files
-            
-    db = open_sqlite_db_readonly(file_found)
-    
+            return file_found
+    return ''
+
+
+def _run(source_path, sql):
+    if not source_path:
+        return []
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
-    cursor.execute('''
-    select
-    datetime(items.date_added/1000,'unixepoch') as "Timestamp Added",
-    items.added_by_uid,
-    items.content,
-    items.description,
-    items.due_date,
-    items.due_timezone,
-    items.due_string,
-    case items.due_is_recurring
-        when 0 then ''
-        when 1 then 'Yes'
-    end as "Recurring Due Date",
-    items.priority,
-    items.child_order,
-    projects.name as "Project Name",
-    item_labels.label_name,
-    items._id
-    from items
-    left outer join projects on items.project_id = projects._id
-    left outer join item_labels on items._id = item_labels.item_id
-    ''')
-    
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Todoist - Items')
-        report.start_artifact_report(report_folder, 'Todoist - Items')
-        report.add_script()
-        data_headers = ('Timestamp Added','Added By UID','Content','Description','Due Date','Due Timezone','Due String','Recurring Due Date','Priority','Child Order','Project Name','Label','Item ID')
-        
-        data_list = []
-        for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11],row[12]))
-            
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Todoist - Items'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Todoist - Items'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-    else:
-        logfunc('No Todoist - Items data available')
-        
-    cursor.execute('''
-    select
-    datetime(notes.posted/1000,'unixepoch') as "Timestamp Posted",
-    notes.content,
-    note_file_attachments.resource_type,
-    note_file_attachments.file_url,
-    note_file_attachments.file_name,
-    note_file_attachments.file_type,
-    note_file_attachments.file_size,
-    note_file_attachments.image,
-    note_file_attachments.title,
-    note_file_attachments.description,
-    notes._id
-    from notes
-    left outer join note_file_attachments on notes._id = note_file_attachments.note_id
-    ''')
-    
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Todoist - Notes')
-        report.start_artifact_report(report_folder, 'Todoist - Notes')
-        report.add_script()
-        data_headers = ('Timestamp Posted','Content','Resource Type','File URL','File Name','File Type','File Size','Image','Title','Description','Note ID')
-        
-        data_list = []
-        for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10]))
-            
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Todoist - Notes'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Todoist - Notes'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-    else:
-        logfunc('No Todoist - Notes data available')
-        
-    cursor.execute('''
-    select
-    name,
-    color,
-    view_style,
-    child_order,
-    case collapsed
-        when 0 then ''
-        when 1 then 'Yes'
-    end,
-    case shared
-        when 0 then ''
-        when 1 then 'Yes'
-    end,
-    case favorite
-        when 0 then ''
-        when 1 then 'Yes'
-    end,
-    type
-    from projects
-    ''')
-    
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        report = ArtifactHtmlReport('Todoist - Projects')
-        report.start_artifact_report(report_folder, 'Todoist - Projects')
-        report.add_script()
-        data_headers = ('Project Name','Color','View Style','Child Order','Collapsed','Shared','Favorited','Type')
-        
-        data_list = []
-        for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7]))
-            
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Todoist - Projects'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-    else:
-        logfunc('No Todoist - Projects data available') 
-                
+    try:
+        cursor.execute(sql)
+        rows = cursor.fetchall()
+    except sqlite3.Error:
+        rows = []
     db.close()
+    return rows
+
+
+@artifact_processor
+def get_Todoist(files_found, report_folder, seeker, wrap_text):
+    source_path = _todoist_db(files_found)
+    rows = _run(source_path, '''
+        SELECT items.date_added, items.added_by_uid, items.content, items.description, items.due_date,
+        items.due_timezone, items.due_string,
+        CASE items.due_is_recurring WHEN 0 THEN '' WHEN 1 THEN 'Yes' END,
+        items.priority, items.child_order, projects.name, item_labels.label_name, items._id
+        FROM items
+        LEFT OUTER JOIN projects ON items.project_id = projects._id
+        LEFT OUTER JOIN item_labels ON items._id = item_labels.item_id
+    ''')
+    data_list = [(_ms_to_utc(r[0]), r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10], r[11], r[12])
+                 for r in rows]
+    data_headers = (
+        ('Timestamp Added', 'datetime'), 'Added By UID', 'Content', 'Description', 'Due Date',
+        'Due Timezone', 'Due String', 'Recurring Due Date', 'Priority', 'Child Order', 'Project Name',
+        'Label', 'Item ID')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_Todoist_notes(files_found, report_folder, seeker, wrap_text):
+    source_path = _todoist_db(files_found)
+    rows = _run(source_path, '''
+        SELECT notes.posted, notes.content, note_file_attachments.resource_type,
+        note_file_attachments.file_url, note_file_attachments.file_name, note_file_attachments.file_type,
+        note_file_attachments.file_size, note_file_attachments.image, note_file_attachments.title,
+        note_file_attachments.description, notes._id
+        FROM notes
+        LEFT OUTER JOIN note_file_attachments ON notes._id = note_file_attachments.note_id
+    ''')
+    data_list = [(_ms_to_utc(r[0]), r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10]) for r in rows]
+    data_headers = (
+        ('Timestamp Posted', 'datetime'), 'Content', 'Resource Type', 'File URL', 'File Name', 'File Type',
+        'File Size', 'Image', 'Title', 'Description', 'Note ID')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_Todoist_projects(files_found, report_folder, seeker, wrap_text):
+    source_path = _todoist_db(files_found)
+    rows = _run(source_path, '''
+        SELECT name, color, view_style, child_order,
+        CASE collapsed WHEN 0 THEN '' WHEN 1 THEN 'Yes' END,
+        CASE shared WHEN 0 THEN '' WHEN 1 THEN 'Yes' END,
+        CASE favorite WHEN 0 THEN '' WHEN 1 THEN 'Yes' END, type
+        FROM projects
+    ''')
+    data_headers = ('Project Name', 'Color', 'View Style', 'Child Order', 'Collapsed', 'Shared',
+                    'Favorited', 'Type')
+    return data_headers, [tuple(r) for r in rows], source_path


### PR DESCRIPTION
Converts `Todoist.py` (Kevin Pagano) to the decorated `@artifact_processor` pattern — **Items**, **Notes**, **Projects** (category **Todoist**).

- Added/Posted timestamps → aware UTC `datetime` from raw epoch ms.
- Drops the dead `kmlgen` import (no geo data). Reserved-word audit clean.

Original author and dates (2023-04-26) preserved.