### PR TITLE
Convert blueskyposts to LAVA @artifact_processor (+ feed bug fix)

### DIFF
--- a/scripts/artifacts/blueskyposts.py
+++ b/scripts/artifacts/blueskyposts.py
@@ -1,157 +1,74 @@
-# pylint: disable=W0611,W0612,W0613,W0702,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_blueskyposts": {
         "name": "Bluesky - Posts",
-        "description": "Bluesky Feed Posts",
+        "description": "Bluesky feed and posts cached in the http-cache",
         "author": "Alexis Brignoni",
         "creation_date": "2024-11-20",
         "last_update_date": "2024-11-20",
         "requirements": "none",
         "category": "Bluesky",
         "notes": "",
-        "paths": ('*/xyz.blueskyweb.app/cache/http-cache/*.*'),
-        "output_types": None,
+        "paths": ('*/xyz.blueskyweb.app/cache/http-cache/*.*',),
+        "output_types": "standard",
         "artifact_icon": "edit",
-        "function": "get_blueskyposts",
     }
 }
 
-import os
+import datetime
 import json
-import sqlite3
-from pathlib import Path 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, timeline, is_platform_windows,open_sqlite_db_readonly,convert_ts_human_to_utc,tsv,utf8_in_extended_ascii
 
+from scripts.ilapfuncs import artifact_processor
+
+
+def _iso_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromisoformat(str(value).replace('Z', '+00:00')).astimezone(
+            datetime.timezone.utc)
+    except (ValueError, TypeError):
+        return ''
+
+
+def _extract_post(post, collection):
+    record = post.get('record', {})
+    author = post.get('author', {})
+    langs = record.get('langs')
+    langs = ', '.join(langs) if isinstance(langs, list) else (langs or '')
+    return (
+        collection, _iso_to_utc(record.get('createdAt')), _iso_to_utc(author.get('createdAt')),
+        record.get('$type'), author.get('handle'), author.get('displayName'), record.get('text'),
+        post.get('replyCount'), post.get('repostCount'), post.get('likeCount'), post.get('quoteCount'),
+        author.get('avatar'), author.get('did'), langs, post.get('cid'), post.get('uri'))
+
+
+@artifact_processor
 def get_blueskyposts(files_found, report_folder, seeker, wrap_text):
-    
-    feed_data_list = []
-    posts_data_list = []
-    
-    
+    seen = set()
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-
         try:
-            with open(file_found, 'r',encoding='utf-8') as file:
-                data = json.load(file)
-                value = data.get('feed')
-                if value is not None:
-                    if len(value) > 0:
-                        for items in value:
-                            urip = (data['feed'][0]['post']['uri'])
-                            cidp = (data['feed'][0]['post']['cid'])
-                            typep = (data['feed'][0]['post']['record']['$type'])#
-                            createdatp = (data['feed'][0]['post']['record']['createdAt'])#
-                            langsp = (data['feed'][0]['post']['record']['langs'])#
-                            textp = (data['feed'][0]['post']['record']['text'])#
-                            didp = (data['feed'][0]['post']['author']['did'])#
-                            handlep = (data['feed'][0]['post']['author']['handle'])#
-                            displaynamep = (data['feed'][0]['post']['author']['displayName'])#
-                            avatarp = (data['feed'][0]['post']['author']['avatar'])#
-                            authorcreatedatp = (data['feed'][0]['post']['author']['createdAt'])#
-                            replycountp =(data['feed'][0]['post']['replyCount'])#
-                            repostcountp = (data['feed'][0]['post']['repostCount'])#
-                            likecountp = (data['feed'][0]['post']['likeCount'])#
-                            quotecountp = (data['feed'][0]['post']['quoteCount'])#
-                            
-                        
-                            createdatp = createdatp.replace('T',' ')
-                            createdatp = createdatp[:-1]
-                            createdatp = convert_ts_human_to_utc(createdatp)#
-                            
-                            
-                            authorcreatedatp = authorcreatedatp.replace('T',' ')
-                            authorcreatedatp = authorcreatedatp[:-1]
-                            authorcreatedatp = convert_ts_human_to_utc(authorcreatedatp)#
-                            
-                            source = file_found
-                            
-                            feedtuple = tuple((createdatp,authorcreatedatp,typep,handlep,displaynamep,textp,replycountp,repostcountp,likecountp,quotecountp,avatarp,didp,langsp,cidp,urip,source))
-                            
-                            if feedtuple in feed_data_list:
-                                pass
-                            else:
-                                feed_data_list.append((feedtuple))
-                    else:
-                        pass
-                posts = data.get('posts')
-                if posts is not None:
-                    if len(posts) > 0:
-                        for post in posts:
-                            urips = (post['uri'])
-                            cidps = (post['cid'])
-                            typeps = (post['record']['$type'])#
-                            createdatps = (post['record']['createdAt'])#
-                            langsps = (post['record']['langs'])#
-                            textps = (post['record']['text'])#
-                            didps = (post['author']['did'])#
-                            handleps = (post['author']['handle'])#
-                            displaynameps = (post['author']['displayName'])#
-                            avatarps = (post['author']['avatar'])#
-                            authorcreatedatps = (post['author']['createdAt'])#
-                            replycountps =(post['replyCount'])#
-                            repostcountps = (post['repostCount'])#
-                            likecountps = (post['likeCount'])#
-                            quotecountps = (post['quoteCount'])#
-                            
-                            createdatps = createdatps.replace('T',' ')
-                            createdatps = createdatps[:-1]
-                            createdatps = convert_ts_human_to_utc(createdatps)#
-                            
-                            
-                            authorcreatedatps = authorcreatedatps.replace('T',' ')
-                            authorcreatedatps = authorcreatedatps[:-1]
-                            authorcreatedatps = convert_ts_human_to_utc(authorcreatedatps)#
-                            
-                            sources = file_found
-                            
-                            poststuple = tuple((createdatps,authorcreatedatps,typeps,handleps,displaynameps,textps,replycountps,repostcountps,likecountps,quotecountps,avatarps,didps,langsps,cidps,urips,sources))
-                            
-                            if poststuple in posts_data_list:
-                                pass
-                            else:
-                                posts_data_list.append((poststuple))
-                                
-                    else:
-                        pass            
-        except:
-            pass
+            with open(file_found, 'r', encoding='utf-8') as handle:
+                data = json.load(handle)
+        except (ValueError, OSError, UnicodeDecodeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        source_path = file_found
+        for collection, key in (('Feed', 'feed'), ('Posts', 'posts')):
+            for entry in data.get(key) or []:
+                post = entry.get('post') if collection == 'Feed' else entry
+                if not isinstance(post, dict):
+                    continue
+                row = _extract_post(post, collection)
+                if row not in seen:
+                    seen.add(row)
+                    data_list.append(row)
 
-            
-    if len(feed_data_list) > 0:
-        report = ArtifactHtmlReport('Bluesky Feed Posts')
-        report.start_artifact_report(report_folder, f'Bluesky Feed Posts')
-        report.add_script()
-        data_headers = ('Timestamp','Author Created At','Type','Handle','Display Name','Text','Reply Count','Repost Count','Like Count','Quote Count', 'Avatar','DID','Language','CID','URI','Source')
-        report.write_artifact_data_table(data_headers, feed_data_list, 'See report')
-        report.end_artifact_report()
-        
-        tsvname = f'Bluesky Feed Posts'
-        tsv(report_folder, data_headers, feed_data_list, tsvname)
-        
-        tlactivity = f'Bluesky Feed Posts'
-        timeline(report_folder, tlactivity, feed_data_list, data_headers)
-        
-    else:
-        logfunc(f'No Bluesky Feed Posts data available')
-        
-    
-    if len(posts_data_list) > 0:
-        report = ArtifactHtmlReport('Bluesky Posts')
-        report.start_artifact_report(report_folder, f'Bluesky Posts')
-        report.add_script()
-        data_headers = ('Timestamp','Author Created At','Type','Handle','Display Name','Text','Reply Count','Repost Count','Like Count','Quote Count', 'Avatar','DID','Language','CID','URI','Source')
-        report.write_artifact_data_table(data_headers, posts_data_list, 'See report')
-        report.end_artifact_report()
-        
-        tsvname = f'Bluesky Posts'
-        tsv(report_folder, data_headers, posts_data_list, tsvname)
-        
-        tlactivity = f'Bluesky Posts'
-        timeline(report_folder, tlactivity, posts_data_list, data_headers)
-        
-    else:
-        logfunc(f'No Bluesky Posts data available')
-        
-        
+    data_headers = ('Collection', ('Timestamp', 'datetime'), ('Author Created At', 'datetime'), 'Type',
+                    'Handle', 'Display Name', 'Text', 'Reply Count', 'Repost Count', 'Like Count',
+                    'Quote Count', 'Avatar', 'DID', 'Language', 'CID', 'URI')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts `blueskyposts.py` (Bluesky feed/posts http-cache) to the decorated `@artifact_processor` pattern.

**Bug fix:** the feed loop read `data['feed'][0]['post']` (hard-coded index 0) inside `for items in value`, so **every feed entry was a copy of the first post** and deduped down to a single row. Now reads each entry's own `post`. Verified with a 2-post fixture: yields 2 distinct rows (was 1).

**Other**
- Consolidates the two identical-shape reports (`feed` + `posts`) into one table with a `Collection` column.
- ISO timestamps → aware UTC `datetime`; `langs` list joined to a string.
- Bare `except:` removed; each cache file read once. Reserved-word audit clean.

Own artifact; author and dates (2024-11-20) preserved.