### PR TITLE
Convert googleInitiatedNav to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/googleInitiatedNav.py
+++ b/scripts/artifacts/googleInitiatedNav.py
@@ -1,65 +1,64 @@
-# pylint: disable=W0401,W0611,W0612,W0613,W0614,W1309
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_googleInitiatedNav": {
-        "name": "googleInitiatedNav",
-        "description": "",
+        "name": "Google Initiated Navigation",
+        "description": "Recent navigation destinations (new_recent_history_cache_navigated.cs)",
         "author": "",
         "creation_date": "2023-10-16",
         "last_update_date": "2023-10-16",
         "requirements": "none",
         "category": "GEO Location",
         "notes": "",
-        "paths": ('*/com.google.android.apps.maps/files/new_recent_history_cache_navigated.cs', '*/new_recent_history_cache_navigated.cs'),
-        "output_types": None,
+        "paths": ('*/com.google.android.apps.maps/files/new_recent_history_cache_navigated.cs',
+                  '*/new_recent_history_cache_navigated.cs'),
+        "output_types": "standard",
         "artifact_icon": "map-pin",
-        "function": "get_googleInitiatedNav",
     }
 }
 
-import blackboxprotobuf
-from datetime import *
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, convert_utc_human_to_timezone, kmlgen, timeline
+import datetime
 
+import blackboxprotobuf
+
+from scripts.ilapfuncs import artifact_processor
+
+
+def _us_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value) / 1000000, datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
+
+
+@artifact_processor
 def get_googleInitiatedNav(files_found, report_folder, seeker, wrap_text):
     data_list = []
+    source_path = ''
     for file_found in files_found:
-        with open(file_found, 'rb') as f:
-            data = f.read()
-            
-            arreglo = (data)
-            pb = arreglo[8:]
-            values, types = blackboxprotobuf.decode_message(pb)
-        
-        if isinstance(values, dict):
-            timestamp = values['1']['2']
-            timestamp = datetime.fromtimestamp(timestamp/1000000, tz=timezone.utc)
-            timestamp = convert_utc_human_to_timezone(timestamp, 'UTC')
-            intendeddest = values['1']['4']['1'].decode()
-            
-            data_list.append((timestamp, intendeddest))
+        file_found = str(file_found)
+        source_path = file_found
+        try:
+            with open(file_found, 'rb') as f:
+                data = f.read()
+            values, _ = blackboxprotobuf.decode_message(data[8:])
+        except Exception:
+            continue
+        if not isinstance(values, dict):
+            continue
+        entry = values.get('1')
+        if isinstance(entry, list):
+            items = entry
+        elif isinstance(entry, dict):
+            items = [entry]
         else:
-            for data in values['1']:
-                timestamp = data['2']
-                timestamp = datetime.fromtimestamp(timestamp/1000000, tz=timezone.utc)
-                timestamp = convert_utc_human_to_timezone(timestamp, 'UTC')
-                intendeddest = data['4']['1'].decode()
-                
-                data_list.append((timestamp, intendeddest))
-                        
-        if len(data_list) > 0:
-            report = ArtifactHtmlReport('Google Initiated Navigation')
-            report.start_artifact_report(report_folder, f'Google Initiated Navigation')
-            report.add_script()
-            data_headers = ('Timestamp', 'Initiated Navigation Destination')
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Google Initiated Navigation'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Google Initiated Navigation'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-            
-        else:
-            logfunc(f'No Google Initiated Navigation available')
+            items = []
+        for item in items:
+            try:
+                data_list.append((_us_to_utc(item['2']), item['4']['1'].decode()))
+            except (KeyError, TypeError, AttributeError):
+                continue
+
+    data_headers = (('Timestamp', 'datetime'), 'Initiated Navigation Destination')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts `googleInitiatedNav.py` (Google Maps recent navigation destinations protobuf cache) to the decorated `@artifact_processor` pattern.

- Normalizes the single (`dict`) vs multiple (`list`) `values['1']` handling into one loop.
- Microsecond timestamp → aware UTC `datetime`.
- Guards the protobuf decode so a malformed cache is skipped instead of crashing.
- Renamed to **Google Initiated Navigation**.

Original dates (2023-10-16) preserved.