### PR TITLE
Convert googleQuickSearchbox + Recent to artifact_processor

### DIFF
--- a/scripts/artifacts/googleQuickSearchbox.py
+++ b/scripts/artifacts/googleQuickSearchbox.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0511,W0612,W0613,W1309
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_quicksearch": {
-        "name": "Quicksearch",
-        "description": "Represents a search query session",
+        "name": "Google Quick Search Queries",
+        "description": "Search query sessions from the Google Search widget / Assistant (Google Now)",
         "author": "",
         "creation_date": "2020-03-22",
         "last_update_date": "2020-03-22",
@@ -10,167 +10,110 @@ __artifacts_v2__ = {
         "category": "Google Now & QuickSearch",
         "notes": "",
         "paths": ('*/com.google.android.googlequicksearchbox/app_session/*.binarypb',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "search",
-        "function": "get_quicksearch",
     }
 }
 
-import blackboxprotobuf
 import datetime
 import os
 import struct
-from html import escape
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows
 
-is_windows = is_platform_windows()
-slash = '\\' if is_windows else '/' 
+import blackboxprotobuf
 
-class Session:
-    # Represents a search query session
-    def __init__(self, source_file, file_last_mod_date, session_type, session_from, session_queries, mp3_path):
-        self.source_file = source_file
-        self.file_last_mod_date = file_last_mod_date
-        self.session_type = session_type
-        self.session_from = session_from
-        self.session_queries = session_queries
-        self.mp3_path = mp3_path
+from scripts.ilapfuncs import artifact_processor, check_in_embedded_media
 
-def ReadUnixTime(unix_time): # Unix timestamp is time epoch beginning 1970/1/1
-    '''Returns datetime object, or empty string upon error'''
-    if unix_time not in ( 0, None, ''):
-        try:
-            if isinstance(unix_time, str):
-                unix_time = float(unix_time)
-            return datetime.datetime(1970, 1, 1) + datetime.timedelta(seconds=unix_time)
-        except (ValueError, OverflowError, TypeError) as ex:
-            logfunc("ReadUnixTime() Failed to convert timestamp from value " + str(unix_time) + " Error was: " + str(ex))
-    return ''
 
-def get_search_query_from_blob(data):
+def _read_unix_time(value):
+    if value in (0, None, ''):
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(float(value), datetime.timezone.utc)
+    except (ValueError, OverflowError, TypeError, OSError):
+        return ''
+
+
+def _get_search_query_from_blob(data):
     term = 'com.google.android.apps.gsa.shared.search.Query'.encode('utf-16')[2:]
     query = ''
     pos = data.find(term + b'\0\0')
     if pos > 0:
-        if pos % 4: 
+        if pos % 4:
             pos += 2
-        pos += 96 # skip term
-        #if data[pos : pos + 2] in (b'\x01\x4C', b'\x01\x0C'):
-        if data[pos : pos + 2] != b'\x03\x00':
+        pos += 96  # skip term
+        if data[pos: pos + 2] != b'\x03\x00':
             pos += 20
-            str_len = struct.unpack('<I', data[pos:pos+4])[0]
+            str_len = struct.unpack('<I', data[pos:pos + 4])[0]
             if str_len > 0:
                 pos += 4
-                query = data[pos : pos + str_len*2] # TODO PROBLEM - With Android 11, this is utf8! No indication of format anywhere
-                if data[pos + str_len : pos + str_len + 1] == b'\0': # then its utf8
+                query = data[pos: pos + str_len * 2]
+                if data[pos + str_len: pos + str_len + 1] == b'\0':  # utf8
                     query = query[:str_len].decode('utf8', 'ignore')
                 else:
                     query = query.decode('utf-16', 'backslashreplace')
     return query
 
-def parse_session_data(values, file_name, file_last_mod_date, report_folder):
-    '''Parse protobuf dictionary and return a session object'''
-    empty_dict = dict()
-    session_type = values.get('3', b'').decode('utf8')
-    session_from = values.get('146514374', empty_dict).get('1', b'').decode('utf8')
+
+def _parse_session(values):
+    session_type = values.get('3', b'').decode('utf8', 'ignore')
     session_queries = []
     main_query = ''
-    mp3_path = ''
+    mp3_data = b''
 
-    # Main/Last query is in values['132269847']['1']['2']
     try:
         item = values['132269847']['1']['2']
-        if item and isinstance(item, bytes):
-            item = item.decode('utf8', 'backslashreplace')
-            if item:
-                main_query = item
+        if isinstance(item, bytes):
+            main_query = item.decode('utf8', 'backslashreplace')
     except (KeyError, ValueError, TypeError):
         pass
 
-    # Get other queries
     try:
         items = values['132269847']['2']
         if isinstance(items, list):
             for item in items:
                 if isinstance(item, bytes):
-                    term = get_search_query_from_blob(item)
+                    term = _get_search_query_from_blob(item)
                     if term:
                         session_queries.append(term)
-
     except (KeyError, ValueError, TypeError):
         pass
 
-    # main_query is typically the last query or only query. If not in session_queries, add it
-    if session_queries and main_query:
-        try:
-            idx = session_queries.index(main_query)
-        except ValueError:  # not found
-            # add to session_queries
-            session_queries.append(main_query)
+    if main_query and main_query not in session_queries:
+        session_queries.append(main_query)
+    session_queries = [f'"{x}"' for x in session_queries]
 
-    session_queries = [ f'"{x}"' for x in session_queries ]
-
-    # Get mp3 recording of response
     try:
         data = values['132269388']['1']
         if isinstance(data, bytes):
-            mp3_path = os.path.join(report_folder, os.path.splitext(file_name)[0] + ".mp3")
-            f = open(mp3_path, 'wb')
-            f.write(data)
-            f.close()
-    except (KeyError, ValueError):
+            mp3_data = data
+    except (KeyError, ValueError, TypeError):
         pass
 
-    return Session(file_name, file_last_mod_date, session_type, session_from, session_queries, mp3_path)
+    return session_type, session_queries, mp3_data
 
+
+@artifact_processor
 def get_quicksearch(files_found, report_folder, seeker, wrap_text):
-    sessions = []
-    base_folder = ''
+    data_list = []
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        if file_found.find('{0}mirror{0}'.format(slash)) >= 0:
-            # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data
+        if '/mirror/' in file_found.replace('\\', '/') or os.path.isdir(file_found):
             continue
-        elif os.path.isdir(file_found): # skip folders (there shouldn't be any)
+        source_path = os.path.dirname(file_found)
+        try:
+            with open(file_found, 'rb') as f:
+                values, _ = blackboxprotobuf.decode_message(f.read())
+        except Exception:
             continue
-        
-        base_folder = os.path.dirname(file_found)
-        file_name = os.path.basename(file_found)
-        with open(file_found, 'rb') as f:
-            pb = f.read()
-            values, types = blackboxprotobuf.decode_message(pb)
-            file_last_mod_date = str(ReadUnixTime(os.path.getmtime(file_found)))
-            s = parse_session_data(values, file_name, file_last_mod_date, report_folder)
-            sessions.append(s)
+        session_type, queries, mp3_data = _parse_session(values)
+        response = ''
+        if mp3_data:
+            name = os.path.splitext(os.path.basename(file_found))[0] + '.mp3'
+            response = check_in_embedded_media(file_found, mp3_data, name,
+                                               force_type='audio/mpeg', force_extension='mp3')
+        data_list.append((_read_unix_time(os.path.getmtime(file_found)), session_type,
+                          ', '.join(queries), response, file_found))
 
-    if report_folder[-1] == slash: 
-        folder_name = os.path.basename(report_folder[:-1])
-    else:
-        folder_name = os.path.basename(report_folder)
-    entries = len(sessions)
-    if entries > 0:
-        description = "Recently searched terms from the Google Search widget and any interaction with the Google Personal Assistant / app (previously "\
-                        "known as 'Google Now') appear here. This can include previously searched items from another device too!"
-        report = ArtifactHtmlReport('Google App & Quick Search queries')
-        report.start_artifact_report(report_folder, 'Searches & Personal assistant', description)
-        report.add_script()
-        data_headers = ('File Timestamp', 'Type', 'Queries', 'Response', 'Source File')
-        data_list = []
-        for s in sessions:
-            response = ''
-            if s.mp3_path:
-                filename = os.path.basename(s.mp3_path)
-                response = f'<audio controls><source src="{folder_name}/{filename}"></audio>'
-            data_list.append( (s.file_last_mod_date, s.session_type, escape(', '.join(s.session_queries)), response, s.source_file) )
-
-        report.write_artifact_data_table(data_headers, data_list, base_folder, html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = f'google quick search box'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Google Quick Search Box'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No recent quick search or now data available')
+    data_headers = (('File Timestamp', 'datetime'), 'Type', 'Queries', ('Response', 'media'), 'Source File')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/googleQuickSearchboxRecent.py
+++ b/scripts/artifacts/googleQuickSearchboxRecent.py
@@ -1,157 +1,114 @@
-# pylint: disable=W0611,W0612,W0613,W1309
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_quicksearch_recent": {
-        "name": "Quicksearch_recent",
-        "description": "",
+        "name": "Google Quick Search Recent",
+        "description": "Recently searched terms and pages read from the Google app (Google Now)",
         "author": "",
         "creation_date": "2020-03-22",
         "last_update_date": "2020-03-22",
         "requirements": "none",
         "category": "Google Now & QuickSearch",
         "notes": "",
-        "paths": ('*/com.google.android.googlequicksearchbox/files/recently/*', '*/com.google.android.googlequicksearchbox/files/accounts/*/RecentsDataStore.pb', '*/com.google.android.googlequicksearchbox/databases/accounts.notifications.db'),
-        "output_types": None,
+        "paths": ('*/com.google.android.googlequicksearchbox/files/recently/*',
+                  '*/com.google.android.googlequicksearchbox/files/accounts/*/RecentsDataStore.pb',
+                  '*/com.google.android.googlequicksearchbox/databases/accounts.notifications.db'),
+        "output_types": "standard",
         "artifact_icon": "search",
-        "function": "get_quicksearch_recent",
     }
 }
 
-import blackboxprotobuf
 import datetime
 import json
 import os
-import shutil
 import sqlite3
-from html import escape
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, is_platform_windows, open_sqlite_db_readonly
 
-is_windows = is_platform_windows()
-slash = '\\' if is_windows else '/' 
+import blackboxprotobuf
 
-def recursive_convert_bytes_to_str(obj):
-    '''Recursively convert bytes to strings if possible'''
-    ret = obj
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, check_in_media
+
+_TYPES = {'1': {'type': 'message', 'message_typedef': {
+    '1': {'type': 'uint', 'name': 'id'},
+    '4': {'type': 'uint', 'name': 'timestamp1'},
+    '5': {'type': 'str', 'name': 'search-query'},
+    '7': {'type': 'message', 'message_typedef': {
+        '1': {'type': 'str', 'name': 'url'},
+        '2': {'type': 'str', 'name': 'url-domain'},
+        '3': {'type': 'str', 'name': 'title'}}, 'name': 'page'},
+    '8': {'type': 'message', 'message_typedef': {
+        '1': {'type': 'str', 'name': 'category'},
+        '2': {'type': 'str', 'name': 'engine'}}, 'name': 'search'},
+    '9': {'type': 'int', 'name': 'screenshot-id'},
+    '17': {'type': 'uint', 'name': 'timestamp2'}}, 'name': ''}}
+
+
+def _ms_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
+
+
+def _recursive_bytes_to_str(obj):
     if isinstance(obj, dict):
         for k, v in obj.items():
-            obj[k] = recursive_convert_bytes_to_str(v)
-    elif isinstance(obj, list):
-        for index, v in enumerate(obj):
-            obj[index] = recursive_convert_bytes_to_str(v)
-    elif isinstance(obj, bytes):
-        # test for string
-        try:
-            ret = obj.decode('utf8', 'backslashreplace')
-        except UnicodeDecodeError:
-            ret = str(obj)
-    return ret
+            obj[k] = _recursive_bytes_to_str(v)
+        return obj
+    if isinstance(obj, list):
+        return [_recursive_bytes_to_str(v) for v in obj]
+    if isinstance(obj, bytes):
+        return obj.decode('utf8', 'backslashreplace')
+    return obj
 
+
+@artifact_processor
 def get_quicksearch_recent(files_found, report_folder, seeker, wrap_text):
-    recents = []
-    account_db = ''
     account_name = ''
-    screenshot_path = ''
+    screenshots = {}
+    pb_files = []
     for file_found in files_found:
         file_found = str(file_found)
         if file_found.endswith('accounts.notifications.db'):
-            account_db = str(file_found)
-            
-            db = open_sqlite_db_readonly(account_db)
+            db = open_sqlite_db_readonly(file_found)
             cursor = db.cursor()
-            
-            cursor.execute('''
-            select
-            account_name
-            from accounts''')
-            
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                for row in all_rows:
+            try:
+                cursor.execute('SELECT account_name FROM accounts')
+                for row in cursor.fetchall():
                     account_name = row[0]
-            
+            except sqlite3.Error:
+                pass
             db.close()
-            
-            continue
-        
         elif file_found.endswith('.jpg'):
-            screenshot_path = file_found
-            continue # Skip jpg files, all others should be protobuf
-        elif file_found.find('{0}mirror{0}'.format(slash)) >= 0:
-            # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data
+            screenshots[os.path.basename(file_found)] = file_found
+        elif '/mirror/' in file_found.replace('\\', '/') or os.path.isdir(file_found):
             continue
-        elif os.path.isdir(file_found): # skip folders
+        else:
+            pb_files.append(file_found)
+
+    data_list = []
+    source_path = ''
+    for file_found in pb_files:
+        source_path = file_found
+        try:
+            with open(file_found, 'rb') as f:
+                values, _ = blackboxprotobuf.decode_message(f.read(), _TYPES)
+        except Exception:
             continue
-        
-        with open(file_found, 'rb') as f:
-            pb = f.read()
-            types = {'1': {'type': 'message', 'message_typedef': 
-                {
-                    '1': {'type': 'uint', 'name': 'id'},
-                    '4': {'type': 'uint', 'name': 'timestamp1'}, 
-                    '5': {'type': 'str', 'name': 'search-query'},
-                    '7': {'type': 'message', 'message_typedef': 
-                        {
-                        '1': {'type': 'str', 'name': 'url'}, 
-                        '2': {'type': 'str', 'name': 'url-domain'}, 
-                        '3': {'type': 'str', 'name': 'title'}
-                        }, 'name': 'page'
-                    },
-                    '8': {'type': 'message', 'message_typedef': 
-                        {
-                        '1': {'type': 'str', 'name': 'category'}, 
-                        '2': {'type': 'str', 'name': 'engine'}
-                        }, 'name': 'search'
-                    },
-                    '9': {'type': 'int', 'name': 'screenshot-id'},
-                    '17': {'type': 'uint', 'name': 'timestamp2'},
-                }, 'name': ''} }
-            values, types = blackboxprotobuf.decode_message(pb, types)
-            items = values.get('1', None)
-            
-            if items:
-                if isinstance(items, dict): 
-                    # this means only one element was found
-                    # No array, just a dict of that single element
-                    recents.append( (file_found, [items]) )
-                else:
-                    # Array of dicts found
-                    recents.append( (file_found, items) )
+        items = values.get('1')
+        if isinstance(items, dict):
+            items = [items]
+        elif not isinstance(items, list):
+            continue
+        for item in items:
+            screenshot_id = str(item.get('screenshot-id', ''))
+            search_query = str(item.get('search-query', ''))
+            name = f'{account_name}-{screenshot_id}.jpg'
+            screenshot = check_in_media(screenshots[name], name) if name in screenshots else ''
+            _recursive_bytes_to_str(item)
+            data_list.append((_ms_to_utc(item.get('timestamp1')), search_query, screenshot,
+                              json.dumps(item, ensure_ascii=False), file_found))
 
-    if report_folder[-1] == slash: 
-        folder_name = os.path.basename(report_folder[:-1])
-    else:
-        folder_name = os.path.basename(report_folder)
-    recent_entries = len(recents)
-    if recent_entries > 0:
-        description = "Recently searched terms from the Google Search widget and webpages read from Google app (previously known as 'Google Now') appear here."
-        report = ArtifactHtmlReport('Google Now & Quick Search recent events')
-        report.start_artifact_report(report_folder, 'Recent Searches & Google Now', description)
-        report.add_script()
-        data_headers = ('Timestamp','Screenshot Path','Search Query','Screenshot', 'Protobuf Data')
-        data_list = []
-        for file_path, items in recents:
-            dir_path, base_name = os.path.split(screenshot_path)
-            for item in items:
-                screenshot_id = str(item.get('screenshot-id', ''))  
-                search_timestamp = datetime.datetime.utcfromtimestamp(item.get('timestamp1', '')/1000).strftime('%Y-%m-%d %H:%M:%S')
-                search_query = str(item.get('search-query',''))
-                screenshot_file_path = os.path.join(dir_path, f'{account_name}-{screenshot_id}.jpg')
-                if os.path.exists(screenshot_file_path):
-                    shutil.copy2(screenshot_file_path, report_folder)
-                img_html = '<a href="{1}/{0}"><img src="{1}/{0}" class="img-fluid" style="max-height:600px; min-width:300px" title="{0}"></a>'.format(f'{account_name}-{screenshot_id}.jpg', folder_name)
-                
-                platform = is_platform_windows()
-                if platform:
-                    img_html = img_html.replace('?', '')
-                
-                recursive_convert_bytes_to_str(item) # convert all 'bytes' to str
-                data_list.append((search_timestamp,screenshot_file_path,search_query,img_html, '<pre id="json" style="font-size: 110%">'+ escape(json.dumps(item, indent=4)).replace('\\n', '<br>') +'</pre>'))
-
-        report.write_artifact_data_table(data_headers, data_list, dir_path, html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = f'google quick search box recent'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc('No recent quick search or now data available')
+    data_headers = (('Timestamp', 'datetime'), 'Search Query', ('Screenshot', 'media'),
+                    'Protobuf Data', 'Source File')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts the two Google Quick Search Box artifacts to LAVA `@artifact_processor`.

**googleQuickSearchbox** (`get_quicksearch`)
- Single LAVA table (was an `ArtifactHtmlReport`).
- MP3 voice-response audio migrated from writing an `.mp3` to the report folder + an `<audio>` tag to `check_in_embedded_media` (the audio bytes live in the protobuf, not as a standalone file).
- File-modification timestamp converted to timezone-aware UTC (`datetime` column).
- `/mirror/` magisk-duplicate skip normalized so it works on Windows backslash paths.

**googleQuickSearchboxRecent** (`get_quicksearch_recent`)
- Single LAVA table (was an `ArtifactHtmlReport`).
- Per-item screenshot migrated from `shutil.copy2` + inline `<img>` to `check_in_media`, matched by `{account}-{id}.jpg` against `files_found` (no more manual copy into the report folder).
- `timestamp1` (ms) converted to aware UTC.
- Decoded protobuf payload retained as a plain-text column for forensic completeness.

Verification: both compile; column names clear the SQL-reserved-word audit; pylint clean (`-d C,R`); PluginLoader loads 492 incl. both functions; names unique.