### PR TITLE
Fix teleguard Messages media: skip cache dirs, drop unresolved refs (LAVA crash)

### DIFF
--- a/scripts/artifacts/teleguard.py
+++ b/scripts/artifacts/teleguard.py
@@ -111,11 +111,26 @@ def get_teleguard(files_found, report_folder, seeker, wrap_text):
             except (ValueError, TypeError):
                 files = {}
             for key in files:
-                match = next((str(f) for f in files_found if key in str(f)), None)
+                # The metadata key is a path fragment: TeleGuard stores each item
+                # under cache/<key>/<file>, so match by substring. Require an actual
+                # file so the cache/<key> directory itself is never matched -- a
+                # directory makes check_in_media return None, and a None -> null in
+                # the serialized media list makes the LAVA viewer show a broken-media
+                # marker and crash on hover (the HTML report silently skips it).
+                match = next((str(f) for f in files_found
+                              if os.path.isfile(str(f)) and key in str(f)), None)
                 if match:
-                    media_refs.append(check_in_media(match, os.path.basename(match)))
+                    ref = check_in_media(match, os.path.basename(match))
+                    if ref:
+                        media_refs.append(ref)
+        if len(media_refs) == 1:
+            media_cell = media_refs[0]
+        elif media_refs:
+            media_cell = media_refs
+        else:
+            media_cell = ''
         data_list.append((_str_to_utc(row[0]), _str_to_utc(row[1]), row[2], row[3], row[4], row[5],
-                          media_refs if media_refs else '', row[6], row[7], row[8]))
+                          media_cell, row[6], row[7], row[8]))
 
     data_headers = (('Timestamp', 'datetime'), ('User Time', 'datetime'), 'Type', 'Sender', 'Receiver',
                     'Content', ('Media', 'media'), 'Metadata', 'Status', 'Is Edited?')


### PR DESCRIPTION
Bug reported while testing the converted **Teleguard - Messages** artifact in LAVA: the Media column showed a red broken-media marker and the viewer crashed (black screen) on hover, even though the images rendered fine in the HTML report.

**Root cause**
The media matcher used a loose substring match (`key in str(f)`). TeleGuard stores each attachment at `cache/<key>/<file>`, so the metadata `key` is a *sub-path*, and the substring also matched the `cache/<key>` **directory**. `check_in_media()` returns `None` for a directory, and that `None` was appended into the media list. `lava_insert_sqlite_data` `json.dumps`'s a list cell, so it became `["validref", null]`; the LAVA viewer chokes on the `null` (broken marker + crash on hover). The HTML path (`get_data_list_with_media`) silently skips unresolved refs, which is why it only reproduced in LAVA.

**Fix**
- Require `os.path.isfile` on the match, so the `cache/<key>` directory is never selected.
- Only append the ref `if check_in_media(...)` returned one (no `None` in the cell).
- Collapse a single-attachment message to a bare ref (renders like any other single-media cell); keep a list only for genuine multi-attachment messages.

Kept the substring match itself (not exact-basename) because the key is a sub-path, not a filename — exact-basename matches nothing and the media goes N/A.

**Verification**
- Fixture test on a real `teleguard_database.db` modelling the `cache/<key>/<file>` layout (inner basename != key) with the cache directories present in `files_found`: resolves the inner file, skips both directories, never emits `None`, single attachment → bare ref, missing/text rows → empty.
- pylint clean (`-d C,R`); PluginLoader loads 492.
- Reporter confirmed images now render in both the HTML report and the LAVA Media column, no crash.