### PR TITLE
Harden media-list None handling in FairEmail, SamsungNotes, gmailIMAPEmails

### DIFF
--- a/scripts/artifacts/FairEmail.py
+++ b/scripts/artifacts/FairEmail.py
@@ -213,19 +213,34 @@ def get_fair_mail_messages(files_found, _report_folder, _seeker, _wrap_text):
         seen = row[16]
         # check if the mail has attachments, if yes - add them
         # Also inline Attachemts are linked
-        if row[19] is None:
-            attachment = 0
-        else:
-            attachment = []
+        attachment = ''
+        if row[19] is not None:
+            # Require an actual file so a matched directory is never passed to
+            # check_in_media (which returns None for a directory), and only append a
+            # truthy ref so no None lands in the media list -- a None serialized to
+            # null in the json.dumps'd media cell crashes the LAVA viewer on hover.
+            attachment_refs = []
             for att_path in attachments:
+                if not os.path.isfile(att_path):
+                    continue
                 for att_id in row[19].split(','):
                     if str(att_id) in os.path.basename(att_path):
-                        attachment.append(check_in_media(att_path, os.path.basename(att_path)))
+                        ref = check_in_media(att_path, os.path.basename(att_path))
+                        if ref:
+                            attachment_refs.append(ref)
+            if len(attachment_refs) == 1:
+                attachment = attachment_refs[0]
+            elif attachment_refs:
+                attachment = attachment_refs
         infrastructure = row[18]
         for path in messages:
+            if not os.path.isfile(path):
+                continue
             try:
                 if int(os.path.basename(path)) == message_id:
-                    content = check_in_media(path, os.path.basename(path))
+                    ref = check_in_media(path, os.path.basename(path))
+                    if ref:
+                        content = ref
                     
             except ValueError:
                 continue

--- a/scripts/artifacts/SamsungNotes.py
+++ b/scripts/artifacts/SamsungNotes.py
@@ -70,10 +70,22 @@ def snotes(files_found, _report_folder, _seeker, _wrap_text):
         last_opened = convert_unix_ts_to_utc(int(row[8])/1000)
         file_path = row[9]
 
-        media = []
+        # Require an actual file so a matched directory is never passed to
+        # check_in_media (which returns None for a directory), and only keep truthy
+        # refs so no None lands in the media list -- a None serialized to null in
+        # the json.dumps'd media cell crashes the LAVA viewer on hover.
+        media_refs = []
         for media_path in medias:
-            if os.path.basename(file_path) in media_path:
-                media.append(check_in_media(media_path, os.path.basename(media_path)))
+            if os.path.isfile(media_path) and os.path.basename(file_path) in media_path:
+                ref = check_in_media(media_path, os.path.basename(media_path))
+                if ref:
+                    media_refs.append(ref)
+        if len(media_refs) == 1:
+            media = media_refs[0]
+        elif media_refs:
+            media = media_refs
+        else:
+            media = ''
 
         data_list.append((  created,
                             last_modified,

--- a/scripts/artifacts/gmailIMAPEmails.py
+++ b/scripts/artifacts/gmailIMAPEmails.py
@@ -121,8 +121,10 @@ def gmailIMAPEmails(files_found, _report_folder, _seeker, _wrap_text):
                     if (row_a[4] is None):
                         # Received Attachment */data/com.google.android.gm/databases/*.db_att/*.*
                         for rAttach in attachRecv_list:
-                            if (((os.path.basename(rAttach)) == f'{attachmentID}') and ((os.path.basename(os.path.dirname(rAttach))) == f'{accountID}.db_att')):
-                                AttachmentPaths.append(check_in_media(rAttach, row_a[2]))
+                            if (os.path.isfile(rAttach) and ((os.path.basename(rAttach)) == f'{attachmentID}') and ((os.path.basename(os.path.dirname(rAttach))) == f'{accountID}.db_att')):
+                                ref = check_in_media(rAttach, row_a[2])
+                                if ref:
+                                    AttachmentPaths.append(ref)
                     else:
                         # Sent Attachment /data/com.google.android.gm/cache/*.attachment
                         uri = row_a[4]
@@ -137,10 +139,22 @@ def gmailIMAPEmails(files_found, _report_folder, _seeker, _wrap_text):
                             fileName = os.path.basename(filePath).replace(":", "_")
                             
                             for sAttach in attachSent_list:
-                                if ((os.path.basename(sAttach)) == fileName):
-                                    AttachmentPaths.append(check_in_media(sAttach, row_a[2]))
+                                if (os.path.isfile(sAttach) and ((os.path.basename(sAttach)) == fileName)):
+                                    ref = check_in_media(sAttach, row_a[2])
+                                    if ref:
+                                        AttachmentPaths.append(ref)
                            
-            data_list.append((row[0], row[1], row[2], tBody, hBody, row[3], row[4], row[5], row[6], row[7], row[8], row[9], AttachmentPaths, row[11], emailProviderDB))
+            # Collapse to a bare ref for a single attachment, list for several, and
+            # '' when none resolved -- mirrors the other media artifacts. The None
+            # guards above keep any unresolved ref (which the LAVA viewer chokes on)
+            # out of the list.
+            if len(AttachmentPaths) == 1:
+                attachment_cell = AttachmentPaths[0]
+            elif AttachmentPaths:
+                attachment_cell = AttachmentPaths
+            else:
+                attachment_cell = ''
+            data_list.append((row[0], row[1], row[2], tBody, hBody, row[3], row[4], row[5], row[6], row[7], row[8], row[9], attachment_cell, row[11], emailProviderDB))
 
     data_headers = (('Timestamp','datetime'),'_id','Snippet', 'Body(TXT)', 'Body(HTML)', 'Recipient','Reply To','Subject Line','Mailed By','Signed by', 'Read', 'AttachmentFlag', ('Attachments', 'media'), 'Mailbox Folder', 'Source File')
     return data_headers, data_list, 'See source file(s) below:'


### PR DESCRIPTION
Hardens three more LAVA media columns against the same `None`-in-a-media-list crash just fixed for **Teleguard - Messages** (#858).

**Root cause**
`check_in_media(path, name)` returns `None` when `path` does not resolve to a checked-in file in the current artifact's `files_found` — e.g. the loose match landed on a **directory**, or the file is missing. That `None` was appended straight into a media-typed list column. `lava_insert_sqlite_data` `json.dumps`'s a list cell, so it serialized to e.g. `["validref", null]`; the LAVA viewer parses the array, hits the `null`, shows a red broken-media marker and crashes (black screen) on hover. The HTML path (`get_data_list_with_media`) silently skips unresolved refs, so this only reproduced in LAVA.

**Fix** (per artifact, mirroring #858)
- Capture the ref first and append **only when truthy** — no `None` ever lands in the media list.
- Require `os.path.isfile(...)` on the loose path match, so a directory is never passed to `check_in_media`.
- Collapse a single resolved ref to a bare value (a list only for genuine multi-attachment cells, `''` when none resolve), so single-media cells render like every other artifact.
- No change to *which* files are matched.

**Files**
- `scripts/artifacts/FairEmail.py` — `('Attachments','media')` and `('Content','media')` columns. Also replaces the stray `0` sentinel previously written into the Attachments media cell when a message had no attachments.
- `scripts/artifacts/SamsungNotes.py` — `('Media','media')` column.
- `scripts/artifacts/gmailIMAPEmails.py` — `('Attachments','media')` column (both the received `.db_att` and sent `.attachment` match paths).

**Verification**
- `py_compile` clean on all three.
- pylint `-d C,R` → 10.00/10 (only the expected `E0401` import-errors, ignored).
- `PluginLoader()` loads **492** plugins — identical to `main`, no module dropped, no load warnings for the three modules.
