### PR TITLE
Drop legacy ArtifactHtmlReport from 7 Chromium artifacts

### DIFF
--- a/scripts/artifacts/chromeBookmarks.py
+++ b/scripts/artifacts/chromeBookmarks.py
@@ -19,8 +19,7 @@ import datetime
 import json
 import os
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, get_next_unused_name, lava_process_artifact, lava_insert_sqlite_data, artifact_processor
+from scripts.ilapfuncs import logfunc, artifact_processor
 from scripts.artifacts.chrome import get_browser_name
 
 
@@ -76,24 +75,6 @@ def get_chromeBookmarks(files_found, report_folder, seeker, wrap_text):
                                 children_items = list()
 
         if len(data_list) > 0:
-            report_name = f'{browser_name} - Bookmarks'
-            report = ArtifactHtmlReport(report_name)
-            # check for existing and get next name for report file, so report from another file does not get overwritten
-            report_path = os.path.join(report_folder, f'{report_name}.temphtml')
-            report_path = get_next_unused_name(report_path)[:-9]  # remove .temphtml
-            report.start_artifact_report(report_folder, os.path.basename(report_path))
-            report.add_script()
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-
-            # Per-browser LAVA table
-            category = "Chromium"
-            module_name = "get_chromeBookmarks"
-            table_name, object_columns, column_map = lava_process_artifact(
-                category, module_name, report_name, lava_data_headers, len(data_list))
-            lava_insert_sqlite_data(table_name, data_list, object_columns, lava_data_headers, column_map)
-
-            # Add the browser name column and accumulate for the combined output
             data_list = [row + (browser_name,) for row in data_list]
             all_data.extend(data_list)
         else:

--- a/scripts/artifacts/chromeCookies.py
+++ b/scripts/artifacts/chromeCookies.py
@@ -18,8 +18,7 @@ __artifacts_v2__ = {
 import os
 import textwrap
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, get_next_unused_name, open_sqlite_db_readonly, lava_process_artifact, lava_insert_sqlite_data, artifact_processor, convert_human_ts_to_utc
+from scripts.ilapfuncs import logfunc, open_sqlite_db_readonly, artifact_processor, convert_human_ts_to_utc
 from scripts.artifacts.chrome import get_browser_name
 
 
@@ -95,21 +94,6 @@ def get_chromeCookies(files_found, report_folder, seeker, wrap_text):
                     data_list.append((convert_human_ts_to_utc(row[0]),row[1],(textwrap.fill(row[2], width=50)),row[3],convert_human_ts_to_utc(row[4]),convert_human_ts_to_utc(row[5]),row[6]))
                 else:
                     data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],row[3],convert_human_ts_to_utc(row[4]),convert_human_ts_to_utc(row[5]),row[6]))
-
-            report_name = f'{browser_name} - Cookies'
-            report = ArtifactHtmlReport(report_name)
-            report_path = os.path.join(report_folder, f'{report_name}.temphtml')
-            report_path = get_next_unused_name(report_path)[:-9]  # remove .temphtml
-            report.start_artifact_report(report_folder, os.path.basename(report_path))
-            report.add_script()
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-
-            category = "Chromium"
-            module_name = "get_chromeCookies"
-            table_name, object_columns, column_map = lava_process_artifact(
-                category, module_name, report_name, lava_data_headers, len(data_list))
-            lava_insert_sqlite_data(table_name, data_list, object_columns, lava_data_headers, column_map)
 
             data_list = [row + (browser_name,) for row in data_list]
             all_data.extend(data_list)

--- a/scripts/artifacts/chromeDIPS.py
+++ b/scripts/artifacts/chromeDIPS.py
@@ -18,10 +18,8 @@ __artifacts_v2__ = {
 # Thanks to Ryan Benson for awareness https://github.com/obsidianforensics/hindsight/pull/146/commits/015ee189c97c0a4e48deb59568dfe4f536ace8aa
 
 import datetime
-import os
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, get_next_unused_name, lava_process_artifact, lava_insert_sqlite_data, artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import logfunc, artifact_processor, open_sqlite_db_readonly
 from scripts.artifacts.chrome import get_browser_name
 
 
@@ -104,24 +102,6 @@ def get_chromeDIPS(files_found, report_folder, seeker, wrap_text):
                               _webkit_to_utc(row[7]), _webkit_to_utc(row[8])))
 
         if len(data_list) > 0:
-            description = 'DIPS - Incidental parties are sites without meaningful user interactions, such as bounce trackers'
-            report_name = f'{browser_name} - Detect Incidental Party State'
-            report = ArtifactHtmlReport(report_name)
-            report_path = os.path.join(report_folder, f'{report_name}.temphtml')
-            report_path = get_next_unused_name(report_path)[:-9]  # remove .temphtml
-            report.start_artifact_report(report_folder, os.path.basename(report_path), description)
-            report.add_script()
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-
-            # Per-browser LAVA table
-            category = "Chromium"
-            module_name = "get_chromeDIPS"
-            table_name, object_columns, column_map = lava_process_artifact(
-                category, module_name, report_name, lava_data_headers, len(data_list))
-            lava_insert_sqlite_data(table_name, data_list, object_columns, lava_data_headers, column_map)
-
-            # Add the browser name column and accumulate for the combined output
             data_list = [row + (browser_name,) for row in data_list]
             all_data.extend(data_list)
         else:

--- a/scripts/artifacts/chromeLoginData.py
+++ b/scripts/artifacts/chromeLoginData.py
@@ -21,8 +21,7 @@ import re
 
 from Crypto.Cipher import AES
 from Crypto.Protocol.KDF import PBKDF2
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, get_next_unused_name, open_sqlite_db_readonly, lava_process_artifact, lava_insert_sqlite_data, artifact_processor, convert_human_ts_to_utc
+from scripts.ilapfuncs import logfunc, open_sqlite_db_readonly, artifact_processor, convert_human_ts_to_utc
 from scripts.artifacts.chrome import get_browser_name
 
 
@@ -112,21 +111,6 @@ def get_chromeLoginData(files_found, report_folder, seeker, wrap_text):
                     password = decrypt(password_enc).decode("utf-8", 'replace')
                 valid_date = get_valid_date(row[2], row[3])
                 data_list.append((convert_human_ts_to_utc(valid_date), row[0], password, row[4], row[5]))
-
-            report_name = f'{browser_name} - Login Data'
-            report = ArtifactHtmlReport(report_name)
-            report_path = os.path.join(report_folder, f'{report_name}.temphtml')
-            report_path = get_next_unused_name(report_path)[:-9]  # remove .temphtml
-            report.start_artifact_report(report_folder, os.path.basename(report_path))
-            report.add_script()
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-
-            category = "Chromium"
-            module_name = "get_chromeLoginData"
-            table_name, object_columns, column_map = lava_process_artifact(
-                category, module_name, report_name, lava_data_headers, len(data_list))
-            lava_insert_sqlite_data(table_name, data_list, object_columns, lava_data_headers, column_map)
 
             data_list = [row + (browser_name,) for row in data_list]
             all_data.extend(data_list)

--- a/scripts/artifacts/chromeNetworkActionPredictor.py
+++ b/scripts/artifacts/chromeNetworkActionPredictor.py
@@ -15,10 +15,7 @@ __artifacts_v2__ = {
     }
 }
 
-import os
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, get_next_unused_name, open_sqlite_db_readonly, lava_process_artifact, lava_insert_sqlite_data, artifact_processor
+from scripts.ilapfuncs import logfunc, open_sqlite_db_readonly, artifact_processor
 from scripts.artifacts.chrome import get_browser_name
 
 
@@ -61,21 +58,6 @@ def get_chromeNetworkActionPredictor(files_found, report_folder, seeker, wrap_te
             data_list = []
             for row in all_rows:
                 data_list.append((row[0],row[1],row[2],row[3]))
-
-            report_name = f'{browser_name} - Network Action Predictor'
-            report = ArtifactHtmlReport(report_name)
-            report_path = os.path.join(report_folder, f'{report_name}.temphtml')
-            report_path = get_next_unused_name(report_path)[:-9]  # remove .temphtml
-            report.start_artifact_report(report_folder, os.path.basename(report_path))
-            report.add_script()
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-
-            category = "Chromium"
-            module_name = "get_chromeNetworkActionPredictor"
-            table_name, object_columns, column_map = lava_process_artifact(
-                category, module_name, report_name, lava_data_headers, len(data_list))
-            lava_insert_sqlite_data(table_name, data_list, object_columns, lava_data_headers, column_map)
 
             data_list = [row + (browser_name,) for row in data_list]
             all_data.extend(data_list)

--- a/scripts/artifacts/chromeOfflinePages.py
+++ b/scripts/artifacts/chromeOfflinePages.py
@@ -18,8 +18,7 @@ __artifacts_v2__ = {
 import os
 import textwrap
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, get_next_unused_name, open_sqlite_db_readonly, lava_process_artifact, lava_insert_sqlite_data, artifact_processor, convert_human_ts_to_utc
+from scripts.ilapfuncs import logfunc, open_sqlite_db_readonly, artifact_processor, convert_human_ts_to_utc
 from scripts.artifacts.chrome import get_browser_name
 
 
@@ -69,21 +68,6 @@ def get_chromeOfflinePages(files_found, report_folder, seeker, wrap_text):
                     data_list.append((convert_human_ts_to_utc(row[0]),convert_human_ts_to_utc(row[1]),(textwrap.fill(row[2], width=75)),row[3],row[4],row[5],row[6]))
                 else:
                     data_list.append((convert_human_ts_to_utc(row[0]),convert_human_ts_to_utc(row[1]),row[2],row[3],row[4],row[5],row[6]))
-
-            report_name = f'{browser_name} - Offline Pages'
-            report = ArtifactHtmlReport(report_name)
-            report_path = os.path.join(report_folder, f'{report_name}.temphtml')
-            report_path = get_next_unused_name(report_path)[:-9]  # remove .temphtml
-            report.start_artifact_report(report_folder, os.path.basename(report_path))
-            report.add_script()
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-
-            category = "Chromium"
-            module_name = "get_chromeOfflinePages"
-            table_name, object_columns, column_map = lava_process_artifact(
-                category, module_name, report_name, lava_data_headers, len(data_list))
-            lava_insert_sqlite_data(table_name, data_list, object_columns, lava_data_headers, column_map)
 
             data_list = [row + (browser_name,) for row in data_list]
             all_data.extend(data_list)

--- a/scripts/artifacts/chromeTopSites.py
+++ b/scripts/artifacts/chromeTopSites.py
@@ -17,8 +17,7 @@ __artifacts_v2__ = {
 
 import os
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, get_next_unused_name, open_sqlite_db_readonly, lava_process_artifact, lava_insert_sqlite_data, artifact_processor
+from scripts.ilapfuncs import logfunc, open_sqlite_db_readonly, artifact_processor
 from scripts.artifacts.chrome import get_browser_name
 
 
@@ -64,21 +63,6 @@ def get_chromeTopSites(files_found, report_folder, seeker, wrap_text):
             data_list = []
             for row in all_rows:
                 data_list.append((row[0],row[1],row[2],row[3]))
-
-            report_name = f'{browser_name} - Top Sites'
-            report = ArtifactHtmlReport(report_name)
-            report_path = os.path.join(report_folder, f'{report_name}.temphtml')
-            report_path = get_next_unused_name(report_path)[:-9]  # remove .temphtml
-            report.start_artifact_report(report_folder, os.path.basename(report_path))
-            report.add_script()
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-
-            category = "Chromium"
-            module_name = "get_chromeTopSites"
-            table_name, object_columns, column_map = lava_process_artifact(
-                category, module_name, report_name, lava_data_headers, len(data_list))
-            lava_insert_sqlite_data(table_name, data_list, object_columns, lava_data_headers, column_map)
 
             data_list = [row + (browser_name,) for row in data_list]
             all_data.extend(data_list)


### PR DESCRIPTION
Removes the legacy `ArtifactHtmlReport` dependency from seven Chromium artifacts that were in a hybrid state.

**The hybrid problem**
Each of these was already `@artifact_processor`-decorated and returned a consolidated result (all browsers + a `Browser Name` discriminator column). But inside the loop they *also* redundantly:
- built a per-browser `ArtifactHtmlReport` (with `get_next_unused_name`/`.temphtml` dynamic naming), and
- made manual `lava_process_artifact` + `lava_insert_sqlite_data` calls creating a separate per-browser LAVA table.

The `@artifact_processor` wrapper (`scripts/ilapfuncs.py`) already generates HTML, TSV, timeline, and LAVA from the returned `(data_headers, data_list, source_path)`. So the manual blocks just produced **duplicate** per-browser tables/reports alongside the consolidated one.

**Change**
Removed the redundant per-browser report + manual LAVA blocks (and now-unused imports) from:
`chromeNetworkActionPredictor`, `chromeTopSites`, `chromeOfflinePages`, `chromeBookmarks`, `chromeCookies`, `chromeDIPS`, `chromeLoginData`.

Each now emits a single consolidated LAVA table + HTML report with the `Browser Name` column — the standard consolidation pattern. **No change** to parsing, SQL, timestamp conversion, or the returned data.

**Verification**
- All 7 compile; pylint clean (`-d C,R`); no leftover `ArtifactHtmlReport`/`lava_process_artifact`/`lava_insert_sqlite_data`/`get_next_unused_name` references.
- PluginLoader loads 494 with all 7 functions present.