### PR TITLE
Convert FCMQueuedMessagesTwitter to artifact_processor

### DIFF
--- a/scripts/artifacts/FCMQueuedMessagesTwitter.py
+++ b/scripts/artifacts/FCMQueuedMessagesTwitter.py
@@ -1,21 +1,4 @@
-# pylint: disable=W0611,W0613
-__artifacts_v2__ = {
-    "get_fcm_twitter": {
-        "name": "FCM_Twitter",
-        "description": "",
-        "author": "",
-        "creation_date": "2022-07-28",
-        "last_update_date": "2022-07-28",
-        "requirements": "none",
-        "category": "Firebase Cloud Messaging",
-        "notes": "",
-        "paths": ('*/fcm_queued_messages.ldb/*',),
-        "output_types": None,
-        "artifact_icon": "database",
-        "function": "get_fcm_twitter",
-    }
-}
-
+# pylint: disable=W0613
 """
 Copyright 2022, CCL Forensics
 
@@ -37,120 +20,94 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
+__artifacts_v2__ = {
+    "get_fcm_twitter": {
+        "name": "FCM - Twitter DMs",
+        "description": "Twitter direct messages recovered from the fcm_queued_messages.ldb leveldb",
+        "author": "Alex Caithness (research [at] cclsolutionsgroup.com)",
+        "creation_date": "2022-07-28",
+        "last_update_date": "2022-07-28",
+        "requirements": "none",
+        "category": "Firebase Cloud Messaging",
+        "notes": "",
+        "paths": ('*/fcm_queued_messages.ldb/*',),
+        "output_types": "standard",
+        "artifact_icon": "message-square",
+    }
+}
 
-import sys
-import pathlib
 import datetime
 import json
-from scripts.ccl.ccl_android_fcm_queued_messages import FcmRecord, FcmIterator
-from scripts.artifact_report import ArtifactHtmlReport
-import scripts.ilapfuncs
+import pathlib
 
-__version__ = "0.4.0"
-__description__ = """
-Reads records from the fcm_queued_messages.ldb leveldb in com.google.android.gms related to com.twitter.android 
-(currently only direct messages)"""
-__contact__ = "Alex Caithness (research [at] cclsolutionsgroup.com)"
-
-EPOCH = datetime.datetime(1970, 1, 1)
+from scripts.ccl.ccl_android_fcm_queued_messages import FcmIterator
+from scripts.ilapfuncs import artifact_processor, logfunc
 
 
-def unix_ms(ms: int):
-    return EPOCH + datetime.timedelta(milliseconds=ms)
+def _unix_ms(ms):
+    try:
+        return datetime.datetime.fromtimestamp(int(ms) / 1000, datetime.timezone.utc)
+    except (ValueError, TypeError, OverflowError, OSError):
+        return ''
 
 
-def process_dm(rec: FcmRecord):
+def _process_dm(rec):
     user_obj = json.loads(rec.key_values["users"])
-    notification_data = json.loads(rec.key_values["notification_event_data"])
+    msg = json.loads(rec.key_values["notification_event_data"])["message"]["message_data"]
     sender = f"{user_obj['sender']['screen_name']} ({user_obj['sender']['id']})"
     recipient = f"{user_obj['recipient']['screen_name']} ({user_obj['recipient']['id']})"
-    timestamp = unix_ms(int(notification_data["message"]["message_data"]["time"]))
-    text = notification_data["message"]["message_data"]["text"]
-
-    conversation_key = tuple([user_obj['sender']['id'], user_obj['recipient']['id']])
-
-    other_party = user_obj['sender']
+    conv_key = f"{user_obj['sender']['id']}, {user_obj['recipient']['id']}"
+    other_party = json.dumps(user_obj['sender'], ensure_ascii=False)
 
     entities = []
-    if "entities" in notification_data["message"]["message_data"]:
-        entity_details = notification_data["message"]["message_data"]["entities"]
-        hash_tags = entity_details.get("hashtags")
-        symbols = entity_details.get("symbols")
-        user_mentions = entity_details.get("user_mentions")
-        urls = entity_details.get("urls")
+    if "entities" in msg:
+        for url in msg["entities"].get("urls") or []:
+            entities.append(f"Url: {url['url']} (Expanded: {url['expanded_url']})")
+        for label, key in (("Hashtags", "hashtags"), ("Symbols", "symbols"),
+                           ("User mentions", "user_mentions")):
+            if msg["entities"].get(key):
+                logfunc(f"Twitter FCM: {label} present in DMs, not currently processed")
 
-        if hash_tags:
-            scripts.ilapfuncs.logfunc("Hashtags present in DMs, these are not currently processed")
-        if symbols:
-            scripts.ilapfuncs.logfunc("Symbols present in DMs, these are not currently processed")
-        if user_mentions:
-            scripts.ilapfuncs.logfunc("User mentions present in DMs, these are not currently processed")
-        if urls:
-            for url in urls:
-                entities.append(f"Url: {url['url']} (Expanded: {url['expanded_url']})")
+    attachments = []
+    for att_key, att_item in (msg.get("attachment") or {}).items():
+        if att_key == "card":
+            attachments.extend([
+                f"URL: {att_item['url']}",
+                f"URL Title: {att_item['binding_values']['title']['string_value']}",
+                f"URL Description: {att_item['binding_values']['description']['string_value']}"])
+        elif att_key == "photo":
+            attachments.extend([
+                f"Photo ID: {att_item['id']}",
+                f"Photo Media URL: {att_item['media_url']}",
+                f"Photo URL: {att_item['url']} (Expanded: {att_item['expanded_url']})",
+                f"Photo Dimensions: {att_item['original_info']['width']}, {att_item['original_info']['height']}"])
+        else:
+            logfunc(f"Twitter FCM: unknown attachment type {att_key} in DMs")
 
-    attachment_details = []
-    if "attachment" in notification_data["message"]["message_data"]:
-        attachment = notification_data["message"]["message_data"]["attachment"]
-        for att_key, att_item in attachment.items():
-            if att_key == "card":
-                attachment_details.extend([
-                    f"URL: {att_item['url']}",
-                    f"URL Title: {att_item['binding_values']['title']['string_value']}",
-                    f"URL Description: {att_item['binding_values']['description']['string_value']}",
-                ])
-            elif att_key == "photo":
-                attachment_details.extend([
-                    f"Photo ID: {att_item['id']}",
-                    f"Photo Media URL: {att_item['media_url']}",
-                    f"Photo URL: {att_item['url']} (Expanded: {att_item['expanded_url']})",
-                    f"Photo Dimensions: {att_item['original_info']['width']}, {att_item['original_info']['height']}"
-                ])
-            else:
-                # print(att_key, att_item)
-                scripts.ilapfuncs.logfunc(f"Unknown attachment type {att_key} in DMs, please contact the developer")
-
-    return conversation_key, other_party, (sender, recipient, timestamp, text, entities, attachment_details)
+    return (conv_key, other_party, sender, recipient, _unix_ms(msg["time"]), msg.get("text", ""),
+            "; ".join(entities), "; ".join(attachments))
 
 
+@artifact_processor
 def get_fcm_twitter(files_found, report_folder, seeker, wrap_text):
-    channels = set()
-
-    in_dirs = set(pathlib.Path(x).parent for x in files_found)
-    rows = []
-    data_headers = [
-        "Conversation Key", "Other party", "Sender", "Recipient", "Timestamp", "Text", "Entities", "Attachments"
-    ]
-
+    in_dirs = set(pathlib.Path(str(x)).parent for x in files_found)
+    source = " ".join(str(x) for x in in_dirs)
+    data_list = []
     for in_db_path in in_dirs:
-        with FcmIterator(in_db_path) as record_iterator:
-            for rec in record_iterator:
-                if rec.package == "com.twitter.android":
-                    if "channel" not in rec.key_values:
-                        scripts.ilapfuncs.logfunc(f"Record without channel: {rec.key_values}")
+        try:
+            with FcmIterator(in_db_path) as record_iterator:
+                for rec in record_iterator:
+                    if rec.package != "com.twitter.android":
                         continue
-                    channel = rec.key_values["channel"]
+                    if rec.key_values.get("channel") != "dms":
+                        continue
+                    try:
+                        data_list.append(_process_dm(rec))
+                    except (KeyError, ValueError, TypeError) as exc:
+                        logfunc(f"Twitter FCM: could not parse DM record: {exc}")
+        except Exception as exc:  # pylint: disable=W0718
+            logfunc(f"Twitter FCM: error reading {in_db_path}: {exc}")
 
-                    if channel == "dms":
-                        conv_key, other_party, row = process_dm(rec)
-                        rows.append([conv_key, other_party, *row])
-                    else:
-                        channels.add(channel)
-
-    if rows:
-        report = ArtifactHtmlReport("Twitter DM Notifications (Firebase Cloud Messaging Queued Messages)")
-        report_name = "FCM-Twitter DM Notifications"
-        report.start_artifact_report(report_folder, report_name)
-        report.add_script()
-        source_files = " ".join(str(x) for x in in_dirs)
-
-        report.write_artifact_data_table(data_headers, rows, source_files)
-        report.end_artifact_report()
-
-        scripts.ilapfuncs.tsv(report_folder, data_headers, rows, report_name, source_files)
-        scripts.ilapfuncs.timeline(report_folder, report_name, rows, data_headers)
-    else:
-        scripts.ilapfuncs.logfunc("No FCM Twitter DM notifications found")
-
-    scripts.ilapfuncs.logfunc("Un-processed 'channels' (contact R&D if you think these are required for your case):")
-    scripts.ilapfuncs.logfunc("\n".join(channels))
+    data_headers = ('Conversation Key', 'Other Party', 'Sender', 'Recipient',
+                    ('Timestamp', 'datetime'), 'Text', 'Entities', 'Attachments')
+    return data_headers, data_list, source


### PR DESCRIPTION
Converts the standalone Twitter FCM parser to LAVA `@artifact_processor` (no Dump-decoder equivalent exists, so this is additive — it does app-specific DM parsing the generic dump doesn't).

**Change**
- Single consolidated LAVA table of Twitter DM notifications (was an `ArtifactHtmlReport` + manual tsv/timeline).
- `conversation_key` was a Python **tuple**; LAVA's `lava_insert_sqlite_data` only JSON-serializes lists/dicts, so a tuple cell would fail the insert — rendered it to a `"sender_id, recipient_id"` string.
- `other_party` (sender dict) kept as a JSON string; `entities`/`attachments` lists joined with `; `.
- Message `time` (epoch ms) → timezone-aware UTC `datetime` column.
- Per-record parsing wrapped in try/except so one malformed DM logs and is skipped instead of aborting the whole artifact (the original would raise).
- Preserved the CCL MIT license as the module docstring (avoids a pointless-string-statement lint and keeps attribution).

**Verification**
- Compiles; pylint clean (`-d C,R`); column names pass a live `CREATE TABLE` reserved-word check; PluginLoader 493 incl. `get_fcm_twitter`.
- Integration test with a synthetic DM record (fake `FcmIterator`): one 8-column row with string conversation key, `alice (111)` sender, joined URL entity + photo attachment, aware-UTC timestamp.