### PR TITLE
Convert FCMQueuedMessagesXbox to artifact_processor (3-way split)

### DIFF
--- a/scripts/artifacts/FCMQueuedMessagesXbox.py
+++ b/scripts/artifacts/FCMQueuedMessagesXbox.py
@@ -1,21 +1,4 @@
 # pylint: disable=W0613
-__artifacts_v2__ = {
-    "get_fcm_xbox": {
-        "name": "FCM_XBox",
-        "description": "",
-        "author": "",
-        "creation_date": "2022-07-28",
-        "last_update_date": "2022-07-28",
-        "requirements": "none",
-        "category": "Firebase Cloud Messaging",
-        "notes": "",
-        "paths": ('*/fcm_queued_messages.ldb/*',),
-        "output_types": None,
-        "artifact_icon": "database",
-        "function": "get_fcm_xbox",
-    }
-}
-
 """
 Copyright 2022, CCL Forensics
 
@@ -37,132 +20,154 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
+__artifacts_v2__ = {
+    "get_fcm_xbox": {
+        "name": "FCM - Xbox Messages",
+        "description": "Xbox (com.microsoft.xboxone.smartglass) message notifications from fcm_queued_messages.ldb",
+        "author": "Alex Caithness (research [at] cclsolutionsgroup.com)",
+        "creation_date": "2022-07-28",
+        "last_update_date": "2022-07-28",
+        "requirements": "none",
+        "category": "Firebase Cloud Messaging",
+        "notes": "",
+        "paths": ('*/fcm_queued_messages.ldb/*',),
+        "output_types": "standard",
+        "artifact_icon": "message-square",
+    },
+    "get_fcm_xbox_party": {
+        "name": "FCM - Xbox Party Invites",
+        "description": "Xbox party invite notifications from fcm_queued_messages.ldb",
+        "author": "Alex Caithness (research [at] cclsolutionsgroup.com)",
+        "creation_date": "2022-07-28",
+        "last_update_date": "2022-07-28",
+        "requirements": "none",
+        "category": "Firebase Cloud Messaging",
+        "notes": "",
+        "paths": ('*/fcm_queued_messages.ldb/*',),
+        "output_types": "standard",
+        "artifact_icon": "user-plus",
+    },
+    "get_fcm_xbox_presence": {
+        "name": "FCM - Xbox Presence",
+        "description": "Xbox presence notifications from fcm_queued_messages.ldb",
+        "author": "Alex Caithness (research [at] cclsolutionsgroup.com)",
+        "creation_date": "2022-07-28",
+        "last_update_date": "2022-07-28",
+        "requirements": "none",
+        "category": "Firebase Cloud Messaging",
+        "notes": "",
+        "paths": ('*/fcm_queued_messages.ldb/*',),
+        "output_types": "standard",
+        "artifact_icon": "activity",
+    }
+}
 
+import base64
 import datetime
 import json
-import base64
 import pathlib
+
 from scripts.ccl.ccl_android_fcm_queued_messages import FcmIterator
-from scripts.artifact_report import ArtifactHtmlReport
-import scripts.ilapfuncs
+from scripts.ilapfuncs import artifact_processor, logfunc
 
-__version__ = "0.1"
-__description__ = """
-Reads records from the fcm_queued_messages.ldb leveldb in com.google.android.gms related to com.microsoft.xboxone.smartglass"""
-__contact__ = "Alex Caithness (research [at] cclsolutionsgroup.com)"
-
-EXPECTED_PACKAGES = ("com.microsoft.xboxone.smartglass",)
-RUN_PER_PACKAGE = False
-
-EPOCH = datetime.datetime(1970, 1, 1)
+_CACHE = {}
 
 
-def unix_ms(ms):
-    return EPOCH + datetime.timedelta(milliseconds=ms)
+def _to_utc(value):
+    if isinstance(value, datetime.datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=datetime.timezone.utc)
+        return value.astimezone(datetime.timezone.utc)
+    return value if value else ''
 
 
-def process_payload(payload):
+def _unix_ms(ms):
+    try:
+        return datetime.datetime.fromtimestamp(int(ms) / 1000, datetime.timezone.utc)
+    except (ValueError, TypeError, OverflowError, OSError):
+        return ''
+
+
+def _process_payload(payload):
     processed = []
-    for part in payload["parts"]:
-        content_type = part["contentType"]
+    for part in payload.get("parts", []):
+        content_type = part.get("contentType")
         if content_type == "text":
-            processed.append(part["text"])
+            processed.append(part.get("text", ""))
         elif content_type == "image":
             processed.extend([
-                f"<em>Image attachment id: {part['attachmentId']}</em>",
-                f"<em>File type: {part['filetype']}; hash: {base64.b64decode(part['hash']).hex()}; " +
-                f"dimensions: {part['width']}x{part['height']}</em>",
-                f"<em>uri: {part['downloadUri']}</em>"
-            ])
+                f"Image attachment id: {part['attachmentId']}",
+                f"File type: {part['filetype']}; hash: {base64.b64decode(part['hash']).hex()}; "
+                f"dimensions: {part['width']}x{part['height']}",
+                f"uri: {part['downloadUri']}"])
         elif content_type == "deeplink":
-            processed.append(f"<em>Link text: {part['buttonText']}</em>")
+            processed.append(f"Link text: {part['buttonText']}")
             if part.get("appUri"):
-                processed.append(f"<em>App URI: {part['appUri']}</em>")
+                processed.append(f"App URI: {part['appUri']}")
             if part.get("webUri"):
-                processed.append(f"<em>Web URI: {part['webUri']}</em>")
+                processed.append(f"Web URI: {part['webUri']}")
         else:
-            print(part)
-            raise NotImplementedError(f"Not implemented {content_type} in payload parts")
-    return processed
+            logfunc(f"Xbox FCM: unhandled payload content type {content_type}")
+    return "\n".join(processed)
 
 
-def get_fcm_xbox(files_found, report_folder, seeker, wrap_text):
-    in_dirs = set(pathlib.Path(x).parent for x in files_found)
-    message_headers = ["FCM Key", "FCM Timestamp", "Conversation ID", "Message Timestamp", "Sender", "Text", "Content"]
-    message_rows = []
-    party_headers = ["FCM Key", "FCM Timestamp", "Sender"]
-    party_rows = []
-    presence_headers = ["FCM Key", "FCM Timestamp", "User"]
-    presence_rows = []
-
+def _load(files_found):
+    key = tuple(sorted(str(f) for f in files_found))
+    if key in _CACHE:
+        return _CACHE[key]
+    in_dirs = set(pathlib.Path(str(x)).parent for x in files_found)
+    source = " ".join(str(x) for x in in_dirs)
+    messages, parties, presence = [], [], []
     for in_db_path in in_dirs:
-        with FcmIterator(in_db_path) as record_iterator:
-            for rec in record_iterator:
-                if rec.package == "com.microsoft.xboxone.smartglass":
-                    notification_type = rec.key_values["type"]
-                    if notification_type == "MESSAGE":
-                        obj = json.loads(rec.key_values["xbl"])
-                        payload = process_payload(json.loads(obj["messagePayload"]))
-                        message_rows.append([
-                            rec.key,
-                            rec.timestamp,
-                            obj["conversationId"],
-                            unix_ms(obj["timestamp"]),
-                            [obj["senderGamerTag"], obj["senderXuid"]],
-                            obj["text"],
-                            payload
-                        ])
+        try:
+            with FcmIterator(in_db_path) as record_iterator:
+                for rec in record_iterator:
+                    if rec.package != "com.microsoft.xboxone.smartglass":
+                        continue
+                    ntype = rec.key_values.get("type")
+                    try:
+                        if ntype == "MESSAGE":
+                            obj = json.loads(rec.key_values["xbl"])
+                            content = _process_payload(json.loads(obj["messagePayload"]))
+                            messages.append((rec.key, _to_utc(rec.timestamp), obj["conversationId"],
+                                             _unix_ms(obj["timestamp"]),
+                                             f"{obj['senderGamerTag']} ({obj['senderXuid']})",
+                                             obj.get("text", ""), content))
+                        elif ntype == "partyInvite":
+                            obj = json.loads(rec.key_values["xbl"])["invite_handle"]
+                            if obj.get("type") != "invite":
+                                logfunc(f"Xbox FCM: unknown partyInvite type {obj.get('type')}")
+                                continue
+                            parties.append((rec.key, _to_utc(rec.timestamp),
+                                            f"{obj['inviteInfo']['senderUniqueModernGamertag']} ({obj['senderXuid']})"))
+                        elif ntype == "presence":
+                            presence.append((rec.key, _to_utc(rec.timestamp),
+                                             f"{rec.key_values['gamertag']} ({rec.key_values['xuid']})"))
+                    except (KeyError, ValueError, TypeError) as exc:
+                        logfunc(f"Xbox FCM: could not parse {ntype} record: {exc}")
+        except Exception as exc:  # pylint: disable=W0718
+            logfunc(f"Xbox FCM: error reading {in_db_path}: {exc}")
+    _CACHE[key] = (messages, parties, presence, source)
+    return _CACHE[key]
 
-                    elif notification_type == "partyInvite":
-                        obj = json.loads(rec.key_values["xbl"])["invite_handle"]
-                        if obj["type"] != "invite":
-                            raise NotImplementedError("Unknown partyInvite type")
-                        party_rows.append([
-                            rec.key,
-                            rec.timestamp,
-                            f"{obj['inviteInfo']['senderUniqueModernGamertag']} ({obj['senderXuid']})"
-                        ])
-                    elif notification_type == "presence":
-                        presence_rows.append([
-                            rec.key,
-                            rec.timestamp,
-                            f"{rec.key_values['gamertag']} ({rec.key_values['xuid']})"
-                        ])
 
-    source_files = " ".join(str(x) for x in in_dirs)
+@artifact_processor
+def get_fcm_xbox(files_found, report_folder, seeker, wrap_text):
+    messages, _parties, _presence, source = _load(files_found)
+    data_headers = ('FCM Key', ('FCM Timestamp', 'datetime'), 'Conversation ID',
+                    ('Message Timestamp', 'datetime'), 'Sender', 'Text', 'Content')
+    return data_headers, messages, source
 
-    def make_report(title, name, headers, rows):
-        report = ArtifactHtmlReport(title)
-        report_name = name
-        report.start_artifact_report(report_folder, report_name)
-        report.add_script()
 
-        report.write_artifact_data_table(headers, rows, source_files)
-        report.end_artifact_report()
+@artifact_processor
+def get_fcm_xbox_party(files_found, report_folder, seeker, wrap_text):
+    _messages, parties, _presence, source = _load(files_found)
+    data_headers = ('FCM Key', ('FCM Timestamp', 'datetime'), 'Sender')
+    return data_headers, parties, source
 
-        scripts.ilapfuncs.tsv(report_folder, headers, rows, report_name, source_files)
-        scripts.ilapfuncs.timeline(report_folder, report_name, rows, headers)
 
-    if message_rows:
-        make_report(
-            "XBox Message Notifications (Firebase Cloud Messaging Queued Messages)",
-            "FCM-Xbox Message Notifications",
-            message_headers,
-            message_rows
-        )
-    if party_rows:
-        make_report(
-            "XBox Party Invite Notifications (Firebase Cloud Messaging Queued Messages)",
-            "FCM-Xbox Party Invite Notifications",
-            party_headers,
-            party_rows
-        )
-    if presence_rows:
-        make_report(
-            "XBox Presence Notifications (Firebase Cloud Messaging Queued Messages)",
-            "FCM-Xbox Presence Notifications",
-            presence_headers,
-            presence_rows
-        )
-    if not message_rows and not party_rows and not presence_rows:
-        scripts.ilapfuncs.logfunc("No Xbox FCM data found")
+@artifact_processor
+def get_fcm_xbox_presence(files_found, report_folder, seeker, wrap_text):
+    _messages, _parties, presence, source = _load(files_found)
+    data_headers = ('FCM Key', ('FCM Timestamp', 'datetime'), 'User')
+    return data_headers, presence, source


### PR DESCRIPTION
Converts the standalone Xbox FCM parser to LAVA `@artifact_processor` (no Dump-decoder equivalent — additive, app-specific parsing).

**Change**
- The single `ArtifactHtmlReport` emitted **three** tables; split into three artifacts sharing one cached leveldb loader (`_load`): `get_fcm_xbox` (Messages), `get_fcm_xbox_party` (Party Invites), `get_fcm_xbox_presence` (Presence).
- `rec.timestamp` (naive `datetime`) → aware UTC; message-payload `timestamp` (epoch ms) → aware UTC.
- **Sender** was a `[gamertag, xuid]` list (would be JSON-blobbed in LAVA) — flattened to `"gamertag (xuid)"`. **Content** payload rendered to plain text (dropped the `<em>` HTML markup) joined by newlines; image hash still surfaced as hex.
- Both `raise` statements (unknown payload content type / unknown `partyInvite` type) made **defensive** — log and skip instead of aborting the whole artifact.
- Preserved the CCL MIT license as the module docstring.

**Verification**
- Compiles; pylint clean (`-d C,R`); all 3 header sets pass a live `CREATE TABLE` (incl. `user`/`text`/`content`); names unique; PluginLoader 495 with all three functions.
- Integration test with one record of each type (fake `FcmIterator`): Messages row has flattened sender, plain-text content containing the image hash, and both timestamps aware-UTC; Party Invite and Presence rows resolve their gamertag/xuid strings.