### PR TITLE
Fix battery_usage_v9 KeyError on absent protobuf fields; convert to artifact_processor

### DIFF
--- a/scripts/artifacts/battery_usage_v9.py
+++ b/scripts/artifacts/battery_usage_v9.py
@@ -1,20 +1,17 @@
-# pylint: disable=W0311,W0611,W0612,W0613,W0702,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
-
-    
     "get_battery_usage_v9": {
         "name": "Settings Services - Battery Usages v9 - Battery States",
         "description": "Getting Battery Usage data out of the database battery-usage-db-v9. Introduced with Android 14",
         "author": "Marco Neumann {kalinko@be-binary.de}",
         "creation_date": "2024-05-12",
         "last_update_date": "2024-05-12",
-        "requirements": "re",
+        "requirements": "blackboxprotobuf",
         "category": "Settings Services - Battery Usage v9 - Battery States",
         "notes": "Getting battery usage data from Settings Services - Android 14 - Based on post https://bebinary4n6.blogspot.com/2024/05/android-14-battery-usage-and-app-usage.html",
-        "paths": ('*/user_de/*/com.android.settings/databases/battery-usage-db-v9'),
-        "output_types": None,
+        "paths": ('*/user_de/*/com.android.settings/databases/battery-usage-db-v9',),
+        "output_types": "standard",
         "artifact_icon": "battery",
-        "function": "get_battery_usage_v9",
     },
     "get_app_usage_events": {
         "name": "Settings Services - App Battery Usages v9 - App Battery Usage Events",
@@ -22,198 +19,142 @@ __artifacts_v2__ = {
         "author": "Marco Neumann {kalinko@be-binary.de}",
         "creation_date": "2024-05-12",
         "last_update_date": "2024-05-12",
-        "requirements": "re",
+        "requirements": "blackboxprotobuf",
         "category": "Settings Services - Battery Usage v9 - App Battery Usage Events",
         "notes": "Getting App Battery Usage Event from Settings Services - Based on https://bebinary4n6.blogspot.com/2024/05/android-14-battery-usage-and-app-usage.html",
-        "paths": ('*/user_de/*/com.android.settings/databases/battery-usage-db-v9'),
-        "output_types": None,
+        "paths": ('*/user_de/*/com.android.settings/databases/battery-usage-db-v9',),
+        "output_types": "standard",
         "artifact_icon": "battery",
-        "function": "get_app_usage_events",
     }
 }
 
-# Android Settings Services -  Battery Usages v9 (com.android.settings)
-# Author:  Marco Neumann (kalinko@be-binary.de)
-# Version: 0.0.2
-# 
-# Tested with the following versions/devices:
-# 2024-05-19: Android 14 - Fairphone3 and Fairphone 4
-
-
-# Requirements: re, blackboxprotobuf
-import re
-import blackboxprotobuf
 import base64
+import datetime
+import sqlite3
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+import blackboxprotobuf
 
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+
+_STATUS = {2: 'Charging', 3: 'Discharging', 5: 'Fully charged'}
+_HEALTH = {1: 'Unknown', 2: 'Good', 3: 'Overheat', 4: 'Dead', 5: 'Over Voltage',
+           6: 'Unspecified Failure', 7: 'Cold'}
+
+
+def _ms_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
+
+
+def _as_int(value):
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return None
+
+
+def _txt(value):
+    if isinstance(value, bytes):
+        return value.decode('utf-8', 'replace')
+    return value if value is not None else ''
+
+
+def _ms_field(proto, key):
+    '''Optional numeric proto field divided by 1000; '' when the field is absent.'''
+    value = proto.get(key)
+    return value / 1000 if isinstance(value, (int, float)) else ''
+
+
+def _parse_debug(text):
+    out = {}
+    if isinstance(text, bytes):
+        text = text.decode('utf-8', 'replace')
+    for line in (text or '').split('\n'):
+        parts = line.split(':', 1)
+        if len(parts) == 2:
+            out[parts[0].strip()] = parts[1].strip().replace('"', '')
+    return out
+
+
+def _db(files_found):
+    for file_found in files_found:
+        if str(file_found).endswith('battery-usage-db-v9'):
+            return str(file_found)
+    return ''
+
+
+def _run(source_path, sql):
+    if not source_path:
+        return []
+    db = open_sqlite_db_readonly(source_path)
+    cursor = db.cursor()
+    try:
+        cursor.execute(sql)
+        rows = cursor.fetchall()
+    except sqlite3.Error:
+        rows = []
+    db.close()
+    return rows
+
+
+@artifact_processor
 def get_battery_usage_v9(files_found, report_folder, seeker, wrap_text):
-    
-    data_headers = []
+    source_path = _db(files_found)
     data_list = []
-    
-    for file_found in files_found:
-        file_name = str(file_found)
-    
-        if file_name.endswith('battery-usage-db-v9'):
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            cursor.execute('''
-                SELECT 
-                    uid, 
-                    packageName,  
-                    DATETIME(timestamp/1000, 'unixepoch') AS timestamp, 
-                    consumerType,
-                    isFullChargeCycleStart, 
-                    batteryInformation,
-                    batteryInformationDebug
-                    
-                FROM BatteryState
-            ''')
+    rows = _run(source_path, '''
+        SELECT uid, packageName, timestamp, consumerType, isFullChargeCycleStart,
+        batteryInformation, batteryInformationDebug
+        FROM BatteryState
+    ''')
+    for row in rows:
+        try:
+            proto, _ = blackboxprotobuf.decode_message(base64.b64decode(row[5]))
+        except Exception:  # pylint: disable=W0718
+            continue
+        if not isinstance(proto, dict):
+            continue
+        info = proto.get('1') if isinstance(proto.get('1'), dict) else {}
+        debug = _parse_debug(row[6])
+        data_list.append((
+            _ms_to_utc(row[2]),
+            _txt(proto.get('7')),                              # Application label
+            row[1],                                            # Package Name
+            _txt(proto.get('2')),                              # Hidden
+            _ms_field(proto, '3'),                             # Boot Timestamp
+            _txt(proto.get('4')),                              # Timezone
+            debug.get('total_power', 'NOVALUE'),
+            debug.get('consume_power', 'NOVALUE'),
+            _ms_field(proto, '14'),                            # Foreground
+            _ms_field(proto, '20'),                            # Foreground Service (optional - was KeyError)
+            _ms_field(proto, '15'),                            # Background
+            info.get('1', ''),                                 # Battery Level
+            _STATUS.get(_as_int(info.get('2')), 'Unknown'),    # Battery Status
+            _HEALTH.get(_as_int(info.get('3')), 'None'),       # Battery Health
+            _txt(proto.get('13')),                             # Drain Type
+            source_path))
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                
-                for row in all_rows:
-                    # we need to parse the column batteryInformationDebug - a lot of data is in here
-                    battery_info_proto, types = blackboxprotobuf.decode_message(base64.b64decode(row[5]))
-                    app_label = battery_info_proto['7']
-                    is_hidden = battery_info_proto['2']
-                    boot_timestamp = battery_info_proto['3'] / 1000
-                    timezone = battery_info_proto['4']
-                    total_power = 'NOVALUE'
-                    consume_power = 'NOVALUE'
-                    foreground = battery_info_proto['14'] / 1000
-                    foreground_service = battery_info_proto['20'] / 1000
-                    background = battery_info_proto['15'] / 1000
-                    battery_level = battery_info_proto['1']['1']
-                    match int(battery_info_proto['1']['2']):
-                             case 2:
-                                 battery_status= 'Charging'
-                             case 3:
-                                 battery_status = 'Discharging'
-                             case 5:
-                                 battery_status = 'Fully charged'
-                             case _:
-                                 battery_status = 'Unknown'
-                    match int(battery_info_proto['1']['3']):
-                        case 1:
-                            battery_health= 'Unknown'
-                        case 2:
-                            battery_health= 'Good'
-                        case 3:
-                            battery_health = 'Overheat'
-                        case 4:
-                            battery_health = 'Dead'
-                        case 5:
-                            battery_health = 'Over Voltage'
-                        case 6:
-                            battery_health = 'Unspecified Failure'
-                        case 7:
-                            battery_health = 'Cold'
-                        case _:
-                            battery_health = 'None'
-                    drain_type = battery_info_proto['13']
-                    battery_debug = {}
-                    if row[6]:
-                        lines = re.split('\\n', row[6])
-
-                        for line in lines:
-                            try:
-                                key, value =re.split(':', line)
-                                battery_debug[str(key.strip())] =  value.strip().replace('"','')
-                            except:
-                                continue
-                    try:
-                        total_power = battery_debug['total_power']
-                    except:
-                        pass                    
-                    try:
-                        consume_power = battery_debug['consume_power']
-                    except:
-                        pass
-
-                    data_list.append((row[2], app_label, row[1], is_hidden, boot_timestamp, timezone, total_power, consume_power, foreground, foreground_service, background, battery_level, battery_status, battery_health, drain_type, file_found))
-                        
-            
-            db.close()
-        else:
-            continue # Skip all other files (-shm, -wal, etc.)
-    
-    if data_list:
-        description = 'This is battery usage details pulled from Settings Services - new version introduced with Android 14 - Based on https://bebinary4n6.blogspot.com/2024/05/android-14-battery-usage-and-app-usage.html'
-        report = ArtifactHtmlReport('Settings Services - Battery Usage v9 - Battery States')
-        report.start_artifact_report(report_folder, 'Settings Services - Battery Usage v9 - Battery States', description)
-        report.add_script()
-        data_headers = ('Timestamp','Application','Package Name','Hidden','Boot Timestamp','Timezone','Total Power','Consumed Power','Foreground Usage (Seconds)', 'Foreground Service Usage (seconds)', 'Background Usage (Seconds)','Battery Level (%)','Battery Status', 'Battery Health', 'Drain Type', 'Source File') 
-
-        report.write_artifact_data_table(data_headers, data_list, ','.join(files_found))
-        report.end_artifact_report()
-        
-        tsvname = f'Settings Services - Battery Usage v9 - Battery States'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Settings Services - Battery Usage v9 - Battery States'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Settings Services - Battery Usage v9 - Battery States data available')
+    data_headers = (('Timestamp', 'datetime'), 'Application', 'Package Name', 'Hidden',
+                    'Boot Timestamp', 'Timezone', 'Total Power', 'Consumed Power',
+                    'Foreground Usage (Seconds)', 'Foreground Service Usage (seconds)',
+                    'Background Usage (Seconds)', 'Battery Level (%)', 'Battery Status',
+                    'Battery Health', 'Drain Type', 'Source File')
+    return data_headers, data_list, source_path
 
 
+@artifact_processor
 def get_app_usage_events(files_found, report_folder, seeker, wrap_text):
-    
-    data_headers = []
-    data_list = []
-    
-    for file_found in files_found:
-        file_name = str(file_found)
-    
-        if file_name.endswith('battery-usage-db-v9'):
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            cursor.execute('''
-                SELECT 
-                    uid,
-                    userId,
-                    DATETIME(timestamp/1000, 'unixepoch') AS timestamp, 
-                    case appUsageEventType
-                        when 1 then 'Paused'
-                        when 2 then 'Resumed'
-                    end,
-                    packageName,  
-                    taskRootPackageName,
-                    instanceId
-                    
-                FROM AppUsageEventEntity
-            ''')
-
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                
-                for row in all_rows:
-                    data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], file_name))
-                        
-            
-            db.close()
-        else:
-            continue # Skip all other files (-shm, -wal, etc.)
-    
-    if data_list:
-        description = 'This is app battery usage events pulled from Settings Services - Based on https://bebinary4n6.blogspot.com/2024/05/android-14-battery-usage-and-app-usage.html'
-        report = ArtifactHtmlReport('Settings Services - App Battery Usage Events')
-        report.start_artifact_report(report_folder, 'Settings Services - App Battery Usage Events', description)
-        report.add_script()
-        data_headers = ('uid', 'userId', 'Timestamp', 'App Usage Event Type', 'Package Name', 'Root Package Name', 'Instance Id', 'Source File') 
-
-        report.write_artifact_data_table(data_headers, data_list, ','.join(files_found))
-        report.end_artifact_report()
-        
-        tsvname = f'Settings Services - App Battery Usage Events'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = f'Settings Services - App Battery Usage Events'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No Settings Services - App Battery Usage Events data available')
+    source_path = _db(files_found)
+    rows = _run(source_path, '''
+        SELECT uid, userId, timestamp,
+        CASE appUsageEventType WHEN 1 THEN 'Paused' WHEN 2 THEN 'Resumed' END,
+        packageName, taskRootPackageName, instanceId
+        FROM AppUsageEventEntity
+    ''')
+    data_list = [(r[0], r[1], _ms_to_utc(r[2]), r[3], r[4], r[5], r[6], source_path) for r in rows]
+    data_headers = ('uid', 'userId', ('Timestamp', 'datetime'), 'App Usage Event Type',
+                    'Package Name', 'Root Package Name', 'Instance Id', 'Source File')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
**Bug:** while running ALEAPP, `get_battery_usage_v9` aborted with `KeyError: '20'` (`Error was '20'`). A `BatteryState` record whose `batteryInformation` protobuf lacked field `'20'` (foreground-service usage) crashed the whole artifact — and every `battery_info_proto['N']` access was unguarded, so any missing field would do the same.

**Fix + conversion**
- All protobuf field reads are now **defensive**: `_ms_field()` returns blank when an optional numeric field is absent (instead of `proto['20']/1000` raising), `_txt()` handles absent/bytes fields, and the battery status/health lookups guard the `int()` conversion. A record missing a field now yields a row with blanks rather than killing the parser.
- Converted both artifacts (Battery States + App Battery Usage Events) to `@artifact_processor`; SQLite timestamps → aware UTC `datetime`; read-only DB access.
- Fixed the `paths` values, which were a bare parenthesized **string** (no trailing comma) rather than a tuple.

**Verification**
- Compiles; pylint clean (`-d C,R`); both header sets pass a live `CREATE TABLE`; PluginLoader 495 with both functions.
- Fixture test with a real `battery-usage-db-v9`: a **sparse** proto record (missing `'20'`, `'3'`, `'7'`) and a full record both produce rows — the sparse one has blanks for the absent fields (no crash), status/health/total-power resolve correctly, timestamps are aware-UTC, and the app-usage CASE maps to 'Resumed'.