### PR TITLE
Convert FCMQueuedMessagesJungrammer to artifact_processor

### DIFF
--- a/scripts/artifacts/FCMQueuedMessagesJungrammer.py
+++ b/scripts/artifacts/FCMQueuedMessagesJungrammer.py
@@ -1,21 +1,4 @@
 # pylint: disable=W0613
-__artifacts_v2__ = {
-    "get_fcm_jungrammer": {
-        "name": "FCM_Jungrammer",
-        "description": "",
-        "author": "",
-        "creation_date": "2022-07-28",
-        "last_update_date": "2022-07-28",
-        "requirements": "none",
-        "category": "Firebase Cloud Messaging",
-        "notes": "",
-        "paths": ('*/fcm_queued_messages.ldb/*',),
-        "output_types": None,
-        "artifact_icon": "database",
-        "function": "get_fcm_jungrammer",
-    }
-}
-
 """
 Copyright 2022, CCL Forensics
 
@@ -37,164 +20,89 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
+__artifacts_v2__ = {
+    "get_fcm_jungrammer": {
+        "name": "FCM - Jungrammer",
+        "description": "Jungrammer chat-app notifications (kr.jungrammer.*) from fcm_queued_messages.ldb",
+        "author": "Alex Caithness (research [at] cclsolutionsgroup.com)",
+        "creation_date": "2022-07-28",
+        "last_update_date": "2022-07-28",
+        "requirements": "none",
+        "category": "Firebase Cloud Messaging",
+        "notes": "",
+        "paths": ('*/fcm_queued_messages.ldb/*',),
+        "output_types": "standard",
+        "artifact_icon": "message-square",
+    }
+}
 
-import pathlib
 import datetime
-import dataclasses
-from scripts.ccl.ccl_android_fcm_queued_messages import FcmRecord, FcmIterator
-from scripts.artifact_report import ArtifactHtmlReport
-import scripts.ilapfuncs
+import pathlib
 
-__version__ = "0.2.0"
-__description__ = """
-Reads records from the fcm_queued_messages.ldb leveldb in com.google.android.gms related to various kr.jungrammer apps 
-"""
-__contact__ = "Alex Caithness (research [at] cclsolutionsgroup.com)"
+from scripts.ccl.ccl_android_fcm_queued_messages import FcmIterator
+from scripts.ilapfuncs import artifact_processor, logfunc
 
 KNOWN_JUNGRAMMERS = {
     "kr.jungrammer.bluetalk",
     "kr.jungrammer.randomchat",
     "kr.jungrammer.superranchat",
-    "kr.jungrammer.talkchat"
+    "kr.jungrammer.talkchat",
 }
-
-EXPECTED_PACKAGES = tuple(KNOWN_JUNGRAMMERS)
-RUN_PER_PACKAGE = False
+_RELEVANT_TYPES = {"CONNECT", "MESSAGE", "DISCONNECT", "NOTICE"}
 
 
-def might_be_jungrammer_actually(rec: FcmRecord):
-    if rec.package.startswith("kr.jungrammer"):
-        return True
-    if rec.key_values.get("google.c.sender.id") == "717420241212":
-        return True
-    if "fromToken" in rec.key_values:
-        from_token = rec.key_values["fromToken"].split(":")
-        if len(from_token) == 2 and len(from_token[0]) == 22 and len(from_token[1]) == 140:
-            return True
-
-    return False
+def _to_utc(value):
+    if isinstance(value, datetime.datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=datetime.timezone.utc)
+        return value.astimezone(datetime.timezone.utc)
+    return value if value else ''
 
 
-@dataclasses.dataclass(frozen=True, eq=True)
-class OtherParty:
-    user_id: str
-    user_key: str
-    nickname: str
-    client_type: str
-    country_code: str
-
-    def to_annotation(self):
-        return (
-            f"User ID: {self.user_id} \n" +
-            f"User Key: {self.user_key} \n" +
-            f"Nickname: {self.nickname} \n" +
-            f"Country Code: {self.country_code} \n" +
-            f"Client Type: {self.client_type}"
-        )
+def _annotation(kv):
+    return (f"User ID: {kv.get('userId', '')} \n"
+            f"User Key: {kv.get('userKey', '')} \n"
+            f"Nickname: {kv.get('nickname', '')} \n"
+            f"Country Code: {kv.get('countryCode', '')} \n"
+            f"Client Type: {kv.get('clientType', '')}")
 
 
-@dataclasses.dataclass(frozen=True)
-class Message:
-    message: str
-    timestamp: datetime.datetime
-    message_type: str
-
-
-class MessagePackage:
-    def __init__(self, from_token: str, package: str):
-        self.from_token = from_token
-        self.package = package
-        self.messages: list[Message] = []
-        self.other_party_details: list[OtherParty] = []
-
-
+@artifact_processor
 def get_fcm_jungrammer(files_found, report_folder, seeker, wrap_text):
-    in_dirs = set(pathlib.Path(x).parent for x in files_found)
-
-    maybe_jungrammer = set()
-    definitely_jungrammer = set()
-
-    conversations: dict[str, MessagePackage] = {}  # key is package-fromToken
-    relevant_types = {"CONNECT", "MESSAGE", "DISCONNECT", "NOTICE"}
+    in_dirs = set(pathlib.Path(str(x)).parent for x in files_found)
+    source = " ".join(str(x) for x in in_dirs)
+    conversations = {}  # conv_key -> {package, from_token, parties: [], messages: [(ts, type, text)]}
 
     for in_db_path in in_dirs:
-        with FcmIterator(in_db_path) as record_iterator:
-            for rec in record_iterator:
-                if rec.package in KNOWN_JUNGRAMMERS:
-                    definitely_jungrammer.add(rec.package)
-                    if rec.key_values.get("type") in relevant_types:
-                        # special case for some notices not belonging to a conversation
-                        if rec.key_values["type"] == "NOTICE" and "fromToken" not in rec.key_values:
-                            continue
-                        conv_key = f"{rec.package}-{rec.key_values['fromToken']}"
-                        conversations.setdefault(conv_key, MessagePackage(rec.key_values['fromToken'], rec.package))
+        try:
+            with FcmIterator(in_db_path) as record_iterator:
+                for rec in record_iterator:
+                    if rec.package not in KNOWN_JUNGRAMMERS:
+                        continue
+                    rtype = rec.key_values.get("type")
+                    from_token = rec.key_values.get("fromToken")
+                    if rtype not in _RELEVANT_TYPES or not from_token:
+                        continue
+                    conv_key = f"{rec.package}-{from_token}"
+                    conv = conversations.setdefault(
+                        conv_key, {"package": rec.package, "from_token": from_token,
+                                   "parties": [], "messages": []})
+                    ts = _to_utc(rec.timestamp)
+                    if rtype == "CONNECT":
+                        annotation = _annotation(rec.key_values)
+                        conv["parties"].append(annotation)
+                        conv["messages"].append((ts, rtype, annotation))
+                    else:
+                        conv["messages"].append((ts, rtype, rec.key_values.get("message")))
+        except Exception as exc:  # pylint: disable=W0718
+            logfunc(f"Jungrammer FCM: error reading {in_db_path}: {exc}")
 
-                        if rec.key_values["type"] == "CONNECT":
-                            op = OtherParty(
-                                rec.key_values["userId"],
-                                rec.key_values["userKey"],
-                                rec.key_values["nickname"],
-                                rec.key_values["clientType"],
-                                rec.key_values["countryCode"],
-                            )
+    data_list = []
+    for conv_key, conv in conversations.items():
+        parties = "\n".join(conv["parties"])
+        for ts, mtype, message in conv["messages"]:
+            data_list.append((ts, conv_key, conv["package"], parties, conv["from_token"], mtype, message))
 
-                            conversations[conv_key].other_party_details.append(op)
-                            conversations[conv_key].messages.append(
-                                Message(
-                                    op.to_annotation(),
-                                    rec.timestamp,
-                                    rec.key_values["type"]
-                                ))
-                        else:
-                            conversations[conv_key].messages.append(
-                                Message(
-                                    rec.key_values.get("message"),
-                                    rec.timestamp,
-                                    rec.key_values["type"]
-                                ))
-
-                elif might_be_jungrammer_actually(rec):
-                    maybe_jungrammer.add(rec.package)
-
-    if conversations:
-        rows = []
-        for conv_key, conversation in conversations.items():
-            for message in conversation.messages:
-                rows.append(
-                    [
-                        message.timestamp,
-                        conv_key,
-                        conversation.package,
-                        "\n".join(x.to_annotation() for x in conversation.other_party_details),
-                        conversation.from_token,
-                        message.message_type,
-                        message.message
-                    ])
-
-        report = ArtifactHtmlReport("Jungrammer Notifications (Firebase Cloud Messaging Queued Messages)")
-        report_name = "FCM-Jungrammer Notifications"
-        report.start_artifact_report(report_folder, report_name)
-        report.add_script()
-        data_headers = [
-            "Timestamp", "Conversation Key", "Package", "Other Party Details", "From Token", "Message Type", "Message"
-        ]
-        source_files = " ".join(str(x) for x in in_dirs)
-
-        report.write_artifact_data_table(data_headers, rows, source_files)
-        report.end_artifact_report()
-
-        scripts.ilapfuncs.tsv(report_folder, data_headers, rows, report_name, source_files)
-        scripts.ilapfuncs.timeline(report_folder, report_name, rows, data_headers)
-
-        scripts.ilapfuncs.logfunc("Data relating to the following known Jungrammer apps was processed:")
-        scripts.ilapfuncs.logfunc("\n".join(definitely_jungrammer))
-
-        if maybe_jungrammer:
-            scripts.ilapfuncs.logfunc(
-                "The following packages were identified which may also be related to the same set of apps but were not "
-                "processed:")
-            scripts.ilapfuncs.logfunc("\n".join(maybe_jungrammer))
-            scripts.ilapfuncs.logfunc("Please contact the developer of this plugin as this should be easy to fix!")
-            scripts.ilapfuncs.logfunc()
-    else:
-        scripts.ilapfuncs.logfunc("No FCM Jungrammer notifications found")
+    data_headers = (('Timestamp', 'datetime'), 'Conversation Key', 'Package', 'Other Party Details',
+                    'From Token', 'Message Type', 'Message')
+    return data_headers, data_list, source


### PR DESCRIPTION
Converts the standalone Jungrammer FCM parser to LAVA `@artifact_processor` (no Dump-decoder equivalent — additive).

**Change**
- Single consolidated LAVA table of Jungrammer (`kr.jungrammer.*`) chat notifications (was an `ArtifactHtmlReport`). Each message row carries the conversation's accumulated other-party details.
- Replaced the dataclass plumbing (`OtherParty`/`Message`/`MessagePackage`) with a plain conversation dict — same output, less machinery.
- **Defensive:** the `CONNECT` branch read `rec.key_values['userId'/'userKey'/'nickname'/'clientType'/'countryCode']` directly — a CONNECT missing any field would `KeyError`. Now `.get`-based (blanks instead of a crash); the per-db read is also guarded.
- `rec.timestamp` → aware UTC.
- Dropped the developer-only "maybe jungrammer" heuristic logging (those packages were never processed into data, only logged).
- Preserved the CCL MIT license as the module docstring.

**Verification**
- Compiles; pylint clean (`-d C,R`); column names pass a live `CREATE TABLE`; name unique; PluginLoader 498 incl. `get_fcm_jungrammer`.
- Integration test: a CONNECT+MESSAGE conversation yields 2 rows with the party annotation attached; a CONNECT missing user fields yields blanks (no crash); a NOTICE without `fromToken` and a non-Jungrammer package are skipped; timestamps aware-UTC.