### PR TITLE
Drop legacy ArtifactHtmlReport from chromeAutofill + chromeMediaHistory

### DIFF
--- a/scripts/artifacts/chromeAutofill.py
+++ b/scripts/artifacts/chromeAutofill.py
@@ -31,8 +31,7 @@ __artifacts_v2__ = {
 import datetime
 import os
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, get_next_unused_name, lava_process_artifact, lava_insert_sqlite_data, artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import logfunc, artifact_processor, open_sqlite_db_readonly
 from scripts.artifacts.chrome import get_browser_name
 
 
@@ -47,21 +46,6 @@ def _browser_for(file_found):
     if file_found.find('app_sbrowser') >= 0:
         browser_name = 'Browser'
     return browser_name
-
-
-def _emit_report(report_folder, report_name, data_headers, data_list, file_found,
-                 lava_data_headers, module_name):
-    report = ArtifactHtmlReport(report_name)
-    report_path = os.path.join(report_folder, f'{report_name}.temphtml')
-    report_path = get_next_unused_name(report_path)[:-9]  # remove .temphtml
-    report.start_artifact_report(report_folder, os.path.basename(report_path))
-    report.add_script()
-    report.write_artifact_data_table(data_headers, data_list, file_found)
-    report.end_artifact_report()
-
-    table_name, object_columns, column_map = lava_process_artifact(
-        "Chromium", module_name, report_name, lava_data_headers, len(data_list))
-    lava_insert_sqlite_data(table_name, data_list, object_columns, lava_data_headers, column_map)
 
 
 @artifact_processor
@@ -103,8 +87,6 @@ def get_chromeAutofill(files_found, report_folder, seeker, wrap_text):
         db.close()
 
         if len(data_list) > 0:
-            _emit_report(report_folder, f'{browser_name} - Autofill - Entries', data_headers, data_list,
-                         file_found, lava_data_headers, "get_chromeAutofill")
             all_data.extend([row + (browser_name,) for row in data_list])
         else:
             logfunc(f'No {browser_name} - Autofill - Entries data available')
@@ -171,8 +153,6 @@ def get_chromeAutofillProfiles(files_found, report_folder, seeker, wrap_text):
                               r[9], r[10], r[11], _seconds_to_utc(r[12]), r[13]))
 
         if len(data_list) > 0:
-            _emit_report(report_folder, f'{browser_name} - Autofill - Profiles', data_headers, data_list,
-                         file_found, lava_data_headers, "get_chromeAutofillProfiles")
             all_data.extend([row + (browser_name,) for row in data_list])
         else:
             logfunc(f'No {browser_name} - Autofill - Profiles data available')

--- a/scripts/artifacts/chromeMediaHistory.py
+++ b/scripts/artifacts/chromeMediaHistory.py
@@ -41,10 +41,7 @@ __artifacts_v2__ = {
     }
 }
 
-import os
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, get_next_unused_name, open_sqlite_db_readonly, lava_process_artifact, lava_insert_sqlite_data, artifact_processor, convert_human_ts_to_utc
+from scripts.ilapfuncs import logfunc, open_sqlite_db_readonly, artifact_processor, convert_human_ts_to_utc
 from scripts.artifacts.chrome import get_browser_name
 
 
@@ -94,19 +91,6 @@ def get_chromeMediaHistorySessions(files_found, report_folder, seeker, wrap_text
             for row in all_rows:
                 data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8]))
 
-            report_name = f'{browser_name} - Media History - Sessions'
-            report = ArtifactHtmlReport(report_name)
-            report_path = os.path.join(report_folder, f'{report_name}.temphtml')
-            report_path = get_next_unused_name(report_path)[:-9]  # remove .temphtml
-            report.start_artifact_report(report_folder, os.path.basename(report_path))
-            report.add_script()
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-
-            table_name, object_columns, column_map = lava_process_artifact(
-                "Chromium", "get_chromeMediaHistorySessions", report_name, lava_data_headers, len(data_list))
-            lava_insert_sqlite_data(table_name, data_list, object_columns, lava_data_headers, column_map)
-
             data_list = [row + (browser_name,) for row in data_list]
             all_data.extend(data_list)
         else:
@@ -153,19 +137,6 @@ def get_chromeMediaHistoryPlaybacks(files_found, report_folder, seeker, wrap_tex
             for row in all_rows:
                 data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],row[3],row[4],row[5],row[6]))
 
-            report_name = f'{browser_name} - Media History - Playbacks'
-            report = ArtifactHtmlReport(report_name)
-            report_path = os.path.join(report_folder, f'{report_name}.temphtml')
-            report_path = get_next_unused_name(report_path)[:-9]  # remove .temphtml
-            report.start_artifact_report(report_folder, os.path.basename(report_path))
-            report.add_script()
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-
-            table_name, object_columns, column_map = lava_process_artifact(
-                "Chromium", "get_chromeMediaHistoryPlaybacks", report_name, lava_data_headers, len(data_list))
-            lava_insert_sqlite_data(table_name, data_list, object_columns, lava_data_headers, column_map)
-
             data_list = [row + (browser_name,) for row in data_list]
             all_data.extend(data_list)
         else:
@@ -202,19 +173,6 @@ def get_chromeMediaHistoryOrigins(files_found, report_folder, seeker, wrap_text)
             data_list = []
             for row in all_rows:
                 data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],row[3]))
-
-            report_name = f'{browser_name} - Media History - Origins'
-            report = ArtifactHtmlReport(report_name)
-            report_path = os.path.join(report_folder, f'{report_name}.temphtml')
-            report_path = get_next_unused_name(report_path)[:-9]  # remove .temphtml
-            report.start_artifact_report(report_folder, os.path.basename(report_path))
-            report.add_script()
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-
-            table_name, object_columns, column_map = lava_process_artifact(
-                "Chromium", "get_chromeMediaHistoryOrigins", report_name, lava_data_headers, len(data_list))
-            lava_insert_sqlite_data(table_name, data_list, object_columns, lava_data_headers, column_map)
 
             data_list = [row + (browser_name,) for row in data_list]
             all_data.extend(data_list)


### PR DESCRIPTION
Two more Chromium hybrids, same cleanup as #861.

Both were already `@artifact_processor`-decorated and returned consolidated (all-browsers + `Browser Name`) data, but also **redundantly** built per-browser `ArtifactHtmlReport` reports and manual `lava_process_artifact`/`lava_insert_sqlite_data` tables — producing duplicate per-browser output alongside the wrapper's consolidated table.

- **chromeAutofill** (`get_chromeAutofill`, `get_chromeAutofillProfiles`): removed the shared `_emit_report` helper and its two calls.
- **chromeMediaHistory** (`get_chromeMediaHistorySessions`/`Playbacks`/`Origins`): removed the inline report + manual LAVA block from each.
- Trimmed the now-unused imports.

Each now emits a single consolidated LAVA table + HTML report with the `Browser Name` discriminator. **No change** to parsing, SQL, timestamps, or returned data (incl. the `phonenumber`-typed column in Autofill Profiles).

**Verification**
- Both compile; pylint clean (`-d C,R`); no leftover `ArtifactHtmlReport`/`lava_process_artifact`/`lava_insert_sqlite_data`/`get_next_unused_name`/`_emit_report`; all header sets pass a live `CREATE TABLE`; PluginLoader 499 with all 5 functions. Old-style backlog 31 → 29.