### PR TITLE
Convert lgRCS to artifact_processor

### DIFF
--- a/scripts/artifacts/lgRCS.py
+++ b/scripts/artifacts/lgRCS.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0611,W0612,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_lgRCS": {
-        "name": "lgRCS",
-        "description": "",
+        "name": "LG RCS Chats",
+        "description": "RCS chat messages from LG phones (mmssms.db)",
         "author": "",
         "creation_date": "2021-01-06",
         "last_update_date": "2021-01-06",
@@ -10,101 +10,63 @@ __artifacts_v2__ = {
         "category": "RCS Chats",
         "notes": "",
         "paths": ('*/mmssms.db*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "message-square",
-        "function": "get_lgRCS",
     }
 }
 
+import datetime
 import os
-import shutil
 import sqlite3
-import textwrap
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, does_table_exist_in_db
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, does_table_exist_in_db
 
-is_windows = is_platform_windows()
-slash = '\\' if is_windows else '/' 
 
-def get_rcs_db_path(files_found):
+def _ms_to_utc(value):
+    if not value or int(value) <= 0:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
+
+
+def _rcs_db(files_found):
     for file_found in files_found:
         file_found = str(file_found)
-        if not os.path.basename(file_found) == 'mmssms.db': # skip -journal and other files
+        if os.path.basename(file_found) != 'mmssms.db':  # skip -journal and other files
             continue
-        elif file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
-            continue # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data??
+        if '.magisk' in file_found and 'mirror' in file_found:
+            continue  # skip sbin/.magisk/mirror duplicate data
         return file_found
     return ''
 
-def get_offline_path(files_found, blob_name):
-    #offline_path_relative = "/files/shiny_blobs/blobs"
-    for file_found in files_found:
-        if file_found.endswith(blob_name):
-            file_found = str(file_found)
-            return file_found
-    return ''
 
+@artifact_processor
 def get_lgRCS(files_found, report_folder, seeker, wrap_text):
-    file_found = get_rcs_db_path(files_found)
-    if not file_found:
-        logfunc('Error: Could not get RCS chat database path for LG phones')
-        return
+    data_list = []
+    source_path = _rcs_db(files_found)
+    data_headers = (('Date', 'datetime'), 'Address', 'Body', 'Read?', 'Thread ID', 'Is File?',
+                    'Filename', 'File Path', 'File Size', 'Thumb File Path', 'Thumb File Size',
+                    'File XML Path')
 
-    if report_folder[-1] == slash: 
-        folder_name = os.path.basename(report_folder[:-1])
-    else:
-        folder_name = os.path.basename(report_folder)
+    if source_path and does_table_exist_in_db(source_path, 'message'):
+        db = open_sqlite_db_readonly(source_path)
+        cursor = db.cursor()
+        try:
+            cursor.execute('''
+                SELECT date, address, body, read, message.thread_id, is_file, file_name, file_path,
+                       file_size, thumb_file_path, thumb_file_size, file_xml_path
+                FROM message
+                LEFT JOIN file_info ON message.message_id = file_info.message_id
+                ORDER BY date
+            ''')
+            rows = cursor.fetchall()
+        except sqlite3.Error:
+            rows = []
+        db.close()
+        for r in rows:
+            data_list.append((_ms_to_utc(r[0]), r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8],
+                              r[9], r[10], r[11]))
 
-    db = open_sqlite_db_readonly(file_found)
-    if not does_table_exist_in_db(file_found, 'message'):
-        logfunc('No RCS data in this db, \'message\' table is absent!')
-        return
-    cursor = db.cursor()
-    cursor.execute('''
-    SELECT 
-        CASE WHEN date>0 THEN datetime(date/1000, 'UNIXEPOCH')
-            ELSE ""
-        END as date,
-        address, 
-        body,
-        read,
-        message.thread_id, 
-        is_file,
-        file_name,
-        file_path,
-        file_size,
-        thumb_file_path,
-        thumb_file_size,
-        file_xml_path
-    FROM message
-    left join file_info on  message.message_id = file_info.message_id
-    ORDER BY date
-        ''')
-
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        report = ArtifactHtmlReport('RCS Chats')
-        report.start_artifact_report(report_folder, 'RCS')
-        report.add_script()
-        data_headers = ('Date','Address','Body','Read?','Thread ID','Is File?','Filename','File Path','File Size','Thumb File Path','Thumb File Size','File XML Path')
-        data_list = []
-        tsv_list = []
-        
-        for row in all_rows:
-            data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11],))
-        
-
-        report.write_artifact_data_table(data_headers, data_list, file_found, html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = f'RCS Chats - LG'
-        tsv(report_folder, data_headers, tsv_list, tsvname)
-        
-        tlactivity = f'RCS Chats - LG'
-        timeline(report_folder, tlactivity, tsv_list, data_headers)
-    else:
-        logfunc('No RCS Chats - LG data available')
-    
-    db.close()
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts the LG RCS chats artifact to LAVA `@artifact_processor` — a single consolidated table of `message` ⟕ `file_info` from `mmssms.db`.

**Change**
- Was an `ArtifactHtmlReport` with a **latent bug**: it populated `data_list` for the HTML table but built a separate, always-empty `tsv_list` and passed *that* to `tsv()` and `timeline()` — so the TSV and timeline exports were always empty. The framework now generates all outputs from the returned rows.
- Timestamp (epoch ms) → timezone-aware UTC `datetime` (blank when `date <= 0`, matching the original CASE).
- Dropped the dead `get_offline_path` helper; query wrapped in `try/except sqlite3.Error`; kept the `mmssms.db` basename + magisk-mirror filtering and the `message`-table existence check.

**Verification**
- Compiles; pylint clean (`-d C,R`); column names pass a live `CREATE TABLE` (incl. `read`/`date`/`body`); name unique; PluginLoader 499 incl. `get_lgRCS`.
- Fixture test (`message` ⟕ `file_info`): a message with an attachment joins its file fields, a `date=0` message yields a blank timestamp, and a message with no `file_info` row gets NULL file fields — timestamps aware-UTC.