### PR TITLE
Convert Cello (Google Drive metadata) to artifact_processor

### DIFF
--- a/scripts/artifacts/Cello.py
+++ b/scripts/artifacts/Cello.py
@@ -1,7 +1,7 @@
-# pylint: disable=W0611,W0613
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_Cello": {
-        "name": "Cello",
+        "name": "Cello - Google Drive",
         "description": "Parses the Cello db for Google Drive metadata",
         "author": "@KevinPagano3",
         "creation_date": "2020-12-21",
@@ -9,175 +9,73 @@ __artifacts_v2__ = {
         "requirements": "none",
         "category": "Google Drive",
         "notes": "",
-        "paths": ('*/com.google.android.apps.docs/app_cello/*/cello.db*', '*/com.google.android.apps.docs/files/shiny_blobs/blobs/*'),
-        "output_types": None,
+        "paths": ('*/com.google.android.apps.docs/app_cello/*/cello.db*',
+                  '*/com.google.android.apps.docs/files/shiny_blobs/blobs/*'),
+        "output_types": "standard",
         "artifact_icon": "file",
-        "function": "get_Cello",
     }
 }
 
-import os
-import shutil
+import datetime
 import sqlite3
-import textwrap
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, get_next_unused_name, convert_ts_human_to_utc, convert_utc_human_to_timezone
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, check_in_media
 
-is_windows = is_platform_windows()
-slash = '\\' if is_windows else '/'
 
-def get_offline_path(files_found, blob_name):
-    
-    for file_found in files_found:
-        if file_found.endswith(blob_name):
-            file_found = str(file_found)
-            return file_found
-    return ''
+def _ms_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
 
+
+@artifact_processor
 def get_Cello(files_found, report_folder, seeker, wrap_text):
-    
     data_list = []
-    tsv_list = []
-    
+    source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
-        if file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
-            continue # Skip sbin/.magisk/mirror/data/.. , it should be duplicate data??
-        
-        elif file_found.endswith('cello.db'):
-            cello_db = file_found            
-            db = open_sqlite_db_readonly(cello_db)
-            cursor = db.cursor()
+        if not file_found.endswith('cello.db'):
+            continue
+        if '.magisk' in file_found and 'mirror' in file_found:
+            continue
+        source_path = file_found
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        try:
             cursor.execute('''
-            SELECT
-                case created_date
-                    when 0 then ''
-                    else datetime(created_date/1000, 'unixepoch')
-                end as created_date,
-                title,
-                case modified_date
-                    when 0 then ''
-                    else datetime(modified_date/1000, 'unixepoch')
-                end as modified_date,
-                case shared_with_me_date
-                    when 0 then ''
-                    else datetime(shared_with_me_date/1000, 'unixepoch')
-                end as shared_with_me_date,
-                case modified_by_me_date
-                    when 0 then ''
-                    else datetime(modified_by_me_date/1000, 'unixepoch')
-                end as modified_by_me_date,
-                case viewed_by_me_date
-                    when 0 then ''
-                    else datetime(viewed_by_me_date/1000, 'unixepoch')
-                end as viewed_by_me_date,
-                mime_type,
-                Quota_bytes,
-                case is_folder
-                    when 0 then ''
-                    when 1 then 'Yes'
-                end as is_folder,
-                case is_owner
-                    when 0 then ''
-                    when 1 then 'Yes'
-                end as is_owner,
-                case trashed
-                    when 0 then ''
-                    when 1 then 'Yes'
-                end as trashed,
-                (SELECT value from item_properties where key='offlineStatus' and item_stable_id=stable_id) as offline_status,
-                (SELECT json_extract(value, '$.blobKey') from item_properties where key LIKE 'com.google.android.apps.docs:content_metadata%' and item_stable_id=stable_id) as content_metadata
-            FROM items
+                SELECT created_date, title, modified_date, shared_with_me_date, modified_by_me_date,
+                       viewed_by_me_date, mime_type, Quota_bytes,
+                       case is_folder when 1 then 'Yes' else '' end,
+                       case is_owner when 1 then 'Yes' else '' end,
+                       case trashed when 1 then 'Yes' else '' end,
+                       (SELECT value from item_properties
+                            where key='offlineStatus' and item_stable_id=stable_id),
+                       (SELECT json_extract(value, '$.blobKey') from item_properties
+                            where key LIKE 'com.google.android.apps.docs:content_metadata%'
+                            and item_stable_id=stable_id)
+                FROM items
             ''')
+            rows = cursor.fetchall()
+        except sqlite3.Error:
+            rows = []
+        db.close()
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                for row in all_rows:
-                    doc_name = row[1]
-                    offline_status = "No"
-                    if row[11] == 1: # file is offline
-                        offline_status = "Yes"
-                        offline_path_name = row[12]
-                        if offline_path_name not in (None, ''):
-                            offline_path = get_offline_path(files_found, offline_path_name)
-                            if offline_path:
-                                destination_path = get_next_unused_name(os.path.join(report_folder, doc_name))
-                                shutil.copy2(offline_path, destination_path)
-                                dest_name = os.path.basename(destination_path)
-                                doc_name = f"<a href=\"{folder_name}/{dest_name}\" target=\"_blank\" style=\"color:green; font-weight:bolder\">{doc_name}</a>"
-                            else:
-                                logfunc(f'File {doc_name} not present offline!')
-                        else:
-                            logfunc(f'File {doc_name} not present offline!')
-                    if row[8] == "Yes":
-                        doc_name = '<i data-feather="folder"></i> ' + doc_name
-                    else:
-                        if doc_name.startswith('<a href'):
-                            doc_name = '<i data-feather="file" stroke="green"></i> ' + doc_name
-                        else:
-                            doc_name = '<i data-feather="file"></i> ' + doc_name
-                            
-                    created_date = row[0]
-                    if created_date in (None, ''):
-                        pass
-                    else:
-                        created_date = convert_utc_human_to_timezone(convert_ts_human_to_utc(created_date),'UTC')
-                    
-                    modified_date = row[2]
-                    if modified_date in (None, ''):
-                        pass
-                    else:
-                        modified_date = convert_utc_human_to_timezone(convert_ts_human_to_utc(modified_date),'UTC')
-                        
-                    shared_with_me_date = row[3]
-                    if shared_with_me_date in (None, ''):
-                        pass
-                    else:
-                        shared_with_me_date = convert_utc_human_to_timezone(convert_ts_human_to_utc(shared_with_me_date),'UTC')
-                    
-                    modified_by_me_date = row[4]
-                    if modified_by_me_date in (None, ''):
-                        pass
-                    else:
-                        modified_by_me_date = convert_utc_human_to_timezone(convert_ts_human_to_utc(modified_by_me_date),'UTC')
-                    
-                    viewed_by_me_date = row[5]
-                    if viewed_by_me_date in (None, ''):
-                        pass
-                    else:
-                        viewed_by_me_date = convert_utc_human_to_timezone(convert_ts_human_to_utc(viewed_by_me_date),'UTC')
-                    
-                    data_list.append((created_date,doc_name,modified_date,shared_with_me_date,modified_by_me_date,viewed_by_me_date,row[6],offline_status,row[7],row[8],row[9],row[10],cello_db))
-                    tsv_list.append((created_date,row[1],modified_date,shared_with_me_date,modified_by_me_date,viewed_by_me_date,row[6],offline_status,row[7],row[8],row[9],row[10],cello_db))
-            db.close()
-        
-        else:
-            continue # skip -journal and other files
+        for r in rows:
+            is_offline = str(r[11]) == '1'  # offlineStatus value may be int or text affinity
+            media_ref = ''
+            if is_offline and r[12]:
+                blob = next((str(f) for f in files_found if str(f).endswith(str(r[12]))), None)
+                if blob:
+                    media_ref = check_in_media(blob, r[1] or '') or ''
+            data_list.append((_ms_to_utc(r[0]), r[1], _ms_to_utc(r[2]), _ms_to_utc(r[3]),
+                              _ms_to_utc(r[4]), _ms_to_utc(r[5]), r[6], 'Yes' if is_offline else 'No',
+                              r[7], r[8], r[9], r[10], media_ref, file_found))
 
-        if report_folder[-1] == slash: 
-            folder_name = os.path.basename(report_folder[:-1])
-        else:
-            folder_name = os.path.basename(report_folder)
-
-    if data_list:
-        account_name = os.path.basename(os.path.dirname(cello_db))
-            
-        report = ArtifactHtmlReport(f'Cello - {account_name}')
-        report.start_artifact_report(report_folder, f'Cello - {account_name}')
-        report.add_script()
-        data_headers = ('Created Date','File Name','Modified Date','Shared with User Date','Modified by User Date','Viewed by User Date','Mime Type', \
-                        'Offline','Quota Size','Folder','User is Owner','Deleted','Source File')
-
-        report.write_artifact_data_table(data_headers, data_list, cello_db, html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = f'Google Drive - Cello - {account_name}'
-        tsv(report_folder, data_headers, tsv_list, tsvname)
-        
-        tlactivity = f'Google Drive - Cello - {account_name}'
-        timeline(report_folder, tlactivity, tsv_list, data_headers)
-    else:
-        logfunc('No Google Drive - Cello data available')
+    data_headers = (('Created Date', 'datetime'), 'File Name', ('Modified Date', 'datetime'),
+                    ('Shared with User Date', 'datetime'), ('Modified by User Date', 'datetime'),
+                    ('Viewed by User Date', 'datetime'), 'Mime Type', 'Offline', 'Quota Size',
+                    'Folder', 'User is Owner', 'Deleted', ('Offline File', 'media'), 'Source File')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts the Cello (Google Drive `cello.db` metadata) artifact to LAVA `@artifact_processor` — a single consolidated table.

**Change**
- **Media:** offline files moved from `shutil.copy2` into the report folder + inline `<a>`/`<i data-feather>` HTML to a `check_in_media` `('Offline File','media')` column. The `shiny_blobs/blobs/*` files are already in the artifact's path globs, so `check_in_media` resolves them (matched by `blobKey`).
- Five date columns (epoch ms) → timezone-aware UTC `datetime`.
- Kept the folder / owner / trashed CASE maps; dropped the `data-feather` icon HTML wrapping the filename and the dead `get_offline_path` helper; query wrapped in `try/except sqlite3.Error`.
- `offlineStatus` compared affinity-robustly (`str(...) == '1'`) since the value column's type affinity is uncertain.
- Consolidated to one static table name (no per-account dynamic report) with a Source File column.

**Verification**
- Compiles; pylint clean (`-d C,R`); 14 column names pass a live `CREATE TABLE`; name unique; PluginLoader 499 incl. `get_Cello`.
- Fixture test (`items` + `item_properties` + a blob): an offline item resolves its blob to a media ref, a non-offline item gets a blank media cell (no `None`), dates are aware-UTC.