### PR TITLE
Convert BadooChat to artifact_processor (2-way split: Users + Messages)

### DIFF
--- a/scripts/artifacts/BadooChat.py
+++ b/scripts/artifacts/BadooChat.py
@@ -1,138 +1,132 @@
-# pylint: disable=E0606,W0613,W0622,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_badoo_chat": {
-        "name": "BadooChat",
-        "description": "Get Information related to the Chats of the user with other users from the Badoo app (com.badoo.mobile)",
+        "name": "Badoo - Users",
+        "description": "Badoo matched users / conversations (com.badoo.mobile)",
         "author": "Fabian Nunes {fabiannunes12@gmail.com}",
         "creation_date": "2023-05-03",
         "last_update_date": "2023-05-03",
-        "requirements": "Python 3.7 or higher, json",
+        "requirements": "none",
         "category": "Badoo",
         "notes": "",
         "paths": ('*com.badoo.mobile/databases/ChatComDatabase*',),
-        "output_types": None,
+        "output_types": "standard",
+        "artifact_icon": "users",
+    },
+    "get_badoo_messages": {
+        "name": "Badoo - Messages",
+        "description": "Badoo chat messages (com.badoo.mobile)",
+        "author": "Fabian Nunes {fabiannunes12@gmail.com}",
+        "creation_date": "2023-05-03",
+        "last_update_date": "2023-05-03",
+        "requirements": "none",
+        "category": "Badoo",
+        "notes": "",
+        "paths": ('*com.badoo.mobile/databases/ChatComDatabase*',),
+        "output_types": "standard",
         "artifact_icon": "message-square",
-        "function": "get_badoo_chat",
     }
 }
 
-# Get Information related to the Chats of the user with other users from the Badoo app (com.badoo.mobile)
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-05-03
-# Version: 1.0
-# Requirements: Python 3.7 or higher, json
+import datetime
 import json
+import sqlite3
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-
-def get_badoo_chat(files_found, report_folder, seeker, wrap_text):
-    logfunc("Processing data for Badoo Conections")
-    files_found = [x for x in files_found if not x.endswith('-journal')]
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
+_GENDER = {0: 'Male', 1: 'Female'}
 
 
+def _ms_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
+
+
+def _db(files_found):
+    for file_found in files_found:
+        file_found = str(file_found)
+        if 'ChatComDatabase' in file_found and not file_found.endswith('-journal'):
+            return file_found
+    return ''
+
+
+def _run(source_path, sql):
+    if not source_path:
+        return []
+    db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
-    cursor.execute('''
-        Select user_id, gender, user_name, user_image_url, age, user_photos, work, education, encrypted_user_id
-        from conversation_info
-    ''')
-
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        logfunc(f"Found {usageentries} entries in conversation_info")
-        report = ArtifactHtmlReport('Chat')
-        report.start_artifact_report(report_folder, 'Badoo Chat')
-        report.add_script()
-        data_headers = ('ID', 'Gender', 'User Name', 'User Image URL', 'Age', 'User Photos', 'Work', 'Education', 'Encrypted User ID', 'Button')
-        data_list = []
-
-        for row in all_rows:
-            id = row[0]
-            gender = row[1]
-            if (gender == 0):
-                gender_text = "Male"
-            elif (gender == 1):
-                gender_text = "Female"
-            else:
-                gender_text = "Other"
-            user_name = row[2]
-            user_image_url = row[3]
-            user_image = '<img src="' + user_image_url + '" width="100" height="100">'
-            age = row[4]
-            user_photos = row[5]
-            # convert string to array
-            user_photos = json.loads(user_photos)
-            photo_urls = ''
-            for i in range(len(user_photos)):
-                photo_url = user_photos[i]['url']
-                #photo_urls = photo_urls + '<img src="' + photo_url + '" width="100" height="100">'
-                photo_urls = photo_urls + '<a href="' + photo_url + '" target="_blank">Photo ' + str(i+1) + '</a><br>'
-
-            work = row[6]
-            education = row[7]
-            encrypted_user_id = row[8]
-            cursor.execute(f'''
-                                        Select sender_id, recipient_id, datetime("created_timestamp"/1000,'unixepoch'), payload, payload_type
-                                        from message
-                                        where sender_id = '{encrypted_user_id}' or recipient_id = '{encrypted_user_id}'
-                                    ''')
-            messages = cursor.fetchall()
-            usageentries_m = len(messages)
-            if usageentries_m > 0:
-                logfunc(f"Found {usageentries_m} entries in message")
-                message_list = []
-                for message in messages:
-                    text = message[3]
-                    text = json.loads(text)
-                    type = message[4]
-                    # Check if text exists
-                    if type == 'TEXT':
-                        message_text = text['text']
-                        typeM = 'text'
-                    elif type == 'QUESTION_GAME':
-                        message_text = text['text']
-                        if 'answer_own' in text:
-                            message_text = message_text + ';Own Answer:' + text['answer_own']
-                        if 'answer_other' in text:
-                            message_text = message_text + ';Other Answer:' + text['answer_other']
-                        typeM = 'question'
-                    elif type == 'INSTANT_VIDEO' or type == 'AUDIO' or type == 'IMAGE':
-                        message_text = text['url']
-                        typeM = 'url'
-
-                    message_dic = {
-                        'sender': message[0],
-                        'message': message_text,
-                        'time': message[2],
-                        'type': typeM
-                    }
-                    message_list.append(message_dic)
-                chat = {'name': user_name, 'messages': message_list}
-                chat = json.dumps(chat)
-                report.add_chat_invisble(encrypted_user_id, chat)
-                button = f'<button type="button" class="btn btn-primary" onclick="createChat(\'' + str(encrypted_user_id) + '\', \'' + str(user_image_url) + '\')">Open Chat</button>'
-            else:
-                button = '<button type="button" class="btn btn-primary" disabled>Open Chat</button>'
-            data_list.append((id, gender_text, user_name, user_image, age, photo_urls, work, education, encrypted_user_id, button))
-        # Filter by date
-        table_id = "BadooChat"
-        report.write_artifact_data_table(data_headers, data_list, file_found, table_id=table_id, html_escape=False)
-        # Add the map to the report
-        report.add_section_heading('Badoo Chat')
-        report.add_chat()
-        report.end_artifact_report()
-
-        tsvname = f'Badoo - Chat'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = f'Badoo - Chat'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-
-    else:
-        logfunc('No Badoo Chat data available')
-
+    try:
+        cursor.execute(sql)
+        rows = cursor.fetchall()
+    except sqlite3.Error:
+        rows = []
     db.close()
+    return rows
+
+
+def _photo_urls(raw):
+    try:
+        photos = json.loads(raw)
+    except (ValueError, TypeError):
+        return ''
+    if not isinstance(photos, list):
+        return ''
+    return '\n'.join(p.get('url', '') for p in photos if isinstance(p, dict))
+
+
+def _msg_text(ptype, raw):
+    try:
+        text = json.loads(raw)
+    except (ValueError, TypeError):
+        return raw if isinstance(raw, str) else ''
+    if not isinstance(text, dict):
+        return str(text)
+    if ptype == 'TEXT':
+        return text.get('text', '')
+    if ptype == 'QUESTION_GAME':
+        msg = text.get('text', '')
+        if 'answer_own' in text:
+            msg += ';Own Answer:' + str(text['answer_own'])
+        if 'answer_other' in text:
+            msg += ';Other Answer:' + str(text['answer_other'])
+        return msg
+    if ptype in ('INSTANT_VIDEO', 'AUDIO', 'IMAGE'):
+        return text.get('url', '')
+    # unknown type: best-effort (the original left message_text undefined here)
+    return text.get('text') or text.get('url') or json.dumps(text, ensure_ascii=False)
+
+
+@artifact_processor
+def get_badoo_chat(files_found, report_folder, seeker, wrap_text):
+    source_path = _db(files_found)
+    rows = _run(source_path, '''
+        SELECT user_id, gender, user_name, user_image_url, age, user_photos, work, education,
+               encrypted_user_id
+        FROM conversation_info
+    ''')
+    data_list = []
+    for r in rows:
+        data_list.append((r[0], _GENDER.get(r[1], 'Other'), r[2], r[3], r[4], _photo_urls(r[5]),
+                          r[6], r[7], r[8]))
+    data_headers = ('User ID', 'Gender', 'User Name', 'User Image URL', 'Age', 'User Photos',
+                    'Work', 'Education', 'Encrypted User ID')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_badoo_messages(files_found, report_folder, seeker, wrap_text):
+    source_path = _db(files_found)
+    users = {r[0]: r[1] for r in
+             _run(source_path, 'SELECT encrypted_user_id, user_name FROM conversation_info')}
+    data_list = []
+    for r in _run(source_path,
+                  'SELECT sender_id, recipient_id, created_timestamp, payload, payload_type FROM message'):
+        partner = users.get(r[0]) or users.get(r[1]) or ''
+        data_list.append((_ms_to_utc(r[2]), partner, r[0], r[1], r[4], _msg_text(r[4], r[3])))
+    data_headers = (('Timestamp', 'datetime'), 'Conversation With', 'Sender ID', 'Recipient ID',
+                    'Type', 'Message')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts the Badoo chat artifact to LAVA `@artifact_processor`.

**Why a split**
The original built an interactive chat widget (`report.add_chat_invisble`/`createChat`), so the actual **messages only existed inside that widget's JSON** — there was no message table. Split into:
- **get_badoo_chat** ("Badoo - Users") — the `conversation_info` matches (gender mapped, profile photo URLs joined).
- **get_badoo_messages** ("Badoo - Messages") — the chat `message` rows as real data: timestamp → aware UTC, payload decoded per `payload_type`, and the conversation partner's name resolved from `encrypted_user_id`.

**Bug fix**
The original left `message_text` **undefined** for any `payload_type` outside TEXT / QUESTION_GAME / INSTANT_VIDEO / AUDIO / IMAGE (the file suppressed `E0606` possibly-undefined). An unknown type would reuse the previous row's text or error — now unknown types get a best-effort `text`/`url`/JSON fallback.

Dropped the inline `<img>`/`<a>`/button HTML; JSON parsing guarded throughout.

**Verification**
- Compiles; pylint clean (`-d C,R`); both header sets pass a live `CREATE TABLE`; names unique; PluginLoader 500 with both functions.
- Fixture test (`conversation_info` + 4 `message` rows incl. TEXT/IMAGE/QUESTION_GAME and an unknown `STICKER` type): users row has joined photo URLs and mapped gender; all four messages decode correctly with the partner resolved to the user name; the unknown type yields its text instead of crashing; timestamps aware-UTC.