### PR TITLE
Convert firefox to artifact_processor (4-way split)

### DIFF
--- a/scripts/artifacts/firefox.py
+++ b/scripts/artifacts/firefox.py
@@ -1,8 +1,8 @@
-# pylint: disable=W0611,W0613,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
-    "get_firefox": {
-        "name": "Firefox",
-        "description": "",
+    "get_firefox_history": {
+        "name": "Firefox - Web History",
+        "description": "Firefox places.sqlite web history",
         "author": "",
         "creation_date": "2022-01-12",
         "last_update_date": "2022-01-12",
@@ -10,198 +10,155 @@ __artifacts_v2__ = {
         "category": "Firefox",
         "notes": "",
         "paths": ('*/org.mozilla.firefox/files/places.sqlite*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "globe",
-        "function": "get_firefox",
+    },
+    "get_firefox_visits": {
+        "name": "Firefox - Web Visits",
+        "description": "Firefox places.sqlite individual page visits",
+        "author": "",
+        "creation_date": "2022-01-12",
+        "last_update_date": "2022-01-12",
+        "requirements": "none",
+        "category": "Firefox",
+        "notes": "",
+        "paths": ('*/org.mozilla.firefox/files/places.sqlite*',),
+        "output_types": "standard",
+        "artifact_icon": "globe",
+    },
+    "get_firefox_bookmarks": {
+        "name": "Firefox - Bookmarks",
+        "description": "Firefox places.sqlite bookmarks",
+        "author": "",
+        "creation_date": "2022-01-12",
+        "last_update_date": "2022-01-12",
+        "requirements": "none",
+        "category": "Firefox",
+        "notes": "",
+        "paths": ('*/org.mozilla.firefox/files/places.sqlite*',),
+        "output_types": "standard",
+        "artifact_icon": "bookmark",
+    },
+    "get_firefox_searches": {
+        "name": "Firefox - Search Terms",
+        "description": "Firefox places.sqlite search queries",
+        "author": "",
+        "creation_date": "2022-01-12",
+        "last_update_date": "2022-01-12",
+        "requirements": "none",
+        "category": "Firefox",
+        "notes": "",
+        "paths": ('*/org.mozilla.firefox/files/places.sqlite*',),
+        "output_types": "standard",
+        "artifact_icon": "search",
     }
 }
 
+import datetime
 import os
 import sqlite3
-import textwrap
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-def get_firefox(files_found, report_folder, seeker, wrap_text):
-    
+
+def _ms_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
+
+
+def _db(files_found):
     for file_found in files_found:
         file_found = str(file_found)
-        if not os.path.basename(file_found) == 'places.sqlite': # skip -journal and other files
-            continue
-        
-        db = open_sqlite_db_readonly(file_found)
-        cursor = db.cursor()
-        cursor.execute('''
-        SELECT
-        datetime(moz_places.last_visit_date_local/1000, 'unixepoch') AS LastVisitDate,
-        moz_places.url AS URL,
-        moz_places.title AS Title,
-        moz_places.visit_count_local AS VisitCount,
-        moz_places.description AS Description,
-        CASE
-            WHEN moz_places.hidden = 0 THEN 'No'
-            WHEN moz_places.hidden = 1 THEN 'Yes'
-        END AS Hidden,
-        CASE
-            WHEN moz_places.typed = 0 THEN 'No'
-            WHEN moz_places.typed = 1 THEN 'Yes'
-        END AS Typed,
-        moz_places.frecency AS Frecency,
-        moz_places.preview_image_url AS PreviewImageURL
-        FROM
-        moz_places
+        if os.path.basename(file_found) == 'places.sqlite':
+            return file_found
+    return ''
+
+
+def _run(source_path, sql):
+    if not source_path:
+        return []
+    db = open_sqlite_db_readonly(source_path)
+    cursor = db.cursor()
+    try:
+        cursor.execute(sql)
+        rows = cursor.fetchall()
+    except sqlite3.Error:
+        rows = []
+    db.close()
+    return rows
+
+
+@artifact_processor
+def get_firefox_history(files_found, report_folder, seeker, wrap_text):
+    source_path = _db(files_found)
+    rows = _run(source_path, '''
+        SELECT moz_places.last_visit_date_local, moz_places.url, moz_places.title,
+        moz_places.visit_count_local, moz_places.description,
+        CASE moz_places.hidden WHEN 0 THEN 'No' WHEN 1 THEN 'Yes' END,
+        CASE moz_places.typed WHEN 0 THEN 'No' WHEN 1 THEN 'Yes' END,
+        moz_places.frecency, moz_places.preview_image_url
+        FROM moz_places
         INNER JOIN moz_historyvisits ON moz_places.origin_id = moz_historyvisits.id
         INNER JOIN moz_places_metadata ON moz_places.id = moz_places_metadata.id
-        ORDER BY
-        moz_places.last_visit_date_local ASC  
-        ''')
+        ORDER BY moz_places.last_visit_date_local ASC
+    ''')
+    data_list = [(_ms_to_utc(r[0]), r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8]) for r in rows]
+    data_headers = (('Last Visit Date', 'datetime'), 'URL', 'Title', 'Visit Count', 'Description',
+                    'Hidden', 'Typed', 'Frecency', 'Preview Image URL')
+    return data_headers, data_list, source_path
 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Firefox - Web History')
-            report.start_artifact_report(report_folder, 'Firefox - Web History')
-            report.add_script()
-            data_headers = ('Last Visit Date','URL','Title','Visit Count','Description','Hidden','Typed','Frecency','Preview Image URL') 
-            data_list = []
-            for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8]))
 
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Firefox - Web History'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Firefox - Web History'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Firefox - Web History data available')
-            
-        cursor = db.cursor()
-        cursor.execute('''
-        SELECT
-        datetime(moz_historyvisits.visit_date/1000, 'unixepoch') AS VisitDate,
-        moz_places.url AS URL,
-        moz_places.title AS Title,
-        moz_historyvisits.id AS VisitID,
-        moz_historyvisits.from_visit AS FromVisitID,
+@artifact_processor
+def get_firefox_visits(files_found, report_folder, seeker, wrap_text):
+    source_path = _db(files_found)
+    rows = _run(source_path, '''
+        SELECT moz_historyvisits.visit_date, moz_places.url, moz_places.title,
+        moz_historyvisits.id, moz_historyvisits.from_visit,
         CASE moz_historyvisits.visit_type
-            WHEN 1 THEN 'TRANSITION_LINK'
-            WHEN 2 THEN 'TRANSITION_TYPED'
-            WHEN 3 THEN 'TRANSITION_BOOKMARK'
-            WHEN 4 THEN 'TRANSITION_EMBED'
-            WHEN 5 THEN 'TRANSITION_REDIRECT_PERMANENT'
-            WHEN 6 THEN 'TRANSITION_REDIRECT_TEMPORARY'
-            WHEN 7 THEN 'TRANSITION_DOWNLOAD'
-            WHEN 8 THEN 'TRANSITION_FRAMED_LINK'
-            WHEN 9 THEN 'TRANSITION_RELOAD'
-        END AS VisitType,
-        CASE
-            WHEN moz_places.typed = 0 THEN 'No'
-            WHEN moz_places.typed = 1 THEN 'Yes'
-        END AS Typed
-        FROM
-        moz_historyvisits
+            WHEN 1 THEN 'TRANSITION_LINK' WHEN 2 THEN 'TRANSITION_TYPED'
+            WHEN 3 THEN 'TRANSITION_BOOKMARK' WHEN 4 THEN 'TRANSITION_EMBED'
+            WHEN 5 THEN 'TRANSITION_REDIRECT_PERMANENT' WHEN 6 THEN 'TRANSITION_REDIRECT_TEMPORARY'
+            WHEN 7 THEN 'TRANSITION_DOWNLOAD' WHEN 8 THEN 'TRANSITION_FRAMED_LINK'
+            WHEN 9 THEN 'TRANSITION_RELOAD' END,
+        CASE moz_places.typed WHEN 0 THEN 'No' WHEN 1 THEN 'Yes' END
+        FROM moz_historyvisits
         INNER JOIN moz_places ON moz_places.id = moz_historyvisits.place_id
-        ORDER BY
-        moz_historyvisits.visit_date ASC  
-        ''')
+        ORDER BY moz_historyvisits.visit_date ASC
+    ''')
+    data_list = [(_ms_to_utc(r[0]), r[1], r[2], r[3], r[4], r[5], r[6]) for r in rows]
+    data_headers = (('Visit Date', 'datetime'), 'URL', 'Title', 'Visit ID', 'From Visit ID',
+                    'Visit Type', 'Typed')
+    return data_headers, data_list, source_path
 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Firefox - Web Visits')
-            report.start_artifact_report(report_folder, 'Firefox - Web Visits')
-            report.add_script()
-            data_headers = ('Visit Date','URL','Title','Visit ID','From Visit ID','Visit Type','Typed') 
-            data_list = []
-            for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
 
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Firefox - Web Visits'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Firefox - Web Visits'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Firefox - Web Visits data available')
-        
-        cursor = db.cursor()
-        cursor.execute('''
-        SELECT
-        datetime(moz_bookmarks.dateAdded/1000,'unixepoch'),
-        datetime(moz_bookmarks.lastModified/1000,'unixepoch'),
-        moz_bookmarks.title,
-        moz_places.url,
-        CASE moz_bookmarks.type
-            WHEN 1 THEN 'URL'
-            WHEN 2 THEN 'Folder'
-            WHEN 3 THEN 'Separator'
-        END,
-        moz_bookmarks.id,
-        moz_bookmarks.parent,
-        moz_bookmarks.position,
-        moz_bookmarks.syncStatus
+@artifact_processor
+def get_firefox_bookmarks(files_found, report_folder, seeker, wrap_text):
+    source_path = _db(files_found)
+    rows = _run(source_path, '''
+        SELECT moz_bookmarks.dateAdded, moz_bookmarks.lastModified, moz_bookmarks.title, moz_places.url,
+        CASE moz_bookmarks.type WHEN 1 THEN 'URL' WHEN 2 THEN 'Folder' WHEN 3 THEN 'Separator' END,
+        moz_bookmarks.id, moz_bookmarks.parent, moz_bookmarks.position, moz_bookmarks.syncStatus
         FROM moz_bookmarks
         LEFT JOIN moz_places ON moz_bookmarks.fk = moz_places.id
         ORDER BY moz_bookmarks.id ASC
-        ''')
+    ''')
+    data_list = [(_ms_to_utc(r[0]), _ms_to_utc(r[1]), r[2], r[3], r[4], r[5], r[6], r[7], r[8])
+                 for r in rows]
+    data_headers = (('Added Timestamp', 'datetime'), ('Modified Timestamp', 'datetime'), 'Title',
+                    'URL', 'Bookmark Type', 'ID', 'Parent', 'Position', 'Sync Status')
+    return data_headers, data_list, source_path
 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Firefox - Bookmarks')
-            report.start_artifact_report(report_folder, 'Firefox - Bookmarks')
-            report.add_script()
-            data_headers = ('Added Timestamp','Modified Timestamp','Title','URL','Bookmark Type','ID','Parent','Position','Sync Status') 
-            data_list = []
-            for row in all_rows:
-                data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8]))
 
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Firefox - Bookmarks'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-            tlactivity = f'Firefox - Bookmarks'
-            timeline(report_folder, tlactivity, data_list, data_headers)
-        else:
-            logfunc('No Firefox - Bookmarks data available')
-            
-        cursor = db.cursor()
-        cursor.execute('''
-        SELECT
-        id AS 'ID',
-        term AS 'Search Term'
-        FROM moz_places_metadata_search_queries
-        ORDER BY id ASC
-        ''')
-
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        if usageentries > 0:
-            report = ArtifactHtmlReport('Firefox - Search Terms')
-            report.start_artifact_report(report_folder, 'Firefox - Search Terms')
-            report.add_script()
-            data_headers = ('ID','Search Term') 
-            data_list = []
-            for row in all_rows:
-                data_list.append((row[0],row[1]))
-
-            report.write_artifact_data_table(data_headers, data_list, file_found)
-            report.end_artifact_report()
-            
-            tsvname = f'Firefox - Search Terms'
-            tsv(report_folder, data_headers, data_list, tsvname)
-            
-        else:
-            logfunc('No Firefox - Search Terms data available')
-        
-        db.close()
-    
+@artifact_processor
+def get_firefox_searches(files_found, report_folder, seeker, wrap_text):
+    source_path = _db(files_found)
+    rows = _run(source_path, '''
+        SELECT id, term FROM moz_places_metadata_search_queries ORDER BY id ASC
+    ''')
+    data_list = [(r[0], r[1]) for r in rows]
+    data_headers = ('ID', 'Search Term')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts the Firefox `places.sqlite` artifact to LAVA `@artifact_processor`.

The single `ArtifactHtmlReport` emitted four tables; split into four artifacts:
- **get_firefox_history** (Web History) — `moz_places` ⋈ `moz_historyvisits` ⋈ `moz_places_metadata`
- **get_firefox_visits** (Web Visits) — `moz_historyvisits` ⋈ `moz_places`, with the visit-type map
- **get_firefox_bookmarks** (Bookmarks) — `moz_bookmarks` ⟕ `moz_places`, with the bookmark-type map
- **get_firefox_searches** (Search Terms) — `moz_places_metadata_search_queries`

Timestamps (epoch ms) → timezone-aware UTC `datetime` columns; the `hidden`/`typed`/`visit_type`/bookmark-type CASE maps are kept in SQL; reads go through a shared `_run` helper with `sqlite3.Error` guarding.

**Verification**
- Compiles; pylint clean (`-d C,R`); all 4 header sets pass a live `CREATE TABLE`; names unique; PluginLoader 503 with all four functions (old `get_firefox` gone).
- Fixture `places.sqlite` exercising all four joins: each report returns its row with joins resolved, CASE maps applied, and timestamps aware-UTC.