### PR TITLE
Convert NikeActivities to artifact_processor

### DIFF
--- a/scripts/artifacts/NikeActivities.py
+++ b/scripts/artifacts/NikeActivities.py
@@ -1,174 +1,108 @@
-# pylint: disable=W0613,W0622,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_nike_activities": {
-        "name": "NikeActivities",
-        "description": "Get Information relative to the user activities that are present in the database (com.nike.nrc.room) from the Nike Run app",
+        "name": "Nike - Activities",
+        "description": "User activities from the Nike Run app database (com.nike.nrc.room)",
         "author": "Fabian Nunes {fabiannunes12@gmail.com}",
         "creation_date": "2023-03-18",
         "last_update_date": "2023-03-18",
-        "requirements": "Python 3.7 or higher and json",
+        "requirements": "none",
         "category": "Nike-Run",
         "notes": "",
         "paths": ('*/com.nike.plusgps/databases/com.nike.nrc.room*',),
-        "output_types": None,
+        "output_types": "standard",
         "artifact_icon": "activity",
-        "function": "get_nike_activities",
     }
 }
 
-# Get Information relative to the user activities that are present in the database (com.nike.nrc.room) from the Nike Run app
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-03-18
-# Version: 1.0
-# Requirements: Python 3.7 or higher and json
 import datetime
-import json
+import sqlite3
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
+def _ms_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
+
+
+def _round(value):
+    try:
+        return round(float(value), 2)
+    except (ValueError, TypeError):
+        return value
+
+
+def _db(files_found):
+    for file_found in files_found:
+        file_found = str(file_found)
+        if 'com.nike.nrc.room' in file_found and not file_found.endswith(('wal', 'shm', '-journal')):
+            return file_found
+    return ''
+
+
+def _q(cursor, sql, params):
+    try:
+        cursor.execute(sql, params)
+        return cursor.fetchall()
+    except sqlite3.Error:
+        return []
+
+
+@artifact_processor
 def get_nike_activities(files_found, report_folder, seeker, wrap_text):
-    logfunc("Processing data for Garmin Activities")
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
+    source_path = _db(files_found)
+    data_list = []
+    if source_path:
+        db = open_sqlite_db_readonly(source_path)
+        cursor = db.cursor()
+        activities = _q(cursor, 'SELECT * FROM activity', ())
+        for row in activities:
+            act_id = row[0]
+            duration = _round(row[5] / 60000) if row[5] else ''
+            name = location = version = temperature = weather = None
+            calories = max_speed = mean_speed = steps = distance = pace = cadence = None
 
-    cursor = db.cursor()
-    cursor.execute('''
-    Select *
-    from activity;
-    ''')
+            for tag in _q(cursor, 'SELECT * FROM activity_tag WHERE as2_t_activity_id = ?', (act_id,)):
+                key = tag[2]
+                if key == 'com.nike.name':
+                    name = tag[3]
+                elif key == 'location':
+                    location = tag[3]
+                elif key == 'com.nike.running.recordingappversion':
+                    version = tag[3]
+                elif key == 'com.nike.temperature':
+                    temperature = tag[3]
+                elif key == 'com.nike.weather':
+                    weather = tag[3]
 
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        logfunc(f"Found {usageentries} Nike Activities")
-        report = ArtifactHtmlReport('Nike - Activities')
-        report.start_artifact_report(report_folder, 'Nike - Activities')
-        report.add_script()
-        data_headers = ('Activity ID', 'Name', 'Start Time UTC', 'End Time UTC', 'Location', 'Source', 'Version', 'Temperature', 'Weather', 'Duration', 'Calories', 'Max Speed', 'Mean Speed', 'Steps', 'Distance', 'Pace', 'Cadence')
-        data_list = []
-        activity_date = ''
-        activity_json = []
-        for row in all_rows:
-            # If the second column of the row is not null, then the row is from the "activity_summaries" table, the data is then parsed from the json column
-            id = row[0]
-            source = row[2]
-            start_time_utc = row[3]
-            # convert ms to date
-            start_time_utc = datetime.datetime.utcfromtimestamp(start_time_utc / 1000.0).strftime('%Y-%m-%d %H:%M:%S')
-            end_time_utc = row[4]
-            # convert ms to date
-            end_time_utc = datetime.datetime.utcfromtimestamp(end_time_utc / 1000.0).strftime('%Y-%m-%d %H:%M:%S')
-            duration = row[5]
-            # convert ms to minutes
-            duration = duration / 60000
-            # round to 2 decimals
-            duration = round(duration, 2)
-            name = None
-            location = None
-            version = None
-            temperature = None
-            weather = None
-            calories = None
-            max_speed = None
-            mean_speed = None
-            steps = None
-            distance = None
-            pace = None
-            cadence = None
+            for summ in _q(cursor, 'SELECT * FROM activity_summary WHERE as2_s_activity_id = ?', (act_id,)):
+                metric, val = summ[3], summ[6]
+                if metric == 'calories':
+                    calories = _round(val)
+                elif metric == 'speed' and summ[5] == 'max':
+                    max_speed = _round(val)
+                elif metric == 'speed' and summ[5] == 'mean':
+                    mean_speed = _round(val)
+                elif metric == 'steps':
+                    steps = val
+                elif metric == 'distance':
+                    distance = _round(val)
+                elif metric == 'pace':
+                    pace = _round(val)
+                elif metric == 'cadence':
+                    cadence = _round(val)
 
-            cursor.execute('''
-                Select *
-                from activity_tag
-                where as2_t_activity_id = ''' + str(id) + '''
-            ''')
-            tag_rows = cursor.fetchall()
-            usageentries_t = len(tag_rows)
-            if usageentries_t > 0:
-                for t_row in tag_rows:
-                    activity_id = t_row[1]
-                    if activity_id == id:
-                        if t_row[2] == 'com.nike.name':
-                            name = t_row[3]
-                        elif t_row[2] == 'location':
-                            location = t_row[3]
-                        elif t_row[2] == 'com.nike.running.recordingappversion':
-                            version = t_row[3]
-                        elif t_row[2] == 'com.nike.temperature':
-                            temperature = t_row[3]
-                        elif t_row[2] == 'com.nike.weather':
-                            weather = t_row[3]
+            data_list.append((act_id, name, _ms_to_utc(row[3]), _ms_to_utc(row[4]), location, row[2],
+                              version, temperature, weather, duration, calories, max_speed, mean_speed,
+                              steps, distance, pace, cadence))
+        db.close()
 
-                cursor.execute('''
-                                Select *
-                                from activity_summary
-                                where as2_s_activity_id = ''' + str(id) + '''
-                            ''')
-                sum_rows = cursor.fetchall()
-                usageentries_s = len(sum_rows)
-                if usageentries_s > 0:
-                    for row_s in sum_rows:
-                        activity_id = row_s[1]
-                        if activity_id == id:
-                            if row_s[3] == 'calories':
-                                calories = row_s[6]
-                                # round to 2 decimals
-                                calories = round(calories, 2)
-                            elif row_s[3] == 'speed':
-                                if row_s[5] == 'max':
-                                    max_speed = row_s[6]
-                                    # round to 2 decimals
-                                    max_speed = round(max_speed, 2)
-                                elif row_s[5] == 'mean':
-                                    mean_speed = row_s[6]
-                                    # round to 2 decimals
-                                    mean_speed = round(mean_speed, 2)
-                            elif row_s[3] == 'steps':
-                                steps = row_s[6]
-                            elif row_s[3] == 'distance':
-                                distance = row_s[6]
-                                # round to 2 decimals
-                                distance = round(distance, 2)
-                            elif row_s[3] == 'pace':
-                                pace = row_s[6]
-                                # round to 2 decimals
-                                pace = round(pace, 2)
-                            elif row_s[3] == 'cadence':
-                                cadence = row_s[6]
-                                # round to 2 decimals
-                                cadence = round(cadence, 2)
-
-
-            # extract date from startTimeGMT
-            current_date = start_time_utc
-            if current_date != activity_date:
-                activity_json.append({
-                    'date': current_date,
-                    'total': 1,
-                })
-                activity_date = current_date
-            else:
-                # Change the total of the last element of the list
-                activity_json[-1]['total'] += 1
-
-            data_list.append((id, name, start_time_utc, end_time_utc, location, source, version, temperature, weather, duration, calories, max_speed, mean_speed, steps, distance, pace, cadence))
-        # Added feature to allow the user to sort the data by the selected collumns and with the ID of the table
-        tableID = 'nike_activities'
-        report.add_heat_map(json.dumps(activity_json))
-        report.filter_by_date(tableID, 1)
-
-        report.write_artifact_data_table(data_headers, data_list, file_found, table_id=tableID)
-        report.end_artifact_report()
-
-        tsvname = f'Nike - Activities'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = f'Nike - Activities'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-
-    else:
-        logfunc('No Nike Activities data available')
-
-    db.close()
+    data_headers = ('Activity ID', 'Name', ('Start Time UTC', 'datetime'), ('End Time UTC', 'datetime'),
+                    'Location', 'Source', 'Version', 'Temperature', 'Weather', 'Duration (min)',
+                    'Calories', 'Max Speed', 'Mean Speed', 'Steps', 'Distance', 'Pace', 'Cadence')
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Converts the Nike Run **Activities** artifact to LAVA `@artifact_processor` — a single consolidated table.

**Change**
- Each `activity` row is enriched from `activity_tag` (name, location, app version, temperature, weather) and `activity_summary` (calories, max/mean speed, steps, distance, pace, cadence).
- Start/End times (epoch ms) → timezone-aware UTC `datetime` columns; numeric metrics rounded to 2 dp; the per-activity subqueries are now **parameterized** (were string-concatenated) and run independently (the original only queried the summary when tags existed).
- Dropped the interactive **heat-map** + **date-filter** HTML widgets (not LAVA-renderable; the tabular data is unchanged) and fixed the `'Garmin Activities'` copy-paste log message.

**Verification**
- Compiles; pylint clean (`-d C,R`); 17 column names pass a live `CREATE TABLE`; name unique; PluginLoader 516 incl. `get_nike_activities`.
- Fixture (`activity` + `activity_tag` + `activity_summary`): one activity merges its tags and summary metrics, timestamps are aware-UTC, speeds/distance/calories rounded.