### PR TITLE
Convert AdidasActivities to artifact_processor (offline route media)

### DIFF
--- a/scripts/artifacts/AdidasActivities.py
+++ b/scripts/artifacts/AdidasActivities.py
@@ -1,290 +1,103 @@
-# pylint: disable=W0613,W0702,W1309,W1514
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_adidas_activities": {
-        "name": "Adidas Activities",
-        "description": "Get information relative to user activities from the Adidas Running app",
+        "name": "Adidas Running - Activities",
+        "description": "Adidas Running (Runtastic) activities with GPS routes",
         "author": "Fabian Nunes {fabiannunes12@gmail.com}",
-        "creation_date": "2023-03-24",
-        "last_update_date": "2023-03-24",
-        "requirements": "Python 3.7 or higher, json, polyline, folium",
-        "category": "Adidas-Running",
-        "notes": "",
+        "creation_date": "2023-02-24",
+        "last_update_date": "2023-02-24",
+        "requirements": "polyline",
+        "category": "Adidas",
+        "notes": "Interactive folium map and online reverse-geocoding removed; route shown as an "
+                 "offline image (media) + a downloadable route KML.",
         "paths": ('*/com.runtastic.android/databases/db*',),
-        "output_types": None,
+        "output_types": "all",
         "artifact_icon": "activity",
-        "function": "get_adidas_activities",
     }
 }
 
-# Get Information relative to the user activities that are present in the database (db) from the Adidas Running app, the activities are stored the table (session)
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-03-24
-# Version: 1.0
-# Requirements: Python 3.7 or higher, json, polyline, folium
-import json
-import os
+import datetime
 import sqlite3
 
-import folium
 import polyline
-import xlsxwriter
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly, check_raw_fields, get_raw_fields, check_internet_connection
+from scripts.geo_utils import render_gps_track_png, build_track_kml
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, check_in_embedded_media
 
 
+def _ms_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
+
+
+def _db(files_found):
+    for file_found in files_found:
+        file_found = str(file_found)
+        if 'com.runtastic.android' in file_found and not file_found.endswith(('wal', 'shm', '-journal')):
+            return file_found
+    return ''
+
+
+@artifact_processor
 def get_adidas_activities(files_found, report_folder, seeker, wrap_text):
-    logfunc("Processing data for Adidas Activities")
-    use_network = check_internet_connection()
-    if use_network:
-        conn = sqlite3.connect('coordinates.db')
-        c = conn.cursor()
-        c.execute(
-            '''CREATE TABLE IF NOT EXISTS raw_fields (id INTEGER PRIMARY KEY AUTOINCREMENT, stored_time TIMESTAMP DATETIME DEFAULT 
-            CURRENT_TIMESTAMP, latitude text, longitude text, road text, city text, postcode text, country text)''')
-    files_found = [x for x in files_found if not x.endswith('-journal')]
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
+    source_path = _db(files_found)
+    data_list = []
+    if source_path:
+        db = open_sqlite_db_readonly(source_path)
+        cursor = db.cursor()
+        try:
+            cursor.execute('''
+                SELECT sampleId, userId, distance, startTime, endTime, runtime, maxSpeed, calories,
+                       temperature, note, maxPulse, avgPulse, maxElevation, minElevation, humidity,
+                       encodedTrace
+                FROM session
+            ''')
+            rows = cursor.fetchall()
+        except sqlite3.Error:
+            rows = []
+        db.close()
 
-    cursor = db.cursor()
-    cursor.execute('''
-    Select sampleId, userId, distance, datetime("startTime"/1000, 'unixepoch'), datetime("endTime"/1000, 'unixepoch'), runtime, maxSpeed, calories, temperature, note, maxPulse, avgPulse, maxElevation, minElevation, humidity, encodedTrace, firstLatitude, firstLongitude
-    from session;
-    ''')
+        for r in rows:
+            try:
+                coords = polyline.decode(r[15]) if r[15] else []
+            except Exception:
+                coords = []
+            start_lat, start_lon = coords[0] if coords else ('', '')
+            end_lat, end_lon = coords[-1] if coords else ('', '')
+            runtime = round(r[5] / 60000, 2) if r[5] else ''
+            max_speed = round(r[6], 2) if r[6] else r[6]
+            temperature = 'N/A' if r[8] == -300 else r[8]
+            max_elev = 'N/A' if r[12] == -32768 else r[12]
+            min_elev = 'N/A' if r[13] == 32767 else r[13]
+            humidity = 'N/A' if r[14] == -1 else r[14]
+            start_t = _ms_to_utc(r[3])
+            title = f'Adidas activity {r[0]}'
+            subtitle = '  -  '.join(x for x in [
+                start_t.strftime('%Y-%m-%d %H:%M UTC') if start_t else '',
+                f'{runtime} min' if runtime != '' else ''] if x)
 
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        logfunc(f"Found {usageentries} Adidas Activities")
-        report = ArtifactHtmlReport('Activities')
-        report.start_artifact_report(report_folder, 'Adidas Activities')
-        report.add_script()
-        data_headers = ('Sample ID', 'User ID', 'Distance', 'Start Time', 'End Time', 'Run Time', 'Max Speed', 'Calories', 'Temperature', 'Note', 'Max Pulse', 'Avg Pulse', 'Max Elevation', 'Min Elevation', 'Humidity', 'Coordinates KML', 'Coordinates Excel', 'Button')
-        data_list = []
-        activity_date = ''
-        activity_json = []
-        html_map = []
-        for row in all_rows:
-            sampleId = row[0]
-            userId = row[1]
-            distance = row[2]
-            startTime = row[3]
-            endTime = row[4]
-            runtime = row[5]
-            # convert ms to minutes
-            runtime = runtime / 60000
-            maxSpeed = row[6]
-            if maxSpeed:
-                maxSpeed = round(maxSpeed, 2)
-            calories = row[7]
-            temperature = row[8]
-            if temperature == -300:
-                temperature = 'N/A'
-            note = row[9]
-            maxPulse = row[10]
-            avgPulse = row[11]
-            maxElevation = row[12]
-            if maxElevation == -32768:
-                maxElevation = 'N/A'
-            minElevation = row[13]
-            if minElevation == 32767:
-                minElevation = 'N/A'
-            humidity = row[14]
-            if humidity == -1:
-                humidity = 'N/A'
-            poly = row[15]
-            if poly:
-                # logfunc(f"Polyline: {poly}")
-                try:
-                    coordinates = polyline.decode(poly)
-                except:
-                    logfunc(f"Polyline: {poly} could not be decoded")
-                    poly = None
-                    break
-                place_lat = []
-                place_lon = []
-                if use_network:
-                    if os.name == 'nt':
-                        f = open(report_folder + "\\" + str(row[0]) + ".xlsx", "w")
-                        workbook = xlsxwriter.Workbook(report_folder + "\\" + str(row[0]) + ".xlsx")
-                    else:
-                        f = open(report_folder + "/" + str(row[0]) + ".xlsx", "w")
-                        workbook = xlsxwriter.Workbook(report_folder + "/" + str(row[0]) + ".xlsx")
-                    worksheet = workbook.add_worksheet()
-                    rowE = 0
-                    col = 0
-                    worksheet.write(rowE, col, "Latitude")
-                    worksheet.write(rowE, col + 1, "Longitude")
-                    worksheet.write(rowE, col + 2, "Road")
-                    worksheet.write(rowE, col + 3, "City")
-                    worksheet.write(rowE, col + 4, "Postcode")
-                    worksheet.write(rowE, col + 5, "Country")
-                    rowE += 1
-                    for coordinate in coordinates:
-                        coordinate = str(coordinate)
-                        # remove the parenthesis
-                        coordinate = coordinate.replace("(", "")
-                        coordinate = coordinate.replace(")", "")
-                        coordinate = coordinate.split(",")
-                        lat = float(coordinate[0])
-                        lon = float(coordinate[1])
-                        lat = round(lat, 3)
-                        lon = round(lon, 3)
-                        worksheet.write(rowE, col, lat)
-                        worksheet.write(rowE, col + 1, lon)
-                        location = check_raw_fields(lat, lon, c)
-                        if location is None:
-                            logfunc('Getting coordinates data from API might take some time')
-                            location = get_raw_fields(lat, lon, c, conn)
-                            for key, value in location.items():
-                                if key == "road":
-                                    worksheet.write(rowE, col + 2, value)
-                                elif key == "city":
-                                    worksheet.write(rowE, col + 3, value)
-                                elif key == "postcode":
-                                    worksheet.write(rowE, col + 4, value)
-                                elif key == "country":
-                                    worksheet.write(rowE, col + 5, value)
-                        else:
-                            logfunc('Getting coordinate data from database')
-                            worksheet.write(rowE, col + 2, location[4])
-                            worksheet.write(rowE, col + 3, location[5])
-                            worksheet.write(rowE, col + 4, location[6])
-                            worksheet.write(rowE, col + 5, location[7])
-                        rowE += 1
-                    workbook.close()
+            route_map = ''
+            png = render_gps_track_png(coords, title=title, subtitle=subtitle)
+            if png:
+                route_map = check_in_embedded_media(source_path, png, f'{r[0]}_route.png',
+                                                    force_type='image/png', force_extension='png') or ''
+            route_kml = ''
+            kml = build_track_kml(coords, name=title)
+            if kml:
+                route_kml = check_in_embedded_media(source_path, kml, f'{r[0]}_route.kml',
+                                                    force_type='application/vnd.google-earth.kml+xml',
+                                                    force_extension='kml') or ''
+            data_list.append((r[0], r[1], r[2], start_t, _ms_to_utc(r[4]), runtime, max_speed, r[7],
+                              temperature, r[9], r[10], r[11], max_elev, min_elev, humidity,
+                              start_lat, start_lon, end_lat, end_lon, route_map, route_kml))
 
-                m = folium.Map(location=[row[16], row[17]], zoom_start=10, max_zoom=19)
-
-                for coordinate in coordinates:
-                    # if points are to close, skip
-                    if len(place_lat) > 0 and abs(place_lat[-1] - coordinate[0]) < 0.0001 and abs(
-                            place_lon[-1] - coordinate[1]) < 0.0001:
-                        continue
-                    else:
-                        place_lat.append(coordinate[0])
-                        place_lon.append(coordinate[1])
-
-                points = []
-                for i in range(len(place_lat)):
-                    points.append([place_lat[i], place_lon[i]])
-
-                # Add points to map
-                for index, lat in enumerate(place_lat):
-                    # Start point
-                    if index == 0:
-                        folium.Marker([lat, place_lon[index]],
-                                      popup=(('Start Location\nActivity ID \n' + str(row[0])).format(index)),
-                                      icon=folium.Icon(color='blue', icon='flag', prefix='fa')).add_to(m)
-                    # last point
-                    elif index == len(place_lat) - 1:
-                        folium.Marker([lat, place_lon[index]],
-                                      popup=(('End Location\nActivity ID \n' + str(row[0])).format(index)),
-                                      icon=folium.Icon(color='red', icon='flag', prefix='fa')).add_to(m)
-                    # middle points
-
-                # Create polyline
-                folium.PolyLine(points, color="red", weight=2.5, opacity=1).add_to(m)
-                # Save the map to an HTML file
-                title = 'Adidas_Polyline_Map_' + str(sampleId)
-                if os.name == 'nt':
-                    m.save(report_folder + '\\' + title + '.html')
-                else:
-                    m.save(report_folder + '/' + title + '.html')
-                html_map.append('<iframe id="' + str(
-                    sampleId) + '" src="Adidas-Running/' + title + '.html" width="100%" height="500" class="map" hidden></iframe>')
-                # save coords to a kml file
-                kml = """
-                                    <?xml version="1.0" encoding="UTF-8"?>
-                                    <kml xmlns="http://www.opengis.net/kml/2.2">
-                                    <Document>
-                                    <name>Coordinates</name>
-                                    <description>Coordinates</description>
-                                    <Style id="yellowLineGreenPoly">
-                                        <LineStyle>
-                                            <color>7f00ffff</color>
-                                            <width>4</width>
-                                        </LineStyle>
-                                        <PolyStyle>
-                                            <color>7f00ff00</color>
-                                        </PolyStyle>
-                                    </Style>
-                                    <Placemark>
-                                        <name>Absolute Extruded</name>
-                                        <description>Transparent green wall with yellow outlines</description>
-                                        <styleUrl>#yellowLineGreenPoly</styleUrl>
-                                        <LineString>
-                                            <extrude>1</extrude>
-                                            <tessellate>1</tessellate>
-                                            <altitudeMode>clampedToGround</altitudeMode>
-                                            <coordinates>
-                                            """
-                for i in range(len(place_lat)):
-                    kml += str(place_lon[i]) + ',' + str(place_lat[i]) + ',0 '
-                kml = kml[:-1]
-                kml += """
-                                            </coordinates>
-                                        </LineString>
-                                    </Placemark>
-                                    </Document>
-                                    </kml>
-                                    """
-                # remove the first space
-                kml = kml[1:]
-                # remove last line
-                kml = kml[:-1]
-                # remove extra indentation
-                kml = kml.replace("    ", "")
-                if os.name == 'nt':
-                    with open(report_folder + '\\' + str(row[0]) + '.kml', 'w') as f:
-                        f.write(kml)
-                        f.close()
-                else:
-                    with open(report_folder + '/' + str(row[0]) + '.kml', 'w') as f:
-                        f.write(kml)
-                        f.close()
-
-
-
-            # extract date from startTimeGMT
-            current_date = startTime.split(' ')[0]
-            if current_date != activity_date:
-                activity_json.append({
-                    'date': current_date,
-                    'total': 1,
-                })
-                activity_date = current_date
-            else:
-                # Change the total of the last element of the list
-                activity_json[-1]['total'] += 1
-            if poly:
-                if use_network:
-                    data_list.append((sampleId, userId, distance, startTime, endTime, runtime, maxSpeed, calories, temperature, note, maxPulse, avgPulse, maxElevation, minElevation, humidity, '<a href=Adidas-Running/'+str(row[0])+'.kml class="badge badge-light" target="_blank">'+str(row[0])+'.kml</a>', '<a href=Adidas-Running/'+str(row[0])+'.xlsx class="badge badge-light" target="_blank">'+str(row[0])+'.xlsx</a>', '<button type="button" class="btn btn-light btn-sm" onclick="openMap(\''+str(sampleId)+'\')">Show Map</button>'))
-                else:
-                    data_list.append((sampleId, userId, distance, startTime, endTime, runtime, maxSpeed, calories, temperature, note, maxPulse, avgPulse, maxElevation, minElevation, humidity, '<a href=Adidas-Running/'+str(row[0])+'.kml class="badge badge-light" target="_blank">'+str(row[0])+'.kml</a>', 'N/A', '<button type="button" class="btn btn-light btn-sm" onclick="openMap(\''+str(sampleId)+'\')">Show Map</button>'))
-            else:
-                data_list.append((sampleId, userId, distance, startTime, endTime, runtime, maxSpeed, calories, temperature, note, maxPulse, avgPulse, maxElevation, minElevation, humidity, 'N/A', 'N/A', 'N/A'))
-        # Added feature to allow the user to sort the data by the selected collumns and with the ID of the table
-        tableID = 'adidas_activities'
-        report.add_heat_map(json.dumps(activity_json))
-        report.filter_by_date(tableID, 3)
-
-        report.write_artifact_data_table(data_headers, data_list, file_found, table_id=tableID, html_escape=False)
-        # Add the map to the report
-        report.add_section_heading('Adidas Polyline Map')
-        for htmlMap in html_map:
-            report.add_map(htmlMap)
-        report.end_artifact_report()
-
-        tsvname = f'Adidas - Activities'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = f'Adidas - Activities'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-
-    else:
-        logfunc('No Adidas Activities data available')
-
-    if use_network:
-        conn.close()
-    db.close()
+    data_headers = ('Sample ID', 'User ID', 'Distance', ('Start Time', 'datetime'),
+                    ('End Time', 'datetime'), 'Run Time (min)', 'Max Speed', 'Calories', 'Temperature',
+                    'Note', 'Max Pulse', 'Avg Pulse', 'Max Elevation', 'Min Elevation', 'Humidity',
+                    'Latitude', 'Longitude', 'End Latitude', 'End Longitude', ('Route Map', 'media'),
+                    ('Route KML', 'media'))
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Adidas Running (Runtastic) GPS activities — same offline cluster treatment.

- One row per `session`; coordinates decoded from `encodedTrace`.
- `('Route Map','media')` offline image + `('Route KML','media')` downloadable route via `geo_utils`.
- Start/End (ms) → aware UTC; runtime → minutes; maxSpeed rounded; the sentinel values (`-300` temp, `-32768`/`32767` elevation, `-1` humidity) preserved as `N/A`; start coords feed `kmlgen` via `Latitude`/`Longitude`.
- **Removed:** folium map, Excel export, online reverse-geocoding, Show Map button. **No network.**

**Verification**
- Compiles; pylint clean; 21 column names pass a live `CREATE TABLE`; name unique; PluginLoader 516.
- Fixture `session` with sentinels + encoded polyline: sentinels → `N/A`, runtime/maxSpeed rounded, route image (`image/png`) + KML (`<LineString>`) embedded, timestamps aware-UTC.