### PR TITLE
Convert RunkeeperActivities to artifact_processor (offline route media)

### DIFF
--- a/scripts/artifacts/RunkeeperActivities.py
+++ b/scripts/artifacts/RunkeeperActivities.py
@@ -1,270 +1,93 @@
-# pylint: disable=W0613,W0622,W1309,W1514
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_run_activities": {
-        "name": "RunkeeperActivities",
-        "description": "Get Information related to the activities of the user from the Runkeeper app database",
+        "name": "Runkeeper - Activities",
+        "description": "Runkeeper activities with GPS routes (RunKeeper.sqlite)",
         "author": "Fabian Nunes {fabiannunes12@gmail.com}",
         "creation_date": "2023-03-25",
         "last_update_date": "2023-03-25",
-        "requirements": "Python 3.7 or higher, folium",
+        "requirements": "none",
         "category": "Runkeeper",
-        "notes": "",
+        "notes": "Interactive folium map and online reverse-geocoding removed; route shown as an "
+                 "offline image (media) + a downloadable route KML.",
         "paths": ('*com.fitnesskeeper.runkeeper.pro/databases/RunKeeper.sqlite*',),
-        "output_types": None,
+        "output_types": "all",
         "artifact_icon": "activity",
-        "function": "get_run_activities",
     }
 }
 
-# Get Information related to the activities of the user from the Runkeeper app database
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-03-25
-# Version: 1.0
-# Requirements: Python 3.7 or higher, folium
 import datetime
-import json
-import os
 import sqlite3
 
-import folium
-import xlsxwriter
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly, check_raw_fields, get_raw_fields, check_internet_connection
+from scripts.geo_utils import render_gps_track_png, build_track_kml
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, check_in_embedded_media
 
 
+def _ms_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
+
+
+def _db(files_found):
+    for file_found in files_found:
+        file_found = str(file_found)
+        if file_found.endswith('RunKeeper.sqlite'):
+            return file_found
+    return ''
+
+
+def _q(cursor, sql, params=()):
+    try:
+        cursor.execute(sql, params)
+        return cursor.fetchall()
+    except sqlite3.Error:
+        return []
+
+
+def _route_media(source, coords, title, subtitle, base):
+    route_map = ''
+    png = render_gps_track_png(coords, title=title, subtitle=subtitle)
+    if png:
+        route_map = check_in_embedded_media(source, png, f'{base}.png', force_type='image/png',
+                                            force_extension='png') or ''
+    route_kml = ''
+    kml = build_track_kml(coords, name=base)
+    if kml:
+        route_kml = check_in_embedded_media(source, kml, f'{base}.kml',
+                                            force_type='application/vnd.google-earth.kml+xml',
+                                            force_extension='kml') or ''
+    return route_map, route_kml
+
+
+@artifact_processor
 def get_run_activities(files_found, report_folder, seeker, wrap_text):
-    logfunc("Processing data for Runkeeper Activities")
-    use_network = check_internet_connection()
-    if use_network:
-        conn = sqlite3.connect('coordinates.db')
-        c = conn.cursor()
-        c.execute(
-            '''CREATE TABLE IF NOT EXISTS raw_fields (id INTEGER PRIMARY KEY AUTOINCREMENT, stored_time TIMESTAMP DATETIME DEFAULT 
-            CURRENT_TIMESTAMP, latitude text, longitude text, road text, city text, postcode text, country text)''')
-    files_found = [x for x in files_found if not x.endswith('-journal')]
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
+    source_path = _db(files_found)
+    data_list = []
+    if source_path:
+        db = open_sqlite_db_readonly(source_path)
+        cursor = db.cursor()
+        trips = _q(cursor, '''SELECT _id, start_date, device_sync_time, distance, elapsed_time,
+            activity_type, calories, heart_rate, totalClimb, uuid, nickname FROM trips''')
+        for t in trips:
+            tid = t[0]
+            pts = _q(cursor, 'SELECT latitude, longitude FROM points WHERE trip_id = ?', (tid,))
+            coords = [(p[0], p[1]) for p in pts if p[0] is not None and p[1] is not None]
+            start_lat, start_lon = coords[0] if coords else ('', '')
+            end_lat, end_lon = coords[-1] if coords else ('', '')
+            start_t = _ms_to_utc(t[1])
+            title = f'{t[5] or "Runkeeper"} {tid}'
+            subtitle = start_t.strftime('%Y-%m-%d %H:%M UTC') if start_t else ''
+            route_map, route_kml = _route_media(source_path, coords, title, subtitle, f'{tid}_route')
+            data_list.append((tid, start_t, _ms_to_utc(t[2]), t[3], t[4], t[5], t[6], t[7], t[8], t[9],
+                              t[10], start_lat, start_lon, end_lat, end_lon, route_map, route_kml))
+        db.close()
 
-    # Get information from the table device_sync_audit
-    cursor = db.cursor()
-    cursor.execute('''
-        Select _id, datetime("start_date"/1000,'unixepoch'), datetime("device_sync_time"/1000,'unixepoch'), distance, elapsed_time, activity_type, calories, heart_rate, totalClimb, uuid, nickname
-        from trips
-    ''')
-
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        logfunc(f"Found {usageentries} entries in completed_exercises")
-        report = ArtifactHtmlReport('Activities')
-        report.start_artifact_report(report_folder, 'Runkeeper Activities')
-        report.add_script()
-        data_headers = ('ID', 'Start Time', 'End Time', 'Distance', 'Duration', 'Activity Type', 'Calories', 'Heart Rate', 'Total Climb', 'UUID', 'Nickname', 'Coordinates KML', 'Coordinates Excel', 'Button')
-        data_list = []
-        activity_date = ''
-        activity_json = []
-        html_map = []
-        for row in all_rows:
-            id = row[0]
-            map = False
-            coordinates = []
-            coordinatesE = []
-            cursor.execute(f'''
-                            Select latitude, longitude, time_at_point
-                            from points
-                            where trip_id = '{id}'
-                        ''')
-            positions = cursor.fetchall()
-            usageentries_p = len(positions)
-            if usageentries_p > 0:
-                for row_p in positions:
-                    coordinates.append((row_p[0], row_p[1]))
-                    time = datetime.datetime.utcfromtimestamp(row_p[2] / 1000).strftime('%Y-%m-%d %H:%M:%S')
-                    coordinatesE.append((row_p[0], row_p[1], time))
-                place_lat = []
-                place_lon = []
-                m = folium.Map(location=[coordinates[0][0], coordinates[0][1]], zoom_start=10, max_zoom=19)
-
-                for coordinate in coordinates:
-                    # if points are to close, skip
-                    if len(place_lat) > 0 and abs(place_lat[-1] - coordinate[0]) < 0.0001 and abs(
-                            place_lon[-1] - coordinate[1]) < 0.0001:
-                        continue
-                    else:
-                        place_lat.append(coordinate[0])
-                        place_lon.append(coordinate[1])
-
-                points = []
-                for i in range(len(place_lat)):
-                    points.append([place_lat[i], place_lon[i]])
-
-                # Add points to map
-                for index, lat in enumerate(place_lat):
-                    # Start point
-                    if index == 0:
-                        folium.Marker([lat, place_lon[index]],
-                                      popup=(('Start Location\nActivity ID \n' + str(row[0])).format(index)),
-                                      icon=folium.Icon(color='blue', icon='flag', prefix='fa')).add_to(m)
-                    # last point
-                    elif index == len(place_lat) - 1:
-                        folium.Marker([lat, place_lon[index]],
-                                      popup=(('End Location\nActivity ID \n' + str(row[0])).format(index)),
-                                      icon=folium.Icon(color='red', icon='flag', prefix='fa')).add_to(m)
-                    # middle points
-
-                # Create an excel file with the coordinates
-                # Create an excel file with the coordinates
-                if use_network:
-                    if os.name == 'nt':
-                        f = open(report_folder + "\\" + str(row[0]) + ".xlsx", "w")
-                        workbook = xlsxwriter.Workbook(report_folder + "\\" + str(row[0]) + ".xlsx")
-                    else:
-                        f = open(report_folder + "/" + str(row[0]) + ".xlsx", "w")
-                        workbook = xlsxwriter.Workbook(report_folder + "/" + str(row[0]) + ".xlsx")
-                    worksheet = workbook.add_worksheet()
-                    rowE = 0
-                    col = 0
-                    worksheet.write(rowE, col, "Timestamp")
-                    worksheet.write(rowE, col + 1, "Latitude")
-                    worksheet.write(rowE, col + 2, "Longitude")
-                    worksheet.write(rowE, col + 3, "Road")
-                    worksheet.write(rowE, col + 4, "City")
-                    worksheet.write(rowE, col + 5, "Postcode")
-                    worksheet.write(rowE, col + 6, "Country")
-                    rowE += 1
-
-                    for coordinate in coordinatesE:
-                        # coordinate = str(coordinate)
-                        # round to 5 decimal cases
-                        lat = round(coordinate[0], 3)
-                        lon = round(coordinate[1], 3)
-                        worksheet.write(rowE, col, coordinate[2])
-                        worksheet.write(rowE, col + 1, lat)
-                        worksheet.write(rowE, col + 2, lon)
-                        location = check_raw_fields(lat, lon, c)
-                        if location is None:
-                            logfunc('Getting coordinates data from API might take some time')
-                            location = get_raw_fields(lat, lon, c, conn)
-                            for key, value in location.items():
-                                if key == "road":
-                                    worksheet.write(rowE, col + 3, value)
-                                elif key == "city":
-                                    worksheet.write(rowE, col + 4, value)
-                                elif key == "postcode":
-                                    worksheet.write(rowE, col + 5, value)
-                                elif key == "country":
-                                    worksheet.write(rowE, col + 6, value)
-                        else:
-                            logfunc('Getting coordinate data from database')
-                            worksheet.write(rowE, col + 3, location[4])
-                            worksheet.write(rowE, col + 4, location[5])
-                            worksheet.write(rowE, col + 5, location[6])
-                            worksheet.write(rowE, col + 6, location[7])
-                        rowE += 1
-                    workbook.close()
-                # Create polyline
-                folium.PolyLine(points, color="red", weight=2.5, opacity=1).add_to(m)
-                # Save the map to an HTML file
-                title = 'Runkeeper_Polyline_Map_' + str(id)
-                if os.name == 'nt':
-                    m.save(report_folder + '\\' + title + '.html')
-                else:
-                    m.save(report_folder + '/' + title + '.html')
-                html_map.append('<iframe id="' + str(
-                    id) + '" src="Runkeeper/' + title + '.html" width="100%" height="500" class="map" hidden></iframe>')
-                # save coords to a kml file
-                kml = """
-                                                    <?xml version="1.0" encoding="UTF-8"?>
-                                                    <kml xmlns="http://www.opengis.net/kml/2.2">
-                                                    <Document>
-                                                    <name>Coordinates</name>
-                                                    <description>Coordinates</description>
-                                                    <Style id="yellowLineGreenPoly">
-                                                        <LineStyle>
-                                                            <color>7f00ffff</color>
-                                                            <width>4</width>
-                                                        </LineStyle>
-                                                        <PolyStyle>
-                                                            <color>7f00ff00</color>
-                                                        </PolyStyle>
-                                                    </Style>
-                                                    <Placemark>
-                                                        <name>Absolute Extruded</name>
-                                                        <description>Transparent green wall with yellow outlines</description>
-                                                        <styleUrl>#yellowLineGreenPoly</styleUrl>
-                                                        <LineString>
-                                                            <extrude>1</extrude>
-                                                            <tessellate>1</tessellate>
-                                                            <altitudeMode>clampedToGround</altitudeMode>
-                                                            <coordinates>
-                                                            """
-                for i in range(len(place_lat)):
-                    kml += str(place_lon[i]) + ',' + str(place_lat[i]) + ',0 '
-                kml = kml[:-1]
-                kml += """
-                                                            </coordinates>
-                                                        </LineString>
-                                                    </Placemark>
-                                                    </Document>
-                                                    </kml>
-                                                    """
-                # remove the first space
-                kml = kml[1:]
-                # remove last line
-                kml = kml[:-1]
-                # remove extra indentation
-                kml = kml.replace("    ", "")
-                if os.name == 'nt':
-                    with open(report_folder + '\\' + str(row[0]) + '.kml', 'w') as f:
-                        f.write(kml)
-                        f.close()
-                else:
-                    with open(report_folder + '/' + str(row[0]) + '.kml', 'w') as f:
-                        f.write(kml)
-                        f.close()
-                map = True
-            # extract date from startTimeGMT
-            startTime = row[1]
-            current_date = startTime.split(' ')[0]
-            if current_date != activity_date:
-                activity_json.append({
-                    'date': current_date,
-                    'total': 1,
-                })
-                activity_date = current_date
-            else:
-                # Change the total of the last element of the list
-                activity_json[-1]['total'] += 1
-
-            if map:
-                if use_network:
-                    data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], '<a href=Runkeeper/'+str(row[0])+'.kml class="badge badge-light" target="_blank">'+str(row[0])+'.kml</a>', '<a href=Runkeeper/'+str(row[0])+'.xlsx class="badge badge-light" target="_blank">'+str(row[0])+'.xlsx</a>', '<button type="button" class="btn btn-light btn-sm" onclick="openMap(\''+str(id)+'\')">Show Map</button>'))
-                else:
-                    data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], '<a href=Runkeeper/'+str(row[0])+'.kml class="badge badge-light" target="_blank">'+str(row[0])+'.kml</a>', 'N/A', '<button type="button" class="btn btn-light btn-sm" onclick="openMap(\''+str(id)+'\')">Show Map</button>'))
-            else:
-                data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], 'N/A', 'N/A', 'N/A'))
-
-        # Filter by date
-        report.add_heat_map(json.dumps(activity_json))
-        table_id = "RunkeeperActivities"
-        report.filter_by_date(table_id, 1)
-        report.write_artifact_data_table(data_headers, data_list, file_found, table_id=table_id, html_escape=False)
-        # Add the map to the report
-        report.add_section_heading('Runkeeper Polyline Map')
-        for htmlMap in html_map:
-            report.add_map(htmlMap)
-        report.end_artifact_report()
-
-        tsvname = f'Runkeeper - Activities'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = f'Runkeeper - Activities'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-
-    else:
-        logfunc('No Runkeeper Activities data available')
-
-    if use_network:
-        conn.close()
-    db.close()
+    data_headers = ('ID', ('Start Time', 'datetime'), ('Device Sync Time', 'datetime'), 'Distance',
+                    'Duration', 'Activity Type', 'Calories', 'Heart Rate', 'Total Climb', 'UUID',
+                    'Nickname', 'Latitude', 'Longitude', 'End Latitude', 'End Longitude',
+                    ('Route Map', 'media'), ('Route KML', 'media'))
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Runkeeper GPS activities — same offline cluster treatment.

- One row per `trips` row; coordinates assembled from the per-trip `points` table.
- `('Route Map','media')` offline image + `('Route KML','media')` downloadable route via `geo_utils`.
- Start / device-sync times (ms) → aware UTC; start coords feed `kmlgen` via `Latitude`/`Longitude` (`output_types: all`).
- **Removed:** folium map, Excel export, online reverse-geocoding, the heat-map + date-filter widgets, and the Show Map button. **No network.**

**Verification**
- Compiles; pylint clean; 17 column names pass a live `CREATE TABLE`; name unique; PluginLoader 538.
- Fixture (`trips` + `points`): trip joins its points, embeds route image (`image/png`) + KML (`<LineString>`), coords anchored, timestamps aware-UTC.