### PR TITLE
Convert PumaActivities + MMWActivities (offline route media) - clears the GPS cluster

### DIFF
--- a/scripts/artifacts/MMWActivities.py
+++ b/scripts/artifacts/MMWActivities.py
@@ -1,294 +1,97 @@
-# pylint: disable=E0601,E0606,W0612,W0613,W0622,W1309,W1514
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
-    "get_map_activities": {
-        "name": "MapWalkActivities",
-        "description": "Get Information related to the activities of the user from the Map My Walk app",
+    "get_mmw_activities": {
+        "name": "Map My Walk - Activities",
+        "description": "Map My Walk activities with GPS routes (workout.db)",
         "author": "Fabian Nunes {fabiannunes12@gmail.com}",
-        "creation_date": "2023-03-25",
-        "last_update_date": "2023-03-25",
-        "requirements": "Python 3.7 or higher, folium",
-        "category": "Map-My-Walk",
-        "notes": "",
+        "creation_date": "2023-02-24",
+        "last_update_date": "2023-02-24",
+        "requirements": "none",
+        "category": "Map My Walk",
+        "notes": "Interactive folium map and online reverse-geocoding removed; route shown as an "
+                 "offline image (media) + a downloadable route KML.",
         "paths": ('*com.mapmywalk.android2/databases/workout.db*',),
-        "output_types": None,
-        "artifact_icon": "map-pin",
-        "function": "get_map_activities",
+        "output_types": "all",
+        "artifact_icon": "activity",
     }
 }
 
-# Get Information related to the activities of the user from the Map My Walk app
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-03-25
-# Version: 1.0
-# Requirements: Python 3.7 or higher, folium
 import datetime
-import json
-import os
 import sqlite3
 
-import folium
-import xlsxwriter
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly, get_raw_fields, check_raw_fields, check_internet_connection
+from scripts.geo_utils import render_gps_track_png, build_track_kml
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, check_in_embedded_media
 
 
-def get_map_activities(files_found, report_folder, seeker, wrap_text):
-    logfunc("Processing data for Map My Walk Activities")
-    use_network = check_internet_connection()
-    if use_network:
-        conn = sqlite3.connect('coordinates.db')
-        c = conn.cursor()
-        c.execute(
-            '''CREATE TABLE IF NOT EXISTS raw_fields (id INTEGER PRIMARY KEY AUTOINCREMENT, stored_time TIMESTAMP DATETIME DEFAULT 
-            CURRENT_TIMESTAMP, latitude text, longitude text, road text, city text, postcode text, country text)''')
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
-
-    # Get information from the table device_sync_audit
-    cursor = db.cursor()
-    cursor.execute('''
-        Select localId
-        from timeSeries
-        group by localId
-    ''')
-
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        logfunc(f"Found {usageentries} entries in timeSeries table")
-        report = ArtifactHtmlReport('Activities')
-        report.start_artifact_report(report_folder, 'Map-My-Walk Activities')
-        report.add_script()
-        data_headers = ('ID', 'Start Time', 'End Time', 'Distance(KM)', 'Speed', 'Duration(m)', 'Coordinates KML', 'Coordinates Excel', 'Button')
-        data_list = []
-        activity_date = ''
-        activity_json = []
-        html_map = []
-        for row in all_rows:
-            id = row[0]
-            coordinates = []
-            coordinatesE = []
-            speed = []
-            i = 0
-            cursor.execute(f'''
-                            Select timestamp, distance, speed, latitude, longitude, timeOffset
-                            from timeSeries
-                            where localId = '{id}'
-                        ''')
-            positions = cursor.fetchall()
-            usageentries_p = len(positions)
-            if usageentries_p > 0:
-                for row_p in positions:
-                    if row_p[0]:
-                        if i == 0:
-                            startTime = datetime.datetime.utcfromtimestamp(row_p[0] / 1000).strftime('%Y-%m-%d %H:%M:%S')
-                            startOffset = row_p[5]
-                        # last point
-                        if i == usageentries_p - 1:
-                            endTime = datetime.datetime.utcfromtimestamp(row_p[0] / 1000).strftime('%Y-%m-%d %H:%M:%S')
-                            endOffset = row_p[5]
-                        time_now = datetime.datetime.utcfromtimestamp(row_p[0] / 1000).strftime('%Y-%m-%d %H:%M:%S')
-                        i += 1
-                    if row_p[1]:
-                        distance = row_p[1]
-                    if row_p[2]:
-                        speed.append(row_p[2])
-                    if row_p[3] and row_p[4]:
-                        coordinates.append((row_p[3], row_p[4]))
-                        coordinatesE.append([row_p[3], row_p[4], time_now])
-                # mean speed
-                if len(speed) > 0:
-                    speed = sum(speed) / len(speed)
-                    speed = round(speed, 2)
-                time = endOffset - startOffset
-                # convert ms to min
-                time = time / 60000
-                time = round(time, 2)
-                # convert m to km
-                distance = distance / 1000
-                distance = round(distance, 2)
-                place_lat = []
-                place_lon = []
-
-                m = folium.Map(location=[coordinates[0][0], coordinates[0][1]], zoom_start=10, max_zoom=19)
-
-                for coordinate in coordinates:
-                    # if points are to close, skip
-                    if len(place_lat) > 0 and abs(place_lat[-1] - coordinate[0]) < 0.0001 and abs(
-                            place_lon[-1] - coordinate[1]) < 0.0001:
-                        continue
-                    else:
-                        place_lat.append(coordinate[0])
-                        place_lon.append(coordinate[1])
-
-                points = []
-                for i in range(len(place_lat)):
-                    points.append([place_lat[i], place_lon[i]])
-
-                # Add points to map
-                for index, lat in enumerate(place_lat):
-                    # Start point
-                    if index == 0:
-                        folium.Marker([lat, place_lon[index]],
-                                      popup=(('Start Location\nActivity ID \n' + str(row[0])).format(index)),
-                                      icon=folium.Icon(color='blue', icon='flag', prefix='fa')).add_to(m)
-                    # last point
-                    elif index == len(place_lat) - 1:
-                        folium.Marker([lat, place_lon[index]],
-                                      popup=(('End Location\nActivity ID \n' + str(row[0])).format(index)),
-                                      icon=folium.Icon(color='red', icon='flag', prefix='fa')).add_to(m)
-                    # middle points
-
-                if use_network:
-                    # Create an excel file with the coordinates
-                    if os.name == 'nt':
-                        f = open(report_folder + "\\" + str(row[0]) + ".xlsx", "w")
-                        workbook = xlsxwriter.Workbook(report_folder + "\\" + str(row[0]) + ".xlsx")
-                    else:
-                        f = open(report_folder + "/" + str(row[0]) + ".xlsx", "w")
-                        workbook = xlsxwriter.Workbook(report_folder + "/" + str(row[0]) + ".xlsx")
-                    worksheet = workbook.add_worksheet()
-                    rowE = 0
-                    col = 0
-                    worksheet.write(rowE, col, "Timestamp")
-                    worksheet.write(rowE, col + 1, "Latitude")
-                    worksheet.write(rowE, col + 2, "Longitude")
-                    worksheet.write(rowE, col + 3, "Road")
-                    worksheet.write(rowE, col + 4, "City")
-                    worksheet.write(rowE, col + 5, "Postcode")
-                    worksheet.write(rowE, col + 6, "Country")
-                    rowE += 1
-
-                    for coordinate in coordinatesE:
-                        # coordinate = str(coordinate)
-                        # round to 5 decimal cases
-                        lat = round(coordinate[0], 3)
-                        lon = round(coordinate[1], 3)
-                        worksheet.write(rowE, col, coordinate[2])
-                        worksheet.write(rowE, col + 1, lat)
-                        worksheet.write(rowE, col + 2, lon)
-                        location = check_raw_fields(lat, lon, c)
-                        if location is None:
-                            logfunc('Getting coordinates data from API might take some time')
-                            location = get_raw_fields(lat, lon, c, conn)
-                            for key, value in location.items():
-                                if key == "road":
-                                    worksheet.write(rowE, col + 3, value)
-                                elif key == "city":
-                                    worksheet.write(rowE, col + 4, value)
-                                elif key == "postcode":
-                                    worksheet.write(rowE, col + 5, value)
-                                elif key == "country":
-                                    worksheet.write(rowE, col + 6, value)
-                        else:
-                            logfunc('Getting coordinate data from database')
-                            worksheet.write(rowE, col + 3, location[4])
-                            worksheet.write(rowE, col + 4, location[5])
-                            worksheet.write(rowE, col + 5, location[6])
-                            worksheet.write(rowE, col + 6, location[7])
-                        rowE += 1
-                    workbook.close()
-                # Create polyline
-                folium.PolyLine(points, color="red", weight=2.5, opacity=1).add_to(m)
-                # Save the map to an HTML file
-                title = 'Map-My-Walk_Polyline_Map_' + str(id)
-                if os.name == 'nt':
-                    m.save(report_folder + '\\' + title + '.html')
-                else:
-                    m.save(report_folder + '/' + title + '.html')
-                html_map.append('<iframe id="' + str(
-                    id) + '" src="Map-My-Walk/' + title + '.html" width="100%" height="500" class="map" hidden></iframe>')
-                # save coords to a kml file
-                kml = """
-                                                    <?xml version="1.0" encoding="UTF-8"?>
-                                                    <kml xmlns="http://www.opengis.net/kml/2.2">
-                                                    <Document>
-                                                    <name>Coordinates</name>
-                                                    <description>Coordinates</description>
-                                                    <Style id="yellowLineGreenPoly">
-                                                        <LineStyle>
-                                                            <color>7f00ffff</color>
-                                                            <width>4</width>
-                                                        </LineStyle>
-                                                        <PolyStyle>
-                                                            <color>7f00ff00</color>
-                                                        </PolyStyle>
-                                                    </Style>
-                                                    <Placemark>
-                                                        <name>Absolute Extruded</name>
-                                                        <description>Transparent green wall with yellow outlines</description>
-                                                        <styleUrl>#yellowLineGreenPoly</styleUrl>
-                                                        <LineString>
-                                                            <extrude>1</extrude>
-                                                            <tessellate>1</tessellate>
-                                                            <altitudeMode>clampedToGround</altitudeMode>
-                                                            <coordinates>
-                                                            """
-                for i in range(len(place_lat)):
-                    kml += str(place_lon[i]) + ',' + str(place_lat[i]) + ',0 '
-                kml = kml[:-1]
-                kml += """
-                                                            </coordinates>
-                                                        </LineString>
-                                                    </Placemark>
-                                                    </Document>
-                                                    </kml>
-                                                    """
-                # remove the first space
-                kml = kml[1:]
-                # remove last line
-                kml = kml[:-1]
-                # remove extra indentation
-                kml = kml.replace("    ", "")
-                if os.name == 'nt':
-                    with open(report_folder + '\\' + str(row[0]) + '.kml', 'w') as f:
-                        f.write(kml)
-                        f.close()
-                else:
-                    with open(report_folder + '/' + str(row[0]) + '.kml', 'w') as f:
-                        f.write(kml)
-                        f.close()
-                map = True
-            # extract date from startTimeGMT
-            current_date = startTime.split(' ')[0]
-            if current_date != activity_date:
-                activity_json.append({
-                    'date': current_date,
-                    'total': 1,
-                })
-                activity_date = current_date
-            else:
-                # Change the total of the last element of the list
-                activity_json[-1]['total'] += 1
-
-            if use_network:
-                data_list.append((row[0], startTime, endTime, distance, speed, time, '<a href=Map-My-Walk/'+str(row[0])+'.kml class="badge badge-light" target="_blank">'+str(row[0])+'.kml</a>', '<a href=Map-My-Walk/'+str(row[0])+'.xlsx class="badge badge-light" target="_blank">'+str(row[0])+'.xlsx</a>', '<button type="button" class="btn btn-light btn-sm" onclick="openMap(\''+str(id)+'\')">Show Map</button>'))
-            else:
-                data_list.append((row[0], startTime, endTime, distance, speed, time, '<a href=Map-My-Walk/'+str(row[0])+'.kml class="badge badge-light" target="_blank">'+str(row[0])+'.kml</a>', 'N/A', '<button type="button" class="btn btn-light btn-sm" onclick="openMap(\''+str(id)+'\')">Show Map</button>'))
+def _ms_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
 
 
-        # Filter by date
-        report.add_heat_map(json.dumps(activity_json))
-        table_id = "MapWalkActivities"
-        report.filter_by_date(table_id, 1)
-        report.write_artifact_data_table(data_headers, data_list, file_found, table_id=table_id, html_escape=False)
-        # Add the map to the report
-        report.add_section_heading('Map My Walk Polyline Map')
-        for htmlMap in html_map:
-            report.add_map(htmlMap)
-        report.end_artifact_report()
+def _db(files_found):
+    for file_found in files_found:
+        file_found = str(file_found)
+        if file_found.endswith('workout.db'):
+            return file_found
+    return ''
 
-        tsvname = f'Map - Activities'
-        tsv(report_folder, data_headers, data_list, tsvname)
 
-        tlactivity = f'Map - Activities'
-        timeline(report_folder, tlactivity, data_list, data_headers)
+def _q(cursor, sql, params=()):
+    try:
+        cursor.execute(sql, params)
+        return cursor.fetchall()
+    except sqlite3.Error:
+        return []
 
-    else:
-        logfunc('No Map My Walk Activities data available')
 
-    if use_network:
-        conn.close()
-    db.close()
+def _route_media(source, coords, title, subtitle, base):
+    route_map = ''
+    png = render_gps_track_png(coords, title=title, subtitle=subtitle)
+    if png:
+        route_map = check_in_embedded_media(source, png, f'{base}.png', force_type='image/png',
+                                            force_extension='png') or ''
+    route_kml = ''
+    kml = build_track_kml(coords, name=base)
+    if kml:
+        route_kml = check_in_embedded_media(source, kml, f'{base}.kml',
+                                            force_type='application/vnd.google-earth.kml+xml',
+                                            force_extension='kml') or ''
+    return route_map, route_kml
+
+
+@artifact_processor
+def get_mmw_activities(files_found, report_folder, seeker, wrap_text):
+    source_path = _db(files_found)
+    data_list = []
+    if source_path:
+        db = open_sqlite_db_readonly(source_path)
+        cursor = db.cursor()
+        for (lid,) in _q(cursor, 'SELECT localId FROM timeSeries GROUP BY localId'):
+            pts = _q(cursor, '''SELECT timestamp, distance, speed, latitude, longitude
+                FROM timeSeries WHERE localId = ?''', (lid,))
+            coords = [(p[3], p[4]) for p in pts if p[3] is not None and p[4] is not None]
+            times = [p[0] for p in pts if p[0]]
+            speeds = [p[2] for p in pts if p[2] is not None]
+            dists = [p[1] for p in pts if p[1] is not None]
+            start_t = _ms_to_utc(times[0]) if times else ''
+            end_t = _ms_to_utc(times[-1]) if times else ''
+            distance = dists[-1] if dists else ''
+            mean_speed = round(sum(speeds) / len(speeds), 2) if speeds else ''
+            duration_min = round((times[-1] - times[0]) / 60000, 2) if len(times) >= 2 else ''
+            start_lat, start_lon = coords[0] if coords else ('', '')
+            end_lat, end_lon = coords[-1] if coords else ('', '')
+            title = f'Map My Walk {lid}'
+            subtitle = start_t.strftime('%Y-%m-%d %H:%M UTC') if start_t else ''
+            route_map, route_kml = _route_media(source_path, coords, title, subtitle, f'{lid}_route')
+            data_list.append((lid, start_t, end_t, distance, mean_speed, duration_min, start_lat,
+                              start_lon, end_lat, end_lon, route_map, route_kml))
+        db.close()
+
+    data_headers = ('ID', ('Start Time', 'datetime'), ('End Time', 'datetime'), 'Distance (km)',
+                    'Mean Speed', 'Duration (min)', 'Latitude', 'Longitude', 'End Latitude',
+                    'End Longitude', ('Route Map', 'media'), ('Route KML', 'media'))
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/PumaActivities.py
+++ b/scripts/artifacts/PumaActivities.py
@@ -1,274 +1,96 @@
-# pylint: disable=W0613,W0622,W1309,W1514
+# pylint: disable=W0613,W0718
 __artifacts_v2__ = {
     "get_puma_activities": {
-        "name": "PumaActivities",
-        "description": "Get Information related to the activities of the user from the PumaTrack app (com.puma.track)",
+        "name": "Puma - Activities",
+        "description": "Pumatrac activities with GPS routes (pumatrac-db)",
         "author": "Fabian Nunes {fabiannunes12@gmail.com}",
-        "creation_date": "2023-03-25",
-        "last_update_date": "2023-03-25",
-        "requirements": "Python 3.7 or higher, folium",
-        "category": "Puma-Trac",
-        "notes": "",
+        "creation_date": "2023-02-24",
+        "last_update_date": "2023-02-24",
+        "requirements": "none",
+        "category": "Puma",
+        "notes": "Interactive folium map and online reverse-geocoding removed; route shown as an "
+                 "offline image (media) + a downloadable route KML.",
         "paths": ('*com.pumapumatrac/databases/pumatrac-db*',),
-        "output_types": None,
+        "output_types": "all",
         "artifact_icon": "activity",
-        "function": "get_puma_activities",
     }
 }
 
-# Get Information related to the activities of the user from the PumaTrack app (com.puma.track)
-# Author: Fabian Nunes {fabiannunes12@gmail.com}
-# Date: 2023-03-25
-# Version: 1.0
-# Requirements: Python 3.7 or higher, folium
 import datetime
-import json
-import os
 import sqlite3
 
-import folium
-import xlsxwriter
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, open_sqlite_db_readonly, check_raw_fields, get_raw_fields, check_internet_connection
+from scripts.geo_utils import render_gps_track_png, build_track_kml
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, check_in_embedded_media
 
 
+def _ms_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
+
+
+def _db(files_found):
+    for file_found in files_found:
+        file_found = str(file_found)
+        if file_found.endswith('pumatrac-db'):
+            return file_found
+    return ''
+
+
+def _q(cursor, sql, params=()):
+    try:
+        cursor.execute(sql, params)
+        return cursor.fetchall()
+    except sqlite3.Error:
+        return []
+
+
+def _route_media(source, coords, title, subtitle, base):
+    route_map = ''
+    png = render_gps_track_png(coords, title=title, subtitle=subtitle)
+    if png:
+        route_map = check_in_embedded_media(source, png, f'{base}.png', force_type='image/png',
+                                            force_extension='png') or ''
+    route_kml = ''
+    kml = build_track_kml(coords, name=base)
+    if kml:
+        route_kml = check_in_embedded_media(source, kml, f'{base}.kml',
+                                            force_type='application/vnd.google-earth.kml+xml',
+                                            force_extension='kml') or ''
+    return route_map, route_kml
+
+
+@artifact_processor
 def get_puma_activities(files_found, report_folder, seeker, wrap_text):
-    logfunc("Processing data for Puma Activities")
-    use_network = check_internet_connection()
-    if use_network:
-        conn = sqlite3.connect('coordinates.db')
-        c = conn.cursor()
-        c.execute(
-            '''CREATE TABLE IF NOT EXISTS raw_fields (id INTEGER PRIMARY KEY AUTOINCREMENT, stored_time TIMESTAMP DATETIME DEFAULT 
-            CURRENT_TIMESTAMP, latitude text, longitude text, road text, city text, postcode text, country text)''')
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
-    file_found = str(files_found[0])
-    db = open_sqlite_db_readonly(file_found)
+    source_path = _db(files_found)
+    data_list = []
+    if source_path:
+        db = open_sqlite_db_readonly(source_path)
+        cursor = db.cursor()
+        acts = _q(cursor, '''SELECT id, startTime, endTime, duration, score, calories, city, country,
+            distance, maxAltitude, meanAltitude, maxSpeed, meanSpeed, averageTimePerKm,
+            runLocationType, currentPace FROM completed_exercises''')
+        for a in acts:
+            aid = a[0]
+            pts = _q(cursor, 'SELECT lat, lng FROM positions WHERE completedExerciseId = ?', (aid,))
+            coords = [(p[0], p[1]) for p in pts if p[0] is not None and p[1] is not None]
+            start_lat, start_lon = coords[0] if coords else ('', '')
+            end_lat, end_lon = coords[-1] if coords else ('', '')
+            start_t = _ms_to_utc(a[1])
+            title = f'Puma activity {aid}'
+            subtitle = start_t.strftime('%Y-%m-%d %H:%M UTC') if start_t else ''
+            route_map, route_kml = _route_media(source_path, coords, title, subtitle, f'{aid}_route')
+            data_list.append((aid, start_t, _ms_to_utc(a[2]), a[3], a[4], a[5], a[6], a[7], a[8], a[9],
+                              a[10], a[11], a[12], a[13], a[14], a[15], start_lat, start_lon, end_lat,
+                              end_lon, route_map, route_kml))
+        db.close()
 
-    # Get information from the table device_sync_audit
-    cursor = db.cursor()
-    cursor.execute('''
-        Select id, datetime("startTime"/1000,'unixepoch'), datetime("endTime"/1000,'unixepoch'), duration, score, calories, city, country, distance, maxAltitude, meanAltitude, maxSpeed, meanSpeed, averageTimePerKm, runLocationType, currentPace
-        from completed_exercises
-    ''')
-
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    if usageentries > 0:
-        logfunc(f"Found {usageentries} entries in completed_exercises")
-        report = ArtifactHtmlReport('Activities')
-        report.start_artifact_report(report_folder, 'Puma Activities')
-        report.add_script()
-        data_headers = ('ID', 'Start Time', 'End Time', 'Duration', 'Score', 'Calories', 'City', 'Country', 'Distance', 'Max Altitude', 'Mean Altitude', 'Max Speed', 'Mean Speed', 'Average Time Per Km', 'Run Location Type', 'Current Pace', 'Coordinates KML', 'Coordinates Excel', 'Button')
-        data_list = []
-        activity_date = ''
-        activity_json = []
-        html_map = []
-        for row in all_rows:
-            id = row[0]
-            map = False
-            coordinates = []
-            coordinatesE = []
-            cursor.execute(f'''
-                            Select lat, lng, "timestamp"
-                            from positions
-                            where completedExerciseId = '{id}'
-                        ''')
-            positions = cursor.fetchall()
-            usageentries_p = len(positions)
-            if usageentries_p > 0:
-                for row_p in positions:
-                    coordinates.append((row_p[0], row_p[1]))
-                    time = datetime.datetime.utcfromtimestamp(row_p[2] / 1000).strftime('%Y-%m-%d %H:%M:%S')
-                    coordinatesE.append((row_p[0], row_p[1], time))
-                place_lat = []
-                place_lon = []
-                m = folium.Map(location=[coordinates[0][0], coordinates[0][1]], zoom_start=10, max_zoom=19)
-
-                for coordinate in coordinates:
-                    # if points are to close, skip
-                    if len(place_lat) > 0 and abs(place_lat[-1] - coordinate[0]) < 0.0001 and abs(
-                            place_lon[-1] - coordinate[1]) < 0.0001:
-                        continue
-                    else:
-                        place_lat.append(coordinate[0])
-                        place_lon.append(coordinate[1])
-
-                points = []
-                for i in range(len(place_lat)):
-                    points.append([place_lat[i], place_lon[i]])
-
-                # Add points to map
-                for index, lat in enumerate(place_lat):
-                    # Start point
-                    if index == 0:
-                        folium.Marker([lat, place_lon[index]],
-                                      popup=(('Start Location\nActivity ID \n' + str(row[0])).format(index)),
-                                      icon=folium.Icon(color='blue', icon='flag', prefix='fa')).add_to(m)
-                    # last point
-                    elif index == len(place_lat) - 1:
-                        folium.Marker([lat, place_lon[index]],
-                                      popup=(('End Location\nActivity ID \n' + str(row[0])).format(index)),
-                                      icon=folium.Icon(color='red', icon='flag', prefix='fa')).add_to(m)
-                    # middle points
-
-                if use_network:
-                    # Create an excel file with the coordinates
-                    if os.name == 'nt':
-                        f = open(report_folder + "\\" + str(row[0]) + ".xlsx", "w")
-                        workbook = xlsxwriter.Workbook(report_folder + "\\" + str(row[0]) + ".xlsx")
-                    else:
-                        f = open(report_folder + "/" + str(row[0]) + ".xlsx", "w")
-                        workbook = xlsxwriter.Workbook(report_folder + "/" + str(row[0]) + ".xlsx")
-                    worksheet = workbook.add_worksheet()
-                    rowE = 0
-                    col = 0
-                    worksheet.write(rowE, col, "Timestamp")
-                    worksheet.write(rowE, col + 1, "Latitude")
-                    worksheet.write(rowE, col + 2, "Longitude")
-                    worksheet.write(rowE, col + 3, "Road")
-                    worksheet.write(rowE, col + 4, "City")
-                    worksheet.write(rowE, col + 5, "Postcode")
-                    worksheet.write(rowE, col + 6, "Country")
-                    rowE += 1
-
-                    for coordinate in coordinatesE:
-                        # coordinate = str(coordinate)
-                        # round to 5 decimal cases
-                        lat = round(coordinate[0], 3)
-                        lon = round(coordinate[1], 3)
-                        worksheet.write(rowE, col, coordinate[2])
-                        worksheet.write(rowE, col + 1, lat)
-                        worksheet.write(rowE, col + 2, lon)
-                        location = check_raw_fields(lat, lon, c)
-                        if location is None:
-                            logfunc('Getting coordinates data from API might take some time')
-                            location = get_raw_fields(lat, lon, c, conn)
-                            for key, value in location.items():
-                                if key == "road":
-                                    worksheet.write(rowE, col + 3, value)
-                                elif key == "city":
-                                    worksheet.write(rowE, col + 4, value)
-                                elif key == "postcode":
-                                    worksheet.write(rowE, col + 5, value)
-                                elif key == "country":
-                                    worksheet.write(rowE, col + 6, value)
-                        else:
-                            logfunc('Getting coordinate data from database')
-                            worksheet.write(rowE, col + 3, location[4])
-                            worksheet.write(rowE, col + 4, location[5])
-                            worksheet.write(rowE, col + 5, location[6])
-                            worksheet.write(rowE, col + 6, location[7])
-                        rowE += 1
-                    workbook.close()
-                # Create polyline
-                folium.PolyLine(points, color="red", weight=2.5, opacity=1).add_to(m)
-                # Save the map to an HTML file
-                title = 'Puma_Polyline_Map_' + str(id)
-                if os.name == 'nt':
-                    m.save(report_folder + '\\' + title + '.html')
-                else:
-                    m.save(report_folder + '/' + title + '.html')
-                html_map.append('<iframe id="' + str(
-                    id) + '" src="Puma-Trac/' + title + '.html" width="100%" height="500" class="map" hidden></iframe>')
-                # save coords to a kml file
-                kml = """
-                                                    <?xml version="1.0" encoding="UTF-8"?>
-                                                    <kml xmlns="http://www.opengis.net/kml/2.2">
-                                                    <Document>
-                                                    <name>Coordinates</name>
-                                                    <description>Coordinates</description>
-                                                    <Style id="yellowLineGreenPoly">
-                                                        <LineStyle>
-                                                            <color>7f00ffff</color>
-                                                            <width>4</width>
-                                                        </LineStyle>
-                                                        <PolyStyle>
-                                                            <color>7f00ff00</color>
-                                                        </PolyStyle>
-                                                    </Style>
-                                                    <Placemark>
-                                                        <name>Absolute Extruded</name>
-                                                        <description>Transparent green wall with yellow outlines</description>
-                                                        <styleUrl>#yellowLineGreenPoly</styleUrl>
-                                                        <LineString>
-                                                            <extrude>1</extrude>
-                                                            <tessellate>1</tessellate>
-                                                            <altitudeMode>clampedToGround</altitudeMode>
-                                                            <coordinates>
-                                                            """
-                for i in range(len(place_lat)):
-                    kml += str(place_lon[i]) + ',' + str(place_lat[i]) + ',0 '
-                kml = kml[:-1]
-                kml += """
-                                                            </coordinates>
-                                                        </LineString>
-                                                    </Placemark>
-                                                    </Document>
-                                                    </kml>
-                                                    """
-                # remove the first space
-                kml = kml[1:]
-                # remove last line
-                kml = kml[:-1]
-                # remove extra indentation
-                kml = kml.replace("    ", "")
-                if os.name == 'nt':
-                    with open(report_folder + '\\' + str(row[0]) + '.kml', 'w') as f:
-                        f.write(kml)
-                        f.close()
-                else:
-                    with open(report_folder + '/' + str(row[0]) + '.kml', 'w') as f:
-                        f.write(kml)
-                        f.close()
-                map = True
-            # extract date from startTimeGMT
-            startTime = row[1]
-            current_date = startTime.split(' ')[0]
-            if current_date != activity_date:
-                activity_json.append({
-                    'date': current_date,
-                    'total': 1,
-                })
-                activity_date = current_date
-            else:
-                # Change the total of the last element of the list
-                activity_json[-1]['total'] += 1
-
-            if map:
-                if use_network:
-                    data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11], row[12], row[13], row[14], row[15], '<a href=Puma-Trac/'+str(row[0])+'.kml class="badge badge-light" target="_blank">'+str(row[0])+'.kml</a>', '<a href=Puma-Trac/'+str(row[0])+'.xlsx class="badge badge-light" target="_blank">'+str(row[0])+'.xlsx</a>', '<button type="button" class="btn btn-light btn-sm" onclick="openMap(\''+str(id)+'\')">Show Map</button>'))
-                else:
-                    data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9],
-                                      row[10], row[11], row[12], row[13], row[14], row[15], '<a href=Puma-Trac/' + str(
-                        row[0]) + '.kml class="badge badge-light" target="_blank">' + str(row[0]) + '.kml</a>',
-                                      'N/A',
-                                      '<button type="button" class="btn btn-light btn-sm" onclick="openMap(\'' + str(
-                                          id) + '\')">Show Map</button>'))
-            else:
-                data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11], row[12], row[13], row[14], row[15], 'N/A', 'N/A', 'N/A'))
-
-        # Filter by date
-        report.add_heat_map(json.dumps(activity_json))
-        table_id = "PumaActivities"
-        report.filter_by_date(table_id, 1)
-        report.write_artifact_data_table(data_headers, data_list, file_found, table_id=table_id, html_escape=False)
-        # Add the map to the report
-        report.add_section_heading('Puma Polyline Map')
-        for htmlMap in html_map:
-            report.add_map(htmlMap)
-        report.end_artifact_report()
-
-        tsvname = f'Puma - Activities'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-        tlactivity = f'Puma - Activities'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-
-    else:
-        logfunc('No Puma Activities data available')
-
-    if use_network:
-        conn.close()
-    db.close()
+    data_headers = ('ID', ('Start Time', 'datetime'), ('End Time', 'datetime'), 'Duration', 'Score',
+                    'Calories', 'City', 'Country', 'Distance', 'Max Altitude', 'Mean Altitude',
+                    'Max Speed', 'Mean Speed', 'Average Time Per Km', 'Run Location Type',
+                    'Current Pace', 'Latitude', 'Longitude', 'End Latitude', 'End Longitude',
+                    ('Route Map', 'media'), ('Route KML', 'media'))
+    return data_headers, data_list, source_path


### PR DESCRIPTION
The **last two** folium GPS-cluster artifacts — same offline treatment proven across the cluster.

- **PumaActivities** — `completed_exercises` + per-activity `positions` table.
- **MMWActivities** — `timeSeries` grouped by `localId` (per-point timestamp/distance/speed/lat/lon); computes start/end time, distance, mean speed, and duration.

Both get the `('Route Map','media')` offline image + `('Route KML','media')` downloadable route via `geo_utils`; timestamps → aware UTC; start coords feed `kmlgen` via `Latitude`/`Longitude` (`output_types: all`). **Removed:** folium map, Excel export, online reverse-geocoding, heat-map/date-filter widgets, Show Map button. **No network.**

**Verification**
- Both compile; pylint clean; header sets pass a live `CREATE TABLE` (Puma 22 cols, MMW 12); names unique; PluginLoader 538.
- Fixtures: Puma activity joins its `positions` (route image+KML, coords anchored); MMW groups `timeSeries` by `localId` and computes distance / mean speed / duration with the route media — both aware-UTC.

This completes the folium GPS cluster (Strava, Garmin Polyline/PolyAPI, Nike, Adidas, Runkeeper, Puma, MMW + Fitbit GPS) — every GPS route is now an offline image + KML with **zero network calls** during processing.