### PR TITLE
Remove unused ArtifactHtmlReport import from chatgpt2

### DIFF
--- a/scripts/artifacts/chatgpt2.py
+++ b/scripts/artifacts/chatgpt2.py
@@ -21,7 +21,6 @@ import textwrap
 import json
 from datetime import datetime, timezone
 from collections import defaultdict
-from scripts.artifact_report import ArtifactHtmlReport
 from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
 @artifact_processor


### PR DESCRIPTION
`chatgpt2` is already `@artifact_processor`-based; the leftover `from scripts.artifact_report import ArtifactHtmlReport` import was unused (it only kept the file flagged as old-style). Removed it. No behaviour change; pylint clean (`-d C,R`); PluginLoader unchanged.