### PR TITLE
Convert Life360 to artifact_processor (split into 4 artifacts)

### DIFF
--- a/scripts/artifacts/Life360.py
+++ b/scripts/artifacts/Life360.py
@@ -1,252 +1,212 @@
-# pylint: disable=W0401,W0611,W0612,W0613,W0614,W1309
+# pylint: disable=W0613
 __artifacts_v2__ = {
-    "get_Life360": {
-        "name": "Life360",
-        "description": "Parses the Life360 app locations, device battery, and more",
+    "get_Life360_chat_messages": {
+        "name": "Life360 - Chat Messages",
+        "description": "Parses Life360 chat messages (messaging.db)",
         "author": "@KevinPagano3",
         "creation_date": "2024-01-17",
         "last_update_date": "2024-01-17",
         "requirements": "none",
         "category": "Life360",
         "notes": "",
-        "paths": ('*/com.life360.android.safetymapd/databases/messaging.db*','*/com.life360.android.safetymapd/databases/L360LocalStoreRoomDatabase*','*/com.life360.android.safetymapd/databases/L360EventStore.db*'),
-        "output_types": None,
+        "paths": ('*/com.life360.android.safetymapd/databases/messaging.db*',),
+        "output_types": "all",
+        "artifact_icon": "message-circle",
+    },
+    "get_Life360_places": {
+        "name": "Life360 - Places",
+        "description": "Parses Life360 saved places (L360LocalStoreRoomDatabase)",
+        "author": "@KevinPagano3",
+        "creation_date": "2024-01-17",
+        "last_update_date": "2024-01-17",
+        "requirements": "none",
+        "category": "Life360",
+        "notes": "",
+        "paths": ('*/com.life360.android.safetymapd/databases/L360LocalStoreRoomDatabase*',),
+        "output_types": ['html', 'tsv', 'lava', 'kml'],
         "artifact_icon": "map-pin",
-        "function": "get_Life360",
+    },
+    "get_Life360_locations": {
+        "name": "Life360 - Locations",
+        "description": "Parses Life360 device geolocation events (L360EventStore.db)",
+        "author": "@KevinPagano3",
+        "creation_date": "2024-01-17",
+        "last_update_date": "2024-01-17",
+        "requirements": "none",
+        "category": "Life360",
+        "notes": "",
+        "paths": ('*/com.life360.android.safetymapd/databases/L360EventStore.db*',),
+        "output_types": "all",
+        "artifact_icon": "map-pin",
+    },
+    "get_Life360_device_battery": {
+        "name": "Life360 - Device Battery",
+        "description": "Parses Life360 device battery events (L360EventStore.db)",
+        "author": "@KevinPagano3",
+        "creation_date": "2024-01-17",
+        "last_update_date": "2024-01-17",
+        "requirements": "none",
+        "category": "Life360",
+        "notes": "",
+        "paths": ('*/com.life360.android.safetymapd/databases/L360EventStore.db*',),
+        "output_types": "standard",
+        "artifact_icon": "battery",
     }
 }
 
-from datetime import *
+import datetime
 import json
-import os
-import shutil
 import sqlite3
-import textwrap
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, open_sqlite_db_readonly, get_next_unused_name, convert_ts_human_to_utc, convert_utc_human_to_timezone, kmlgen
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-is_windows = is_platform_windows()
-slash = '\\' if is_windows else '/'
 
-def get_Life360(files_found, report_folder, seeker, wrap_text):
-    
-    data_list_messaging = []
-    data_list_places = []
-    data_list_places_kml = []
-    data_list_geo = []
-    data_list_battery = []
-    
+def _sec_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value), datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
+
+
+def _ms_to_utc(value):
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+    except (ValueError, OverflowError, OSError, TypeError):
+        return ''
+
+
+def _find(files_found, suffix):
     for file_found in files_found:
         file_found = str(file_found)
-        
-        # Chat Messages
-        if file_found.endswith('messaging.db'):
-            messaging_db = file_found            
-            db = open_sqlite_db_readonly(messaging_db)
-            cursor = db.cursor()
-            cursor.execute('''
-            select
-            datetime(message.created_at,'unixepoch'),
+        if file_found.endswith(suffix):
+            return file_found
+    return ''
+
+
+def _q(cursor, sql):
+    try:
+        cursor.execute(sql)
+        return cursor.fetchall()
+    except sqlite3.Error:
+        return []
+
+
+def _ble_events(file_found):
+    """Parse the BLE geolocation/battery events from L360EventStore.db into dicts."""
+    rows = []
+    db = open_sqlite_db_readonly(file_found)
+    cursor = db.cursor()
+    # Filter to BLE events in Python (json_extract in SQL errors on any malformed-JSON row).
+    for data, ev_id in _q(cursor, 'SELECT data, id FROM event WHERE eventVersion = 5'):
+        try:
+            j = json.loads(data)
+        except (ValueError, TypeError):
+            continue
+        if j.get('tag') != 'BLE':
+            continue
+        loc = j.get('locationData') or {}
+        meta = j.get('metaData') or {}
+        wifi = (meta.get('wifiData') or {}).get('connectedAccessPoint') or {}
+        rows.append({
+            'time': _ms_to_utc(loc.get('time')),
+            'lat': loc.get('latitude', ''), 'lon': loc.get('longitude', ''),
+            'alt': loc.get('altitude', ''), 'speed': loc.get('speed', ''),
+            'course': loc.get('course', ''), 'bearing': loc.get('bearing', ''),
+            'vert': loc.get('verticalAccuracy', ''), 'hor': loc.get('horizontalAccuracy', ''),
+            'lmode': meta.get('lmode', ''), 'battery': meta.get('battery', ''),
+            'charging': meta.get('chargingState', ''),
+            'bssid': wifi.get('bssid', ''),
+            'ssid': (wifi.get('ssid', '') or '').replace('"', ''),
+            'id': ev_id,
+        })
+    db.close()
+    return rows
+
+
+@artifact_processor
+def get_Life360_chat_messages(files_found, report_folder, seeker, wrap_text):
+    source = _find(files_found, 'messaging.db')
+    data_list = []
+    if source:
+        db = open_sqlite_db_readonly(source)
+        cursor = db.cursor()
+        rows = _q(cursor, '''
+        SELECT
+            message.created_at,
             message.thread_id,
             message.sender_id,
-            thread_participant.participant_name as 'Sender',
+            thread_participant.participant_name,
             message.content,
-            case message.sent
-                when 0 then ''
-                when 1 then 'Yes'
-            end as 'Message Sent',
-            case message.read
-                when 0 then ''
-                when 1 then 'Yes'
-            end as 'Message Read',
-            case message.dismissed
-                when 0 then ''
-                when 1 then 'Yes'
-            end as 'Message Dismissed',
-            case message.deleted
-                when 0 then ''
-                when 1 then 'Yes'
-            end as 'Message Deleted',
-            case message.has_location 
-                when 0 then ''
-                when 1 then 'Yes'
-            end as 'Has Location',
+            CASE message.sent WHEN 1 THEN 'Yes' ELSE '' END,
+            CASE message.read WHEN 1 THEN 'Yes' ELSE '' END,
+            CASE message.dismissed WHEN 1 THEN 'Yes' ELSE '' END,
+            CASE message.deleted WHEN 1 THEN 'Yes' ELSE '' END,
+            CASE message.has_location WHEN 1 THEN 'Yes' ELSE '' END,
             message.location_latitude,
             message.location_longitude,
             message.location_name,
-            datetime(message.location_timestamp,'unixepoch')
-            from message
-            left join thread_participant on message.sender_id = thread_participant.participant_id
-            ''')
+            message.location_timestamp
+        FROM message
+        LEFT JOIN thread_participant ON message.sender_id = thread_participant.participant_id
+        ''')
+        for row in rows:
+            data_list.append((_sec_to_utc(row[0]), row[1], row[2], row[3], row[4], row[5], row[6],
+                              row[7], row[8], row[9], row[10], row[11], row[12], _sec_to_utc(row[13]),
+                              source))
+        db.close()
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                for row in all_rows:
-                    time_create = convert_utc_human_to_timezone(convert_ts_human_to_utc(row[0]),'UTC')
-                    loc_time = ''
-                    if not row[13] is None:
-                        loc_time = convert_utc_human_to_timezone(convert_ts_human_to_utc(row[13]),'UTC')
-                    data_list_messaging.append((time_create,row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11],row[12],loc_time,messaging_db))
-            db.close()
-        
-        # Places        
-        if file_found.endswith('L360LocalStoreRoomDatabase'):
-            places_db = file_found            
-            db = open_sqlite_db_readonly(places_db)
-            cursor = db.cursor()
-            cursor.execute('''
-            select
-            name,
-            latitude,
-            longitude,
-            radius,
-            source,
-            source_id,
-            owner_id
-            from places
-            ''')
+    data_headers = (('Timestamp', 'datetime'), 'Thread ID', 'Sender ID', 'Sender Name', 'Message',
+                    'Message Sent', 'Message Read', 'Message Dismissed', 'Message Deleted',
+                    'Has Location', 'Latitude', 'Longitude', 'Location Name',
+                    ('Location Timestamp', 'datetime'), 'Source File')
+    return data_headers, data_list, source
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                for row in all_rows:
-                    data_list_places.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],places_db))
-                    data_list_places_kml.append(('',row[1],row[2],row[0]))
-            db.close()
-            
-        # Geolocation & Device Battery
-        if file_found.endswith('L360EventStore.db'):
-            geo_db = file_found            
-            db = open_sqlite_db_readonly(geo_db)
-            cursor = db.cursor()
-            cursor.execute('''
-            select
-            datetime(timestamp/1000,'unixepoch'),
-            data,
-            id,
-            json_extract(data, '$.tag') as 'Tag'
-            from event
-            where eventVersion = 5 and Tag = 'BLE'
-            ''')
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                for row in all_rows:
-                    json_load = json.loads(row[1])
-                
-                    json_timestamp = str(datetime.fromtimestamp(json_load['locationData'].get('time','')/1000,tz=timezone.utc))[:-6]
-                    time_create = convert_utc_human_to_timezone(convert_ts_human_to_utc(json_timestamp),'UTC')
-                    
-                    json_lat = json_load['locationData'].get('latitude','')
-                    json_long = json_load['locationData'].get('longitude','')
-                    json_speed = json_load['locationData'].get('speed','')
-                    json_alt = json_load['locationData'].get('altitude','')
-                    json_course = json_load['locationData'].get('course','')
-                    json_bearing = json_load['locationData'].get('bearing','')
-                    json_vert = json_load['locationData'].get('verticalAccuracy','')
-                    json_hor = json_load['locationData'].get('horizontalAccuracy','')
-                    
-                    
-                    json_battery = json_load['metaData'].get('battery','')
-                    json_charging = json_load['metaData'].get('chargingState','')
-                    json_lmode = json_load['metaData'].get('lmode','')
-                    
-                    json_bssid = ''
-                    json_ssid = ''
-                    if not (json_load['metaData']['wifiData'].get('connectedAccessPoint') is None):
-                        json_bssid = json_load['metaData']['wifiData']['connectedAccessPoint'].get('bssid','')
-                        json_ssid = json_load['metaData']['wifiData']['connectedAccessPoint'].get('ssid','').replace('\"','')
-                    
-                    data_list_geo.append((time_create,json_lat,json_long,json_alt,json_speed,json_course,json_bearing,json_vert,json_hor,json_lmode,json_bssid,json_ssid,row[2],geo_db))
-                    data_list_battery.append((time_create,json_battery,json_charging,geo_db))
-            db.close()
-        
-        else:
-            continue # skip -journal and other files
+@artifact_processor
+def get_Life360_places(files_found, report_folder, seeker, wrap_text):
+    source = _find(files_found, 'L360LocalStoreRoomDatabase')
+    data_list = []
+    if source:
+        db = open_sqlite_db_readonly(source)
+        cursor = db.cursor()
+        for row in _q(cursor, '''SELECT name, latitude, longitude, radius, source, source_id, owner_id
+                FROM places'''):
+            data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], source))
+        db.close()
 
-        if report_folder[-1] == slash: 
-            folder_name = os.path.basename(report_folder[:-1])
-        else:
-            folder_name = os.path.basename(report_folder)
+    data_headers = ('Place Name', 'Latitude', 'Longitude', 'Radius (m)', 'Places Source', 'Source ID',
+                    'Owner ID', 'Source File')
+    return data_headers, data_list, source
 
-    # Chat Messages Report
-    if len(data_list_messaging) > 0:
-        report = ArtifactHtmlReport(f'Life360 - Chat Messages')
-        report.start_artifact_report(report_folder, f'Life360 - Chat Messages')
-        report.add_script()
-        data_headers = ('Timestamp','Thread ID','Sender ID','Sender Name','Message','Message Sent','Message Read','Message Dismissed','Message Deleted','Has Location','Latitude','Longitude','Location Name','Location Timestamp','Source File')
 
-        report.write_artifact_data_table(data_headers, data_list_messaging, messaging_db, html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = f'Life360 - Chat Messages'
-        tsv(report_folder, data_headers, data_list_messaging, tsvname)
-        
-        tlactivity = f'Life360 - Chat Messages'
-        timeline(report_folder, tlactivity, data_list_messaging, data_headers)
-    else:
-        logfunc('No Life360 - Chat Messages data available')
-    
-    # Places Report
-    if len(data_list_places) > 0:
-        report = ArtifactHtmlReport(f'Life360 - Places')
-        report.start_artifact_report(report_folder, f'Life360 - Places')
-        report.add_script()
-        data_headers = ('Place Name','Latitude','Longitude','Radius (m)','Places Source','Source ID','Owner ID','Source File')
-        data_headers_kml = ('Timestamp','Latitude','Longitude','Place Name')
+@artifact_processor
+def get_Life360_locations(files_found, report_folder, seeker, wrap_text):
+    source = _find(files_found, 'L360EventStore.db')
+    data_list = []
+    if source:
+        for e in _ble_events(source):
+            data_list.append((e['time'], e['lat'], e['lon'], e['alt'], e['speed'], e['course'],
+                              e['bearing'], e['vert'], e['hor'], e['lmode'], e['bssid'], e['ssid'],
+                              e['id'], source))
 
-        report.write_artifact_data_table(data_headers, data_list_places, places_db, html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = f'Life360 - Places'
-        tsv(report_folder, data_headers, data_list_places, tsvname)
-        
-        kmlactivity = 'Life360 - Places'
-        kmlgen(report_folder, kmlactivity, data_list_places_kml, data_headers_kml)
-        
-    else:
-        logfunc('No Life360 - Places data available')
-        
-    # Geolocation Report
-    if len(data_list_geo) > 0:
-        report = ArtifactHtmlReport(f'Life360 - Locations')
-        report.start_artifact_report(report_folder, f'Life360 - Locations')
-        report.add_script()
-        data_headers = ('Timestamp','Latitude','Longitude','Altitude','Speed (mps)','Course','Bearing','Vertical Accuracy (+/- m)','Horizontal Accuracy (+/- m)','Location Mode','Connected Access Point BSSID','Connected Access Point SSID','ID','Source File')
+    data_headers = (('Timestamp', 'datetime'), 'Latitude', 'Longitude', 'Altitude', 'Speed (mps)',
+                    'Course', 'Bearing', 'Vertical Accuracy (+/- m)', 'Horizontal Accuracy (+/- m)',
+                    'Location Mode', 'Connected Access Point BSSID', 'Connected Access Point SSID',
+                    'ID', 'Source File')
+    return data_headers, data_list, source
 
-        report.write_artifact_data_table(data_headers, data_list_geo, geo_db, html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = f'Life360 - Locations'
-        tsv(report_folder, data_headers, data_list_geo, tsvname)
-        
-        tlactivity = f'Life360 - Locations'
-        timeline(report_folder, tlactivity, data_list_geo, data_headers)
-        
-        kmlactivity = 'Life360 - Locations'
-        kmlgen(report_folder, kmlactivity, data_list_geo, data_headers)
-        
-    else:
-        logfunc('No Life360 - Locations data available')
-        
-    # Battery Report
-    if len(data_list_battery) > 0:
-        report = ArtifactHtmlReport(f'Life360 - Device Battery')
-        report.start_artifact_report(report_folder, f'Life360 - Device Battery')
-        report.add_script()
-        data_headers = ('Timestamp','Device Battery (%)','Charging','Source File')
 
-        report.write_artifact_data_table(data_headers, data_list_battery, geo_db, html_escape=False)
-        report.end_artifact_report()
-        
-        tsvname = f'Life360 - Device Battery'
-        tsv(report_folder, data_headers, data_list_battery, tsvname)
-        
-        tlactivity = f'Life360 - Device Battery'
-        timeline(report_folder, tlactivity, data_list_battery, data_headers)
-        
-    else:
-        logfunc('No Life360 - Device Battery data available')
+@artifact_processor
+def get_Life360_device_battery(files_found, report_folder, seeker, wrap_text):
+    source = _find(files_found, 'L360EventStore.db')
+    data_list = []
+    if source:
+        for e in _ble_events(source):
+            data_list.append((e['time'], e['battery'], e['charging'], source))
+
+    data_headers = (('Timestamp', 'datetime'), 'Device Battery (%)', 'Charging', 'Source File')
+    return data_headers, data_list, source


### PR DESCRIPTION
## Summary
`Life360` was a single old-style function emitting **four reports from three databases**. Split into four `@artifact_processor` functions, one per table, each scoped to only the DB it needs.

| Artifact | Source DB | KML |
|---|---|---|
| **Life360 - Chat Messages** | messaging.db | ✅ message location lat/lon |
| **Life360 - Places** | L360LocalStoreRoomDatabase | ✅ saved-place lat/lon |
| **Life360 - Locations** | L360EventStore.db | ✅ BLE geolocation events |
| **Life360 - Device Battery** | L360EventStore.db | — battery/charging |

## Changes
- Timestamps returned as **aware UTC datetimes** (per-file `_sec_to_utc`/`_ms_to_utc`) instead of string conversions, so timeline/LAVA handle them correctly.
- **More robust BLE parsing:** events are filtered to `tag == 'BLE'` in Python instead of with `json_extract` in the SQL `WHERE` clause — the latter errors out on *any* malformed-JSON row in the table (the original was fragile here). Each row is also `json.loads`-guarded.
- Lat/lon columns flow to the framework's KML export (`output_types` includes `kml` for the three location artifacts).
- Dropped `ArtifactHtmlReport` / manual `tsv` / `timeline` / `kmlgen`.

## Validation
- `ast.parse` OK; no old-style code refs.
- Reserved-word audit: all 4 header sets create SQLite tables cleanly.
- pylint (CI config): **10.00/10**.
- PluginLoader: **541** (was 538; +3 net from the 1→4 split).
- Functional smoke test on synthetic fixtures for all three DBs: Chat (with/without location), Places, Locations, Battery all return correct rows; malformed-JSON and non-BLE events are skipped.