### PR TITLE
Convert FacebookMessenger to artifact_processor (split into 7 artifacts)

### DIFF
--- a/scripts/artifacts/FacebookMessenger.py
+++ b/scripts/artifacts/FacebookMessenger.py
@@ -1,390 +1,427 @@
-# pylint: disable=W0611,W0613,W0702,W1514
+# pylint: disable=W0613
 __artifacts_v2__ = {
-    "get_FacebookMessenger": {
-        "name": "FacebookMessenger",
-        "description": "2023-02-03: Added support for new msys_database format - Kevin Pagano",
-        "author": "",
+    "get_fb_user_id": {
+        "name": "Facebook Messenger - User ID",
+        "description": "Facebook/Messenger logged-in user id (threads_db2-uid)",
+        "author": "Kevin Pagano",
         "creation_date": "2021-03-03",
         "last_update_date": "2021-03-03",
         "requirements": "none",
         "category": "Facebook Messenger",
         "notes": "",
-        "paths": ('*/*threads_db2*', '*/msys_database*'),
-        "output_types": None,
+        "paths": ('*/*threads_db2-uid',),
+        "output_types": "standard",
+        "artifact_icon": "user",
+    },
+    "get_fb_msys_chats": {
+        "name": "Facebook Messenger - Chats (msys_database)",
+        "description": "Facebook/Messenger chat messages (msys_database)",
+        "author": "Kevin Pagano",
+        "creation_date": "2021-03-03",
+        "last_update_date": "2021-03-03",
+        "requirements": "none",
+        "category": "Facebook Messenger",
+        "notes": "",
+        "paths": ('*/msys_database*',),
+        "output_types": "standard",
         "artifact_icon": "message-square",
-        "function": "get_FacebookMessenger",
+    },
+    "get_fb_msys_calls": {
+        "name": "Facebook Messenger - Calls (msys_database)",
+        "description": "Facebook/Messenger call log (msys_database)",
+        "author": "Kevin Pagano",
+        "creation_date": "2021-03-03",
+        "last_update_date": "2021-03-03",
+        "requirements": "none",
+        "category": "Facebook Messenger",
+        "notes": "",
+        "paths": ('*/msys_database*',),
+        "output_types": "standard",
+        "artifact_icon": "phone",
+    },
+    "get_fb_msys_contacts": {
+        "name": "Facebook Messenger - Contacts (msys_database)",
+        "description": "Facebook/Messenger contacts (msys_database)",
+        "author": "Kevin Pagano",
+        "creation_date": "2021-03-03",
+        "last_update_date": "2021-03-03",
+        "requirements": "none",
+        "category": "Facebook Messenger",
+        "notes": "",
+        "paths": ('*/msys_database*',),
+        "output_types": "standard",
+        "artifact_icon": "users",
+    },
+    "get_fb_threads_chats": {
+        "name": "Facebook Messenger - Chats (threads_db2)",
+        "description": "Facebook/Messenger chat messages (threads_db2)",
+        "author": "Kevin Pagano",
+        "creation_date": "2021-03-03",
+        "last_update_date": "2021-03-03",
+        "requirements": "none",
+        "category": "Facebook Messenger",
+        "notes": "",
+        "paths": ('*/*threads_db2',),
+        "output_types": "standard",
+        "artifact_icon": "message-square",
+    },
+    "get_fb_threads_calls": {
+        "name": "Facebook Messenger - Calls (threads_db2)",
+        "description": "Facebook/Messenger call log (threads_db2)",
+        "author": "Kevin Pagano",
+        "creation_date": "2021-03-03",
+        "last_update_date": "2021-03-03",
+        "requirements": "none",
+        "category": "Facebook Messenger",
+        "notes": "",
+        "paths": ('*/*threads_db2',),
+        "output_types": "standard",
+        "artifact_icon": "phone",
+    },
+    "get_fb_threads_contacts": {
+        "name": "Facebook Messenger - Contacts (threads_db2)",
+        "description": "Facebook/Messenger contacts (threads_db2)",
+        "author": "Kevin Pagano",
+        "creation_date": "2021-03-03",
+        "last_update_date": "2021-03-03",
+        "requirements": "none",
+        "category": "Facebook Messenger",
+        "notes": "",
+        "paths": ('*/*threads_db2',),
+        "output_types": "standard",
+        "artifact_icon": "users",
     }
 }
 
-#2023-02-03: Added support for new msys_database format - Kevin Pagano
-
-import os
+import datetime
 import sqlite3
-import textwrap
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, timeline, is_platform_windows, get_next_unused_name, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-def get_FacebookMessenger(files_found, report_folder, seeker, wrap_text):
-    
-    slash = '\\' if is_platform_windows() else '/'
-    
+
+def _str_to_utc(value):
+    """Parse a 'YYYY-MM-DD HH:MM:SS' UTC string (from SQL datetime()) into an aware datetime."""
+    if not value:
+        return ''
+    try:
+        return datetime.datetime.strptime(str(value), '%Y-%m-%d %H:%M:%S').replace(
+            tzinfo=datetime.timezone.utc)
+    except (ValueError, TypeError):
+        return ''
+
+
+def _candidate(file_found):
+    # Skip mirror copies and the /user/0/ duplicate of /data/data/com.facebook.orca.
+    return 'mirror' not in file_found and '/user/0/' not in file_found
+
+
+def _src(file_found, seeker):
+    try:
+        return file_found.replace(seeker.data_folder, '')
+    except AttributeError:
+        return file_found
+
+
+def _q(cursor, sql):
+    try:
+        cursor.execute(sql)
+        return cursor.fetchall()
+    except sqlite3.Error:
+        return []
+
+
+@artifact_processor
+def get_fb_user_id(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source = ''
     for file_found in files_found:
         file_found = str(file_found)
-        
-        if 'mirror' in file_found: #remove to process mirror data. Should be a copy of actual data.
-            continue 
-        
-        if '/user/0/' in file_found: #remove to process user 0. Should be a copy data in /data/data/com.facebook.orca
+        if not _candidate(file_found) or not file_found.endswith('threads_db2-uid'):
             continue
-            
-                
-        if 'user' in file_found:
-            usernum = file_found.split(slash)
-            usernum = '_'+str(usernum[-4])
-        else:
-            usernum = ''
-            
-        if 'katana' in file_found:
-            typeof = ' App '
-        elif 'orca' in file_found:
-            typeof = ' Messenger '
-        else:
-            typeof =''
-        
-        if file_found.endswith('threads_db2-uid'):
-            source_file = file_found.replace(seeker.data_folder, '')
-            userid = ''
-            data_list = []
-            with open(file_found, 'r') as dat:
+        source = source or file_found
+        rel = _src(file_found, seeker)
+        try:
+            with open(file_found, 'r', encoding='utf-8', errors='replace') as dat:
                 for line in dat:
-                    userid = line
-                    if userid != '':
-                        data_list.append((userid,))
-            logfunc(f'Userid: {str(userid)}')            
-            if len(userid) > 0:
-                report = ArtifactHtmlReport('Facebook - User ID')
-                report.start_artifact_report(report_folder, f'Facebook{typeof}- User ID{usernum}')
-                report.add_script()
-                data_headers = ('User ID',) # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Facebook{typeof}- User ID{usernum}'
-                tsv(report_folder, data_headers, data_list, tsvname, source_file)
-                
+                    uid = line.strip()
+                    if uid:
+                        data_list.append((uid, rel))
+        except OSError:
             continue
-        
-        if file_found.endswith(('-shm','-wal')):
+
+    data_headers = ('User ID', 'Source File')
+    return data_headers, data_list, source
+
+
+@artifact_processor
+def get_fb_msys_chats(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if not _candidate(file_found) or file_found.endswith(('-shm', '-wal')):
             continue
-        
-        if file_found.find('msys_database_') >= 0:
-            source_file = file_found.replace(seeker.data_folder, '')
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            cursor.execute('''
-            select
-            datetime(messages.timestamp_ms/1000,'unixepoch') as "Message Time",
-            contacts.name as "Sender",
-            messages.sender_id as "Sender Account ID",
-            messages.thread_key as "Thread Key",
-            messages.text as "Message",
-            attachments.title_text as "Snippet",
-            attachments.subtitle_text as "Call/Location Information",
-            attachments.filename as "Attachment File Name",
-            attachments.playable_url_mime_type as "Attachment Type",
-            attachments.playable_url as "Attachment URL",
-            attachment_ctas.native_url as "Location Lat/Long",
-            reactions.reaction as "Reaction",
-            datetime(reactions.reaction_creation_timestamp_ms/1000,'unixepoch') as "Reaction Time",
-            case
-            when messages.is_admin_message = 1 then "Yes"
-            when messages.is_admin_message = 0 then "No"
-            else messages.is_admin_message
-            end as "Is Admin Message",
-            messages.message_id as "Message ID"
-            from messages
-            join contacts on contacts.id = messages.sender_id
-            left join attachments on attachments.message_id = messages.message_id
-            left join attachment_ctas on messages.message_id = attachment_ctas.message_id
-            left join reactions on reactions.message_id = messages.message_id
-            order by "Message Time" ASC
-            ''')
+        if 'msys_database_' not in file_found:
+            continue
+        source = source or file_found
+        rel = _src(file_found, seeker)
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        rows = _q(cursor, '''
+        SELECT
+            datetime(messages.timestamp_ms/1000,'unixepoch'),
+            contacts.name,
+            messages.sender_id,
+            messages.thread_key,
+            messages.text,
+            attachments.title_text,
+            attachments.subtitle_text,
+            attachments.filename,
+            attachments.playable_url_mime_type,
+            attachments.playable_url,
+            attachment_ctas.native_url,
+            reactions.reaction,
+            datetime(reactions.reaction_creation_timestamp_ms/1000,'unixepoch'),
+            CASE
+                WHEN messages.is_admin_message = 1 THEN "Yes"
+                WHEN messages.is_admin_message = 0 THEN "No"
+                ELSE messages.is_admin_message
+            END,
+            messages.message_id
+        FROM messages
+        JOIN contacts ON contacts.id = messages.sender_id
+        LEFT JOIN attachments ON attachments.message_id = messages.message_id
+        LEFT JOIN attachment_ctas ON messages.message_id = attachment_ctas.message_id
+        LEFT JOIN reactions ON reactions.message_id = messages.message_id
+        ORDER BY messages.timestamp_ms ASC
+        ''')
+        for row in rows:
+            data_list.append((_str_to_utc(row[0]), row[1], row[2], row[3], row[4], row[5], row[6],
+                              row[7], row[8], row[9], row[10], row[11], _str_to_utc(row[12]), row[13],
+                              row[14], rel))
+        db.close()
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                report = ArtifactHtmlReport('Facebook - Chats - msys_database')
-                report.start_artifact_report(report_folder, f'Facebook{typeof}- Chats{usernum} - msys_database')
-                report.add_script()
-                data_headers = ('Message Timestamp','Sender','Sender ID','Thread Key','Message','Snippet','Call/Location Information','Attachment Name','Attachment Type','Attachment URL','Location Lat/Long','Reaction','Reaction Timestamp','Is Admin Message','Message ID') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-                data_list = []
-                for row in all_rows:
-                    data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11],row[12],row[13],row[14]))
+    data_headers = (('Message Timestamp', 'datetime'), 'Sender', 'Sender ID', 'Thread Key', 'Message',
+                    'Snippet', 'Call/Location Information', 'Attachment Name', 'Attachment Type',
+                    'Attachment URL', 'Location Lat/Long', 'Reaction',
+                    ('Reaction Timestamp', 'datetime'), 'Is Admin Message', 'Message ID',
+                    'Source File')
+    return data_headers, data_list, source
 
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Facebook{typeof}- Chats{usernum} - msys_database'
-                tsv(report_folder, data_headers, data_list, tsvname, source_file)
-                
-            else:
-                logfunc(f'No Facebook{typeof}- Chats{usernum} - msys_database data available')
-            
-            cursor.execute('''
-            select
-            datetime(call_log.call_timestamp_ms/1000,'unixepoch') as "Call Timestamp",
-            strftime('%H:%M:%S',call_log.call_duration, 'unixepoch')as "Call Duration",
-            contacts.name as "Party Name",
-            case call_log.call_direction
-                when 1 then "Outgoing"
-                when 2 then "Incoming"
-            end as "Call Direction",
-            case call_log.call_media_type
-                when 2 then "Yes"
-                else ""
-            end as "Video Call",
-            case has_been_seen
-                when 0 then 'No'
-                when 1 then 'Yes'
-            end as "Call Answered",
+
+@artifact_processor
+def get_fb_msys_calls(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if not _candidate(file_found) or file_found.endswith(('-shm', '-wal')):
+            continue
+        if 'msys_database_' not in file_found:
+            continue
+        source = source or file_found
+        rel = _src(file_found, seeker)
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        rows = _q(cursor, '''
+        SELECT
+            datetime(call_log.call_timestamp_ms/1000,'unixepoch'),
+            strftime('%H:%M:%S',call_log.call_duration, 'unixepoch'),
+            contacts.name,
+            CASE call_log.call_direction WHEN 1 THEN "Outgoing" WHEN 2 THEN "Incoming" END,
+            CASE call_log.call_media_type WHEN 2 THEN "Yes" ELSE "" END,
+            CASE has_been_seen WHEN 0 THEN 'No' WHEN 1 THEN 'Yes' END,
             call_log.thread_key
-            from call_log
-            left join contacts on contacts.id = call_log.thread_key
-            ''')
+        FROM call_log
+        LEFT JOIN contacts ON contacts.id = call_log.thread_key
+        ''')
+        for row in rows:
+            data_list.append((_str_to_utc(row[0]), row[1], row[2], row[3], row[4], row[5], row[6],
+                              rel))
+        db.close()
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                report = ArtifactHtmlReport('Facebook - Calls - msys_database')
-                report.start_artifact_report(report_folder, f'Facebook{typeof}- Calls{usernum} - msys_database')
-                report.add_script()
-                data_headers = ('Call Timestamp','Call Duration','Party Name','Call Direction','Video Call','Call Answered','Thread Key') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-                data_list = []
-                for row in all_rows:
-                    data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
+    data_headers = (('Call Timestamp', 'datetime'), 'Call Duration', 'Party Name', 'Call Direction',
+                    'Video Call', 'Call Answered', 'Thread Key', 'Source File')
+    return data_headers, data_list, source
 
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Facebook{typeof}- Calls{usernum} - msys_database'
-                tsv(report_folder, data_headers, data_list, tsvname, source_file)
-                
-            else:
-                logfunc(f'No Facebook{typeof}- Calls{usernum} - msys_database data available')
-                
-            cursor.execute('''
-            select
-            id,
-            name,
-            normalized_name_for_search,
-            username,
-            profile_picture_large_url,
-            email_address,
-            phone_number,
-            case is_messenger_user
-                when 0 then ""
-                when 1 then "Yes"
-            end as "Messenger User",
-            case friendship_status
-                when 0 then "N/A (Self)"
-                when 1 then "Friends"
-                when 2 then "Friend Request Received"
-                when 3 then "Friend Request Sent"
-                when 4 then "Not Friends"
-            end as "Friendship Status",
-            substr(datetime(birthday_timestamp,'unixepoch'),6,5) as "Birthdate (MM-DD)"
-            from contacts
-            ''')
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                report = ArtifactHtmlReport('Facebook - Contacts - msys_database')
-                report.start_artifact_report(report_folder, f'Facebook{typeof}- Contacts{usernum} - msys_database')
-                report.add_script()
-                data_headers = ('Facebook ID','Name','Normalized Name','User Name','Profile Pic URL','Email Address','Phone Number','Is Messenger User','Friendship Status','Birthday Timestamp') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-                data_list = []
-                for row in all_rows:
-                    data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9]))
-
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Facebook{typeof}- Contacts{usernum} - msys_database'
-                tsv(report_folder, data_headers, data_list, tsvname, source_file)
-                
-            else:
-                logfunc(f'No Facebook{typeof}- Contacts{usernum} - msys_database data available')   
-            
-            db.close()
-            
+@artifact_processor
+def get_fb_msys_contacts(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if not _candidate(file_found) or file_found.endswith(('-shm', '-wal')):
             continue
+        if 'msys_database_' not in file_found:
+            continue
+        source = source or file_found
+        rel = _src(file_found, seeker)
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        rows = _q(cursor, '''
+        SELECT
+            id, name, normalized_name_for_search, username, profile_picture_large_url,
+            email_address, phone_number,
+            CASE is_messenger_user WHEN 0 THEN "" WHEN 1 THEN "Yes" END,
+            CASE friendship_status
+                WHEN 0 THEN "N/A (Self)" WHEN 1 THEN "Friends"
+                WHEN 2 THEN "Friend Request Received" WHEN 3 THEN "Friend Request Sent"
+                WHEN 4 THEN "Not Friends"
+            END,
+            substr(datetime(birthday_timestamp,'unixepoch'),6,5)
+        FROM contacts
+        ''')
+        for row in rows:
+            data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8],
+                              row[9], rel))
+        db.close()
 
-        if (file_found.startswith('ssus.') and file_found.endswith('threads_db2')) or file_found.endswith('threads_db2'):
-            source_file = file_found.replace(seeker.data_folder, '')
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            try:
-                cursor.execute('''
-                select
-                case messages.timestamp_ms
-                    when 0 then ''
-                    else datetime(messages.timestamp_ms/1000,'unixepoch')
-                End	as Datestamp,
-                (select json_extract (messages.sender, '$.name')) as "Sender",
-                substr((select json_extract (messages.sender, '$.user_key')),10) as "Sender ID",
-                messages.thread_key,
-                messages.text,
-                messages.snippet,
-                (select json_extract (messages.attachments, '$[0].filename')) as AttachmentName,
-                (select json_extract (messages.shares, '$[0].name')) as ShareName,
-                (select json_extract (messages.shares, '$[0].description')) as ShareDesc,
-                (select json_extract (messages.shares, '$[0].href')) as ShareLink,
-                message_reactions.reaction as "Message Reaction",
-                datetime(message_reactions.reaction_timestamp/1000,'unixepoch') as "Message Reaction Timestamp",
-                messages.msg_id
-                from messages, threads
-                left join message_reactions on message_reactions.msg_id = messages.msg_id
-                where messages.thread_key=threads.thread_key and generic_admin_message_extensible_data IS NULL and msg_type != -1
-                order by messages.thread_key, datestamp;
-                ''')
-                snippet = 1
-            except:
-                cursor.execute('''
-                select
-                case messages.timestamp_ms
-                    when 0 then ''
-                    else datetime(messages.timestamp_ms/1000,'unixepoch')
-                End	as Datestamp,
-                (select json_extract (messages.sender, '$.name')) as "Sender",
-                substr((select json_extract (messages.sender, '$.user_key')),10) as "Sender ID",
-                messages.thread_key,
-                messages.text,
-                (select json_extract (messages.attachments, '$[0].filename')) as AttachmentName,
-                (select json_extract (messages.shares, '$[0].name')) as ShareName,
-                (select json_extract (messages.shares, '$[0].description')) as ShareDesc,
-                (select json_extract (messages.shares, '$[0].href')) as ShareLink,
-                message_reactions.reaction as "Message Reaction",
-                datetime(message_reactions.reaction_timestamp/1000,'unixepoch') as "Message Reaction Timestamp",
-                messages.msg_id
-                from messages, threads
-                left join message_reactions on message_reactions.msg_id = messages.msg_id
-                where messages.thread_key=threads.thread_key and generic_admin_message_extensible_data IS NULL and msg_type != -1
-                order by messages.thread_key, datestamp;
-                ''')
-                
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                report = ArtifactHtmlReport('Facebook - Chats - threads_db2')
-                report.start_artifact_report(report_folder, f'Facebook{typeof}- Chats{usernum} - threads_db2')
-                report.add_script()
-                data_list = []
-                
-                if snippet == 1:
-                    data_headers = ('Timestamp','Sender Name','Sender ID','Thread Key','Message','Snippet','Attachment Name','Share Name','Share Description','Share Link','Message Reaction','Message Reaction Timestamp','Message ID')
-                    for row in all_rows:
-                        data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11],row[12]))
-                else:
-                    data_headers = ('Timestamp','Sender Name','Sender ID','Thread Key','Message','Attachment Name','Share Name','Share Description','Share Link','Message Reaction','Message Reaction Timestamp','Message ID')
-                    for row in all_rows:
-                        data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11]))
-                        
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Facebook Messenger{typeof}- Chats{usernum} - threads_db2'
-                tsv(report_folder, data_headers, data_list, tsvname, source_file)
-                
-                tlactivity = f'Facebook Messenger{typeof}- Chats{usernum} - threads_db2'
-                timeline(report_folder, tlactivity, data_list, data_headers)
+    data_headers = ('Facebook ID', 'Name', 'Normalized Name', 'User Name', 'Profile Pic URL',
+                    'Email Address', 'Phone Number', 'Is Messenger User', 'Friendship Status',
+                    'Birthdate (MM-DD)', 'Source File')
+    return data_headers, data_list, source
+
+
+@artifact_processor
+def get_fb_threads_chats(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source = ''
+    primary = '''
+        SELECT
+            CASE messages.timestamp_ms WHEN 0 THEN ''
+                ELSE datetime(messages.timestamp_ms/1000,'unixepoch') END,
+            json_extract(messages.sender, '$.name'),
+            substr(json_extract(messages.sender, '$.user_key'),10),
+            messages.thread_key,
+            messages.text,
+            messages.snippet,
+            json_extract(messages.attachments, '$[0].filename'),
+            json_extract(messages.shares, '$[0].name'),
+            json_extract(messages.shares, '$[0].description'),
+            json_extract(messages.shares, '$[0].href'),
+            message_reactions.reaction,
+            datetime(message_reactions.reaction_timestamp/1000,'unixepoch'),
+            messages.msg_id
+        FROM messages, threads
+        LEFT JOIN message_reactions ON message_reactions.msg_id = messages.msg_id
+        WHERE messages.thread_key=threads.thread_key
+            AND generic_admin_message_extensible_data IS NULL AND msg_type != -1
+        ORDER BY messages.thread_key, messages.timestamp_ms
+        '''
+    fallback = '''
+        SELECT
+            CASE messages.timestamp_ms WHEN 0 THEN ''
+                ELSE datetime(messages.timestamp_ms/1000,'unixepoch') END,
+            json_extract(messages.sender, '$.name'),
+            substr(json_extract(messages.sender, '$.user_key'),10),
+            messages.thread_key,
+            messages.text,
+            json_extract(messages.attachments, '$[0].filename'),
+            json_extract(messages.shares, '$[0].name'),
+            json_extract(messages.shares, '$[0].description'),
+            json_extract(messages.shares, '$[0].href'),
+            message_reactions.reaction,
+            datetime(message_reactions.reaction_timestamp/1000,'unixepoch'),
+            messages.msg_id
+        FROM messages, threads
+        LEFT JOIN message_reactions ON message_reactions.msg_id = messages.msg_id
+        WHERE messages.thread_key=threads.thread_key
+            AND generic_admin_message_extensible_data IS NULL AND msg_type != -1
+        ORDER BY messages.thread_key, messages.timestamp_ms
+        '''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if not _candidate(file_found) or not file_found.endswith('threads_db2'):
+            continue
+        source = source or file_found
+        rel = _src(file_found, seeker)
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        try:
+            cursor.execute(primary)
+            rows, has_snippet = cursor.fetchall(), True
+        except sqlite3.Error:
+            rows, has_snippet = _q(cursor, fallback), False
+        for row in rows:
+            if has_snippet:
+                data_list.append((_str_to_utc(row[0]), row[1], row[2], row[3], row[4], row[5], row[6],
+                                  row[7], row[8], row[9], row[10], _str_to_utc(row[11]), row[12], rel))
             else:
-                logfunc(f'No Facebook{typeof}- Chats{usernum} - threads_db2 data available')
-            
-            cursor.execute('''
-            select
-            datetime((messages.timestamp_ms/1000)-(select json_extract (messages.generic_admin_message_extensible_data, '$.call_duration')),'unixepoch') as "Call Timestamp",
-            strftime('%H:%M:%S',(select json_extract (messages.generic_admin_message_extensible_data, '$.call_duration')), 'unixepoch')as "Call Duration",
-            (select json_extract (messages.generic_admin_message_extensible_data, '$.caller_id')) as "Caller ID",
-            (select json_extract (messages.sender, '$.name')) as "Receiver",
-            substr((select json_extract (messages.sender, '$.user_key')),10) as "Receiver ID",
-            case (select json_extract (messages.generic_admin_message_extensible_data, '$.video'))
-                when false then ''
-                else 'Yes'
-            End as "Video Call",
+                data_list.append((_str_to_utc(row[0]), row[1], row[2], row[3], row[4], '', row[5],
+                                  row[6], row[7], row[8], row[9], _str_to_utc(row[10]), row[11], rel))
+        db.close()
+
+    data_headers = (('Timestamp', 'datetime'), 'Sender Name', 'Sender ID', 'Thread Key', 'Message',
+                    'Snippet', 'Attachment Name', 'Share Name', 'Share Description', 'Share Link',
+                    'Message Reaction', ('Message Reaction Timestamp', 'datetime'), 'Message ID',
+                    'Source File')
+    return data_headers, data_list, source
+
+
+@artifact_processor
+def get_fb_threads_calls(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if not _candidate(file_found) or not file_found.endswith('threads_db2'):
+            continue
+        source = source or file_found
+        rel = _src(file_found, seeker)
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        rows = _q(cursor, '''
+        SELECT
+            datetime((messages.timestamp_ms/1000)-(json_extract(messages.generic_admin_message_extensible_data, '$.call_duration')),'unixepoch'),
+            strftime('%H:%M:%S',json_extract(messages.generic_admin_message_extensible_data, '$.call_duration'), 'unixepoch'),
+            json_extract(messages.generic_admin_message_extensible_data, '$.caller_id'),
+            json_extract(messages.sender, '$.name'),
+            substr(json_extract(messages.sender, '$.user_key'),10),
+            CASE json_extract(messages.generic_admin_message_extensible_data, '$.video')
+                WHEN false THEN '' ELSE 'Yes' END,
             messages.thread_key
-            from messages, threads
-            where messages.thread_key=threads.thread_key and generic_admin_message_extensible_data NOT NULL
-            order by messages.thread_key, "Date/Time End";
-            ''')
+        FROM messages, threads
+        WHERE messages.thread_key=threads.thread_key AND generic_admin_message_extensible_data NOT NULL
+        ORDER BY messages.thread_key
+        ''')
+        for row in rows:
+            data_list.append((_str_to_utc(row[0]), row[1], row[2], row[3], row[4], row[5], row[6],
+                              rel))
+        db.close()
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                report = ArtifactHtmlReport('Facebook - Calls - threads_db2')
-                report.start_artifact_report(report_folder, f'Facebook{typeof}- Calls{usernum} - threads_db2')
-                report.add_script()
-                data_headers = ('Timestamp','Call Duration','Caller ID','Receiver Name','Receiver ID','Video Call','Thread Key') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-                data_list = []
-                for row in all_rows:
-                    data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6]))
+    data_headers = (('Timestamp', 'datetime'), 'Call Duration', 'Caller ID', 'Receiver Name',
+                    'Receiver ID', 'Video Call', 'Thread Key', 'Source File')
+    return data_headers, data_list, source
 
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Facebook{typeof}- Calls{usernum} - threads_db2'
-                tsv(report_folder, data_headers, data_list, tsvname, source_file)
-                
-                tlactivity = f'Facebook{typeof}- Calls{usernum} - threads_db2'
-                timeline(report_folder, tlactivity, data_list, data_headers)
-            else:
-                logfunc(f'No Facebook{typeof}- Calls{usernum} - threads_db2 data available')
-            
-            cursor.execute('''
-            select
-            substr(user_key,10),
-            first_name,
-            last_name,
-            username,
-            (select json_extract (profile_pic_square, '$[0].url')) as profile_pic_square,
-            case is_messenger_user
-                when 0 then ''
-                else 'Yes'
-            end is_messenger_user,
-            case is_friend
-                when 0 then 'No'
-                when 1 then 'Yes'
-            end is_friend,
-            friendship_status,
-            contact_relationship_status
-            from thread_users
-            ''')
 
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            if usageentries > 0:
-                report = ArtifactHtmlReport('Facebook - Contacts - threads_db2')
-                report.start_artifact_report(report_folder, f'Facebook{typeof}- Contacts{usernum} - threads_db2')
-                report.add_script()
-                data_headers = ('User ID','First Name','Last Name','Username','Profile Pic URL','Is Messenger User','Is Friend','Friendship Status','Contact Relationship Status') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-                data_list = []
-                for row in all_rows:
-                    data_list.append((row[0],row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8]))
-
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'Facebook{typeof}- Contacts{usernum} - threads_db2'
-                tsv(report_folder, data_headers, data_list, tsvname, source_file)
-                
-            else:
-                logfunc(f'No Facebook{typeof}- Contacts{usernum} - threads_db2 data available')
-            
-            db.close()
-            
+@artifact_processor
+def get_fb_threads_contacts(files_found, report_folder, seeker, wrap_text):
+    data_list = []
+    source = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        if not _candidate(file_found) or not file_found.endswith('threads_db2'):
             continue
+        source = source or file_found
+        rel = _src(file_found, seeker)
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        rows = _q(cursor, '''
+        SELECT
+            substr(user_key,10), first_name, last_name, username,
+            json_extract(profile_pic_square, '$[0].url'),
+            CASE is_messenger_user WHEN 0 THEN '' ELSE 'Yes' END,
+            CASE is_friend WHEN 0 THEN 'No' WHEN 1 THEN 'Yes' END,
+            friendship_status, contact_relationship_status
+        FROM thread_users
+        ''')
+        for row in rows:
+            data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8],
+                              rel))
+        db.close()
 
-        else:
-            continue # Skip all other files
-    
+    data_headers = ('User ID', 'First Name', 'Last Name', 'Username', 'Profile Pic URL',
+                    'Is Messenger User', 'Is Friend', 'Friendship Status',
+                    'Contact Relationship Status', 'Source File')
+    return data_headers, data_list, source


### PR DESCRIPTION
## Summary
`FacebookMessenger` was a single old-style function building up to **7 reports from three source types** (`threads_db2-uid`, `msys_database`, `threads_db2`), naming each report dynamically per file (App vs Messenger, per-user). Split into **7 `@artifact_processor` functions**, one per report.

| Function | Artifact |
|---|---|
| get_fb_user_id | Facebook Messenger - User ID |
| get_fb_msys_chats / _calls / _contacts | Facebook Messenger - … (msys_database) |
| get_fb_threads_chats / _calls / _contacts | Facebook Messenger - … (threads_db2) |

## Notable points
- **Dynamic names → `Source File` column.** Since each `@artifact_processor` produces one fixed-name artifact, the per-file App/Messenger/user-number distinction is preserved as a **Source File** column; each function consolidates rows across all matching databases.
- **Dual-schema threads chats preserved & hardened.** The original `try/except` handles DBs with vs without `messages.snippet`. The fallback path now always emits a consistent `Snippet` column (`''` when absent) so the consolidated table has a stable 14-column schema. Verified both paths consolidate correctly.
- **Bug fix:** the threads_db2 calls query ordered by a non-existent `"Date/Time End"` identifier (a silent no-op relying on a SQLite quirk) → now `ORDER BY thread_key`.
- Timestamps are aware UTC datetimes (`datetime()` → `_str_to_utc`); the original `mirror` / `user/0` skip filters are preserved.
- Dropped `ArtifactHtmlReport` / manual `tsv` / `timeline`.

## Validation
- `ast.parse` OK; no old-style code refs.
- Reserved-word audit: all 7 header sets create SQLite tables cleanly.
- pylint (CI config): **10.00/10**.
- PluginLoader: **552** (was 546; +6 net from the 1→7 split).
- Functional test on fixtures for all 3 source types: User ID, msys Chats/Calls/Contacts, threads Chats (both with- and without-`snippet` DBs consolidated), Calls (duration + start-time math), Contacts — all correct.