### PR TITLE
Fix naive-datetime handling in lava_insert_sqlite_data (UTC normalization)

### DIFF
--- a/scripts/lavafuncs.py
+++ b/scripts/lavafuncs.py
@@ -396,11 +396,18 @@ def lava_insert_sqlite_data(table_name, data, object_columns, headers, column_ma
                 if isinstance(value, str):
                     try:
                         dt = datetime.datetime.fromisoformat(value)
+                        # Treat naive datetimes as UTC; otherwise int(dt.timestamp()) interprets the
+                        # value in the examiner machine's local tz, producing a wrong epoch off-UTC.
+                        if dt.tzinfo is None:
+                            dt = dt.replace(tzinfo=datetime.timezone.utc)
                         value = int(dt.timestamp())
                     except ValueError:
                         # If conversion fails, keep the original value
                         pass
                 elif isinstance(value, datetime.datetime):
+                    # Treat naive datetimes as UTC (project convention) before converting to epoch.
+                    if value.tzinfo is None:
+                        value = value.replace(tzinfo=datetime.timezone.utc)
                     value = int(value.timestamp())
             processed_row.append(value)
         rows_to_insert.append(tuple(processed_row))


### PR DESCRIPTION
Ports the iLEAPP framework fix (abrignoni/iLEAPP#1582) to ALEAPP — same root cause, slightly different symptom.

## Root cause
`lava_insert_sqlite_data` converts `datetime`-typed columns to epoch seconds with `int(value.timestamp())` (object) and `int(datetime.fromisoformat(value).timestamp())` (string). **`.timestamp()` on a naive datetime interprets it in the examiner machine's local timezone.** SQL `datetime(...,'unixepoch')` returns **UTC** strings, and plist/NSDate values are naive — so on any non-UTC machine, those timestamps were stored **shifted by the local offset**.

Unlike iLEAPP (which subtracts from an aware epoch and therefore *crashed* on naive datetimes), ALEAPP's `.timestamp()` path **does not crash** — it silently stored wrong epochs. Since the ALEAPP LAVA conversion is complete and most artifacts emit SQL-datetime strings, this affects a broad swath of output on non-UTC examiner machines.

## Fix
Both branches normalize a naive datetime to UTC before converting:
```python
if dt.tzinfo is None:
    dt = dt.replace(tzinfo=datetime.timezone.utc)
```

## Verified end-to-end (real `lava_insert_sqlite_data`, in-memory db, on a UTC-5 host)
naive object, aware object, UTC string → all `1678307200` (correct UTC). Before: `naive`/`utc_string` were `1678325200` (5h off).

## Lint
`lavafuncs.py` carries **pre-existing** `global-statement` debt (~9.90/10) unrelated to this change; these added lines introduce no new warnings.