### PR TITLE
Context-form retrofit (batch 1): downloads, googleCast, walStrings, browserCachechrome

### DIFF
--- a/scripts/artifacts/browserCachechrome.py
+++ b/scripts/artifacts/browserCachechrome.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_browserCachechrome": {
         "name": "Chrome Browser Cache",
@@ -37,7 +36,8 @@ def _sec_to_utc(value):
 
 
 @artifact_processor
-def get_browserCachechrome(files_found, report_folder, seeker, wrap_text):
+def get_browserCachechrome(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:
@@ -77,9 +77,9 @@ def get_browserCachechrome(files_found, report_folder, seeker, wrap_text):
         name = f'{filename}.{ext}' if ext else filename
         media = check_in_embedded_media(file_found, filedata, name, force_type=mime, force_extension=ext)
 
-        data_list.append((_sec_to_utc(os.path.getmtime(file_found)), filename, mime, media, url, file_found))
+        data_list.append((_sec_to_utc(os.path.getmtime(file_found)), filename, mime, media, url, context.get_relative_path(file_found)))
 
     data_headers = (
         ('Timestamp Modified', 'datetime'), 'Filename', 'Mime Type', ('Cached File', 'media'),
         'Source URL', 'Source')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/downloads.py
+++ b/scripts/artifacts/downloads.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "downloads": {
         "name": "Native Downloads",
@@ -18,8 +17,8 @@ __artifacts_v2__ = {
 from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone
 
 @artifact_processor
-def downloads(files_found, report_folder, seeker, wrap_text):
-    
+def downloads(context):
+    files_found = context.get_files_found()
     data_list = []
     
     for file_found in files_found:
@@ -64,7 +63,7 @@ def downloads(files_found, report_folder, seeker, wrap_text):
                     else:
                         last_mod_date = convert_utc_human_to_timezone(convert_ts_human_to_utc(last_mod_date),'UTC')
                 
-                    data_list.append((last_mod_date,row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11],row[12],row[13],file_found))
+                    data_list.append((last_mod_date,row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11],row[12],row[13],context.get_relative_path(file_found)))
             db.close()
                     
         else:

--- a/scripts/artifacts/googleCast.py
+++ b/scripts/artifacts/googleCast.py
@@ -14,10 +14,11 @@ __artifacts_v2__ = {
     }
 }
 
-from scripts.ilapfuncs import logfunc, artifact_processor, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone
 
 @artifact_processor
-def googleCast(files_found, report_folder, seeker, wrap_text):
+def googleCast(context):
+    files_found = context.get_files_found()
     data_list = []
     
     for file_found in files_found:
@@ -78,7 +79,7 @@ def googleCast(files_found, report_folder, seeker, wrap_text):
                     else:
                         last_discovered_ble = convert_utc_human_to_timezone(convert_ts_human_to_utc(last_discovered_ble),'UTC')
                 
-                    data_list.append((last_published,row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11],row[12],row[13],last_discovered,last_discovered_ble,file_found))
+                    data_list.append((last_published,row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],row[11],row[12],row[13],last_discovered,last_discovered_ble,context.get_relative_path(file_found)))
             db.close()
         else:
             continue # Skip all other files

--- a/scripts/artifacts/walStrings.py
+++ b/scripts/artifacts/walStrings.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_walStrings": {
         "name": "walStrings",
@@ -31,7 +30,9 @@ ascii_chars_re = re.compile(f'[{printable_chars_for_re}]' + '{4,}')
 
 
 @artifact_processor
-def get_walStrings(files_found, report_folder, seeker, wrap_text):
+def get_walStrings(context):
+    files_found = context.get_files_found()
+    report_folder = context.get_report_folder()
     x = 1
     data_list = []
     for file_found in files_found:
@@ -57,7 +58,7 @@ def get_walStrings(files_found, report_folder, seeker, wrap_text):
 
         if unique_items:
             out = f'<a href="{final}" style = "color:blue" target="_blank">{journalName}</a>'
-            data_list.append((out, file_found))
+            data_list.append((out, context.get_relative_path(file_found)))
         else:
             try:
                 os.remove(outputpath)  # delete empty file


### PR DESCRIPTION
First batch of the ALEAPP **context-form retrofit**, scoped to artifacts where `get_relative_path` actually improves output — i.e. a **full on-disk path was leaking into a data column** (and would otherwise display the examiner's local report path instead of the clean in-extraction path).

## Change (mechanical, logic unchanged)
- 4-arg `(files_found, report_folder, seeker, wrap_text)` → single-arg **`def fn(context)`**; re-establish `files_found = context.get_files_found()` (+ `report_folder = context.get_report_folder()` for walStrings).
- The path column (`Source File` / `Source` / `Location`) that held the raw `file_found` now uses **`context.get_relative_path(file_found)`**. browserCachechrome also relativizes its `dirname` `source_path` return.
- Dropped the now-unnecessary `# pylint: disable=W0613` headers (no unused args in context form); removed a pre-existing unused `logfunc` import in googleCast.

## Validation
- All 4 now context form (1-param), import OK, `__wrapped__` present; pylint **10.00/10**.
- `get_relative_path` mechanism verified: `/extract/base/data/com.app/x.db` → `data/com.app/x.db` (empty/unset → safe no-op).

## Scope
This is **batch 1 of ~5**. I identified **28 artifacts** total with a full path in a data column (the clear "improves output" subset, distinct from the ~554 that are merely on the 4-arg form). Same minimal-diff pattern for the rest.