### PR TITLE
Context-form retrofit (batch 2): browserCachefirefox, NQ_Vault, knuddels, likee

### DIFF
--- a/scripts/artifacts/NQ_Vault.py
+++ b/scripts/artifacts/NQ_Vault.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_NQVault": {
         "name": "NQ Vault Decrypted PINs",
@@ -118,15 +117,16 @@ def _load_db(files_found):
 
 
 @artifact_processor
-def get_NQVault(files_found, report_folder, seeker, wrap_text):
-    _, enc_pins, db_path = _load_db(files_found)
+def get_NQVault(context):
+    _, enc_pins, db_path = _load_db(context.get_files_found())
     data_list = [(encoded_pin, brute_force_pin(encoded_pin)) for encoded_pin in enc_pins]
     data_headers = ('Encrypted PIN', 'Decrypted PIN')
-    return data_headers, data_list, db_path
+    return data_headers, data_list, context.get_relative_path(db_path)
 
 
 @artifact_processor
-def get_NQVault_media(files_found, report_folder, seeker, wrap_text):
+def get_NQVault_media(context):
+    files_found = context.get_files_found()
     dict_of_file_info, enc_pins, db_path = _load_db(files_found)
     pin_xor = {pin: (raw_pin_to_xor_key(brute_force_pin(pin)), brute_force_pin(pin)) for pin in enc_pins}
 
@@ -160,11 +160,11 @@ def get_NQVault_media(files_found, report_folder, seeker, wrap_text):
 
             encrypted_file_name = Path(info['vault_filepath']).stem + '.bin'
             data_list.append((thumb, info['old_filename'], info['old_filepath'], encrypted_file_name,
-                              file_found, info['timestamp'], info['vid_length'], info['resolution'],
+                              context.get_relative_path(file_found), info['timestamp'], info['vid_length'], info['resolution'],
                               info['alb_name'], info['prev_alb_name'], pin_code, info['password_id']))
 
     data_headers = (
         ('Media', 'media'), 'Original Filename', 'Original Filepath', 'Encrypted Filename', 'Full Path',
         ('Timestamp', 'datetime'), 'Video Length', 'File Resolution', 'Album Name', 'Previous Album Name',
         'Password', 'Password Hash')
-    return data_headers, data_list, db_path
+    return data_headers, data_list, context.get_relative_path(db_path)

--- a/scripts/artifacts/browserCachefirefox.py
+++ b/scripts/artifacts/browserCachefirefox.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_browserCachefirefox": {
         "name": "Firefox Browser Cache",
@@ -34,7 +33,8 @@ def _sec_to_utc(value):
 
 
 @artifact_processor
-def get_browserCachefirefox(files_found, report_folder, seeker, wrap_text):
+def get_browserCachefirefox(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:
@@ -72,9 +72,9 @@ def get_browserCachefirefox(files_found, report_folder, seeker, wrap_text):
             name = f'{filename}.{ext}' if ext else filename
             media = check_in_media(file_found, name)
 
-        data_list.append((_sec_to_utc(os.path.getmtime(file_found)), filename, mime, media, url, file_found))
+        data_list.append((_sec_to_utc(os.path.getmtime(file_found)), filename, mime, media, url, context.get_relative_path(file_found)))
 
     data_headers = (
         ('Timestamp Modified', 'datetime'), 'Filename', 'Mime Type', ('Cached File', 'media'),
         'Source URL', 'Source')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/knuddels.py
+++ b/scripts/artifacts/knuddels.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "knuddels_chats": {
         "name": "Knuddels - Chat Messages",
@@ -20,7 +19,8 @@ import re
 from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
 
 @artifact_processor
-def knuddels_chats(files_found, report_folder, seeker, wrap_text):
+def knuddels_chats(context):
+    files_found = context.get_files_found()
     data_list = []
 
     for file_found in files_found:
@@ -47,7 +47,7 @@ def knuddels_chats(files_found, report_folder, seeker, wrap_text):
             for row in db_records:
                 db_name = str(file_found).split("databases")[1].split("knuddels")[1]
                 # Store conversation keys as strings to ensure unique filtering, as the same ID might exist in a different database
-                data_list.append((row[0], row[1], row[2], "chat_" + str(row[3]) + "_" + db_name, file_found, row[4], row[5])) 
+                data_list.append((row[0], row[1], row[2], "chat_" + str(row[3]) + "_" + db_name, context.get_relative_path(file_found), row[4], row[5])) 
 
     data_headers = ("Timestamp", "User Name", "Message", "Conversation Key", "Source File", "Thread Table UID", "Users Table UID")
     return data_headers, data_list, "See source file(s) below:"            

--- a/scripts/artifacts/likee.py
+++ b/scripts/artifacts/likee.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_likee": {
         "name": "LIKEE - User Location",
@@ -77,7 +76,8 @@ def _run(source_path, sql):
 
 
 @artifact_processor
-def get_likee(files_found, report_folder, seeker, wrap_text):
+def get_likee(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:
@@ -94,25 +94,27 @@ def get_likee(files_found, report_folder, seeker, wrap_text):
                         location_text += _CONTROL_RE.sub('', cleaned)
         except OSError:
             pass
-        data_list.append((os.path.basename(file_found), location_text, file_found))
+        data_list.append((os.path.basename(file_found), location_text, context.get_relative_path(file_found)))
 
     data_headers = ('File', 'Location Data', 'Source')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, context.get_relative_path(source_path)
 
 
 @artifact_processor
-def get_likee_users(files_found, report_folder, seeker, wrap_text):
+def get_likee_users(context):
+    files_found = context.get_files_found()
     source_path = next((str(f) for f in files_found if 'like_pub.db' in str(f)
                         and not str(f).endswith(('-wal', '-shm'))), '')
     rows = _run(source_path, '''
         SELECT history_user_name, history_user_bigo_id, history_user_uid FROM user_search_history
     ''')
     data_headers = ('Users', 'Username', 'User ID')
-    return data_headers, [tuple(r) for r in rows], source_path
+    return data_headers, [tuple(r) for r in rows], context.get_relative_path(source_path)
 
 
 @artifact_processor
-def get_likee_messages(files_found, report_folder, seeker, wrap_text):
+def get_likee_messages(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:
@@ -124,4 +126,4 @@ def get_likee_messages(files_found, report_folder, seeker, wrap_text):
             data_list.append((row[0], row[1], _ms_to_utc(row[2])))
 
     data_headers = ('User ID', 'Message Content', ('Timestamp', 'datetime'))
-    return data_headers, data_list, source_path
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Batch 2 of the ALEAPP context-form retrofit (7 functions / 4 files). Same minimal-diff pattern as #906: 4-arg → `def fn(context)`, `files_found = context.get_files_found()`, and `context.get_relative_path()` on the path column / source-path return that previously leaked the examiner's full local path.

- **browserCachefirefox** — `Source` column + `dirname` source.
- **NQ_Vault** — both functions; `get_NQVault_media` has the `Full Path` column.
- **knuddels** — `Source File` column.
- **likee** — all 3 functions (`get_likee` has the path column; the others get the source-path cleanup).

Logic unchanged; dropped the `# pylint: disable=W0613` headers. **pylint 10.00**, all 7 now context form, imports clean, 10 `get_relative_path` applications. (22 of 28 artifacts remain.)