### PR TITLE
Context-form retrofit (batch 3): powerOffReset, shutdown_checkpoints, offlinePages, deviceHealthServices_Battery

### DIFF
--- a/scripts/artifacts/deviceHealthServices_Battery.py
+++ b/scripts/artifacts/deviceHealthServices_Battery.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "Turbo_Battery": {
         "name": "Turbo - Phone Battery",
@@ -33,7 +33,8 @@ import os
 from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone
 
 @artifact_processor
-def Turbo_Battery(files_found, report_folder, seeker, wrap_text):
+def Turbo_Battery(context):
+    files_found = context.get_files_found()
     source_file_turbo = ''
     turbo_db = ''
     data_list = []
@@ -77,7 +78,7 @@ def Turbo_Battery(files_found, report_folder, seeker, wrap_text):
                             timestamp = convert_utc_human_to_timezone(convert_ts_human_to_utc(timestamp), row[4])
                         except Exception:
                             pass
-                    data_list.append((timestamp,row[1],row[2],row[3],row[4],file_found))
+                    data_list.append((timestamp,row[1],row[2],row[3],row[4],context.get_relative_path(file_found)))
             
             db.close()
             
@@ -86,7 +87,8 @@ def Turbo_Battery(files_found, report_folder, seeker, wrap_text):
     return data_headers, data_list, source_file_turbo
             
 @artifact_processor
-def Turbo_Bluetooth(files_found, report_folder, seeker, wrap_text):
+def Turbo_Bluetooth(context):
+    files_found = context.get_files_found()
     source_file_bluetooth = ''
     data_list = []
 
@@ -120,7 +122,7 @@ def Turbo_Bluetooth(files_found, report_folder, seeker, wrap_text):
                             timestamp = convert_utc_human_to_timezone(convert_ts_human_to_utc(timestamp), row[5])
                         except Exception:
                             pass
-                    data_list.append((timestamp,row[1],row[2],row[3],row[4],row[5],file_found))
+                    data_list.append((timestamp,row[1],row[2],row[3],row[4],row[5],context.get_relative_path(file_found)))
             db.close()
 
     data_headers = (('Timestamp','datetime'),'BT Device MAC Address','BT Device ID','Battery Level','Volume Level','Timezone','Source')

--- a/scripts/artifacts/offlinePages.py
+++ b/scripts/artifacts/offlinePages.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_offlinePages": {
         "name": "Offline Pages (MHTML)",
@@ -23,7 +22,8 @@ from scripts.ilapfuncs import artifact_processor, check_in_media
 
 
 @artifact_processor
-def get_offlinePages(files_found, report_folder, seeker, wrap_text):
+def get_offlinePages(context):
+    files_found = context.get_files_found()
     data_list = []
     source_paths = []
     for file_found in files_found:
@@ -38,8 +38,8 @@ def get_offlinePages(files_found, report_folder, seeker, wrap_text):
             mime_date = message['Date']
 
         media = check_in_media(file_found, os.path.basename(file_found))
-        data_list.append((timestamp, media, web_source, subject, mime_date, file_found))
+        data_list.append((timestamp, media, web_source, subject, mime_date, context.get_relative_path(file_found)))
 
     data_headers = (
         ('Timestamp', 'datetime'), ('File', 'media'), 'Web Source', 'Subject', 'MIME Date', 'Source in Extraction')
-    return data_headers, data_list, ', '.join(source_paths)
+    return data_headers, data_list, ', '.join(context.get_relative_path(p) for p in source_paths)

--- a/scripts/artifacts/powerOffReset.py
+++ b/scripts/artifacts/powerOffReset.py
@@ -14,18 +14,18 @@ __artifacts_v2__ = {
     }
 }
 
-from scripts.ilapfuncs import logfunc, artifact_processor
+from scripts.ilapfuncs import artifact_processor
 
 @artifact_processor
-def powerOffReset(files_found, report_folder, seeker, wrap_text):
-    
+def powerOffReset(context):
+    files_found = context.get_files_found()
     data_list = []
     pattern = 'REASON:'
     
     for file_found in files_found:
         file_found = str(file_found)
             
-        with open(file_found, "r") as f:
+        with open(file_found, "r", encoding="utf-8") as f:
             data = f.readlines()
             for line in data:
                 if pattern in line:
@@ -47,7 +47,7 @@ def powerOffReset(files_found, report_folder, seeker, wrap_text):
                     reason_split = entry[3].split(": ")
                     reason = reason_split[1]
                     
-                    data_list.append((timestamp1,timezone,action,reason, file_found))
+                    data_list.append((timestamp1,timezone,action,reason, context.get_relative_path(file_found)))
                 else:
                     continue
 

--- a/scripts/artifacts/shutdown_checkpoints.py
+++ b/scripts/artifacts/shutdown_checkpoints.py
@@ -15,19 +15,18 @@ __artifacts_v2__ = {
 }
 
 import datetime
-from scripts.ilapfuncs import logfunc, artifact_processor
+from scripts.ilapfuncs import artifact_processor
 
 @artifact_processor
-def shutdown_checkpoints(files_found, report_folder, seeker, wrap_text):
-    
+def shutdown_checkpoints(context):
+    files_found = context.get_files_found()
     data_list = []
     pattern = 'Shutdown request from '
-    pattern2 = 'epoch='
-    
+
     for file_found in files_found:
         file_found = str(file_found)
             
-        with open(file_found, "r") as f:
+        with open(file_found, "r", encoding="utf-8") as f:
             data = f.readlines()
             for line in data:
                 if pattern in line:
@@ -40,7 +39,7 @@ def shutdown_checkpoints(files_found, report_folder, seeker, wrap_text):
                     epoch = int(entry_epoch[1].replace(')',''))
                     shutdown_timestamp = datetime.datetime.utcfromtimestamp(epoch/1000).strftime('%Y-%m-%d %H:%M:%S')
                     
-                    data_list.append((shutdown_timestamp, request, line, file_found))
+                    data_list.append((shutdown_timestamp, request, line, context.get_relative_path(file_found)))
                 else:
                     continue
 


### PR DESCRIPTION
Batch 3 (6 functions / 4 files). Same pattern: 4-arg → `def fn(context)`, and `context.get_relative_path()` on the `Source`/`Source File` column (+ offlinePages' joined source-path return).

- **powerOffReset / shutdown_checkpoints** — `Source File` column. Also cleaned **pre-existing** CI lint issues exposed by touching them: `open()` without `encoding=` → `encoding='utf-8'` (the known ALEAPP CI failure), removed an unused `pattern2` and unused `logfunc` import.
- **offlinePages** — `Source in Extraction` column + joined `source_path` return.
- **deviceHealthServices_Battery** — `Turbo_Battery` + `Turbo_Bluetooth` `Source` columns (kept the `W0718` disable for the existing `except Exception` blocks; dropped `W0613`).

pylint **10.00**, all 6 context form, imports clean. **12 of 28 done.**