### PR TITLE
Context-form retrofit (batch 4): googleQuickSearchbox(Recent), vlcthumbsADB, bittorrentDlhist

### DIFF
--- a/scripts/artifacts/bittorrentDlhist.py
+++ b/scripts/artifacts/bittorrentDlhist.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_bittorrentDlhist": {
         "name": "bittorrentDlhist",
@@ -28,8 +27,8 @@ def timestampcalc(timevalue):
 
 
 @artifact_processor
-def get_bittorrentDlhist(files_found, report_folder, seeker, wrap_text):
-
+def get_bittorrentDlhist(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:
@@ -45,7 +44,7 @@ def get_bittorrentDlhist(files_found, report_folder, seeker, wrap_text):
                     time = timestampcalc(x[b'a'])
                     filename = x[b'n'].decode()
                     filepath = x[b's'].decode()
-                data_list.append((time,filename,filepath,textwrap.fill(file_found.strip(), width=25)))
+                data_list.append((time,filename,filepath,textwrap.fill(context.get_relative_path(file_found).strip(), width=25)))
 
     data_headers = (
         ('Record Timestamp', 'datetime'),
@@ -53,4 +52,4 @@ def get_bittorrentDlhist(files_found, report_folder, seeker, wrap_text):
         'Download File Path',
         'Source File',
     )
-    return data_headers, data_list, source_path
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/googleQuickSearchbox.py
+++ b/scripts/artifacts/googleQuickSearchbox.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_quicksearch": {
         "name": "Google Quick Search Queries",
@@ -93,7 +93,8 @@ def _parse_session(values):
 
 
 @artifact_processor
-def get_quicksearch(files_found, report_folder, seeker, wrap_text):
+def get_quicksearch(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:
@@ -113,7 +114,7 @@ def get_quicksearch(files_found, report_folder, seeker, wrap_text):
             response = check_in_embedded_media(file_found, mp3_data, name,
                                                force_type='audio/mpeg', force_extension='mp3')
         data_list.append((_read_unix_time(os.path.getmtime(file_found)), session_type,
-                          ', '.join(queries), response, file_found))
+                          ', '.join(queries), response, context.get_relative_path(file_found)))
 
     data_headers = (('File Timestamp', 'datetime'), 'Type', 'Queries', ('Response', 'media'), 'Source File')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/googleQuickSearchboxRecent.py
+++ b/scripts/artifacts/googleQuickSearchboxRecent.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_quicksearch_recent": {
         "name": "Google Quick Search Recent",
@@ -63,7 +63,8 @@ def _recursive_bytes_to_str(obj):
 
 
 @artifact_processor
-def get_quicksearch_recent(files_found, report_folder, seeker, wrap_text):
+def get_quicksearch_recent(context):
+    files_found = context.get_files_found()
     account_name = ''
     screenshots = {}
     pb_files = []
@@ -107,8 +108,8 @@ def get_quicksearch_recent(files_found, report_folder, seeker, wrap_text):
             screenshot = check_in_media(screenshots[name], name) if name in screenshots else ''
             _recursive_bytes_to_str(item)
             data_list.append((_ms_to_utc(item.get('timestamp1')), search_query, screenshot,
-                              json.dumps(item, ensure_ascii=False), file_found))
+                              json.dumps(item, ensure_ascii=False), context.get_relative_path(file_found)))
 
     data_headers = (('Timestamp', 'datetime'), 'Search Query', ('Screenshot', 'media'),
                     'Protobuf Data', 'Source File')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/vlcthumbsADB.py
+++ b/scripts/artifacts/vlcthumbsADB.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_vlcthumbsADB": {
         "name": "VLC Thumbnails (ADB)",
@@ -45,7 +44,8 @@ def _sec_to_utc(value):
 
 
 @artifact_processor
-def get_vlcthumbsADB(files_found, report_folder, seeker, wrap_text):
+def get_vlcthumbsADB(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:
@@ -55,14 +55,15 @@ def get_vlcthumbsADB(files_found, report_folder, seeker, wrap_text):
         filename = Path(file_found).name
         source_path = str(Path(file_found).parents[1])
         media = check_in_media(file_found, filename)
-        data_list.append((_sec_to_utc(os.path.getmtime(file_found)), media, filename, file_found))
+        data_list.append((_sec_to_utc(os.path.getmtime(file_found)), media, filename, context.get_relative_path(file_found)))
 
     data_headers = (('Modified Timestamp', 'datetime'), ('Thumbnail', 'media'), 'Filename', 'Location')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, context.get_relative_path(source_path)
 
 
 @artifact_processor
-def get_vlcthumbsADB_medialib(files_found, report_folder, seeker, wrap_text):
+def get_vlcthumbsADB_medialib(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:
@@ -72,7 +73,7 @@ def get_vlcthumbsADB_medialib(files_found, report_folder, seeker, wrap_text):
         filename = Path(file_found).name
         source_path = str(Path(file_found).parents[1])
         media = check_in_media(file_found, filename)
-        data_list.append((_sec_to_utc(os.path.getmtime(file_found)), media, filename, file_found))
+        data_list.append((_sec_to_utc(os.path.getmtime(file_found)), media, filename, context.get_relative_path(file_found)))
 
     data_headers = (('Modified Timestamp', 'datetime'), ('Thumbnail', 'media'), 'Filename', 'Location')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Batch 4 (5 functions / 4 files). Same pattern: 4-arg → `def fn(context)`, `context.get_relative_path()` on the `Source File`/`Location` column + `dirname`/file `source_path` returns.

- **googleQuickSearchbox / googleQuickSearchboxRecent** — `Source File` column + source (kept `W0718` for the existing `except Exception` blocks; dropped `W0613`).
- **vlcthumbsADB** — both functions (`Location` column + `parents[1]` source).
- **bittorrentDlhist** — `Source File` column (inside the `textwrap.fill`) + source.

pylint **10.00**, all 5 context form, imports clean. **16 of 28 done.**