### PR TITLE
Context-form retrofit (batch 5): SamsungHoneyboard, SamsungTrash, imagemngCache

### DIFF
--- a/scripts/artifacts/SamsungHoneyboard.py
+++ b/scripts/artifacts/SamsungHoneyboard.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_Honeyboard_Clipboard": {
         "name": "Samsung Honeyboard - Clipboard History",
@@ -56,7 +55,8 @@ def _sec_to_utc(value):
 
 
 @artifact_processor
-def get_Honeyboard_Clipboard(files_found, report_folder, seeker, wrap_text):
+def get_Honeyboard_Clipboard(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:
@@ -72,11 +72,12 @@ def get_Honeyboard_Clipboard(files_found, report_folder, seeker, wrap_text):
         db.close()
 
     data_headers = (('Timestamp', 'datetime'), 'ID', 'Type', 'Clipboard Content', 'Application UID')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, context.get_relative_path(source_path)
 
 
 @artifact_processor
-def get_honeyboard_screenshot(files_found, report_folder, seeker, wrap_text):
+def get_honeyboard_screenshot(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:
@@ -99,8 +100,8 @@ def get_honeyboard_screenshot(files_found, report_folder, seeker, wrap_text):
         thumb = check_in_embedded_media(file_found, buf.getvalue(), name)
 
         modifiedtime = _sec_to_utc(os.path.getmtime(file_found))
-        data_list.append((modifiedtime, thumb, file_found))
+        data_list.append((modifiedtime, thumb, context.get_relative_path(file_found)))
         source_path = os.path.dirname(os.path.dirname(file_found))
 
     data_headers = (('File Modified Time', 'datetime'), ('Thumbnail', 'media'), 'Screenshot Path')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/SamsungTrash.py
+++ b/scripts/artifacts/SamsungTrash.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0612,W0613
 __artifacts_v2__ = {
     "samsungTrash": {
         "name": "Samsung Trash",
@@ -19,16 +18,14 @@ __artifacts_v2__ = {
     }
 }
 
-import inspect
 from pathlib import Path
 
 from scripts.ilapfuncs import artifact_processor, check_in_media, convert_unix_ts_to_utc, get_sqlite_db_records
 
 
 @artifact_processor
-def samsungTrash(files_found, report_folder, seeker, _wrap_text):
-    artifact_info = inspect.stack()[0]
-
+def samsungTrash(context):
+    files_found = context.get_files_found()
     query = """
         SELECT
             _id [File ID],
@@ -88,7 +85,7 @@ def samsungTrash(files_found, report_folder, seeker, _wrap_text):
                 row[7],   # package context of deletion
                 row[8],   # user_id of deletion
                 row[11],  # extra with JSON oinside - addtional info not parsed atm.
-                file_found
+                context.get_relative_path(file_found)
             ))
 
     data_headers = (

--- a/scripts/artifacts/imagemngCache.py
+++ b/scripts/artifacts/imagemngCache.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_imagemngCache": {
         "name": "Image Manager Cache",
@@ -31,7 +30,8 @@ def _sec_to_utc(value):
 
 
 @artifact_processor
-def get_imagemngCache(files_found, report_folder, seeker, wrap_text):
+def get_imagemngCache(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:
@@ -41,8 +41,8 @@ def get_imagemngCache(files_found, report_folder, seeker, wrap_text):
         filename = os.path.basename(file_found)
         source_path = os.path.dirname(file_found)
         media = check_in_media(file_found, filename)
-        data_list.append((_sec_to_utc(os.path.getmtime(file_found)), media, filename, file_found))
+        data_list.append((_sec_to_utc(os.path.getmtime(file_found)), media, filename, context.get_relative_path(file_found)))
 
     data_headers = (
         ('Timestamp Last Modified', 'datetime'), ('Media', 'media'), 'Filename', 'Source File')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Batch 5 (4 functions / 3 files). Same pattern: 4-arg → `def fn(context)`, `context.get_relative_path()` on the path column / source-path return.

- **SamsungHoneyboard** — `get_honeyboard_screenshot` has the `Screenshot Path` column; `get_Honeyboard_Clipboard` gets the source cleanup.
- **SamsungTrash** — `Source DB` column; also removed dead `inspect.stack()` code + its unused import so the `W0612/W0613` disable header could go.
- **imagemngCache** — `Source File` column + `dirname` source.

pylint **10.00**, all context form, imports clean. **19 of 28 done.**