### PR TITLE
Context-form retrofit (batch 7): FilesByGoogle, playgroundVault, appLockerfishingnet, googleFitGMS

### DIFF
--- a/scripts/artifacts/FilesByGoogle.py
+++ b/scripts/artifacts/FilesByGoogle.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "fbg_master": {
         "name": "Files By Google - Files Master",
@@ -31,7 +30,8 @@ __artifacts_v2__ = {
 from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_ts_human_to_utc, convert_utc_human_to_timezone
 
 @artifact_processor
-def fbg_master(files_found, report_folder, seeker, wrap_text):
+def fbg_master(context):
+    files_found = context.get_files_found()
     data_list_master = []
 
     for file_found in files_found:
@@ -79,14 +79,15 @@ def fbg_master(files_found, report_folder, seeker, wrap_text):
                     else:
                         last_mod_date = convert_utc_human_to_timezone(convert_ts_human_to_utc(last_mod_date),'UTC')
                 
-                    data_list_master.append((last_mod_date,row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],file_found))
+                    data_list_master.append((last_mod_date,row[1],row[2],row[3],row[4],row[5],row[6],row[7],row[8],row[9],row[10],context.get_relative_path(file_found)))
             db.close()
             
     data_headers = (('Date Modified','datetime'),'Root Path','Root Relative Path','File Name','Size','Mime Type','Media Type','URI','Hidden','Title','Parent Folder','Source File') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
     return data_headers, data_list_master, 'See source file(s) below'
             
 @artifact_processor
-def fbg_searchhistory(files_found, report_folder, seeker, wrap_text):
+def fbg_searchhistory(context):
+    files_found = context.get_files_found()
     data_list_search = []
     
     for file_found in files_found:
@@ -115,7 +116,7 @@ def fbg_searchhistory(files_found, report_folder, seeker, wrap_text):
                         pass
                     else:
                         timestamp = convert_utc_human_to_timezone(convert_ts_human_to_utc(timestamp),'UTC')
-                    data_list_search.append((timestamp,row[1],file_found))
+                    data_list_search.append((timestamp,row[1],context.get_relative_path(file_found)))
             db.close()
             
         else:

--- a/scripts/artifacts/appLockerfishingnet.py
+++ b/scripts/artifacts/appLockerfishingnet.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_appLockerfishingnet": {
         "name": "App Locker",
@@ -29,7 +28,8 @@ STANDARD_IV = '526e7934384e693861506a59436e5549'
 
 
 @artifact_processor
-def get_appLockerfishingnet(files_found, report_folder, seeker, wrap_text):
+def get_appLockerfishingnet(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:
@@ -63,7 +63,7 @@ def get_appLockerfishingnet(files_found, report_folder, seeker, wrap_text):
                 thumb = check_in_media(file_found, filename)
                 decrypted = 'False'
 
-        data_list.append((thumb, filename, decrypted, file_found))
+        data_list.append((thumb, filename, decrypted, context.get_relative_path(file_found)))
 
     data_headers = (('Media', 'media'), 'Filename', 'Decrypted?', 'Full Path')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/googleFitGMS.py
+++ b/scripts/artifacts/googleFitGMS.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0611,W0613
 __artifacts_v2__ = {
     "googleFitGMS": {
         "name": "Google Fit (GMS) - Activity Sessions",
@@ -15,10 +14,11 @@ __artifacts_v2__ = {
     }
 }
 
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
 
 @artifact_processor
-def googleFitGMS(files_found, report_folder, seeker, wrap_text):
+def googleFitGMS(context):
+    files_found = context.get_files_found()
     data_list = []
     
     for file_found in files_found:
@@ -46,7 +46,7 @@ def googleFitGMS(files_found, report_folder, seeker, wrap_text):
             db_records = get_sqlite_db_records(file_found, query)
 
             for record in db_records:
-                data_list.append((record[0],record[1],record[2],record[3],record[4],record[5],file_found))
+                data_list.append((record[0],record[1],record[2],record[3],record[4],record[5],context.get_relative_path(file_found)))
 
     data_headers = (('Activity Start Time','datetime'),('Activity End Time','datetime'),'Contributing App','Activity Type','Activity Name','Activity Description','Source File') 
     return data_headers, data_list, 'See source file(s) below'

--- a/scripts/artifacts/playgroundVault.py
+++ b/scripts/artifacts/playgroundVault.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_playgroundVault": {
         "name": "Playground Vault",
@@ -55,7 +54,8 @@ def _find_key(files_found):
 
 
 @artifact_processor
-def get_playgroundVault(files_found, report_folder, seeker, wrap_text):
+def get_playgroundVault(context):
+    files_found = context.get_files_found()
     key = _find_key(files_found)
     data_list = []
     source_path = ''
@@ -90,7 +90,7 @@ def get_playgroundVault(files_found, report_folder, seeker, wrap_text):
 
             match = re.search(r'(?:EIF|EVF)(\d+)', filename)
             enctimestamp = _ms_to_utc(match.group(1)) if match else ''
-            data_list.append((thumb, filename, enctimestamp, file_found))
+            data_list.append((thumb, filename, enctimestamp, context.get_relative_path(file_found)))
 
     data_headers = (('Media', 'media'), 'Filename', ('Encrypted On Timestamp', 'datetime'), 'Full Path')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Batch 7 (5 functions / 4 files). Same pattern: 4-arg → `def fn(context)`, `context.get_relative_path()` on the `Source File`/`Full Path` column (+ the two vaults' `parents[1]` source returns).

- **FilesByGoogle** — `fbg_master` + `fbg_searchhistory` (`Source File` columns).
- **playgroundVault / appLockerfishingnet** — `Full Path` column + source.
- **googleFitGMS** — `Source File` column; also removed a pre-existing unused `get_file_path` import so the `W0611/W0613` disable header could go.

pylint **10.00**, all context form, imports clean. **24 of 28 done** — only 4 left (Cello, DuckDuckGo, OrnetBrowser, chatgpt).