### PR TITLE
Fix Life360 Pet Profile artifact icon

### DIFF
--- a/scripts/artifacts/L360petprofile.py
+++ b/scripts/artifacts/L360petprofile.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         'notes': '',
         'paths': ('*/com.life360.android.safetymapd/databases/PetProfileRoomDatabase*',),
         'output_types': 'standard',
-        'artifact_icon': 'github'
+        'artifact_icon': 'smile'
     }
 }
 


### PR DESCRIPTION
The **Life360 Pet Profile** artifact (`L360petprofile.py`) used `artifact_icon: 'github'` (an octocat), which doesn't reflect a pet.

Changed it to **`smile`**, a valid Feather icon better suited to a pet profile. Feather has no paw/dog/cat icon, so this is an approximation from the available set (validates against `feather_icon_names`, so no `alert-triangle` fallback).

One-line, icon-only change. Lint 10.00/10.