### PR TITLE
Add threaded conversation view to Burner - Messages

### DIFF
--- a/scripts/artifacts/burnerMessages.py
+++ b/scripts/artifacts/burnerMessages.py
@@ -6,13 +6,25 @@ __artifacts_v2__ = {
         "author": "Heather Charpentier (With Tons of Help from Alexis Brignoni!)",
         "version": "0.0.1",
         "creation_date": "2024-02-15",
-        "last_update_date": "2024-02-15",
+        "last_update_date": "2026-07-02",
         "requirements": "none",
         "category": "Burner",
         "notes": "",
         "paths": ('*/data/com.adhoclabs.burner/databases/burnerDatabase.db*',),
         "output_types": "standard",
         "artifact_icon": "message-square",
+        "data_views": {
+            "conversation": {
+                "conversationDiscriminatorColumn": "Contact",
+                "conversationLabelColumn": "Contact",
+                "textColumn": "Message Text",
+                "directionColumn": "Direction",
+                "directionSentValue": "Outgoing",
+                "timeColumn": "Timestamp",
+                "senderColumn": "Contact",
+                "sentMessageStaticLabel": "Local User"
+            }
+        },
     }
 }
 


### PR DESCRIPTION
## Summary

ALEAPP's **Burner - Messages** (`burnerMessages.py`, by Heather Charpentier) was the one Burner chat artifact across the LEAPPs without a threaded chat view — both iLEAPP Burner message artifacts (`burner.py`, `burnerCache.py`) already have one. This adds the LAVA `conversation` data_view using only the existing columns; parsing and schema are untouched (13-line metadata-only diff).

## Mapping
- Threads keyed and labeled by **Contact** (per-number conversations)
- `directionSentValue: "Outgoing"` (matches the query's CASE output)
- Received bubbles labeled with the contact number; sent bubbles use `sentMessageStaticLabel: "Local User"` — verified against LAVA's `queryConversation` (platform.electron.js:89-96), which substitutes the static label for sent-direction rows, so outgoing messages are never mislabeled with the contact's number
- `timeColumn: Timestamp` (datetime-typed)

Also bumped `last_update_date`.

## Testing
- pylint `--disable=C,R` → **10.00/10**
- All view column refs validated against `data_headers` (no dangling names)
- PluginLoader registers the artifact with `data_views` intact
- ALEAPP lavafuncs normalizes the view and sanitizes column names (`lava_process_artifact`); string `directionSentValue` is quoted by LAVA at query time