### PR TITLE
LinkedIn: migrate legacy 'chat' data_view key to 'conversation'

### DIFF
--- a/scripts/artifacts/LinkedIn.py
+++ b/scripts/artifacts/LinkedIn.py
@@ -26,7 +26,7 @@ __artifacts_v2__ = {
         "paths": ('*/com.linkedin.android/databases/messenger-sdk*'),
         "output_types": "standard",
         "data_views": {
-            "chat": {
+            "conversation": {
                 "directionSentValue": 1,
                 "conversationDiscriminatorColumn": "Conversation Urn",
                 "textColumn": "Message",


### PR DESCRIPTION
One-line key rename: LinkedIn's data_view already used the conversation-form column names (`conversationDiscriminatorColumn`/`conversationLabelColumn`) — only the `chat` view key was legacy. This was the **last in-repo user** of the backward-compat shim in `lavafuncs.py`; every ALEAPP data_view is now `conversation` (verified via PluginLoader), so the shim can be retired in a future framework pass.

Testing: pylint 10.00/10, byte-compile clean, PluginLoader registers the converted view.