### PR TITLE
Android class 2: derived directions + conversation views for 6 chat artifacts

### DIFF
--- a/scripts/artifacts/FacebookMessenger.py
+++ b/scripts/artifacts/FacebookMessenger.py
@@ -18,13 +18,23 @@ __artifacts_v2__ = {
         "description": "Facebook/Messenger chat messages (msys_database)",
         "author": "Kevin Pagano",
         "creation_date": "2021-03-03",
-        "last_update_date": "2021-03-03",
+        "last_update_date": "2026-07-03",
         "requirements": "none",
         "category": "Facebook Messenger",
         "notes": "",
         "paths": ('*/msys_database*',),
         "output_types": "standard",
         "artifact_icon": "message-square",
+        "data_views": {
+            "conversation": {
+                "conversationDiscriminatorColumn": "Thread Key",
+                "textColumn": "Message",
+                "directionColumn": "Direction",
+                "directionSentValue": "Outgoing",
+                "timeColumn": "Message Timestamp",
+                "senderColumn": "Sender"
+            }
+        },
     },
     "get_fb_msys_calls": {
         "name": "Facebook Messenger - Calls (msys_database)",
@@ -164,6 +174,16 @@ def get_fb_msys_chats(files_found, report_folder, seeker, wrap_text):
         if 'msys_database_' not in file_found:
             continue
         source = source or file_found
+        # local account uid from the threads_db2-uid file (fetched via paths)
+        fb_uid = ''
+        for uid_file in files_found:
+            if str(uid_file).endswith('threads_db2-uid'):
+                try:
+                    with open(str(uid_file), 'r', encoding='utf-8', errors='replace') as dat:
+                        fb_uid = next((line.strip() for line in dat if line.strip()), '')
+                except OSError:
+                    fb_uid = ''
+                break
         rel = _src(file_found, seeker)
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
@@ -196,16 +216,20 @@ def get_fb_msys_chats(files_found, report_folder, seeker, wrap_text):
         ORDER BY messages.timestamp_ms ASC
         ''')
         for row in rows:
+            if fb_uid and row[2] is not None:
+                direction = 'Outgoing' if str(row[2]) == fb_uid else 'Incoming'
+            else:
+                direction = ''
             data_list.append((_str_to_utc(row[0]), row[1], row[2], row[3], row[4], row[5], row[6],
                               row[7], row[8], row[9], row[10], row[11], _str_to_utc(row[12]), row[13],
-                              row[14], rel))
+                              row[14], rel, direction))
         db.close()
 
     data_headers = (('Message Timestamp', 'datetime'), 'Sender', 'Sender ID', 'Thread Key', 'Message',
                     'Snippet', 'Call/Location Information', 'Attachment Name', 'Attachment Type',
                     'Attachment URL', 'Location Lat/Long', 'Reaction',
                     ('Reaction Timestamp', 'datetime'), 'Is Admin Message', 'Message ID',
-                    'Source File')
+                    'Source File', 'Direction')
     return data_headers, data_list, source
 
 

--- a/scripts/artifacts/WhatsApp.py
+++ b/scripts/artifacts/WhatsApp.py
@@ -44,7 +44,7 @@ __artifacts_v2__ = {
         "description": "WhatsApp 1:1 messages (modern msgstore.db schema)",
         "author": "",
         "creation_date": "2021-03-11",
-        "last_update_date": "2021-03-11",
+        "last_update_date": "2026-07-03",
         "requirements": "none",
         "category": "WhatsApp",
         "notes": "",
@@ -53,13 +53,25 @@ __artifacts_v2__ = {
                   '*/Android/media/com.whatsapp/WhatsApp/Media/*'),
         "output_types": "standard",
         "artifact_icon": "message-square",
+        "data_views": {
+            "conversation": {
+                "conversationDiscriminatorColumn": "Other Participant WA User Name",
+                "textColumn": "Message",
+                "directionColumn": "Message Direction",
+                "directionSentValue": "Outgoing",
+                "timeColumn": "Message Timestamp",
+                "senderColumn": "Other Participant WA User Name",
+                "sentMessageStaticLabel": "Local User",
+                "mediaColumn": "Media"
+            }
+        },
     },
     "get_whatsapp_group_messages": {
         "name": "WhatsApp - Group Messages",
         "description": "WhatsApp group messages (modern msgstore.db schema)",
         "author": "",
         "creation_date": "2021-03-11",
-        "last_update_date": "2021-03-11",
+        "last_update_date": "2026-07-03",
         "requirements": "none",
         "category": "WhatsApp",
         "notes": "",
@@ -68,6 +80,17 @@ __artifacts_v2__ = {
                   '*/Android/media/com.whatsapp/WhatsApp/Media/*'),
         "output_types": "standard",
         "artifact_icon": "message-square",
+        "data_views": {
+            "conversation": {
+                "conversationDiscriminatorColumn": "Conversation Name",
+                "textColumn": "Message",
+                "directionColumn": "Message Direction",
+                "directionSentValue": "Outgoing",
+                "timeColumn": "Message Timestamp",
+                "senderColumn": "Sending Party",
+                "mediaColumn": "Media"
+            }
+        },
     },
     "get_whatsapp_group_details": {
         "name": "WhatsApp - Group Details",

--- a/scripts/artifacts/googleVoice.py
+++ b/scripts/artifacts/googleVoice.py
@@ -44,13 +44,24 @@ __artifacts_v2__ = {
         "description": "Parses Google Voice Messages",
         "author": "William Campbell (@campwill), Eli Ehresmann (@H-Seek), Reina Girouard (@rgrd59), Paula Rokusek (@paula-rokusek)",
         "creation_date": "2025-10-22",
-        "last_update_date": "2025-11-5",
+        "last_update_date": "2026-07-03",
         "requirements": "blackboxprotobuf",
         "category": "Google Voice",
         "notes": "Tested on version 2025.07.20.788599304 (October 29th, 2025). Tested on Samsung and Motorola devices.",
         "paths": ('*/data/com.google.android.apps.googlevoice/files/accounts/*/LegacyMsgDbInstance.db*', '*/data/com.google.android.apps.googlevoice/cache/Photo MMS images/*', '*/data/com.samsung.android.providers.contacts/databases/contact*'),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "user",
+        "data_views": {
+            "conversation": {
+                "conversationDiscriminatorColumn": "Conversation ID",
+                "textColumn": "Message",
+                "directionColumn": "Direction",
+                "directionSentValue": "Outgoing",
+                "timeColumn": "Timestamp",
+                "senderColumn": "Sender",
+                "mediaColumn": "Image"
+            }
+        },
     }
 }
 

--- a/scripts/artifacts/imo.py
+++ b/scripts/artifacts/imo.py
@@ -18,13 +18,24 @@ __artifacts_v2__ = {
         "description": "",
         "author": "",
         "creation_date": "2021-03-11",
-        "last_update_date": "2021-03-11",
+        "last_update_date": "2026-07-03",
         "requirements": "none",
         "category": "IMO",
         "notes": "",
         "paths": ('*/com.imo.android.imous/databases/imofriends.db*',),
         "output_types": "standard",
         "artifact_icon": "message-square",
+        "data_views": {
+            "conversation": {
+                "conversationDiscriminatorColumn": "Chat Partner",
+                "textColumn": "Last Message",
+                "directionColumn": "Direction",
+                "directionSentValue": "Outgoing",
+                "timeColumn": "Timestamp",
+                "senderColumn": "Chat Partner",
+                "sentMessageStaticLabel": "Local User"
+            }
+        },
     }
 }
 
@@ -101,7 +112,7 @@ def get_imo_messages(files_found, report_folder, seeker, wrap_text):
                         attachmentPath = attachmentLocalPath
 
                 timestamp = datetime.datetime.fromtimestamp(int(row[3]), datetime.timezone.utc)
-                data_list.append((timestamp, from_id, to_id, row[2],  row[4], row[5], attachmentPath))
+                data_list.append((timestamp, from_id, to_id, row[2],  row[4], row[5], attachmentPath, row[0]))
             db.close()
 
     data_headers = (
@@ -112,5 +123,6 @@ def get_imo_messages(files_found, report_folder, seeker, wrap_text):
         'Direction',
         'Message Read',
         'Attachment',
+        'Chat Partner',
     )
     return data_headers, data_list, source_path

--- a/scripts/artifacts/teleguard.py
+++ b/scripts/artifacts/teleguard.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
         "description": "Teleguard messenger messages",
         "author": "",
         "creation_date": "2024-01-09",
-        "last_update_date": "2024-01-09",
+        "last_update_date": "2026-07-03",
         "requirements": "none",
         "category": "Teleguard",
         "notes": "",
@@ -13,6 +13,17 @@ __artifacts_v2__ = {
                   '*/data/ch.swisscows.messenger.teleguardapp/cache/**'),
         "output_types": "standard",
         "artifact_icon": "message-square",
+        "data_views": {
+            "conversation": {
+                "conversationDiscriminatorColumn": "Chat ID",
+                "textColumn": "Content",
+                "directionColumn": "Direction",
+                "directionSentValue": "Outgoing",
+                "timeColumn": "Timestamp",
+                "senderColumn": "Sender",
+                "mediaColumn": "Media"
+            }
+        },
     },
     "get_teleguard_posts": {
         "name": "Teleguard - Posts",
@@ -99,9 +110,16 @@ def get_teleguard(files_found, report_folder, seeker, wrap_text):
     source_path = _db(files_found)
     rows = _run(source_path, '''
         SELECT datetime(createDate/1000,'unixepoch'), datetime(userTime/1000,'unixepoch'),
-        type, sender, receiver, content, metadata, status, isEdited
+        type, sender, receiver, content, metadata, status, isEdited, chatId
         FROM messages
     ''')
+    # local account id lives in the service table ('user' row) of the same db
+    owner_id = ''
+    for (svc_data,) in _run(source_path, "SELECT data FROM service WHERE id = 'user'"):
+        try:
+            owner_id = (json.loads(svc_data) or {}).get('serverId', '')
+        except (ValueError, TypeError):
+            owner_id = ''
     data_list = []
     for row in rows:
         media_refs = []
@@ -129,11 +147,16 @@ def get_teleguard(files_found, report_folder, seeker, wrap_text):
             media_cell = media_refs
         else:
             media_cell = ''
+        if owner_id and row[3]:
+            direction = 'Outgoing' if row[3] == owner_id else 'Incoming'
+        else:
+            direction = ''
         data_list.append((_str_to_utc(row[0]), _str_to_utc(row[1]), row[2], row[3], row[4], row[5],
-                          media_cell, row[6], row[7], row[8]))
+                          media_cell, row[6], row[7], row[8], direction, row[9]))
 
     data_headers = (('Timestamp', 'datetime'), ('User Time', 'datetime'), 'Type', 'Sender', 'Receiver',
-                    'Content', ('Media', 'media'), 'Metadata', 'Status', 'Is Edited?')
+                    'Content', ('Media', 'media'), 'Metadata', 'Status', 'Is Edited?', 'Direction',
+                    'Chat ID')
     return data_headers, data_list, source_path
 
 


### PR DESCRIPTION
## Summary
Android counterpart to iLEAPP #1647/#1648: evidence-derived directions and LAVA conversation views, all **validated against the 12-image Android test set** before implementation.

| Artifact | Change | Validation |
|---|---|---|
| WhatsApp One-To-One | view only (Direction + partner column already emitted) | ~5k rows, 'Outgoing' verified |
| WhatsApp Group | view only ('Sending Party' = 'Self' on own messages) | ~5k rows verified |
| Google Voice Messages | view only | Direction vocabulary verified in test data |
| Teleguard | owner `serverId` from `service` table 'user' row (same db, same source as the iOS artifact) + `chatId` → Chat ID | 42 msgs: 19 Out / 21 In / 2 blank (ownerless service rows stay blank) |
| FB Messenger (msys) | local uid from `threads_db2-uid` (glob added to artifact paths); direction = `sender_id == uid` | 3 images, e.g. 14 Out / 12 In; uid cross-checked against `get_fb_user_id` |
| IMO | `buid` emitted as **Chat Partner** (real thread key); direction existed | buid populated 22/22 |

When direction can't be established (missing uid file / ownerless rows), the column stays blank — never defaulted.

## Testing
pylint 10.00/10 on all 5 files; byte-compile; PluginLoader 6/6 views registered; view column refs validated; derivation SQL/logic executed read-only against the real copied databases with the splits above.

## Still on the Android backlog (need deeper source digging)
Google Messages RCS (Bugle self-participant), TikTok Android, Google Chat (owner row), Discord Android, Teams, GroupMe.