### PR TITLE
Migrate artifact icons to native Tabler names

### DIFF
--- a/scripts/artifacts/AVG.py
+++ b/scripts/artifacts/AVG.py
@@ -24,7 +24,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.antivirus/shared_prefs/PinSettingsImpl.xml', '*/Vault/*'),
         "output_types": "standard",
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     }
 }
 

--- a/scripts/artifacts/BadooChat.py
+++ b/scripts/artifacts/BadooChat.py
@@ -24,7 +24,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*com.badoo.mobile/databases/ChatComDatabase*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     }
 }
 

--- a/scripts/artifacts/ChessComAccount.py
+++ b/scripts/artifacts/ChessComAccount.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.chess/shared_prefs/com.chess.app.login_credentials.xml', '*/data/com.chess/shared_prefs/com.chess.app.session_preferences.xml'),
         "output_types": ['html', 'tsv', 'lava'],
-        "artifact_icon": "grid",
+        "artifact_icon": "layout-grid",
     }
 }
 

--- a/scripts/artifacts/ChessComFriends.py
+++ b/scripts/artifacts/ChessComFriends.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.chess/databases/chess-database*',),
         "output_types": ['html', 'tsv', 'lava'],
-        "artifact_icon": "grid",
+        "artifact_icon": "layout-grid",
     }
 }
 

--- a/scripts/artifacts/ChessComGames.py
+++ b/scripts/artifacts/ChessComGames.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.chess/databases/chess-database*', '*/data/com.chess/shared_prefs/com.chess.app.session_preferences.xml'),
         "output_types": ['html', 'tsv', 'lava'],
-        "artifact_icon": "grid",
+        "artifact_icon": "layout-grid",
     }
 }
 

--- a/scripts/artifacts/ChessComMessages.py
+++ b/scripts/artifacts/ChessComMessages.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.chess/databases/chess-database*',),
         "output_types": ['html', 'tsv', 'lava'],
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     }
 }
 

--- a/scripts/artifacts/ChessWithFriends.py
+++ b/scripts/artifacts/ChessWithFriends.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.zynga.chess.googleplay/databases/wf_database.sqlite', '*/data/com.zynga.chess.googleplay/db/wf_database.sqlite'),
         "output_types": ['html', 'tsv', 'lava'],
-        "artifact_icon": "grid",
+        "artifact_icon": "layout-grid",
     }
 }
 

--- a/scripts/artifacts/Deepseek_ChatMessages.py
+++ b/scripts/artifacts/Deepseek_ChatMessages.py
@@ -1,5 +1,4 @@
 import json
-import html
 #import markdown
 
 from datetime import datetime, timezone
@@ -21,7 +20,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/data/com.deepseek.chat/databases/deepseek_chat_*.db'),
         "output_types": ["html", "lava", "tsv"],
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
         "html_columns": ["Message Content"]
     }
 }
@@ -47,27 +46,27 @@ def extract_content_from_fragments(fragments):
         
         #HTML conversion removed because LAVA will support markdown.
         #HTML escape not allowed do to possible avenue for injection attacks
-        '''' 
-        full_text = html.unescape(full_text)
+        # '''' 
+        # full_text = html.unescape(full_text)
 
-        rendered_html = markdown.markdown(
-            full_text,
-            extensions=[
-                "extra",
-                "nl2br",
-                "sane_lists"
-            ]
-        )
-        '''
+        # rendered_html = markdown.markdown(
+            # full_text,
+            # extensions=[
+                # "extra",
+                # "nl2br",
+                # "sane_lists"
+            # ]
+        # )
+        # '''
 
         return full_text
 
-    except Exception:
+    except Exception:  # pylint: disable=broad-exception-caught
         return (str(fragments))
 
 
 @artifact_processor
-def deepseek_chat_messages(files_found, report_folder, seeker, wrap_text):
+def deepseek_chat_messages(files_found, _report_folder, _seeker, _wrap_text):
 
     data_headers = (
         ('Timestamp', 'datetime'),
@@ -144,7 +143,7 @@ def deepseek_chat_messages(files_found, report_folder, seeker, wrap_text):
                                     tz=timezone.utc
                                 ).strftime('%Y-%m-%d %H:%M:%S')
 
-                            except Exception:
+                            except Exception:  # pylint: disable=broad-exception-caught
 
                                 inserted_at_utc = str(inserted_at)
 
@@ -152,14 +151,14 @@ def deepseek_chat_messages(files_found, report_folder, seeker, wrap_text):
                             fragments
                         )
                         
-                        '''
-                        chat_html = f
-                        <div class="chat-message">
-                            <div class="chat-content">
-                                {content}
-                            </div>
-                        </div>
-                        '''
+                        # '''
+                        # chat_html = f
+                        # <div class="chat-message">
+                            # <div class="chat-content">
+                                # {content}
+                            # </div>
+                        # </div>
+                        # '''
 
                         data_list.append((
                             lava_timestamp,
@@ -169,10 +168,10 @@ def deepseek_chat_messages(files_found, report_folder, seeker, wrap_text):
                             content
                         ))
 
-                except Exception as e:
+                except Exception as e:  # pylint: disable=broad-exception-caught
                     print(f"Error processing table {table_name}: {e}")
 
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-exception-caught
             print(f"Error processing database {source_path}: {e}")
 
         finally:

--- a/scripts/artifacts/DuckDuckGo.py
+++ b/scripts/artifacts/DuckDuckGo.py
@@ -50,7 +50,7 @@ __artifacts_v2__ = {
         "notes": "Tested on version 5.255.0 (Oct, 31st 2025)",
         "paths": ('*/com.duckduckgo.mobile.android/databases/app.db*','*/com.duckduckgo.mobile.android/cache/tabPreviews/*/*.jpg'),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "book-open"
+        "artifact_icon": "book"
     },
         "duckduckgo_fireproof": {
         "name": "DuckDuckGo - FireProof Sites",
@@ -90,7 +90,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.duckduckgo.mobile.android/cache/tabPreviews/*/*.jpg','*/com.duckduckgo.mobile.android/databases/app.db*'),
         "output_types": ["html", "tsv", "timeline", "lava"],
-        "artifact_icon": "image"
+        "artifact_icon": "photo"
     },
         "duckduckgo_duckai": {
         "name": "DuckDuckGo - Duck AI",
@@ -103,7 +103,7 @@ __artifacts_v2__ = {
         "notes": "Tested on version 5.255.0 (Oct, 31st 2025)",
         "paths": ('*com.duckduckgo.mobile.android/app_webview/Default/Local Storage/leveldb/*'),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "message-square"
+        "artifact_icon": "message"
     },
         "duckduckgo_cookies": {
         "name": "DuckDuckGo - Cookies",

--- a/scripts/artifacts/FCMQueuedMessagesDump.py
+++ b/scripts/artifacts/FCMQueuedMessagesDump.py
@@ -24,7 +24,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/fcm_queued_messages.ldb/*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     },
     "get_fcm_dump_tiktok": {
         "name": "FCM Decoded - TikTok",
@@ -37,7 +37,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/fcm_queued_messages.ldb/*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     },
     "get_fcm_dump_instagram": {
         "name": "FCM Decoded - Instagram",
@@ -50,7 +50,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/fcm_queued_messages.ldb/*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     },
     "get_fcm_dump_gqsb": {
         "name": "FCM Decoded - Geolocation",

--- a/scripts/artifacts/FCMQueuedMessagesJungrammer.py
+++ b/scripts/artifacts/FCMQueuedMessagesJungrammer.py
@@ -32,7 +32,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/fcm_queued_messages.ldb/*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     }
 }
 

--- a/scripts/artifacts/FCMQueuedMessagesSkype.py
+++ b/scripts/artifacts/FCMQueuedMessagesSkype.py
@@ -32,7 +32,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/fcm_queued_messages.ldb/*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     },
     "get_fcm_skype_notifications": {
         "name": "FCM - Skype and Teams Notifications",

--- a/scripts/artifacts/FCMQueuedMessagesTumblr.py
+++ b/scripts/artifacts/FCMQueuedMessagesTumblr.py
@@ -32,7 +32,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/fcm_queued_messages.ldb/*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     },
     "get_fcm_tumblr_flagged": {
         "name": "FCM - Tumblr Flagged Posts",

--- a/scripts/artifacts/FCMQueuedMessagesTwitter.py
+++ b/scripts/artifacts/FCMQueuedMessagesTwitter.py
@@ -32,7 +32,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/fcm_queued_messages.ldb/*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     }
 }
 

--- a/scripts/artifacts/FCMQueuedMessagesXbox.py
+++ b/scripts/artifacts/FCMQueuedMessagesXbox.py
@@ -32,7 +32,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/fcm_queued_messages.ldb/*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     },
     "get_fcm_xbox_party": {
         "name": "FCM - Xbox Party Invites",

--- a/scripts/artifacts/FacebookMessenger.py
+++ b/scripts/artifacts/FacebookMessenger.py
@@ -24,7 +24,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/msys_database*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Thread Key",
@@ -73,7 +73,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/*threads_db2',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     },
     "get_fb_threads_calls": {
         "name": "Facebook Messenger - Calls (threads_db2)",

--- a/scripts/artifacts/HideX.py
+++ b/scripts/artifacts/HideX.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.flatfish.cal.privacy/databases/hidex.db*',),
         "output_types": ['html', 'tsv', 'lava'],
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     }
 }
 

--- a/scripts/artifacts/L360petprofile.py
+++ b/scripts/artifacts/L360petprofile.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         'notes': '',
         'paths': ('*/com.life360.android.safetymapd/databases/PetProfileRoomDatabase*',),
         'output_types': 'standard',
-        'artifact_icon': 'smile'
+        'artifact_icon': 'mood-smile'
     }
 }
 

--- a/scripts/artifacts/LinkedIn.py
+++ b/scripts/artifacts/LinkedIn.py
@@ -36,7 +36,7 @@ __artifacts_v2__ = {
                 "conversationLabelColumn": "Conversation Label"
             }
         },
-        "artifact_icon": "message-square"
+        "artifact_icon": "message"
     }
 }
 

--- a/scripts/artifacts/NQ_Vault.py
+++ b/scripts/artifacts/NQ_Vault.py
@@ -25,7 +25,7 @@ __artifacts_v2__ = {
         "paths": ('*/emulated/0/Android/data/com.netqin.ps/files/Documents/SystemAndroid/Data/322w465ay423xy11',
                   '*/SystemAndroid/Data/**', '/media/0/SystemAndroid/Data/322w465ay423xy11'),
         "output_types": "standard",
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     }
 }
 

--- a/scripts/artifacts/OrnetBrowser.py
+++ b/scripts/artifacts/OrnetBrowser.py
@@ -50,7 +50,7 @@ __artifacts_v2__ = {
         "notes": "Tested on version 1.9.26 (Oct, 22nd 2025)",
         "paths": ('*/com.ornet.torbrowser/databases/appDatabase','*/com.ornet.torbrowser/cache/tabPreviews/*/*.jpg'),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "book-open"
+        "artifact_icon": "book"
     },
         "ornetbrowser_frequents": {
         "name": "Ornet Browser - Frequents",
@@ -90,7 +90,7 @@ __artifacts_v2__ = {
         "notes": "Tested on version 1.9.26 (Oct, 22nd 2025)",
         "paths": ('*/com.ornet.torbrowser/cache/tabPreviews/*/*.jpg','*//comcom.ornet.torbrowser/databases/AppDatabase'),
         "output_types": ["html", "tsv", "timeline", "lava"],
-        "artifact_icon": "image"
+        "artifact_icon": "photo"
     },
         "ornetbrowser_searchhistory": {
         "name": "Ornet Browser - Search History",
@@ -129,7 +129,7 @@ __artifacts_v2__ = {
         "notes": "Tested on version 1.9.26 (Oct, 22nd 2025)",
         "paths": ('*/com.ornet.torbrowser/shared_prefs/com.ornet.torbrowser_preferences.xml'),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "info"
+        "artifact_icon": "info-circle"
     }
 }
 

--- a/scripts/artifacts/RandoChat.py
+++ b/scripts/artifacts/RandoChat.py
@@ -21,7 +21,7 @@ __artifacts_v2__ = {
             '*/Android/data/com.random.chat.app/files/Music/RandoChat/*'
             ),
         'output_types': 'standard',
-        'artifact_icon': 'message-square',
+        'artifact_icon': 'message',
         "html_columns": ["Media File"]
     },
     'randochat_account': {

--- a/scripts/artifacts/RomeoDatingApp.py
+++ b/scripts/artifacts/RomeoDatingApp.py
@@ -18,7 +18,7 @@ __artifacts_v2__ = {
             '*/com.planetromeo.android.app/databases/planetromeo-room.db.*' 
             ),
         'output_types': 'standard',
-        'artifact_icon': 'message-square'
+        'artifact_icon': 'message'
     },
     'romeo_dating_contacts': {
         'name': 'Romeo Dating App Contacts',

--- a/scripts/artifacts/SamsungDeviceHealthManagement.py
+++ b/scripts/artifacts/SamsungDeviceHealthManagement.py
@@ -24,7 +24,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.sec.android.sdhms/databases/thermal_log*'),
         "output_types": "all",
-        "artifact_icon": "bar-chart"
+        "artifact_icon": "chart-bar-popular"
     },
     "sdhms_temperature": {
         "name": "SDHMS Temperature Logs",

--- a/scripts/artifacts/SamsungTrash.py
+++ b/scripts/artifacts/SamsungTrash.py
@@ -14,7 +14,7 @@ __artifacts_v2__ = {
             "*/storage/*/Android/.Trash/*",
         ),
         "output_types": "standard",
-        "artifact_icon": "trash-2",
+        "artifact_icon": "trash",
     }
 }
 

--- a/scripts/artifacts/Todoist.py
+++ b/scripts/artifacts/Todoist.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.todoist/databases/database.db*',),
         "output_types": "standard",
-        "artifact_icon": "check-square",
+        "artifact_icon": "square-check",
     },
     "get_Todoist_notes": {
         "name": "Todoist - Notes",

--- a/scripts/artifacts/TorBrowser.py
+++ b/scripts/artifacts/TorBrowser.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "Tested on version 15.0 (140.4.0esr (Oct 28th, 2025)",
         "paths": ('*/org.torproject.torbrowser/cache/mozac_browser_thumbnails/private_thumbnails/*.0'),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "image"
+        "artifact_icon": "photo"
     },
     "torbrowser_bookmarks": {
         "name": "Tor Browser - Bookmarks",
@@ -37,7 +37,7 @@ __artifacts_v2__ = {
         "notes": "Tested on version 15.0 (140.4.0esr (Oct 28th, 2025)",
         "paths": ('*/org.torproject.torbrowser/shared_prefs/fenix_preferences.xml'),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "info"
+        "artifact_icon": "info-circle"
     },
 }
 

--- a/scripts/artifacts/Viber.py
+++ b/scripts/artifacts/Viber.py
@@ -37,7 +37,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.viber.voip/databases/*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Thread ID",

--- a/scripts/artifacts/WhatsApp.py
+++ b/scripts/artifacts/WhatsApp.py
@@ -37,7 +37,7 @@ __artifacts_v2__ = {
         "notes": "Legacy schema only; modern databases are covered by the One To One / Group Messages artifacts.",
         "paths": ('*/com.whatsapp/databases/msgstore.db*', '*/com.whatsapp/databases/wa.db*'),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     },
     "get_whatsapp_one_to_one_messages": {
         "name": "WhatsApp - One To One Messages",
@@ -52,7 +52,7 @@ __artifacts_v2__ = {
                   '*/WhatsApp/Media/*', '*/com.whatsapp/files/Media/*',
                   '*/Android/media/com.whatsapp/WhatsApp/Media/*'),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Other Participant WA User Name",
@@ -79,7 +79,7 @@ __artifacts_v2__ = {
                   '*/WhatsApp/Media/*', '*/com.whatsapp/files/Media/*',
                   '*/Android/media/com.whatsapp/WhatsApp/Media/*'),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Conversation Name",

--- a/scripts/artifacts/WithingsHealthMate.py
+++ b/scripts/artifacts/WithingsHealthMate.py
@@ -52,7 +52,7 @@ __artifacts_v2__ = {
         "notes": "Based on https://bebinary4n6.blogspot.com/2020/10/app-healthmate-on-android-part-1-users.html",
         "paths": ('*/com.withings.wiscale2/databases/Withings-WiScale*'),
         "output_types": "standard",
-        "artifact_icon": "message-square"
+        "artifact_icon": "message"
     },
     "healthmate_contacts": {
         "name": "Health Mate - Contacts",

--- a/scripts/artifacts/WordsWithFriends.py
+++ b/scripts/artifacts/WordsWithFriends.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.zynga.words/db/wf_database.sqlite',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     }
 }
 

--- a/scripts/artifacts/ZangiChats.py
+++ b/scripts/artifacts/ZangiChats.py
@@ -14,7 +14,7 @@ __artifacts_v2__ = {
             '*/data/com.beint.zangi/databases/*',
             '*/data/com.beint.zangi/files/zangi/*'),
         'output_types': 'standard',
-        'artifact_icon': 'message-square',
+        'artifact_icon': 'message',
         'data_views': {
             'conversation': {
                 'conversationDiscriminatorColumn': 'Chat-ID',

--- a/scripts/artifacts/alex_live_data.py
+++ b/scripts/artifacts/alex_live_data.py
@@ -56,7 +56,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/extra/dumpsys_*.txt'),
         "output_types": ["html", "lava", "tsv"],
-        "artifact_icon": "bar-chart-2"
+        "artifact_icon": "chart-bar"
     },
     "alex_live_bt_bonded": {
         "name": "Dumpsys - BTM Bonded Devices",
@@ -89,7 +89,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/extra/dumpsys_*.txt'),
         "output_types": ["html", "lava", "tsv"],
-        "artifact_icon": "watch"
+        "artifact_icon": "device-watch"
     },
     "alex_live_role": {
         "name": "Dumpsys - Role (Default Apps)",
@@ -104,7 +104,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/extra/dumpsys_*.txt'),
         "output_types": ["html", "lava", "tsv"],
-        "artifact_icon": "check-circle"
+        "artifact_icon": "circle-check"
     },
     "alex_live_account": {
         "name": "Dumpsys - Accounts",

--- a/scripts/artifacts/appLockerfishingnet.py
+++ b/scripts/artifacts/appLockerfishingnet.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/.privacy_safe/picture/*', '*/.privacy_safe/video/*'),
         "output_types": "standard",
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     }
 }
 

--- a/scripts/artifacts/appLockerfishingnetdb.py
+++ b/scripts/artifacts/appLockerfishingnetdb.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/.privacy_safe/db/privacy_safe.db',),
         "output_types": ['html', 'tsv', 'lava'],
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     }
 }
 

--- a/scripts/artifacts/appLockerfishingnetpat.py
+++ b/scripts/artifacts/appLockerfishingnetpat.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.hld.anzenbokusufake/shared_prefs/share_privacy_safe.xml',),
         "output_types": ['html', 'tsv', 'lava'],
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     }
 }
 

--- a/scripts/artifacts/blueskymessages.py
+++ b/scripts/artifacts/blueskymessages.py
@@ -12,7 +12,7 @@ __artifacts_v2__ = {
         "paths": ('*/xyz.blueskyweb.app/databases/RKStorage*',
                   '*/xyz.blueskyweb.app/cache/http-cache/*.*'),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     },
     "get_blueskymessages_actors": {
         "name": "Bluesky - Actors",

--- a/scripts/artifacts/build.py
+++ b/scripts/artifacts/build.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/vendor/build.prop',),
         "output_types": ['html', 'tsv', 'lava'],
-        "artifact_icon": "info",
+        "artifact_icon": "info-circle",
     }
 }
 

--- a/scripts/artifacts/bumble.py
+++ b/scripts/artifacts/bumble.py
@@ -14,7 +14,7 @@ __artifacts_v2__ = {
         "author": "@KevinPagano3", "creation_date": "2022-11-07", "last_update_date": "2026-07-03",
         "requirements": "none", "category": "Bumble",
         "paths": ('*/com.bumble.app/databases/ChatComDatabase*', '*/com.bumble.app/files/c2V0dGluZ3M='),
-        "output_types": "standard", "artifact_icon": "message-square",
+        "output_types": "standard", "artifact_icon": "message",
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Conversation ID",

--- a/scripts/artifacts/burner.py
+++ b/scripts/artifacts/burner.py
@@ -24,7 +24,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.adhoclabs.burner/databases/burners.db',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Other Party Number",

--- a/scripts/artifacts/burnerMessages.py
+++ b/scripts/artifacts/burnerMessages.py
@@ -12,7 +12,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/data/com.adhoclabs.burner/databases/burnerDatabase.db*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Contact",

--- a/scripts/artifacts/chatgpt.py
+++ b/scripts/artifacts/chatgpt.py
@@ -101,7 +101,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('**/com.openai.chatgpt/shared_prefs/analytics-android-oai.xml',),
         "output_types": "standard",
-        "artifact_icon": "bar-chart-2",
+        "artifact_icon": "chart-bar",
     },
     "get_chatgpt_media": {
         "name": "ChatGPT - Media Uploads",
@@ -114,7 +114,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('**/com.openai.chatgpt/cache/files/*',),
         "output_types": "standard",
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     }
 }
 

--- a/scripts/artifacts/chromeMediaHistory.py
+++ b/scripts/artifacts/chromeMediaHistory.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/app_chrome/Default/Media History*', '*/app_sbrowser/Default/Media History*', '*/app_opera/Media History*', '*/app_webview/Default/Media History*'),
         "output_types": "standard",
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     },
     "get_chromeMediaHistoryPlaybacks": {
         "name": "Media History - Playbacks",
@@ -24,7 +24,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/app_chrome/Default/Media History*', '*/app_sbrowser/Default/Media History*', '*/app_opera/Media History*', '*/app_webview/Default/Media History*'),
         "output_types": "standard",
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     },
     "get_chromeMediaHistoryOrigins": {
         "name": "Media History - Origins",
@@ -37,7 +37,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/app_chrome/Default/Media History*', '*/app_sbrowser/Default/Media History*', '*/app_opera/Media History*', '*/app_webview/Default/Media History*'),
         "output_types": "standard",
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     }
 }
 

--- a/scripts/artifacts/chromeOfflinePages.py
+++ b/scripts/artifacts/chromeOfflinePages.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/app_chrome/Default/Offline Pages/metadata/OfflinePages.db*', '*/app_sbrowser/Default/Offline Pages/metadata/OfflinePages.db*', '*/app_webview/Default/Offline Pages/metadata/OfflinePages.db*'),
         "output_types": "standard",
-        "artifact_icon": "download-cloud",
+        "artifact_icon": "cloud-download",
     }
 }
 

--- a/scripts/artifacts/deviceHealthServices_AppUsage.py
+++ b/scripts/artifacts/deviceHealthServices_AppUsage.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.google.android.apps.turbo/shared_prefs/app_usage_stats.xml',),
         "output_types": "standard",
-        "artifact_icon": "bar-chart-2",
+        "artifact_icon": "chart-bar",
     }
 }
 

--- a/scripts/artifacts/discordChats.py
+++ b/scripts/artifacts/discordChats.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/data/com.discord/files/kv-storage/*/a*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Channel ID",

--- a/scripts/artifacts/emulatedSmeta.py
+++ b/scripts/artifacts/emulatedSmeta.py
@@ -24,7 +24,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.google.android.providers.media.module/databases/external.db*', '*/com.android.providers.media/databases/external.db*'),
         "output_types": "standard",
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     },
     "get_emulatedSmeta_files": {
         "name": "Emulated Storage Metadata - Files",

--- a/scripts/artifacts/fitbit.py
+++ b/scripts/artifacts/fitbit.py
@@ -19,7 +19,7 @@ def _art(name, desc, paths, icon='activity', outtypes='standard'):
 
 __artifacts_v2__ = {
     "get_fitbit_activity": _art("Fitbit - Activity", "Activity log (phone)", _PATHS_PHONE_ACT),
-    "get_fitbit_device": _art("Fitbit - Device Info", "Paired device info (phone)", _PATHS_PHONE_DEV, "watch"),
+    "get_fitbit_device": _art("Fitbit - Device Info", "Paired device info (phone)", _PATHS_PHONE_DEV, "device-watch"),
     "get_fitbit_exercise": _art("Fitbit - Exercise GPS", "Exercise GPS trackpoints (phone)", _PATHS_PHONE_EX, "map-pin", "all"),
     "get_fitbit_routes": _art("Fitbit - Exercise Routes", "Per-session exercise route map (phone)", _PATHS_PHONE_EX, "map"),
     "get_fitbit_heart": _art("Fitbit - Heart Rate Summary", "Daily heart-rate summary (phone)", _PATHS_PHONE_HR, "heart"),

--- a/scripts/artifacts/galleryTrash.py
+++ b/scripts/artifacts/galleryTrash.py
@@ -12,7 +12,7 @@ __artifacts_v2__ = {
         "paths": ('*/data/com.sec.android.gallery3d/databases/local.db*',
                   '*/data/com.sec.android.gallery3d/files/.Trash/**'),
         "output_types": "all",
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     }
 }
 

--- a/scripts/artifacts/garmin.py
+++ b/scripts/artifacts/garmin.py
@@ -24,7 +24,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/data/com.garmin.android.apps.connectmobile/databases/gcm_cache.db*',),
         "output_types": "standard",
-        "artifact_icon": "watch",
+        "artifact_icon": "device-watch",
     },
     "get_garmin_weather": {
         "name": "Garmin - Weather",

--- a/scripts/artifacts/gboard.py
+++ b/scripts/artifacts/gboard.py
@@ -25,7 +25,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.google.android.inputmethod.latin/databases/trainingcache*.db',),
         "output_types": "standard",
-        "artifact_icon": "chrome",
+        "artifact_icon": "brand-chrome",
     },
     "get_gboardCache_sessions": {
         "name": "Gboard - Sessions",
@@ -38,7 +38,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.google.android.inputmethod.latin/databases/trainingcachev3.db',),
         "output_types": "standard",
-        "artifact_icon": "chrome",
+        "artifact_icon": "brand-chrome",
     }
 }
 

--- a/scripts/artifacts/googleChat.py
+++ b/scripts/artifacts/googleChat.py
@@ -13,7 +13,7 @@ __artifacts_v2__ = {
                   '*/com.google.android.apps.dynamite/databases/dynamite.db*',
                   '*/com.google.android.apps.dynamite/databases/user_accounts/*/dynamite.db*'),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Group ID",

--- a/scripts/artifacts/googleDuo.py
+++ b/scripts/artifacts/googleDuo.py
@@ -38,7 +38,7 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.apps.tachyon/databases/tachyon.db*',
                   '*/com.google.android.apps.tachyon/files/media/*.*'),
         "output_types": "standard",
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     }
 }
 

--- a/scripts/artifacts/googleMessages.py
+++ b/scripts/artifacts/googleMessages.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.google.android.apps.messaging/databases/bugle_db*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Conversation ID",

--- a/scripts/artifacts/googlePhotos.py
+++ b/scripts/artifacts/googlePhotos.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.google.android.apps.photos/databases/gphotos*.db*',),
         "output_types": "all",
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     },
     "get_googlePhotos_remote": {
         "name": "Google Photos - Remote Media",
@@ -24,7 +24,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.google.android.apps.photos/databases/gphotos*.db*',),
         "output_types": "all",
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     },
     "get_googlePhotos_shared": {
         "name": "Google Photos - Shared Media",
@@ -37,7 +37,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.google.android.apps.photos/databases/gphotos*.db*',),
         "output_types": "standard",
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     },
     "get_googlePhotos_folders": {
         "name": "Google Photos - Backed Up Folders",
@@ -64,7 +64,7 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.apps.photos/databases/disk_cache*',
                   '*/com.google.android.apps.photos/cache/glide_cache/*'),
         "output_types": "standard",
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     },
     "get_googlePhotos_trash": {
         "name": "Google Photos - Local Trash",
@@ -78,7 +78,7 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.apps.photos/databases/local_trash.db*',
                   '*/com.google.android.apps.photos/files/trash_files/*'),
         "output_types": "standard",
-        "artifact_icon": "trash-2",
+        "artifact_icon": "trash",
     }
 }
 

--- a/scripts/artifacts/googleVoice.py
+++ b/scripts/artifacts/googleVoice.py
@@ -37,7 +37,7 @@ __artifacts_v2__ = {
         "notes": "Tested on version 2025.07.20.788599304 (October 29th, 2025). Tested on Samsung and Motorola devices.",
         "paths": ('*/data/com.google.android.apps.googlevoice/files/accounts/*/LegacyMsgDbInstance.db*', '*/data/com.google.android.apps.googlevoice/cache/audio/*'),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "voicemail",
+        "artifact_icon": "record-mail",
     },
     "googlevoice_messages": {
         "name": "Google Voice - Messages",

--- a/scripts/artifacts/groupMe.py
+++ b/scripts/artifacts/groupMe.py
@@ -24,7 +24,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.groupme.android/databases/groupme.db',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     }
 }
 

--- a/scripts/artifacts/imagemngCache.py
+++ b/scripts/artifacts/imagemngCache.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/cache/image_manager_disk_cache/*.*', '*/*.cnt'),
         "output_types": "standard",
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     }
 }
 

--- a/scripts/artifacts/imo.py
+++ b/scripts/artifacts/imo.py
@@ -24,7 +24,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.imo.android.imous/databases/imofriends.db*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Chat Partner",

--- a/scripts/artifacts/kleinanzeigen.de.py
+++ b/scripts/artifacts/kleinanzeigen.de.py
@@ -63,7 +63,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*com.ebay.kleinanzeigen/databases/messageBoxDatabase.db*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Counterparty",

--- a/scripts/artifacts/lgRCS.py
+++ b/scripts/artifacts/lgRCS.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/mmssms.db*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     }
 }
 

--- a/scripts/artifacts/likee.py
+++ b/scripts/artifacts/likee.py
@@ -36,7 +36,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/video.like/databases/*.db*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     }
 }
 

--- a/scripts/artifacts/line.py
+++ b/scripts/artifacts/line.py
@@ -24,7 +24,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/jp.naver.line.android/databases/**',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Thread ID",

--- a/scripts/artifacts/mastodon.py
+++ b/scripts/artifacts/mastodon.py
@@ -50,7 +50,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/org.joinmastodon.android/databases/*.db*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     },
     "get_mastodon_accounts": {
         "name": "Mastodon - Account Details",

--- a/scripts/artifacts/mewe.py
+++ b/scripts/artifacts/mewe.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.mewe/databases/app_database',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Thread Id",

--- a/scripts/artifacts/offlinePages.py
+++ b/scripts/artifacts/offlinePages.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/*.mhtml', '*/*.mht'),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     }
 }
 

--- a/scripts/artifacts/persistentProp.py
+++ b/scripts/artifacts/persistentProp.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/property/persistent_properties',),
         "output_types": "standard",
-        "artifact_icon": "info",
+        "artifact_icon": "info-circle",
     }
 }
 

--- a/scripts/artifacts/playgroundVault.py
+++ b/scripts/artifacts/playgroundVault.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/playground.develop.applocker/shared_prefs/crypto.KEY_256.xml', '*/applocker/vault/*'),
         "output_types": "standard",
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     }
 }
 

--- a/scripts/artifacts/sChats.py
+++ b/scripts/artifacts/sChats.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/data/com.sideline.phone.number/databases/textfree*'),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     }
 }
 

--- a/scripts/artifacts/setupWizardinfo.py
+++ b/scripts/artifacts/setupWizardinfo.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.google.android.settings.intelligence/shared_prefs/setup_wizard_info.xml',),
         "output_types": "standard",
-        "artifact_icon": "info",
+        "artifact_icon": "info-circle",
     }
 }
 

--- a/scripts/artifacts/siminfo.py
+++ b/scripts/artifacts/siminfo.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/user_de/*/com.android.providers.telephony/databases/telephony.db',),
         "output_types": "standard",
-        "artifact_icon": "info",
+        "artifact_icon": "info-circle",
     }
 }
 

--- a/scripts/artifacts/skout.py
+++ b/scripts/artifacts/skout.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.skout.android/databases/skoutDatabase*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     },
     "get_skout_users": {
         "name": "Skout Users",

--- a/scripts/artifacts/skype.py
+++ b/scripts/artifacts/skype.py
@@ -24,7 +24,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.skype.raider/databases/live*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Thread ID",

--- a/scripts/artifacts/smsmms.py
+++ b/scripts/artifacts/smsmms.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.android.providers.telephony/databases/mmssms*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Thread ID",
@@ -37,7 +37,7 @@ __artifacts_v2__ = {
                   '*/com.android.providers.telephony/app_parts/*',
                   '*/com.android.providers.telephony/parts/*'),
         "output_types": "standard",
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Thread ID",

--- a/scripts/artifacts/smsmmsBackup.py
+++ b/scripts/artifacts/smsmmsBackup.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.android.providers.telephony/d_f/*_backup',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Recipients",
@@ -35,7 +35,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.android.providers.telephony/d_f/*_backup',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Address",

--- a/scripts/artifacts/smyfilesTrash.py
+++ b/scripts/artifacts/smyfilesTrash.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "Timestamp corroborated with My Files Operation History database",
         "paths": ('*/com.sec.android.app.myfiles/files/trash/*', '*/.Trash/com.sec.android.app.myfiles/*'),
         "output_types": "standard",
-        "artifact_icon": "trash-2",
+        "artifact_icon": "trash",
     }
 }
 

--- a/scripts/artifacts/snapchat.py
+++ b/scripts/artifacts/snapchat.py
@@ -22,7 +22,7 @@ __artifacts_v2__ = {
         "author": "", "creation_date": "2021-11-10", "last_update_date": "2021-11-10",
         "requirements": "none", "category": "Snapchat", "notes": "",
         "paths": ('*/com.snapchat.android/databases/main.db*', '*/com.snapchat.android/databases/tcspahn.db*'),
-        "output_types": "standard", "artifact_icon": "message-square",
+        "output_types": "standard", "artifact_icon": "message",
     },
     "get_snapchat_memories": {
         "name": "Snapchat - Memories",
@@ -30,7 +30,7 @@ __artifacts_v2__ = {
         "author": "", "creation_date": "2021-11-10", "last_update_date": "2021-11-10",
         "requirements": "none", "category": "Snapchat", "notes": "",
         "paths": ('*/com.snapchat.android/databases/memories.db*',),
-        "output_types": "standard", "artifact_icon": "image",
+        "output_types": "standard", "artifact_icon": "photo",
     },
     "get_snapchat_meo": {
         "name": "Snapchat - MEO My Eyes Only",
@@ -47,7 +47,7 @@ __artifacts_v2__ = {
         "author": "", "creation_date": "2021-11-10", "last_update_date": "2021-11-10",
         "requirements": "none", "category": "Snapchat", "notes": "",
         "paths": ('*/com.snapchat.android/databases/memories.db*',),
-        "output_types": "all", "artifact_icon": "image",
+        "output_types": "all", "artifact_icon": "photo",
     },
     "get_snapchat_identity": {
         "name": "Snapchat - Identity Persistent Store",
@@ -63,7 +63,7 @@ __artifacts_v2__ = {
         "author": "", "creation_date": "2021-11-10", "last_update_date": "2021-11-10",
         "requirements": "none", "category": "Snapchat", "notes": "",
         "paths": ('*/com.snapchat.android/shared_prefs/LoginSignupStore.xml',),
-        "output_types": "standard", "artifact_icon": "log-in",
+        "output_types": "standard", "artifact_icon": "login-2",
     }
 }
 

--- a/scripts/artifacts/tangomessage.py
+++ b/scripts/artifacts/tangomessage.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.sgiggle.production/files/tc.db*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     }
 }
 

--- a/scripts/artifacts/teams.py
+++ b/scripts/artifacts/teams.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.microsoft.teams/databases/SkypeTeams.db*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     },
     "get_teams_users": {
         "name": "Teams - Users",

--- a/scripts/artifacts/teleguard.py
+++ b/scripts/artifacts/teleguard.py
@@ -12,7 +12,7 @@ __artifacts_v2__ = {
         "paths": ('*/data/ch.swisscows.messenger.teleguardapp/app_flutter/teleguard_database.db*',
                   '*/data/ch.swisscows.messenger.teleguardapp/cache/**'),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Chat ID",

--- a/scripts/artifacts/textnow.py
+++ b/scripts/artifacts/textnow.py
@@ -24,7 +24,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.enflick.android.TextNow/databases/textnow_data.db*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     },
     "get_textnow_contacts": {
         "name": "Text Now - Contacts",

--- a/scripts/artifacts/tikTok.py
+++ b/scripts/artifacts/tikTok.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*_im.db*', '*db_im_xx*'),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Conversation ID",

--- a/scripts/artifacts/tusky.py
+++ b/scripts/artifacts/tusky.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.keylesspalace.tusky/databases/tuskyDB*',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     },
     "get_tusky_accounts": {
         "name": "Tusky - Account Details",

--- a/scripts/artifacts/usagestatsVersion.py
+++ b/scripts/artifacts/usagestatsVersion.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/system/usagestats/*/version', '*/system_ce/*/usagestats/version'),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "bar-chart-2"
+        "artifact_icon": "chart-bar"
     }
 }
 
@@ -22,7 +22,7 @@ from scripts.ilapfuncs import artifact_processor, \
 
 
 @artifact_processor
-def usagestatsVersion(files_found, report_folder, seeker, wrap_text):
+def usagestatsVersion(files_found, _report_folder, _seeker, _wrap_text):
     source_path = get_file_path(files_found, "version")
     data_list = []
 

--- a/scripts/artifacts/vlcMedia.py
+++ b/scripts/artifacts/vlcMedia.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*vlc_media.db*',),
         "output_types": "standard",
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     }
 }
 

--- a/scripts/artifacts/vlcThumbs.py
+++ b/scripts/artifacts/vlcThumbs.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/org.videolan.vlc/files/medialib/*.jpg',),
         "output_types": "standard",
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     },
     "get_vlcThumbs_data": {
         "name": "VLC Thumbnail Data",
@@ -24,7 +24,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/org.videolan.vlc/files/medialib/*.jpg', '*/org.videolan.vlc/app_db/vlc_media.db*'),
         "output_types": "standard",
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     }
 }
 

--- a/scripts/artifacts/vlcthumbsADB.py
+++ b/scripts/artifacts/vlcthumbsADB.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/org.videolan.vlc/ef/medialib/thumbnails/*.*',),
         "output_types": "standard",
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     },
     "get_vlcthumbsADB_medialib": {
         "name": "VLC Media Lib (ADB)",
@@ -23,7 +23,7 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/org.videolan.vlc/ef/medialib/*.*',),
         "output_types": "standard",
-        "artifact_icon": "image",
+        "artifact_icon": "photo",
     }
 }
 

--- a/scripts/artifacts/waze.py
+++ b/scripts/artifacts/waze.py
@@ -34,7 +34,7 @@ __artifacts_v2__ = {
         "notes": "https://djangofaiola.blogspot.com",
         "paths": ("*/com.waze/session"),
         "output_types": [ "all" ],
-        "artifact_icon": "navigation-2"
+        "artifact_icon": "navigation"
     },
     "waze_track_gps_quality": {
         "name": "Waze - Track GPS Quality",
@@ -49,7 +49,7 @@ __artifacts_v2__ = {
                   "*/com.waze/waze_log.txt",
                   "*/com.waze/*spdlog.logdata.gz"),
         "output_types": [ "all" ],
-        "artifact_icon": "navigation-2"
+        "artifact_icon": "navigation"
     },
     "waze_search_history": {
         "name": "Waze - Search History",

--- a/scripts/artifacts/wireMessenger.py
+++ b/scripts/artifacts/wireMessenger.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "notes": "Tested on: Android 13 Wire v.3.81.35",
         "paths": ('*/com.wire/**',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     },
     "get_wire_contacts": {
         "name": "Wire Contacts",
@@ -24,7 +24,7 @@ __artifacts_v2__ = {
         "notes": "Tested on: Android 13 Wire v.3.81.35",
         "paths": ('*/com.wire/**',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     },
     "get_wire_messages": {
         "name": "Wire Messages",
@@ -37,7 +37,7 @@ __artifacts_v2__ = {
         "notes": "Tested on: Android 13 Wire v.3.81.35",
         "paths": ('*/com.wire/**',),
         "output_types": "standard",
-        "artifact_icon": "message-square",
+        "artifact_icon": "message",
     }
 }
 


### PR DESCRIPTION
Follow-up to #929 (Tabler icons in the HTML report) — the ALEAPP counterpart of iLEAPP's abrignoni/iLEAPP#1640.

## What changed (89 files, 119 icon values)
Every `artifact_icon` still carrying a Feather name is rewritten to the exact Tabler name the `feather_to_tabler_icon_names.json` shim already resolves it to. Includes the `fitbit.py` `_art()` helper's positional `"watch"` → `"device-watch"` (the one non-literal metadata construct).

Top renames: `message-square→message` (57), `image→photo` (29), `info→info-circle` (6), `grid→layout-grid` (4), `bar-chart-2→chart-bar` (4), plus `voicemail→record-mail`, `chrome→brand-chrome`, `log-in→login-2`, `check-square→square-check`, …

## Rendering: identical for 117 of 119 — two deliberate improvements
Verified through the actual `report.py` resolution (shim branch skips the correction map; native branch applies it): **117 of 119 render the exact same SVG before and after.** The two exceptions are the `book-open` artifacts (DuckDuckGo / Ornet Browser "Open Tabs"): they previously rendered `book.svg` (closed book, because the shim branch bypasses the `book→book-2` correction) and now render `book-2.svg` (**open** book) — restoring the original Feather `book-open` intent.

## Full conversion audit (no invented mappings)
- AST-compared every touched file's `__artifacts_v2__` main-vs-branch: **no metadata field other than `artifact_icon` changed anywhere**
- Every old value verified genuinely non-native **and** present in the shim; every new value **equals the shim's mapping exactly** (0 invented) and its SVG **exists on disk** in `assets/tabler_icons/`
- The 86 icon-only files contain **no changed line other than `artifact_icon` lines** (diff-level check)
- `Deepseek_ChatMessages.py`: no live `html` reference remains after the unused-import removal (AST-verified)

## Starting point vs iLEAPP
ALEAPP was already clean where iLEAPP wasn't: **0 icon-less artifacts, 0 broken names, 0 runtime-named report modules** — a pure rename pass, no new icon assignments needed.

## Lint (CI lints every changed file)
Two touched files carried small pre-existing findings, fixed with zero-behavior edits:
- `usagestatsVersion.py`: underscore-prefixed unused arguments
- `Deepseek_ChatMessages.py`: unused args prefixed; unused `import html` removed (only referenced inside a commented-out block); two kept-for-reference triple-quoted string statements converted to real comments; inline `# pylint: disable=broad-exception-caught` on the four existing `except Exception` handlers (repo precedent, e.g. `fitbit.py`)

## Validation
- `py_compile` clean on all 89 files
- `PYTHONPATH=. pylint --disable=C,R` on all 89 changed files: **10.00/10**
- PluginLoader: **583 artifacts load; every icon is a native bundled Tabler name**
- No CRLF files among the touched set (checked before writing)