### PR TITLE
Shorten per-row Source File paths to extraction-relative (follow-up to #931)

### DIFF
--- a/scripts/artifacts/Life360.py
+++ b/scripts/artifacts/Life360.py
@@ -69,6 +69,7 @@ import json
 import sqlite3
 
 from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.context import Context
 
 
 def _sec_to_utc(value):
@@ -166,7 +167,7 @@ def get_Life360_chat_messages(files_found, report_folder, seeker, wrap_text):
         for row in rows:
             data_list.append((_sec_to_utc(row[0]), row[1], row[2], row[3], row[4], row[5], row[6],
                               row[7], row[8], row[9], row[10], row[11], row[12], _sec_to_utc(row[13]),
-                              source))
+                              Context.get_relative_path(source)))
         db.close()
 
     data_headers = (('Timestamp', 'datetime'), 'Thread ID', 'Sender ID', 'Sender Name', 'Message',
@@ -185,7 +186,7 @@ def get_Life360_places(files_found, report_folder, seeker, wrap_text):
         cursor = db.cursor()
         for row in _q(cursor, '''SELECT name, latitude, longitude, radius, source, source_id, owner_id
                 FROM places'''):
-            data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], source))
+            data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], Context.get_relative_path(source)))
         db.close()
 
     data_headers = ('Place Name', 'Latitude', 'Longitude', 'Radius (m)', 'Places Source', 'Source ID',
@@ -201,7 +202,7 @@ def get_Life360_locations(files_found, report_folder, seeker, wrap_text):
         for e in _ble_events(source):
             data_list.append((e['time'], e['lat'], e['lon'], e['alt'], e['speed'], e['course'],
                               e['bearing'], e['vert'], e['hor'], e['lmode'], e['bssid'], e['ssid'],
-                              e['id'], source))
+                              e['id'], Context.get_relative_path(source)))
 
     data_headers = (('Timestamp', 'datetime'), 'Latitude', 'Longitude', 'Altitude', 'Speed (mps)',
                     'Course', 'Bearing', 'Vertical Accuracy (+/- m)', 'Horizontal Accuracy (+/- m)',
@@ -216,7 +217,7 @@ def get_Life360_device_battery(files_found, report_folder, seeker, wrap_text):
     data_list = []
     if source:
         for e in _ble_events(source):
-            data_list.append((e['time'], e['battery'], e['charging'], source))
+            data_list.append((e['time'], e['battery'], e['charging'], Context.get_relative_path(source)))
 
     data_headers = (('Timestamp', 'datetime'), 'Device Battery (%)', 'Charging', 'Source File')
     return data_headers, data_list, source

--- a/scripts/artifacts/SimpleStorage_applaunch.py
+++ b/scripts/artifacts/SimpleStorage_applaunch.py
@@ -17,6 +17,7 @@ __artifacts_v2__ = {
 }
 
 from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, convert_ts_human_to_utc, convert_utc_human_to_timezone
+from scripts.context import Context
 
 @artifact_processor
 def SimpleStorage_applaunch(files_found, report_folder, seeker, wrap_text):
@@ -49,7 +50,7 @@ def SimpleStorage_applaunch(files_found, report_folder, seeker, wrap_text):
             pass
         else:
             time_launched = convert_utc_human_to_timezone(convert_ts_human_to_utc(time_launched),'UTC')
-        data_list.append((time_launched,record[1],record[2], source_path))
+        data_list.append((time_launched,record[1],record[2], Context.get_relative_path(source_path)))
  
     data_headers = (('App Launched Timestamp','datetime'),'App Name','Launched From', 'Source File')
     return data_headers, data_list, 'See source file(s) below'

--- a/scripts/artifacts/battery_usage_v9.py
+++ b/scripts/artifacts/battery_usage_v9.py
@@ -35,6 +35,7 @@ import sqlite3
 import blackboxprotobuf
 
 from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.context import Context
 
 _STATUS = {2: 'Charging', 3: 'Discharging', 5: 'Fully charged'}
 _HEALTH = {1: 'Unknown', 2: 'Good', 3: 'Overheat', 4: 'Dead', 5: 'Over Voltage',
@@ -135,7 +136,7 @@ def get_battery_usage_v9(files_found, report_folder, seeker, wrap_text):
             _STATUS.get(_as_int(info.get('2')), 'Unknown'),    # Battery Status
             _HEALTH.get(_as_int(info.get('3')), 'None'),       # Battery Health
             _txt(proto.get('13')),                             # Drain Type
-            source_path))
+            Context.get_relative_path(source_path)))
 
     data_headers = (('Timestamp', 'datetime'), 'Application', 'Package Name', 'Hidden',
                     'Boot Timestamp', 'Timezone', 'Total Power', 'Consumed Power',
@@ -154,7 +155,7 @@ def get_app_usage_events(files_found, report_folder, seeker, wrap_text):
         packageName, taskRootPackageName, instanceId
         FROM AppUsageEventEntity
     ''')
-    data_list = [(r[0], r[1], _ms_to_utc(r[2]), r[3], r[4], r[5], r[6], source_path) for r in rows]
+    data_list = [(r[0], r[1], _ms_to_utc(r[2]), r[3], r[4], r[5], r[6], Context.get_relative_path(source_path)) for r in rows]
     data_headers = ('uid', 'userId', ('Timestamp', 'datetime'), 'App Usage Event Type',
                     'Package Name', 'Root Package Name', 'Instance Id', 'Source File')
     return data_headers, data_list, source_path

--- a/scripts/artifacts/gmailIMAPEmails.py
+++ b/scripts/artifacts/gmailIMAPEmails.py
@@ -32,6 +32,7 @@ import os
 import urllib.parse
 
 from scripts.ilapfuncs import open_sqlite_db_readonly, artifact_processor, convert_unix_ts_to_utc, logfunc, check_in_media
+from scripts.context import Context
 
 @artifact_processor
 def gmailIMAPEmails(files_found, _report_folder, _seeker, _wrap_text):
@@ -154,7 +155,7 @@ def gmailIMAPEmails(files_found, _report_folder, _seeker, _wrap_text):
                 attachment_cell = AttachmentPaths
             else:
                 attachment_cell = ''
-            data_list.append((row[0], row[1], row[2], tBody, hBody, row[3], row[4], row[5], row[6], row[7], row[8], row[9], attachment_cell, row[11], emailProviderDB))
+            data_list.append((row[0], row[1], row[2], tBody, hBody, row[3], row[4], row[5], row[6], row[7], row[8], row[9], attachment_cell, row[11], Context.get_relative_path(emailProviderDB)))
 
     data_headers = (('Timestamp','datetime'),'_id','Snippet', 'Body(TXT)', 'Body(HTML)', 'Recipient','Reply To','Subject Line','Mailed By','Signed by', 'Read', 'AttachmentFlag', ('Attachments', 'media'), 'Mailbox Folder', 'Source File')
     return data_headers, data_list, 'See source file(s) below:'
@@ -192,7 +193,7 @@ def gmailIMAPAccounts(files_found, _report_folder, _seeker, _wrap_text):
         for row in all_rows:
             row = list(row)
 
-            data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], emailProviderDB))
+            data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], Context.get_relative_path(emailProviderDB)))
 
     data_headers = ('_id', 'displayName', 'emailAddress', 'senderName', 'login','password','address','port', 'Source File')
     return data_headers, data_list, 'See source file(s) below:'

--- a/scripts/artifacts/googleChat.py
+++ b/scripts/artifacts/googleChat.py
@@ -81,6 +81,7 @@ import sqlite3
 import blackboxprotobuf
 
 from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.context import Context
 
 
 def _us_to_utc(value):
@@ -172,7 +173,7 @@ def get_googleChat(files_found, report_folder, seeker, wrap_text):
                 direction = 'Outgoing' if str(r[6]) == owner_id else 'Incoming'
             else:
                 direction = ''
-            data_list.append((_us_to_utc(r[0]), r[1], r[2], r[3]) + ann + (source_path, r[5], direction))
+            data_list.append((_us_to_utc(r[0]), r[1], r[2], r[3]) + ann + (Context.get_relative_path(source_path), r[5], direction))
 
     data_headers = (('Message Timestamp', 'datetime'), 'Group Name', 'Sender', 'Message',
                     'Meeting Code', 'Meeting URL', 'Meeting Sender', 'Meeting Sender Profile Pic URL',
@@ -192,7 +193,7 @@ def get_googleChat_groups(files_found, report_folder, seeker, wrap_text):
             ORDER BY Groups.create_time ASC
         ''')
         for r in rows:
-            data_list.append((_us_to_utc(r[0]), r[1], r[2], _us_to_utc(r[3]), source_path))
+            data_list.append((_us_to_utc(r[0]), r[1], r[2], _us_to_utc(r[3]), Context.get_relative_path(source_path)))
 
     data_headers = (('Group Created Time', 'datetime'), 'Group Name', 'Group Creator',
                     ('Group Last Viewed', 'datetime'), 'Source File')
@@ -210,7 +211,7 @@ def get_googleChat_drafts(files_found, report_folder, seeker, wrap_text):
             LEFT JOIN Groups on drafts.group_id = Groups.group_id
         ''')
         for r in rows:
-            data_list.append((r[0], r[1], r[2], r[3], r[4], source_path))
+            data_list.append((r[0], r[1], r[2], r[3], r[4], Context.get_relative_path(source_path)))
 
     data_headers = ('Group ID', 'Topic ID', 'Message', 'Group Name', 'Group Type', 'Source File')
     return data_headers, data_list, source_path
@@ -226,7 +227,7 @@ def get_googleChat_users(files_found, report_folder, seeker, wrap_text):
             FROM users
         ''')
         for r in rows:
-            data_list.append((_us_to_utc(r[0]), r[1], r[2], r[3], r[4], r[5], source_path))
+            data_list.append((_us_to_utc(r[0]), r[1], r[2], r[3], r[4], r[5], Context.get_relative_path(source_path)))
 
     data_headers = (('Last Updated Time', 'datetime'), 'User ID', 'Name', 'Email', 'Avatar URL',
                     'Dasher Customer ID', 'Source File')

--- a/scripts/artifacts/knuddels.py
+++ b/scripts/artifacts/knuddels.py
@@ -70,6 +70,7 @@ from datetime import datetime, timezone
 from urllib.parse import unquote_plus
 
 from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, check_in_media
+from scripts.context import Context
 from scripts.filetype import guess_mime
 
 SNAP_START = "\u00b0>{Snap}"
@@ -218,7 +219,7 @@ def knuddels_chats(context):
             data_list.append((
                 timestamp, nickname, message, msg_type, media_cell, gif_cell,
                 snap_expired, participants,
-                conversation_key, from_me, file_found, message_id, sender, user_id,
+                conversation_key, from_me, Context.get_relative_path(file_found), message_id, sender, user_id,
             ))
 
     data_headers = (
@@ -287,7 +288,7 @@ def knuddels_contacts(context):
                 ms_to_utc(lastactivetime),
                 profileimagehidden,
                 distance,
-                file_found,
+                Context.get_relative_path(file_found),
             ))
 
     data_headers = (
@@ -354,7 +355,7 @@ def knuddels_account(context):
         }
 
     def active_row(nickname, info, last_msg, extra_sources):
-        sources = " | ".join(extra_sources + info.get("sources", []))
+        sources = " | ".join(Context.get_relative_path(s) for s in extra_sources + info.get("sources", []))
         return (
             nickname, "Yes", info["alias"], info["age"], info["gender"], info["uuid"],
             info["autologin"], info["isloggedin"], info["pw"], info["pw_dec"],
@@ -387,7 +388,7 @@ def knuddels_account(context):
         else:
             data_list.append((
                 nickname, "No", "", "", "", "", "", "", "", "",
-                "", "", "", "", last_msg, db,
+                "", "", "", "", last_msg, Context.get_relative_path(db),
             ))
 
     for instance, info in active.items():

--- a/scripts/artifacts/thunderbird.py
+++ b/scripts/artifacts/thunderbird.py
@@ -43,6 +43,7 @@ import re
 import json
 
 from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records
+from scripts.context import Context
 
 def _map_uuid_to_account(file):
     # Helper method to get the mapping of the uuid to the set up accounts
@@ -185,7 +186,7 @@ def thunderbird_messages(files_found, _report_folder, _seeker, _wrap_text):
             content = row[14]
 
 
-            data_list.append((sent, stored, account, sender, receiver, cc, bcc, subject, preview, content, attachments, read, flagged, answered, forwarded, folder, str(file)))
+            data_list.append((sent, stored, account, sender, receiver, cc, bcc, subject, preview, content, attachments, read, flagged, answered, forwarded, folder, Context.get_relative_path(str(file))))
 
     data_headers = ( 'Timestamp Sent', 'Timestamp Stored', 'Account', 'Sender', 'Receiver', 'CC', 'BCC', 'Subject', 'Preview', 'Content', 'Attachments', 'Read?', 'Flagged?', 'Answered?', 'Forwarded?', 'Folder Name', 'Source File')
 


### PR DESCRIPTION
## Summary
Part 2 of the source-path fix. #931 shortens the *returned* `source_path` centrally in `artifact_processor`, but as @JamesHabben pointed out, artifacts that drop the path into a **per-record Source File column** are a separate population the decorator can't reach. This fixes all of them.

Audit method: for every artifact function, locate `data_headers` entries matching *Source File/Path/DB*, resolve which appended expression feeds that column index, and classify. Result: 26 flagged → 17 already shortened → **19 true positives in 7 files**, all fixed here by wrapping the row-inserted copy with `Context.get_relative_path()` (the absolute path is still used for file/db access):

- **Life360** (chat messages, places, locations, device battery)
- **SimpleStorage_applaunch**
- **battery_usage_v9** (both artifacts)
- **gmailIMAPEmails** (emails + accounts)
- **googleChat** (all 4 artifacts — this was the leak originally observed in test output)
- **knuddels** (chats, contacts, account — including the `active_row` sources join)
- **thunderbird**

Verified false positives, deliberately untouched:
- **FacebookMessenger** — already shortens via its module-level `_src()` helper
- **discreteNative** — emits `Path(file).name` only
- **honorMediaLibrary** — its *Source File Path/Name* columns are **device-side** paths from gallery.db (evidence data, not examiner paths)

## Testing
- Re-ran the audit after the fix: zero unshortened row-level emitters remain (only the three false positives above)
- pylint 10.00/10 on all 7 files; byte-compile; PluginLoader registers all 583 plugins
- `get_relative_path` passthrough semantics make every wrap safe when data_folder is unset