### PR TITLE
Add missing descriptions to 119 artifacts

### DIFF
--- a/scripts/artifacts/DocList.py
+++ b/scripts/artifacts/DocList.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_DocList": {
         "name": "DocList",
-        "description": "",
+        "description": "Parses Google Drive file metadata (name, owner, type, created/modified/opened dates, URIs, MD5 and size) from the DocList.db database.",
         "author": "",
         "creation_date": "2020-12-21",
         "last_update_date": "2020-12-21",

--- a/scripts/artifacts/HideX.py
+++ b/scripts/artifacts/HideX.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_HideX": {
         "name": "HideX",
-        "description": "",
+        "description": "Parses the list of apps hidden or locked by the HideX privacy app (package name and active state) from hidex.db.",
         "author": "",
         "creation_date": "2021-10-12",
         "last_update_date": "2021-10-12",

--- a/scripts/artifacts/Oruxmaps.py
+++ b/scripts/artifacts/Oruxmaps.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_Oruxmaps": {
         "name": "Oruxmaps - POI",
-        "description": "",
+        "description": "Parses saved points of interest (latitude, longitude, altitude, time and name) from the OruxMaps oruxmapstracks.db database.",
         "author": "",
         "creation_date": "2021-03-11",
         "last_update_date": "2021-03-11",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     },
     "get_Oruxmaps_tracks": {
         "name": "Oruxmaps - Tracks",
-        "description": "",
+        "description": "Parses recorded GPS tracks and their trackpoints (name, description, latitude, longitude, altitude and time) from the OruxMaps oruxmapstracks.db database.",
         "author": "",
         "creation_date": "2021-03-11",
         "last_update_date": "2021-03-11",

--- a/scripts/artifacts/Viber.py
+++ b/scripts/artifacts/Viber.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_Viber": {
         "name": "Viber - Call Logs",
-        "description": "",
+        "description": "Parses Viber call logs (timestamp, phone number, direction, duration and call type) from the Viber databases.",
         "author": "",
         "creation_date": "2020-12-24",
         "last_update_date": "2020-12-24",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     },
     "get_Viber_contacts": {
         "name": "Viber - Contacts",
-        "description": "",
+        "description": "Parses Viber contacts (display name and phone number) from the Viber databases.",
         "author": "",
         "creation_date": "2020-12-24",
         "last_update_date": "2020-12-24",
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
     },
     "get_Viber_messages": {
         "name": "Viber - Messages",
-        "description": "",
+        "description": "Parses Viber messages (date, sender and recipients, thread, content, direction, read status and attachments) from the Viber databases.",
         "author": "",
         "creation_date": "2020-12-24",
         "last_update_date": "2026-07-03",

--- a/scripts/artifacts/WordsWithFriends.py
+++ b/scripts/artifacts/WordsWithFriends.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_WordsWithFriends": {
         "name": "WordsWithFriends",
-        "description": "",
+        "description": "Parses in-game chat messages (creation time, message, sender name and email) from the Words With Friends wf_database.sqlite.",
         "author": "",
         "creation_date": "2020-03-21",
         "last_update_date": "2020-03-21",

--- a/scripts/artifacts/Xender.py
+++ b/scripts/artifacts/Xender.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_Xender": {
         "name": "Xender - Contacts",
-        "description": "",
+        "description": "Parses Xender contact profiles (device ID and nickname) from the Xender trans-history database.",
         "author": "",
         "creation_date": "2020-12-24",
         "last_update_date": "2020-12-24",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     },
     "get_Xender_messages": {
         "name": "Xender - Messages",
-        "description": "",
+        "description": "Parses Xender file transfer history (file path, name, size, timestamp, direction and sender and recipient details) from the Xender trans-history database.",
         "author": "",
         "creation_date": "2020-12-24",
         "last_update_date": "2020-12-24",

--- a/scripts/artifacts/Zapya.py
+++ b/scripts/artifacts/Zapya.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_Zapya": {
         "name": "Zapya",
-        "description": "",
+        "description": "Parses Zapya file transfer records (device, name, direction, timestamp, path and title) from the transfer20.db database.",
         "author": "",
         "creation_date": "2020-03-21",
         "last_update_date": "2020-03-21",

--- a/scripts/artifacts/accounts_de.py
+++ b/scripts/artifacts/accounts_de.py
@@ -1,7 +1,8 @@
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "accounts_de": {
         "name": "Accounts_de",
-        "description": "",
+        "description": "Parses device accounts and their authentication activity (account type and name, last password entry, action type and time) from accounts_de.db.",
         "author": "@AlexisBrignoni",
         "creation_date": "2020-03-02",
         "last_update_date": "2025-03-14",

--- a/scripts/artifacts/airtagAndroid.py
+++ b/scripts/artifacts/airtagAndroid.py
@@ -1,7 +1,8 @@
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "airtagAlerts": {
         "name": "Android Airtag Alerts",
-        "description": "",
+        "description": "Parses unknown-tracker (AirTag) alerts (creation and update timestamps, MAC address, device type and alert status) from the Google Play services personalsafety database.",
         "author": "@AlexisBrignoni",
         "creation_date": "2023-08-18",
         "last_update_date": "2025-03-16",
@@ -14,7 +15,7 @@ __artifacts_v2__ = {
     },
     "airtagScans": {
         "name": "Android Airtag Scans",
-        "description": "",
+        "description": "Parses unknown-tracker (AirTag) scan records (timestamps, MAC address, state, RSSI and location) from the Google Play services personalsafety database.",
         "author": "@AlexisBrignoni",
         "creation_date": "2023-08-18",
         "last_update_date": "2025-03-16",
@@ -27,7 +28,7 @@ __artifacts_v2__ = {
     },
     "airtagLastScan": {
         "name": "Android Airtag Last Scan",
-        "description": "",
+        "description": "Parses the last unknown-tracker (AirTag) scan time from the personalsafety_info protobuf file.",
         "author": "@AlexisBrignoni",
         "creation_date": "2023-08-18",
         "last_update_date": "2025-03-16",
@@ -40,7 +41,7 @@ __artifacts_v2__ = {
     },
     "airtagPassiveScan": {
         "name": "Android Airtag Passive Scan",
-        "description": "",
+        "description": "Parses the unknown-tracker (AirTag) passive-scan opt-in setting from the personalsafety_optin protobuf file.",
         "author": "@AlexisBrignoni",
         "creation_date": "2023-08-18",
         "last_update_date": "2025-03-16",
@@ -133,10 +134,10 @@ def airtagScans(files_found, report_folder, seeker, wrap_text):
         creation_timestamp = convert_unix_ts_to_utc(record[0])
         last_updated_timestamp = convert_unix_ts_to_utc(record[1])
 
-        blescan_proto, types = blackboxprotobuf.decode_message(blescan)
+        blescan_proto, _ = blackboxprotobuf.decode_message(blescan)
         posrssi = (blescan_proto['2'])
         
-        location_scan_proto, types = blackboxprotobuf.decode_message(location_scan)
+        location_scan_proto, _ = blackboxprotobuf.decode_message(location_scan)
         latitude = (location_scan_proto['4']/1e7)
         longitude = (location_scan_proto['5']/1e7)
         

--- a/scripts/artifacts/appLockerfishingnetdb.py
+++ b/scripts/artifacts/appLockerfishingnetdb.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_appLockerfishingnetdb": {
         "name": "App Locker DB",
-        "description": "",
+        "description": "Parses the stored unlock pattern for the App Locker privacy app (encrypted and decrypted pattern and key) from privacy_safe.db.",
         "author": "",
         "creation_date": "2021-12-14",
         "last_update_date": "2021-12-14",

--- a/scripts/artifacts/appLockerfishingnetpat.py
+++ b/scripts/artifacts/appLockerfishingnetpat.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_appLockerfishingnetpat": {
         "name": "App Locker Pat",
-        "description": "",
+        "description": "Parses the App Locker unlock pattern (encrypted and decrypted) from the share_privacy_safe.xml preferences file.",
         "author": "",
         "creation_date": "2021-12-14",
         "last_update_date": "2021-12-14",

--- a/scripts/artifacts/atrackerdetect.py
+++ b/scripts/artifacts/atrackerdetect.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_atrackerdetect": {
         "name": "atrackerdetect",
-        "description": "",
+        "description": "Parses preferences from the Apple Tracker Detect Android app (key, value and milliseconds from last boot) from its shared_prefs XML.",
         "author": "",
         "creation_date": "2022-01-08",
         "last_update_date": "2022-01-08",

--- a/scripts/artifacts/battery_usage_v4.py
+++ b/scripts/artifacts/battery_usage_v4.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_battery_usage_v4": {
         "name": "battery_usage_v4",
-        "description": "",
+        "description": "Parses per-app battery usage (timestamp, application, power consumed, foreground and background usage, battery level and status) from the settings intelligence battery-usage-db-v4 database.",
         "author": "",
         "creation_date": "2021-12-21",
         "last_update_date": "2021-12-21",

--- a/scripts/artifacts/bittorrentClientpref.py
+++ b/scripts/artifacts/bittorrentClientpref.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_bittorrentClientpref": {
         "name": "BitTorrent Prefs",
-        "description": "",
+        "description": "Parses BitTorrent client preferences (key, value and text) from the com.bittorrent.client preferences XML.",
         "author": "",
         "creation_date": "2023-03-26",
         "last_update_date": "2023-03-26",

--- a/scripts/artifacts/bittorrentDlhist.py
+++ b/scripts/artifacts/bittorrentDlhist.py
@@ -1,7 +1,7 @@
 __artifacts_v2__ = {
     "get_bittorrentDlhist": {
         "name": "bittorrentDlhist",
-        "description": "",
+        "description": "Parses BitTorrent download history (timestamp, filename and download path) from the dlhistory config files.",
         "author": "",
         "creation_date": "2023-03-26",
         "last_update_date": "2023-03-26",

--- a/scripts/artifacts/bluetoothConnections.py
+++ b/scripts/artifacts/bluetoothConnections.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_bluetoothConnections": {
         "name": "Bluetooth Connections",
-        "description": "",
+        "description": "Parses previously connected Bluetooth devices (first connected timestamp, device name, MAC address and link key) from bt_config.conf.",
         "author": "",
         "creation_date": "2021-06-23",
         "last_update_date": "2021-06-23",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     },
     "get_bluetoothAdapter": {
         "name": "Bluetooth Adapter Information",
-        "description": "",
+        "description": "Parses the local Bluetooth adapter information (key and value) from bt_config.conf.",
         "author": "",
         "creation_date": "2021-06-23",
         "last_update_date": "2021-06-23",

--- a/scripts/artifacts/browserlocation.py
+++ b/scripts/artifacts/browserlocation.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_browserlocation": {
         "name": "Browser Location",
-        "description": "",
+        "description": "Parses cached geolocation positions (timestamp, latitude, longitude and accuracy) from the Android Browser CachedGeoposition.db.",
         "author": "",
         "creation_date": "2021-03-17",
         "last_update_date": "2021-03-17",

--- a/scripts/artifacts/build.py
+++ b/scripts/artifacts/build.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_build": {
         "name": "Build",
-        "description": "",
+        "description": "Parses device build properties (key and value) from the vendor build.prop file.",
         "author": "",
         "creation_date": "2020-03-30",
         "last_update_date": "2020-03-30",

--- a/scripts/artifacts/cachelocation.py
+++ b/scripts/artifacts/cachelocation.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_cachelocation": {
         "name": "Cache Location",
-        "description": "",
+        "description": "Parses cached cell and Wi-Fi location fixes (accuracy, confidence, latitude, longitude and read time) from the Google location cache files.",
         "author": "",
         "creation_date": "2021-03-17",
         "last_update_date": "2021-03-17",

--- a/scripts/artifacts/calllog.py
+++ b/scripts/artifacts/calllog.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_calllog": {
         "name": "Call logs ",
-        "description": "",
+        "description": "Parses the call log (date, number, type, duration, location and transcription) from the contacts provider calllog.db.",
         "author": "",
         "creation_date": "2020-03-02",
         "last_update_date": "2020-03-02",

--- a/scripts/artifacts/calllogs.py
+++ b/scripts/artifacts/calllogs.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_calllogs": {
         "name": "Call Logs",
-        "description": "",
+        "description": "Parses call logs (number, start and end time, direction and name) from the contacts and logs provider databases.",
         "author": "",
         "creation_date": "2021-03-17",
         "last_update_date": "2021-03-17",

--- a/scripts/artifacts/cashApp.py
+++ b/scripts/artifacts/cashApp.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_cashApp": {
         "name": "Cash App",
-        "description": "",
+        "description": "Parses Cash App transactions (date, sender and recipient display names, unique IDs and cashtags, amount, status and note) from cash_money.db.",
         "author": "",
         "creation_date": "2021-10-06",
         "last_update_date": "2021-10-06",

--- a/scripts/artifacts/cmh.py
+++ b/scripts/artifacts/cmh.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_cmh": {
         "name": "cmh",
-        "description": "",
+        "description": "Parses the Samsung CMH media store (image dates, title, bucket, latitude, longitude, address and path) from cmh.db.",
         "author": "",
         "creation_date": "2020-03-05",
         "last_update_date": "2020-03-05",

--- a/scripts/artifacts/discreteNative.py
+++ b/scripts/artifacts/discreteNative.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_discreteNative": {
         "name": "DiscreteNative",
-        "description": "",
+        "description": "Parses discrete app-ops permission usage (timestamp, package, permission module and operation, and usage duration) from the system appops discrete records.",
         "author": "",
         "creation_date": "2022-01-19",
         "last_update_date": "2022-01-19",

--- a/scripts/artifacts/errp.py
+++ b/scripts/artifacts/errp.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_errp": {
         "name": "Errp",
-        "description": "",
+        "description": "Parses provisioning and error events (timestamp, event, code and details) from the system users eRR.p file.",
         "author": "",
         "creation_date": "2021-08-15",
         "last_update_date": "2021-08-15",

--- a/scripts/artifacts/etc_hosts.py
+++ b/scripts/artifacts/etc_hosts.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_etc_hosts": {
         "name": "Etc_hosts",
-        "description": "",
+        "description": "Parses host-to-IP mappings (IP address and hostname) from the system etc/hosts file.",
         "author": "",
         "creation_date": "2020-10-09",
         "last_update_date": "2020-10-09",

--- a/scripts/artifacts/firefoxCookies.py
+++ b/scripts/artifacts/firefoxCookies.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_firefoxCookies": {
         "name": "Firefox - Cookies",
-        "description": "",
+        "description": "Parses Firefox cookies (host, name, value, path, created, last accessed and expiration timestamps) from cookies.sqlite.",
         "author": "",
         "creation_date": "2022-01-12",
         "last_update_date": "2022-01-12",

--- a/scripts/artifacts/firefoxDownloads.py
+++ b/scripts/artifacts/firefoxDownloads.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_firefoxDownloads": {
         "name": "Firefox - Downloads",
-        "description": "",
+        "description": "Parses Firefox downloads (created time, file name, URL, MIME type, size, status and destination) from the mozac downloads database.",
         "author": "",
         "creation_date": "2022-01-12",
         "last_update_date": "2022-01-12",

--- a/scripts/artifacts/firefoxFormHistory.py
+++ b/scripts/artifacts/firefoxFormHistory.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_firefoxFormHistory": {
         "name": "Firefox - Form History",
-        "description": "",
+        "description": "Parses Firefox saved form entries (field name, value, times used, first and last used timestamps) from formhistory.sqlite.",
         "author": "",
         "creation_date": "2022-01-12",
         "last_update_date": "2022-01-12",

--- a/scripts/artifacts/firefoxPermissions.py
+++ b/scripts/artifacts/firefoxPermissions.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_firefoxPermissions": {
         "name": "Firefox - Permissions",
-        "description": "",
+        "description": "Parses Firefox site permissions (origin, permission type, status, modification and expiration timestamps) from permissions.sqlite.",
         "author": "",
         "creation_date": "2022-01-12",
         "last_update_date": "2022-01-12",

--- a/scripts/artifacts/firefoxRecentlyClosedTabs.py
+++ b/scripts/artifacts/firefoxRecentlyClosedTabs.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_firefoxRecentlyClosedTabs": {
         "name": "Firefox - Recently Closed Tabs",
-        "description": "",
+        "description": "Parses Firefox recently closed tabs (timestamp, title and URL) from the recently_closed_tabs database.",
         "author": "",
         "creation_date": "2022-01-12",
         "last_update_date": "2022-01-12",

--- a/scripts/artifacts/firefoxTopSites.py
+++ b/scripts/artifacts/firefoxTopSites.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_firefoxTopSites": {
         "name": "Firefox - Top Sites",
-        "description": "",
+        "description": "Parses Firefox top sites (created timestamp, title, URL and default flag) from the top_sites database.",
         "author": "",
         "creation_date": "2022-01-12",
         "last_update_date": "2022-01-12",

--- a/scripts/artifacts/googleTasks.py
+++ b/scripts/artifacts/googleTasks.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_googleTasks": {
         "name": "GoogleTasks",
-        "description": "",
+        "description": "Parses Google Tasks (created, modified, completed and due times, task name, details and status) from the Google Tasks data.db.",
         "author": "",
         "creation_date": "2021-08-21",
         "last_update_date": "2021-08-21",

--- a/scripts/artifacts/googlemaplocation.py
+++ b/scripts/artifacts/googlemaplocation.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_googlemaplocation": {
         "name": "Googlemaplocation",
-        "description": "",
+        "description": "Parses Google Maps navigation destinations (timestamp, destination and source coordinates, title and address) from the da_destination_history database.",
         "author": "",
         "creation_date": "2021-03-17",
         "last_update_date": "2021-03-17",

--- a/scripts/artifacts/imo.py
+++ b/scripts/artifacts/imo.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_imo_account": {
         "name": "IMO - Account ID",
-        "description": "",
+        "description": "Parses the local IMO account (account ID and name) from the IMO accountdb.db.",
         "author": "",
         "creation_date": "2021-03-11",
         "last_update_date": "2021-03-11",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     },
     "get_imo_messages": {
         "name": "IMO - Messages",
-        "description": "",
+        "description": "Parses IMO messages (timestamp, sender and recipient IDs, message, direction, read status and attachments) from the IMO imofriends.db.",
         "author": "",
         "creation_date": "2021-03-11",
         "last_update_date": "2026-07-03",

--- a/scripts/artifacts/installedappsGass.py
+++ b/scripts/artifacts/installedappsGass.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_installedappsGass": {
         "name": "installedappsGass",
-        "description": "",
+        "description": "Parses installed applications (bundle ID, version code and SHA-256 hash) from the Google Play services gass.db.",
         "author": "",
         "creation_date": "2020-03-01",
         "last_update_date": "2020-03-01",

--- a/scripts/artifacts/installedappsLibrary.py
+++ b/scripts/artifacts/installedappsLibrary.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_installedappsLibrary": {
         "name": "InstalledappsLibrary",
-        "description": "",
+        "description": "Parses app purchase and ownership records (purchase time, account and doc ID) from the Play Store library.db.",
         "author": "",
         "creation_date": "2020-03-01",
         "last_update_date": "2020-03-01",

--- a/scripts/artifacts/installedappsVending.py
+++ b/scripts/artifacts/installedappsVending.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_installedappsVending": {
         "name": "InstalledappsVending",
-        "description": "",
+        "description": "Parses installed applications (package, title, first download and last updated times, install reason and account) from the Play Store localappstate.db.",
         "author": "",
         "creation_date": "2020-03-01",
         "last_update_date": "2020-03-01",

--- a/scripts/artifacts/libretorrent.py
+++ b/scripts/artifacts/libretorrent.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_libretorrent": {
         "name": "Libretorrent",
-        "description": "",
+        "description": "Parses torrents added in LibreTorrent/BitLord (timestamp, name, download path, magnet, paused state and visibility) from libretorrent.db.",
         "author": "",
         "creation_date": "2023-09-12",
         "last_update_date": "2023-09-12",

--- a/scripts/artifacts/libretorrentFR.py
+++ b/scripts/artifacts/libretorrentFR.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_libretorrentFR": {
         "name": "LibretorrentFR",
-        "description": "",
+        "description": "Parses torrent fast-resume data (info hash, name, save path, bytes downloaded and uploaded) from the LibreTorrent libretorrent.db.",
         "author": "",
         "creation_date": "2023-09-15",
         "last_update_date": "2023-09-15",

--- a/scripts/artifacts/line.py
+++ b/scripts/artifacts/line.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_line": {
         "name": "Line - Contacts",
-        "description": "",
+        "description": "Parses LINE contacts (user ID and name) from the LINE databases.",
         "author": "",
         "creation_date": "2021-03-15",
         "last_update_date": "2021-03-15",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     },
     "get_line_messages": {
         "name": "Line - Messages",
-        "description": "",
+        "description": "Parses LINE messages (time, sender and recipient IDs, direction, thread, message and attachments) from the LINE databases.",
         "author": "",
         "creation_date": "2021-03-15",
         "last_update_date": "2026-07-03",
@@ -38,7 +38,7 @@ __artifacts_v2__ = {
     },
     "get_line_calls": {
         "name": "Line - Call Logs",
-        "description": "",
+        "description": "Parses LINE call logs (start and end time, participant IDs, direction and call type) from the LINE databases.",
         "author": "",
         "creation_date": "2021-03-15",
         "last_update_date": "2021-03-15",

--- a/scripts/artifacts/mega_transfers.py
+++ b/scripts/artifacts/mega_transfers.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_mega_transfers": {
         "name": "mega_transfers",
-        "description": "",
+        "description": "Parses completed MEGA uploads and downloads (timestamp, folder, filename, size, direction and state) from the MEGA megapreferences database.",
         "author": "",
         "creation_date": "2022-06-04",
         "last_update_date": "2022-06-04",

--- a/scripts/artifacts/mewe.py
+++ b/scripts/artifacts/mewe.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_mewe_chat": {
         "name": "MeWe - Chat",
-        "description": "",
+        "description": "Parses MeWe chat messages (timestamp, thread, user, message text, direction, type and attachments) from the MeWe app_database.",
         "author": "",
         "creation_date": "2021-11-10",
         "last_update_date": "2026-07-03",
@@ -26,7 +26,7 @@ __artifacts_v2__ = {
     },
     "get_mewe_session": {
         "name": "MeWe - SGSession",
-        "description": "",
+        "description": "Parses MeWe session preferences (key and value) from the SGSession.xml file.",
         "author": "",
         "creation_date": "2021-11-10",
         "last_update_date": "2021-11-10",

--- a/scripts/artifacts/oldpowerOffReset.py
+++ b/scripts/artifacts/oldpowerOffReset.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_oldpowerOffReset": {
         "name": "oldpowerOffReset",
-        "description": "",
+        "description": "Parses power-off and reset reasons (timestamp and reason) from the power_off_reset_reason log files.",
         "author": "",
         "creation_date": "2023-03-14",
         "last_update_date": "2023-03-14",

--- a/scripts/artifacts/pSettings.py
+++ b/scripts/artifacts/pSettings.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_pSettings": {
         "name": "pSettings",
-        "description": "",
+        "description": "Parses Google partner settings (name and value) from the Google services framework googlesettings.db.",
         "author": "",
         "creation_date": "2020-03-21",
         "last_update_date": "2020-03-21",

--- a/scripts/artifacts/packageGplinks.py
+++ b/scripts/artifacts/packageGplinks.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_packageGplinks": {
         "name": "packageGplinks",
-        "description": "",
+        "description": "Parses installed package names and their possible Google Play Store links from the system packages.list.",
         "author": "",
         "creation_date": "2021-03-18",
         "last_update_date": "2021-03-18",

--- a/scripts/artifacts/permissions.py
+++ b/scripts/artifacts/permissions.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_permissions_trees": {
         "name": "Permission Trees",
-        "description": "",
+        "description": "Parses declared permission trees (name and package) from the system packages.xml.",
         "author": "",
         "creation_date": "2021-01-28",
         "last_update_date": "2021-01-28",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     },
     "get_permissions_list": {
         "name": "Permissions",
-        "description": "",
+        "description": "Parses declared permissions (name, package and protection level) from the system packages.xml.",
         "author": "",
         "creation_date": "2021-01-28",
         "last_update_date": "2021-01-28",
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
     },
     "get_permissions_packages": {
         "name": "Package and Shared User",
-        "description": "",
+        "description": "Parses packages and their shared user IDs with granted permissions from the system packages.xml.",
         "author": "",
         "creation_date": "2021-01-28",
         "last_update_date": "2021-01-28",

--- a/scripts/artifacts/persistentProp.py
+++ b/scripts/artifacts/persistentProp.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_persistentProp": {
         "name": "persistentProp",
-        "description": "",
+        "description": "Parses persistent system properties and their set times (timestamp and event) from the persistent_properties file.",
         "author": "",
         "creation_date": "2021-08-18",
         "last_update_date": "2021-08-18",

--- a/scripts/artifacts/pikpakCloudlist.py
+++ b/scripts/artifacts/pikpakCloudlist.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_pikpakCloudlist": {
         "name": "PikPak Cloud List",
-        "description": "",
+        "description": "Parses PikPak cloud-stored files (create, modify, delete and update times, user, name, kind, URL and thumbnail) from the PikPak files database.",
         "author": "",
         "creation_date": "2023-03-24",
         "last_update_date": "2023-03-24",

--- a/scripts/artifacts/pikpakDownloads.py
+++ b/scripts/artifacts/pikpakDownloads.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_pikpakDownloads": {
         "name": "PikPak Downloads",
-        "description": "",
+        "description": "Parses PikPak downloads (create and modify times, title, local storage path and URL) from the PikPak downloads database.",
         "author": "",
         "creation_date": "2023-03-24",
         "last_update_date": "2023-03-24",

--- a/scripts/artifacts/pikpakPlay.py
+++ b/scripts/artifacts/pikpakPlay.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_pikpakPlay": {
         "name": "PikPak Play",
-        "description": "",
+        "description": "Parses PikPak video playback history (last play timestamp, duration, played time and name) from the PikPak greendao.db.",
         "author": "",
         "creation_date": "2023-03-24",
         "last_update_date": "2023-03-24",

--- a/scripts/artifacts/protonVPN.py
+++ b/scripts/artifacts/protonVPN.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_protonvpn_device_info": {
         "name": "ProtonVPN - Device Info",
-        "description": "",
+        "description": "Parses ProtonVPN device and server-list-updater information (key and value) from the ServerListUpdater.xml preferences.",
         "author": "",
         "creation_date": "2022-09-04",
         "last_update_date": "2022-09-04",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     },
     "get_protonvpn_connection_history": {
         "name": "ProtonVPN - Connection History",
-        "description": "",
+        "description": "Parses ProtonVPN connection history (server address and timestamp) from the ProtonVPN Data.log.",
         "author": "",
         "creation_date": "2022-09-04",
         "last_update_date": "2022-09-04",
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
     },
     "get_protonvpn_user_info": {
         "name": "ProtonVPN - User Info",
-        "description": "",
+        "description": "Parses the ProtonVPN user account (email, name, username, display name and account state) from the ProtonVPN database.",
         "author": "",
         "creation_date": "2022-09-04",
         "last_update_date": "2022-09-04",

--- a/scripts/artifacts/protonmail.py
+++ b/scripts/artifacts/protonmail.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_protonmail_messages": {
         "name": "ProtonMail - Messages",
-        "description": "",
+        "description": "Parses ProtonMail messages (timestamp, subject, sender, direction, status, size, folder, attachments and recipient lists) from the ProtonMail messages database.",
         "author": "",
         "creation_date": "2023-04-26",
         "last_update_date": "2023-04-26",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     },
     "get_protonmail_contacts": {
         "name": "ProtonMail - Contacts",
-        "description": "",
+        "description": "Parses ProtonMail contacts (creation and modified timestamps, name and email) from the ProtonMail contacts database.",
         "author": "",
         "creation_date": "2023-04-26",
         "last_update_date": "2023-04-26",

--- a/scripts/artifacts/rarlabPreferences.py
+++ b/scripts/artifacts/rarlabPreferences.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_rarlabPreferences": {
         "name": "rarlabPreferences",
-        "description": "",
+        "description": "Parses RAR (RARLAB) application preferences (key, text and value) from the com.rarlab.rar preferences XML.",
         "author": "",
         "creation_date": "2023-03-29",
         "last_update_date": "2023-03-29",

--- a/scripts/artifacts/roles.py
+++ b/scripts/artifacts/roles.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_roles": {
         "name": "roles",
-        "description": "",
+        "description": "Parses assigned system role holders (Android version, user, role and holder package) from the roles.xml file.",
         "author": "",
         "creation_date": "2021-01-25",
         "last_update_date": "2021-01-25",

--- a/scripts/artifacts/runtimePerms.py
+++ b/scripts/artifacts/runtimePerms.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_runtimePerms": {
         "name": "runtimePerms",
-        "description": "",
+        "description": "Parses granted runtime permissions (user, type, name, permission, granted state and flags) from the runtime-permissions.xml file.",
         "author": "",
         "creation_date": "2021-01-25",
         "last_update_date": "2021-01-25",

--- a/scripts/artifacts/sRecoveryhist.py
+++ b/scripts/artifacts/sRecoveryhist.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_sRecoveryhist": {
         "name": "sRecoveryhist",
-        "description": "",
+        "description": "Parses Samsung recovery history (timestamp, wipe events, reason, reboot reason and locale) from the efs recovery history file.",
         "author": "",
         "creation_date": "2021-08-15",
         "last_update_date": "2021-08-15",

--- a/scripts/artifacts/sWipehist.py
+++ b/scripts/artifacts/sWipehist.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_sWipehist": {
         "name": "sWipehist",
-        "description": "",
+        "description": "Parses Samsung wipe and recovery events (timestamp, wipe events, reason, provider and reboot reason) from the recovery history files.",
         "author": "",
         "creation_date": "2021-08-15",
         "last_update_date": "2021-08-15",

--- a/scripts/artifacts/samsungWeatherClock.py
+++ b/scripts/artifacts/samsungWeatherClock.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_samsungWeatherClockInfo": {
         "name": "Samsung Weather Clock - Info",
-        "description": "",
+        "description": "Parses current conditions from the Samsung Weather Clock (timestamp, timezone, location, temperature, conditions, sunrise and sunset) from the WeatherClock database.",
         "author": "",
         "creation_date": "2021-10-13",
         "last_update_date": "2021-10-13",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     },
     "get_samsungWeatherClockDaily": {
         "name": "Samsung Weather Clock - Daily",
-        "description": "",
+        "description": "Parses the Samsung Weather Clock daily forecast (timestamp, location, temperature, conditions and daily high and low) from the WeatherClock database.",
         "author": "",
         "creation_date": "2021-10-13",
         "last_update_date": "2021-10-13",
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
     },
     "get_samsungWeatherClockHourly": {
         "name": "Samsung Weather Clock - Hourly",
-        "description": "",
+        "description": "Parses the Samsung Weather Clock hourly forecast (timestamp, location, temperature, conditions, rain probability and wind) from the WeatherClock database.",
         "author": "",
         "creation_date": "2021-10-13",
         "last_update_date": "2021-10-13",

--- a/scripts/artifacts/scontextLog.py
+++ b/scripts/artifacts/scontextLog.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_scontextLog": {
         "name": "scontextLog",
-        "description": "",
+        "description": "Parses app foreground usage sessions (start and stop time, timezone, app ID and duration) from the Samsung ContextLog.db.",
         "author": "",
         "creation_date": "2020-04-18",
         "last_update_date": "2020-04-18",

--- a/scripts/artifacts/setupWizardinfo.py
+++ b/scripts/artifacts/setupWizardinfo.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_setupWizardinfo": {
         "name": "setupWizardinfo",
-        "description": "",
+        "description": "Parses device setup wizard events (timestamp and name) from the setup_wizard_info.xml preferences.",
         "author": "",
         "creation_date": "2021-08-15",
         "last_update_date": "2021-08-15",

--- a/scripts/artifacts/shareit.py
+++ b/scripts/artifacts/shareit.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_shareit": {
         "name": "shareit",
-        "description": "",
+        "description": "Parses SHAREit file transfer history (direction, sender and recipient IDs, device name, description, timestamp and file path) from the SHAREit history.db.",
         "author": "",
         "creation_date": "2021-03-11",
         "last_update_date": "2021-03-11",

--- a/scripts/artifacts/skout.py
+++ b/scripts/artifacts/skout.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_skout_messages": {
         "name": "Skout Messages",
-        "description": "",
+        "description": "Parses Skout messages (timestamp, user, message, type, picture and gift URLs and thread) from the Skout database.",
         "author": "",
         "creation_date": "2021-05-10",
         "last_update_date": "2021-05-10",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     },
     "get_skout_users": {
         "name": "Skout Users",
-        "description": "",
+        "description": "Parses Skout users (last message timestamp, user name, picture URL and user ID) from the Skout database.",
         "author": "",
         "creation_date": "2021-05-10",
         "last_update_date": "2021-05-10",

--- a/scripts/artifacts/skype.py
+++ b/scripts/artifacts/skype.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_skype_call_logs": {
         "name": "Skype - Call Logs",
-        "description": "",
+        "description": "Parses Skype call logs (start and end time, participant IDs and direction) from the Skype live database.",
         "author": "",
         "creation_date": "2021-03-15",
         "last_update_date": "2021-03-15",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     },
     "get_skype_messages": {
         "name": "Skype - Messages",
-        "description": "",
+        "description": "Parses Skype messages (send time, thread, content, direction, sender and recipient IDs and attachments) from the Skype live database.",
         "author": "",
         "creation_date": "2021-03-15",
         "last_update_date": "2026-07-03",
@@ -38,7 +38,7 @@ __artifacts_v2__ = {
     },
     "get_skype_contacts": {
         "name": "Skype - Contacts",
-        "description": "",
+        "description": "Parses Skype contacts (entry ID and name) from the Skype live database.",
         "author": "",
         "creation_date": "2021-03-15",
         "last_update_date": "2021-03-15",

--- a/scripts/artifacts/slopes.py
+++ b/scripts/artifacts/slopes.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_slopes": {
         "name": "Slopes - Resort Details",
-        "description": "",
+        "description": "Parses ski resort details (name, location, coordinates, contact numbers, altitudes and run counts) recorded by the Slopes app from slopes.db.",
         "author": "",
         "creation_date": "2022-04-27",
         "last_update_date": "2022-04-27",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     },
     "get_slopes_actions": {
         "name": "Slopes - Actions",
-        "description": "",
+        "description": "Parses recorded ski and snowboard actions (start and end time, duration, type, distance, coordinates, speed and altitude) from the Slopes slopes.db.",
         "author": "",
         "creation_date": "2022-04-27",
         "last_update_date": "2022-04-27",
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
     },
     "get_slopes_lift": {
         "name": "Slopes - Lift Details",
-        "description": "",
+        "description": "Parses ski lift details (name, type, capacity, start and end coordinates and resort) from the Slopes slopes.db.",
         "author": "",
         "creation_date": "2022-04-27",
         "last_update_date": "2022-04-27",

--- a/scripts/artifacts/smanagerCrash.py
+++ b/scripts/artifacts/smanagerCrash.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_smanagerCrash": {
         "name": "smanagerCrash",
-        "description": "",
+        "description": "Parses application crash records (timestamp and package name) from the Samsung device manager sm.db.",
         "author": "",
         "creation_date": "2020-03-21",
         "last_update_date": "2020-03-21",

--- a/scripts/artifacts/smanagerLow.py
+++ b/scripts/artifacts/smanagerLow.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_smanagerLow": {
         "name": "smanagerLow",
-        "description": "",
+        "description": "Parses app usage sessions logged by the Samsung low-power context service (start and end time, package and timestamps) from the lowpowercontext-system database.",
         "author": "",
         "creation_date": "2020-03-21",
         "last_update_date": "2020-03-21",

--- a/scripts/artifacts/smembersAppInv.py
+++ b/scripts/artifacts/smembersAppInv.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_smembersAppInv": {
         "name": "smembersAppInv",
-        "description": "",
+        "description": "Parses the Samsung Members app inventory (last used, display and package name, system-app flag, hashes and classification) from the com_pocketgeek_sdk_app_inventory database.",
         "author": "",
         "creation_date": "2020-03-21",
         "last_update_date": "2020-03-21",

--- a/scripts/artifacts/smembersEvents.py
+++ b/scripts/artifacts/smembersEvents.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_smembersEvents": {
         "name": "smembersEvents",
-        "description": "",
+        "description": "Parses Samsung Members device events (created time, type, value and snapshot flag) from the com_pocketgeek_sdk database.",
         "author": "",
         "creation_date": "2020-03-21",
         "last_update_date": "2020-03-21",

--- a/scripts/artifacts/smyFiles.py
+++ b/scripts/artifacts/smyFiles.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_smyFiles": {
         "name": "My Files - Download History",
-        "description": "",
+        "description": "Parses Samsung My Files download history (timestamp, name, full path, hidden and trashed flags and source) from the My Files database.",
         "author": "",
         "creation_date": "2020-12-17",
         "last_update_date": "2020-12-17",
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
     },
     "get_smyFiles_recent": {
         "name": "My Files - Recent Files (MyFiles DB)",
-        "description": "",
+        "description": "Parses Samsung My Files recent files (timestamp, name, full path, hidden and trashed flags and source) from the My Files database.",
         "author": "",
         "creation_date": "2020-12-17",
         "last_update_date": "2020-12-17",

--- a/scripts/artifacts/smyfilesRecents.py
+++ b/scripts/artifacts/smyfilesRecents.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_smyfilesRecents": {
         "name": "My Files - Recent Files",
-        "description": "",
+        "description": "Parses Samsung My Files recent files (modified timestamp, name, size, path, extension and source) from the My Files database.",
         "author": "",
         "creation_date": "2020-03-21",
         "last_update_date": "2020-03-21",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     },
     "get_smyfilesRecents_fileinfo": {
         "name": "My Files - Recent Files (FileInfo)",
-        "description": "",
+        "description": "Parses Samsung My Files recent files (recent and modified timestamps, file ID, package, path, size and download, hidden and trashed flags) from the My Files FileInfo database.",
         "author": "",
         "creation_date": "2020-03-21",
         "last_update_date": "2020-03-21",

--- a/scripts/artifacts/smyfilesStored.py
+++ b/scripts/artifacts/smyfilesStored.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_smyfilesStored": {
         "name": "smyfilesStored",
-        "description": "",
+        "description": "Parses cached file records (timestamp, storage, path, size and latest access) from the Samsung My Files FileCache.db.",
         "author": "",
         "creation_date": "2020-03-19",
         "last_update_date": "2020-03-19",

--- a/scripts/artifacts/suggestions.py
+++ b/scripts/artifacts/suggestions.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_suggestions": {
         "name": "suggestions",
-        "description": "",
+        "description": "Parses settings suggestion events (timestamp and name) from the settings intelligence suggestions.xml.",
         "author": "",
         "creation_date": "2021-08-15",
         "last_update_date": "2021-08-15",

--- a/scripts/artifacts/swellbeing.py
+++ b/scripts/artifacts/swellbeing.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_swellbeing": {
         "name": "swellbeing",
-        "description": "",
+        "description": "Parses Samsung Digital Wellbeing app usage events (timestamp, event ID, package and event type) from dwbCommon.db.",
         "author": "",
         "creation_date": "2020-05-21",
         "last_update_date": "2020-05-21",

--- a/scripts/artifacts/tangomessage.py
+++ b/scripts/artifacts/tangomessage.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_tangomessage": {
         "name": "tangomessage",
-        "description": "",
+        "description": "Parses Tango messages (create time, direction and message) from the Tango tc.db.",
         "author": "",
         "creation_date": "2021-03-11",
         "last_update_date": "2021-03-11",

--- a/scripts/artifacts/teams.py
+++ b/scripts/artifacts/teams.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_teams": {
         "name": "Teams - Messages",
-        "description": "",
+        "description": "Parses Microsoft Teams messages (timestamp, user, content, topic, delete time and conversation) from SkypeTeams.db.",
         "author": "",
         "creation_date": "2021-04-29",
         "last_update_date": "2021-04-29",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     },
     "get_teams_users": {
         "name": "Teams - Users",
-        "description": "",
+        "description": "Parses Microsoft Teams users (last sync, name, email, phone numbers and account flags) from SkypeTeams.db.",
         "author": "",
         "creation_date": "2021-04-29",
         "last_update_date": "2021-04-29",
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
     },
     "get_teams_calllog": {
         "name": "Teams - Call Log",
-        "description": "",
+        "description": "Parses Microsoft Teams call logs (connect and end time, state, type, originator, direction and participant) from SkypeTeams.db.",
         "author": "",
         "creation_date": "2021-04-29",
         "last_update_date": "2021-04-29",
@@ -41,7 +41,7 @@ __artifacts_v2__ = {
     },
     "get_teams_activity": {
         "name": "Teams - Activity Feed",
-        "description": "",
+        "description": "Parses the Microsoft Teams activity feed (timestamp, display name, message preview, activity type and read state) from SkypeTeams.db.",
         "author": "",
         "creation_date": "2021-04-29",
         "last_update_date": "2021-04-29",
@@ -54,7 +54,7 @@ __artifacts_v2__ = {
     },
     "get_teams_fileinfo": {
         "name": "Teams - File Info",
-        "description": "",
+        "description": "Parses Microsoft Teams file references (modified time, file name, type, object URL, folder flag and last modified by) from SkypeTeams.db.",
         "author": "",
         "creation_date": "2021-04-29",
         "last_update_date": "2021-04-29",

--- a/scripts/artifacts/textnow.py
+++ b/scripts/artifacts/textnow.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_textnow_call_logs": {
         "name": "Text Now - Call Logs",
-        "description": "",
+        "description": "Parses TextNow call logs (start and end time, participant IDs and direction) from the TextNow textnow_data.db.",
         "author": "",
         "creation_date": "2021-03-15",
         "last_update_date": "2021-03-15",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     },
     "get_textnow_messages": {
         "name": "Text Now - Messages",
-        "description": "",
+        "description": "Parses TextNow messages (timestamp, sender and recipient IDs, direction, message, read state and attachments) from the TextNow textnow_data.db.",
         "author": "",
         "creation_date": "2021-03-15",
         "last_update_date": "2021-03-15",
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
     },
     "get_textnow_contacts": {
         "name": "Text Now - Contacts",
-        "description": "",
+        "description": "Parses TextNow contacts (number and name) from the TextNow textnow_data.db.",
         "author": "",
         "creation_date": "2021-03-15",
         "last_update_date": "2021-03-15",

--- a/scripts/artifacts/tikTok.py
+++ b/scripts/artifacts/tikTok.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_tikTok": {
         "name": "TikTok - Messages",
-        "description": "",
+        "description": "Parses TikTok direct messages (timestamp, user, nickname, message, links, read state and conversation) from the TikTok IM databases.",
         "author": "",
         "creation_date": "2021-03-02",
         "last_update_date": "2026-07-03",
@@ -25,7 +25,7 @@ __artifacts_v2__ = {
     },
     "get_tikTok_contacts": {
         "name": "TikTok - Contacts",
-        "description": "",
+        "description": "Parses TikTok contacts (UID, nickname, unique ID, avatar and follow status) from the TikTok IM databases.",
         "author": "",
         "creation_date": "2021-03-02",
         "last_update_date": "2021-03-02",

--- a/scripts/artifacts/torrentData.py
+++ b/scripts/artifacts/torrentData.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_TorrentData": {
         "name": "TorrentData",
-        "description": "",
+        "description": "Parses torrent metadata (torrent name, info hash and file paths) from .torrent files.",
         "author": "",
         "creation_date": "2023-09-15",
         "last_update_date": "2023-09-15",

--- a/scripts/artifacts/torrentResumeinfo.py
+++ b/scripts/artifacts/torrentResumeinfo.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_torrentResumeinfo": {
         "name": "torrentResumeinfo",
-        "description": "",
+        "description": "Parses torrent resume data (file, info hash and data) from .resume files.",
         "author": "",
         "creation_date": "2023-03-26",
         "last_update_date": "2023-03-26",

--- a/scripts/artifacts/torrentinfo.py
+++ b/scripts/artifacts/torrentinfo.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_torrentinfo": {
         "name": "torrentinfo",
-        "description": "",
+        "description": "Parses torrent file metadata (file, info hash and data) from .torrent files.",
         "author": "",
         "creation_date": "2023-03-26",
         "last_update_date": "2023-03-26",

--- a/scripts/artifacts/usageHistory.py
+++ b/scripts/artifacts/usageHistory.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_usageHistory": {
         "name": "Usagehistory",
-        "description": "",
+        "description": "Parses application usage history (timestamp, package and component) from the usage-history.xml file.",
         "author": "",
         "creation_date": "2022-07-06",
         "last_update_date": "2022-07-06",

--- a/scripts/artifacts/userDict.py
+++ b/scripts/artifacts/userDict.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_userDict": {
         "name": "userDict",
-        "description": "",
+        "description": "Parses the personal user dictionary (word, frequency, locale, app ID and shortcut) from the user dictionary database.",
         "author": "",
         "creation_date": "2020-03-21",
         "last_update_date": "2020-03-21",

--- a/scripts/artifacts/vlcMedia.py
+++ b/scripts/artifacts/vlcMedia.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_vlcMedia": {
         "name": "VLC",
-        "description": "",
+        "description": "Parses VLC media library entries (insertion and last played dates, filename, path and favorite flag) from vlc_media.db.",
         "author": "",
         "creation_date": "2021-03-01",
         "last_update_date": "2021-03-01",

--- a/scripts/artifacts/wellbeingaccount.py
+++ b/scripts/artifacts/wellbeingaccount.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_wellbeingaccount": {
         "name": "wellbeingaccount",
-        "description": "",
+        "description": "Parses account data from the Google Digital Wellbeing AccountData protobuf file.",
         "author": "",
         "creation_date": "2020-02-25",
         "last_update_date": "2020-02-25",

--- a/scripts/artifacts/wifiHotspot.py
+++ b/scripts/artifacts/wifiHotspot.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_wifiHotspot": {
         "name": "wifiHotspot",
-        "description": "",
+        "description": "Parses the Wi-Fi hotspot (SoftAP) configuration (SSID, passphrase and security type) from the softap configuration files.",
         "author": "",
         "creation_date": "2020-11-18",
         "last_update_date": "2020-11-18",


### PR DESCRIPTION
## What

Fills in empty \`description\` fields in the \`__artifacts_v2__\` metadata block for **119 artifacts across 86 files**. The \`description\` renders in the artifact's HTML report header and is carried into LAVA, so these artifacts previously showed no explanation of what they do.

Each description was written from the artifact's **actual paths, SQL query and output columns** (not guessed), following the existing house style ("Parses X from Y").

## Coverage

This clears **every** remaining empty-description artifact in ALEAPP (verified: 0 left; `PluginLoader` loads 583 plugins). Files span messaging (Viber, LINE, Skype, Teams, TextNow, IMO, TikTok, MeWe, Tango, Skout, Words With Friends), browsers (Firefox), file transfer (Xender, Zapya, SHAREit, MEGA, PikPak), torrents, GEO/location, Samsung system artifacts (My Files, Weather Clock, Members, ContextLog, recovery/wipe), installed-apps, permissions, Bluetooth, AirTag detection, and more.

## Notes

- Metadata only — **no parser logic changed**. Multi-function files received one description per function (e.g. `teams.py` ×5, `slopes.py` ×3, `airtagAndroid.py` ×4).
- Two touched files (`accounts_de.py`, `airtagAndroid.py`) also get the standard top-of-file \`# pylint: disable=W0613\` pragma that 255 other artifact modules already carry (for the unused \`report_folder/seeker/wrap_text\` signature args), and `airtagAndroid` discards the unused `blackboxprotobuf` type-defs via \`_\`, so the now-touched files lint at **10.00/10**. No behavior change.
- Verified: all changed files compile; \`pylint --disable=C,R\` on all 86 changed files exits 0 at **10.00/10**; original quote styles and line endings preserved.