### PR TITLE
Populate sample_data from an 8-image Android test corpus (Android 10-16)

### DIFF
--- a/scripts/artifacts/Cello.py
+++ b/scripts/artifacts/Cello.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
                   '*/com.google.android.apps.docs/files/shiny_blobs/blobs/*'),
         "output_types": "standard",
         "artifact_icon": "file",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.apps.docs vc 214164863 | 3 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.apps.docs vc 211210540 | 1 row",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.docs vc 214512167 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.apps.docs vc 214173331 | 2 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.docs vc 213440084 | 4 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.apps.docs vc 214258185 | 51 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.apps.docs vc 214207580 | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.apps.docs vc 213692448 | 20 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/DocList.py
+++ b/scripts/artifacts/DocList.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.apps.docs/databases/DocList.db*',),
         "output_types": "standard",
         "artifact_icon": "file",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.apps.docs vc 214164863 | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.apps.docs vc 211210540 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.docs vc 214512167 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.apps.docs vc 214173331 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.docs vc 213440084 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.apps.docs vc 214258185 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.apps.docs vc 214207580 | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.apps.docs vc 213692448 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/DuckDuckGo.py
+++ b/scripts/artifacts/DuckDuckGo.py
@@ -11,7 +11,11 @@ __artifacts_v2__ = {
         "notes": "Tested on version 5.237.0 (June, 3rd 2025)",
         "paths": ('*/com.duckduckgo.mobile.android/databases/app.db*'),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "bookmark"
+        "artifact_icon": "bookmark",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.duckduckgo.mobile.android vc 52831000 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.duckduckgo.mobile.android vc 52072000 | 0 rows",
+        }
     },
     "duckduckgo_favorites": {
         "name": "DuckDuckGo - Favorited Sites",
@@ -24,7 +28,11 @@ __artifacts_v2__ = {
         "notes": "Tested on version 5.237.0 (June, 3rd 2025)",
         "paths": ('*/com.duckduckgo.mobile.android/databases/app.db*'),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "star"
+        "artifact_icon": "star",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.duckduckgo.mobile.android vc 52831000 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.duckduckgo.mobile.android vc 52072000 | 0 rows",
+        }
     },
     "duckduckgo_history": {
         "name": "DuckDuckGo - Web Browser History",
@@ -37,7 +45,11 @@ __artifacts_v2__ = {
         "notes": "Tested on version 5.237.0 (June, 3rd 2025)",
         "paths": ('*/com.duckduckgo.mobile.android/databases/history.db*'),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "globe"
+        "artifact_icon": "globe",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.duckduckgo.mobile.android vc 52831000 | 12 rows",
+            "pixel7a_a14": "Android 14 | com.duckduckgo.mobile.android vc 52072000 | 12 rows",
+        }
     },
     "duckduckgo_opentabs": {
         "name": "DuckDuckGo - Open Tabs",
@@ -50,7 +62,11 @@ __artifacts_v2__ = {
         "notes": "Tested on version 5.255.0 (Oct, 31st 2025)",
         "paths": ('*/com.duckduckgo.mobile.android/databases/app.db*','*/com.duckduckgo.mobile.android/cache/tabPreviews/*/*.jpg'),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "book"
+        "artifact_icon": "book",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.duckduckgo.mobile.android vc 52831000 | 2 rows",
+            "pixel7a_a14": "Android 14 | com.duckduckgo.mobile.android vc 52072000 | 3 rows",
+        }
     },
         "duckduckgo_fireproof": {
         "name": "DuckDuckGo - FireProof Sites",
@@ -63,7 +79,11 @@ __artifacts_v2__ = {
         "notes": "Tested on version 5.255.0 (Oct, 31st 2025)",
         "paths": ('*/com.duckduckgo.mobile.android/databases/app.db*'),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "globe"
+        "artifact_icon": "globe",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.duckduckgo.mobile.android vc 52831000 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.duckduckgo.mobile.android vc 52072000 | 0 rows",
+        }
     },
     
         "duckduckgo_downloads": {
@@ -77,7 +97,11 @@ __artifacts_v2__ = {
         "notes": "Tested on version 5.255.0 (Oct, 31st 2025)",
         "paths": ('*/com.duckduckgo.mobile.android/databases/downloads.db*'),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "download"
+        "artifact_icon": "download",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.duckduckgo.mobile.android vc 52831000 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.duckduckgo.mobile.android vc 52072000 | 0 rows",
+        }
     },
     "duckduckgo_thumbnails": {
         "name": "DuckDuckGo - Tab Thumbnails",
@@ -90,7 +114,11 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.duckduckgo.mobile.android/cache/tabPreviews/*/*.jpg','*/com.duckduckgo.mobile.android/databases/app.db*'),
         "output_types": ["html", "tsv", "timeline", "lava"],
-        "artifact_icon": "photo"
+        "artifact_icon": "photo",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.duckduckgo.mobile.android vc 52831000 | 5 rows",
+            "pixel7a_a14": "Android 14 | com.duckduckgo.mobile.android vc 52072000 | 5 rows",
+        }
     },
         "duckduckgo_duckai": {
         "name": "DuckDuckGo - Duck AI",
@@ -103,7 +131,11 @@ __artifacts_v2__ = {
         "notes": "Tested on version 5.255.0 (Oct, 31st 2025)",
         "paths": ('*com.duckduckgo.mobile.android/app_webview/Default/Local Storage/leveldb/*'),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "message"
+        "artifact_icon": "message",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.duckduckgo.mobile.android vc 52831000 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.duckduckgo.mobile.android vc 52072000 | 0 rows",
+        }
     },
         "duckduckgo_cookies": {
         "name": "DuckDuckGo - Cookies",

--- a/scripts/artifacts/FCMQueuedMessageKik.py
+++ b/scripts/artifacts/FCMQueuedMessageKik.py
@@ -13,6 +13,16 @@ __artifacts_v2__ = {
         "paths": ("*/fcm_queued_messages.ldb/*"),
         "output_types": "standard",  # or ["html", "tsv", "timeline", "lava"]
         "artifact_icon": "database",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 1 row",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+        },
     },
     "fcm_kik_blanks": {
         "name": "FCM-KIK Notifications Blanks",
@@ -27,6 +37,16 @@ __artifacts_v2__ = {
         "paths": ("*/fcm_queued_messages.ldb/*"),
         "output_types": "standard",  # or ["html", "tsv", "timeline", "lava"]
         "artifact_icon": "database",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/FCMQueuedMessageOutlook.py
+++ b/scripts/artifacts/FCMQueuedMessageOutlook.py
@@ -13,6 +13,16 @@ __artifacts_v2__ = {
         "paths": ("*/fcm_queued_messages.ldb/*"),
         "output_types": "standard",  # or ["html", "tsv", "timeline", "lava"]
         "artifact_icon": "database",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/FCMQueuedMessagesDump.py
+++ b/scripts/artifacts/FCMQueuedMessagesDump.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/fcm_queued_messages.ldb/*',),
         "output_types": "standard",
         "artifact_icon": "database",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 5647 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 512 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 31046 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 38204 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 35523 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 5010 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 3914 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 36746 rows",
+        },
     },
     "get_fcm_dump_verizon": {
         "name": "FCM Decoded - Verizon",
@@ -25,6 +35,16 @@ __artifacts_v2__ = {
         "paths": ('*/fcm_queued_messages.ldb/*',),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+        },
     },
     "get_fcm_dump_tiktok": {
         "name": "FCM Decoded - TikTok",
@@ -38,6 +58,16 @@ __artifacts_v2__ = {
         "paths": ('*/fcm_queued_messages.ldb/*',),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 225 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 32 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 475 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 433 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 102 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 40 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 391 rows",
+        },
     },
     "get_fcm_dump_instagram": {
         "name": "FCM Decoded - Instagram",
@@ -51,6 +81,16 @@ __artifacts_v2__ = {
         "paths": ('*/fcm_queued_messages.ldb/*',),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 33 rows",
+        },
     },
     "get_fcm_dump_gqsb": {
         "name": "FCM Decoded - Geolocation",
@@ -64,6 +104,16 @@ __artifacts_v2__ = {
         "paths": ('*/fcm_queued_messages.ldb/*',),
         "output_types": "all",
         "artifact_icon": "map-pin",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 29 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 53 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/FCMQueuedMessagesJungrammer.py
+++ b/scripts/artifacts/FCMQueuedMessagesJungrammer.py
@@ -33,6 +33,16 @@ __artifacts_v2__ = {
         "paths": ('*/fcm_queued_messages.ldb/*',),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/FCMQueuedMessagesSkype.py
+++ b/scripts/artifacts/FCMQueuedMessagesSkype.py
@@ -33,6 +33,16 @@ __artifacts_v2__ = {
         "paths": ('*/fcm_queued_messages.ldb/*',),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 1 row",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+        },
     },
     "get_fcm_skype_notifications": {
         "name": "FCM - Skype and Teams Notifications",
@@ -46,6 +56,16 @@ __artifacts_v2__ = {
         "paths": ('*/fcm_queued_messages.ldb/*',),
         "output_types": "standard",
         "artifact_icon": "bell",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/FCMQueuedMessagesTumblr.py
+++ b/scripts/artifacts/FCMQueuedMessagesTumblr.py
@@ -33,6 +33,16 @@ __artifacts_v2__ = {
         "paths": ('*/fcm_queued_messages.ldb/*',),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+        },
     },
     "get_fcm_tumblr_flagged": {
         "name": "FCM - Tumblr Flagged Posts",
@@ -46,6 +56,16 @@ __artifacts_v2__ = {
         "paths": ('*/fcm_queued_messages.ldb/*',),
         "output_types": "standard",
         "artifact_icon": "flag",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+        },
     },
     "get_fcm_tumblr_notifications": {
         "name": "FCM - Tumblr Notifications",
@@ -59,6 +79,16 @@ __artifacts_v2__ = {
         "paths": ('*/fcm_queued_messages.ldb/*',),
         "output_types": "standard",
         "artifact_icon": "bell",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+        },
     },
     "get_fcm_tumblr_logs": {
         "name": "FCM - Tumblr Logs",
@@ -72,6 +102,16 @@ __artifacts_v2__ = {
         "paths": ('*/fcm_queued_messages.ldb/*',),
         "output_types": "standard",
         "artifact_icon": "file-text",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/FCMQueuedMessagesTwitter.py
+++ b/scripts/artifacts/FCMQueuedMessagesTwitter.py
@@ -33,6 +33,16 @@ __artifacts_v2__ = {
         "paths": ('*/fcm_queued_messages.ldb/*',),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/FCMQueuedMessagesXbox.py
+++ b/scripts/artifacts/FCMQueuedMessagesXbox.py
@@ -33,6 +33,16 @@ __artifacts_v2__ = {
         "paths": ('*/fcm_queued_messages.ldb/*',),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+        },
     },
     "get_fcm_xbox_party": {
         "name": "FCM - Xbox Party Invites",
@@ -46,6 +56,16 @@ __artifacts_v2__ = {
         "paths": ('*/fcm_queued_messages.ldb/*',),
         "output_types": "standard",
         "artifact_icon": "user-plus",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+        },
     },
     "get_fcm_xbox_presence": {
         "name": "FCM - Xbox Presence",
@@ -59,6 +79,16 @@ __artifacts_v2__ = {
         "paths": ('*/fcm_queued_messages.ldb/*',),
         "output_types": "standard",
         "artifact_icon": "activity",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/FacebookMessenger.py
+++ b/scripts/artifacts/FacebookMessenger.py
@@ -12,6 +12,12 @@ __artifacts_v2__ = {
         "paths": ('*/*threads_db2-uid',),
         "output_types": "standard",
         "artifact_icon": "user",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.facebook.orca vc 335215725 | 1 row",
+            "hc_pixel8pro_a16": "Android 16 | com.facebook.orca vc 343213368 | 1 row",
+            "pixel7a_a14": "Android 14 | com.facebook.orca vc 323609457 | 1 row",
+            "sharon_a14": "Android 14 | com.facebook.orca vc 324209509 | 1 row",
+        },
     },
     "get_fb_msys_chats": {
         "name": "Facebook Messenger - Chats (msys_database)",
@@ -25,6 +31,13 @@ __artifacts_v2__ = {
         "paths": ('*/msys_database*',),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.facebook.katana vc 465218038, com.facebook.orca vc 335215725 | 4 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.facebook.katana vc 472143277, com.facebook.orca vc 343213368 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.facebook.orca vc 323609457 | 30 rows",
+            "samsungs20_a13": "Android 13 | com.facebook.katana vc 467618094, com.facebook.orca vc 337415659 | 0 rows",
+            "sharon_a14": "Android 14 | com.facebook.katana vc 454415791, com.facebook.orca vc 324209509 | 23 rows",
+        },
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Thread Key",
@@ -48,6 +61,13 @@ __artifacts_v2__ = {
         "paths": ('*/msys_database*',),
         "output_types": "standard",
         "artifact_icon": "phone",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.facebook.katana vc 465218038, com.facebook.orca vc 335215725 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.facebook.katana vc 472143277, com.facebook.orca vc 343213368 | 4 rows",
+            "pixel7a_a14": "Android 14 | com.facebook.orca vc 323609457 | 8 rows",
+            "samsungs20_a13": "Android 13 | com.facebook.katana vc 467618094, com.facebook.orca vc 337415659 | 0 rows",
+            "sharon_a14": "Android 14 | com.facebook.katana vc 454415791, com.facebook.orca vc 324209509 | 0 rows",
+        },
     },
     "get_fb_msys_contacts": {
         "name": "Facebook Messenger - Contacts (msys_database)",
@@ -61,6 +81,13 @@ __artifacts_v2__ = {
         "paths": ('*/msys_database*',),
         "output_types": "standard",
         "artifact_icon": "users",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.facebook.katana vc 465218038, com.facebook.orca vc 335215725 | 38 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.facebook.katana vc 472143277, com.facebook.orca vc 343213368 | 6 rows",
+            "pixel7a_a14": "Android 14 | com.facebook.orca vc 323609457 | 2 rows",
+            "samsungs20_a13": "Android 13 | com.facebook.katana vc 467618094, com.facebook.orca vc 337415659 | 2 rows",
+            "sharon_a14": "Android 14 | com.facebook.katana vc 454415791, com.facebook.orca vc 324209509 | 65 rows",
+        },
     },
     "get_fb_threads_chats": {
         "name": "Facebook Messenger - Chats (threads_db2)",
@@ -74,6 +101,12 @@ __artifacts_v2__ = {
         "paths": ('*/*threads_db2',),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.facebook.katana vc 465218038 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.facebook.katana vc 472143277 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.facebook.katana vc 467618094 | 0 rows",
+            "sharon_a14": "Android 14 | com.facebook.katana vc 454415791 | 0 rows",
+        },
     },
     "get_fb_threads_calls": {
         "name": "Facebook Messenger - Calls (threads_db2)",
@@ -87,6 +120,12 @@ __artifacts_v2__ = {
         "paths": ('*/*threads_db2',),
         "output_types": "standard",
         "artifact_icon": "phone",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.facebook.katana vc 465218038 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.facebook.katana vc 472143277 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.facebook.katana vc 467618094 | 0 rows",
+            "sharon_a14": "Android 14 | com.facebook.katana vc 454415791 | 0 rows",
+        },
     },
     "get_fb_threads_contacts": {
         "name": "Facebook Messenger - Contacts (threads_db2)",
@@ -100,6 +139,12 @@ __artifacts_v2__ = {
         "paths": ('*/*threads_db2',),
         "output_types": "standard",
         "artifact_icon": "users",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.facebook.katana vc 465218038 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.facebook.katana vc 472143277 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.facebook.katana vc 467618094 | 0 rows",
+            "sharon_a14": "Android 14 | com.facebook.katana vc 454415791 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/FilesByGoogle.py
+++ b/scripts/artifacts/FilesByGoogle.py
@@ -10,7 +10,12 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.google.android.apps.nbu.files/databases/files_master_database*'),
         "output_types": "standard",
-        "artifact_icon": "file"
+        "artifact_icon": "file",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.nbu.files vc 1849879 | 71 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.apps.nbu.files vc 1508395 | 434 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.nbu.files vc 695143 | 228 rows",
+        }
     },
     "fbg_searchhistory": {
         "name": "Files By Google - Search History",

--- a/scripts/artifacts/GarminFacebook.py
+++ b/scripts/artifacts/GarminFacebook.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.garmin.android.apps.connectmobile/shared_prefs/com.facebook*',),
         "output_types": "standard",
         "artifact_icon": "activity",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.garmin.android.apps.connectmobile vc 8806 | 1 row",
+        },
     }
 }
 

--- a/scripts/artifacts/GarminGcmJsonActivities.py
+++ b/scripts/artifacts/GarminGcmJsonActivities.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/gcm_cache.db*',),
         "output_types": "standard",
         "artifact_icon": "activity",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.garmin.android.apps.connectmobile vc 8806 | 3 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/GarminJson.py
+++ b/scripts/artifacts/GarminJson.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/gcm_cache*',),
         "output_types": "standard",
         "artifact_icon": "activity",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.garmin.android.apps.connectmobile vc 8806 | 4 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/GarminLog.py
+++ b/scripts/artifacts/GarminLog.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.garmin.android.apps.connectmobile/files/logs/app.log*',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "activity",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.garmin.android.apps.connectmobile vc 8806 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/GarminNotifications.py
+++ b/scripts/artifacts/GarminNotifications.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/notification-database*',),
         "output_types": "standard",
         "artifact_icon": "activity",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.garmin.android.apps.connectmobile vc 8806 | 45 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/GarminPersistent.py
+++ b/scripts/artifacts/GarminPersistent.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.garmin.android.apps.connectmobile/files/PersistedInstallation*',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "activity",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.garmin.android.apps.connectmobile vc 8806 | 5 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/GarminPolyline.py
+++ b/scripts/artifacts/GarminPolyline.py
@@ -13,6 +13,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
         "output_types": "all",
         "artifact_icon": "activity",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.garmin.android.apps.connectmobile vc 8806 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/GarminResponse.py
+++ b/scripts/artifacts/GarminResponse.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
         "output_types": "standard",
         "artifact_icon": "activity",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.garmin.android.apps.connectmobile vc 8806 | 1 row",
+        },
     }
 }
 

--- a/scripts/artifacts/GarminSync.py
+++ b/scripts/artifacts/GarminSync.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/sync_cache*',),
         "output_types": "standard",
         "artifact_icon": "activity",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.garmin.android.apps.connectmobile vc 8806 | 62 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/GarminUser.py
+++ b/scripts/artifacts/GarminUser.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.garmin.android.apps.connectmobile/shared_prefs/gcm_user_preferences*',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "user",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.garmin.android.apps.connectmobile vc 8806 | 23 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/L360circlesettings.py
+++ b/scripts/artifacts/L360circlesettings.py
@@ -10,7 +10,11 @@ __artifacts_v2__ = {
         'notes': '',
         'paths': ('*/com.life360.android.safetymapd/databases/L360LocalStoreRoomDatabase*',),
         'output_types': 'standard',
-        'artifact_icon': 'circle'
+        'artifact_icon': 'circle',
+        'sample_data': {
+            'hc_pixel8pro_a16': 'Android 16 | com.life360.android.safetymapd vc 2897710 | 1 row',
+            'pixel7a_a14': 'Android 14 | com.life360.android.safetymapd vc 294540 | 0 rows',
+        }
     }
 }
 

--- a/scripts/artifacts/L360driveblade.py
+++ b/scripts/artifacts/L360driveblade.py
@@ -11,7 +11,10 @@ __artifacts_v2__ = {
         'notes': '',
         'paths': ('*/com.life360.android.safetymapd/databases/DriveBladeDB*',),
         'output_types': 'standard',
-        'artifact_icon': 'map-pin'
+        'artifact_icon': 'map-pin',
+        'sample_data': {
+            'hc_pixel8pro_a16': 'Android 16 | com.life360.android.safetymapd vc 2897710 | 9 rows',
+        }
     },
     'Life360_DriveEvents': {
         'name': 'Life360 Drive Events (DriveBladeDB)',
@@ -24,7 +27,10 @@ __artifacts_v2__ = {
         'notes': '',
         'paths': ('*/com.life360.android.safetymapd/databases/DriveBladeDB*',),
         'output_types': ['html', 'tsv', 'lava', 'kml'],
-        'artifact_icon': 'map-pin'
+        'artifact_icon': 'map-pin',
+        'sample_data': {
+            'hc_pixel8pro_a16': 'Android 16 | com.life360.android.safetymapd vc 2897710 | 14 rows',
+        }
     },
     'Life360_DriveWaypoints': {
         'name': 'Life360 Drive Waypoints',
@@ -37,7 +43,10 @@ __artifacts_v2__ = {
         'notes': '',
         'paths': ('*/com.life360.android.safetymapd/databases/DriveBladeDB*',),
         'output_types': ['html', 'tsv', 'lava', 'kml'],
-        'artifact_icon': 'map-pin'
+        'artifact_icon': 'map-pin',
+        'sample_data': {
+            'hc_pixel8pro_a16': 'Android 16 | com.life360.android.safetymapd vc 2897710 | 815 rows',
+        }
     }
 }
 

--- a/scripts/artifacts/L360eventstore.py
+++ b/scripts/artifacts/L360eventstore.py
@@ -10,7 +10,11 @@ __artifacts_v2__ = {
         'notes': '',
         'paths': ('*/com.life360.android.safetymapd/databases/L360EventStore_service.db*',),
         'output_types': ['html', 'tsv', 'lava', 'kml'],
-        'artifact_icon': 'map-pin'
+        'artifact_icon': 'map-pin',
+        'sample_data': {
+            'hc_pixel8pro_a16': 'Android 16 | com.life360.android.safetymapd vc 2897710 | 2758 rows',
+            'pixel7a_a14': 'Android 14 | com.life360.android.safetymapd vc 294540 | 0 rows',
+        }
     },
     'Life360_Waypoints': {
         'name': 'Life360 Waypoints',
@@ -23,7 +27,11 @@ __artifacts_v2__ = {
         'notes': '',
         'paths': ('*/com.life360.android.safetymapd/databases/L360EventStore_service.db*',),
         'output_types': ['html', 'tsv', 'lava', 'kml'],
-        'artifact_icon': 'map-pin'
+        'artifact_icon': 'map-pin',
+        'sample_data': {
+            'hc_pixel8pro_a16': 'Android 16 | com.life360.android.safetymapd vc 2897710 | 953 rows',
+            'pixel7a_a14': 'Android 14 | com.life360.android.safetymapd vc 294540 | 0 rows',
+        }
     },
     'Life360_BatteryLevel': {
         'name': 'Life360 Battery Level',
@@ -36,7 +44,11 @@ __artifacts_v2__ = {
         'notes': '',
         'paths': ('*/com.life360.android.safetymapd/databases/L360EventStore_service.db*',),
         'output_types': 'standard',
-        'artifact_icon': 'battery-charging'
+        'artifact_icon': 'battery-charging',
+        'sample_data': {
+            'hc_pixel8pro_a16': 'Android 16 | com.life360.android.safetymapd vc 2897710 | 4956 rows',
+            'pixel7a_a14': 'Android 14 | com.life360.android.safetymapd vc 294540 | 7 rows',
+        }
     },
     'Life360_Drive_Events': {
         'name': 'Life360 Drive Events (EventStore)',
@@ -49,7 +61,11 @@ __artifacts_v2__ = {
         'notes': '',
         'paths': ('*/com.life360.android.safetymapd/databases/L360EventStore_service.db*',),
         'output_types': ['html', 'tsv', 'lava', 'kml'],
-        'artifact_icon': 'truck'
+        'artifact_icon': 'truck',
+        'sample_data': {
+            'hc_pixel8pro_a16': 'Android 16 | com.life360.android.safetymapd vc 2897710 | 18 rows',
+            'pixel7a_a14': 'Android 14 | com.life360.android.safetymapd vc 294540 | 0 rows',
+        }
     }
 }
 

--- a/scripts/artifacts/L360memberscircles.py
+++ b/scripts/artifacts/L360memberscircles.py
@@ -10,7 +10,11 @@ __artifacts_v2__ = {
         'notes': '',
         'paths': ('*/com.life360.android.safetymapd/databases/MembersEngineRoomDatabase*',),
         'output_types': 'standard',
-        'artifact_icon': 'user'
+        'artifact_icon': 'user',
+        'sample_data': {
+            'hc_pixel8pro_a16': 'Android 16 | com.life360.android.safetymapd vc 2897710 | 4 rows',
+            'pixel7a_a14': 'Android 14 | com.life360.android.safetymapd vc 294540 | 0 rows',
+        }
     }
 }
 

--- a/scripts/artifacts/L360noshowalerts.py
+++ b/scripts/artifacts/L360noshowalerts.py
@@ -11,7 +11,10 @@ __artifacts_v2__ = {
         'notes': 'WAL file recovery',
         'paths': ('*/com.life360.android.safetymapd/databases/NoShowAlertRoomDatabase*',),
         'output_types': 'standard',
-        'artifact_icon': 'alert-triangle'
+        'artifact_icon': 'alert-triangle',
+        'sample_data': {
+            'hc_pixel8pro_a16': 'Android 16 | com.life360.android.safetymapd vc 2897710 | 9 rows',
+        }
     }
 }
 

--- a/scripts/artifacts/L360petprofile.py
+++ b/scripts/artifacts/L360petprofile.py
@@ -10,7 +10,10 @@ __artifacts_v2__ = {
         'notes': '',
         'paths': ('*/com.life360.android.safetymapd/databases/PetProfileRoomDatabase*',),
         'output_types': 'standard',
-        'artifact_icon': 'mood-smile'
+        'artifact_icon': 'mood-smile',
+        'sample_data': {
+            'hc_pixel8pro_a16': 'Android 16 | com.life360.android.safetymapd vc 2897710 | 2 rows',
+        }
     }
 }
 

--- a/scripts/artifacts/L360places.py
+++ b/scripts/artifacts/L360places.py
@@ -11,7 +11,11 @@ __artifacts_v2__ = {
         'notes': '',
         'paths': ('*/com.life360.android.safetymapd/databases/L360LocalStoreRoomDatabase*',),
         'output_types': ['html', 'tsv', 'lava', 'kml'],
-        'artifact_icon': 'home'
+        'artifact_icon': 'home',
+        'sample_data': {
+            'hc_pixel8pro_a16': 'Android 16 | com.life360.android.safetymapd vc 2897710 | 6 rows',
+            'pixel7a_a14': 'Android 14 | com.life360.android.safetymapd vc 294540 | 0 rows',
+        }
     },
     'Life360_PlaceAlerts': {
         'name': 'Life360 Place Alerts',
@@ -24,7 +28,11 @@ __artifacts_v2__ = {
         'notes': '',
         'paths': ('*/com.life360.android.safetymapd/databases/L360LocalStoreRoomDatabase*',),
         'output_types': 'standard',
-        'artifact_icon': 'home'
+        'artifact_icon': 'home',
+        'sample_data': {
+            'hc_pixel8pro_a16': 'Android 16 | com.life360.android.safetymapd vc 2897710 | 12 rows',
+            'pixel7a_a14': 'Android 14 | com.life360.android.safetymapd vc 294540 | 0 rows',
+        }
     },
 
 }

--- a/scripts/artifacts/L360user.py
+++ b/scripts/artifacts/L360user.py
@@ -10,7 +10,12 @@ __artifacts_v2__ = {
         'notes': '',
         'paths': ('*/com.life360.android.safetymapd/databases/com.amplitude.api*',),
         'output_types': 'standard',
-        'artifact_icon': 'user'
+        'artifact_icon': 'user',
+        'sample_data': {
+            'hc_pixel8pro_a16': 'Android 16 | com.life360.android.safetymapd vc 2897710 | 2 rows',
+            'pixel7a_a14': 'Android 14 | com.life360.android.safetymapd vc 294540 | 2 rows',
+            'sharon_a14': 'Android 14 | com.life360.android.safetymapd vc 296030 | 1 row',
+        }
     }
 }
 

--- a/scripts/artifacts/Life360.py
+++ b/scripts/artifacts/Life360.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.life360.android.safetymapd/databases/messaging.db*',),
         "output_types": "all",
         "artifact_icon": "message-circle",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.life360.android.safetymapd vc 294540 | 20 rows",
+        },
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Thread ID",
@@ -35,6 +38,10 @@ __artifacts_v2__ = {
         "paths": ('*/com.life360.android.safetymapd/databases/L360LocalStoreRoomDatabase*',),
         "output_types": ['html', 'tsv', 'lava', 'kml'],
         "artifact_icon": "map-pin",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.life360.android.safetymapd vc 2897710 | 6 rows",
+            "pixel7a_a14": "Android 14 | com.life360.android.safetymapd vc 294540 | 0 rows",
+        },
     },
     "get_Life360_locations": {
         "name": "Life360 - Locations",
@@ -48,6 +55,10 @@ __artifacts_v2__ = {
         "paths": ('*/com.life360.android.safetymapd/databases/L360EventStore.db*',),
         "output_types": "all",
         "artifact_icon": "map-pin",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.life360.android.safetymapd vc 294540 | 15668 rows",
+            "sharon_a14": "Android 14 | com.life360.android.safetymapd vc 296030 | 0 rows",
+        },
     },
     "get_Life360_device_battery": {
         "name": "Life360 - Device Battery",
@@ -61,6 +72,10 @@ __artifacts_v2__ = {
         "paths": ('*/com.life360.android.safetymapd/databases/L360EventStore.db*',),
         "output_types": "standard",
         "artifact_icon": "battery",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.life360.android.safetymapd vc 294540 | 15668 rows",
+            "sharon_a14": "Android 14 | com.life360.android.safetymapd vc 296030 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/LinkedIn.py
+++ b/scripts/artifacts/LinkedIn.py
@@ -36,7 +36,10 @@ __artifacts_v2__ = {
                 "conversationLabelColumn": "Conversation Label"
             }
         },
-        "artifact_icon": "message"
+        "artifact_icon": "message",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.linkedin.android vc 198600 | 0 rows",
+        }
     }
 }
 

--- a/scripts/artifacts/NikeAMoments.py
+++ b/scripts/artifacts/NikeAMoments.py
@@ -13,6 +13,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.nike.plusgps/databases/com.nike.nrc.room*',),
         "output_types": "standard",
         "artifact_icon": "activity",
+        "sample_data": {
+            "samsunga53_a14": "Android 14 | com.nike.plusgps vc 1717605525 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/NikeActivities.py
+++ b/scripts/artifacts/NikeActivities.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.nike.plusgps/databases/com.nike.nrc.room*',),
         "output_types": "standard",
         "artifact_icon": "activity",
+        "sample_data": {
+            "samsunga53_a14": "Android 14 | com.nike.plusgps vc 1717605525 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/NikePolyline.py
+++ b/scripts/artifacts/NikePolyline.py
@@ -13,6 +13,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.nike.plusgps/databases/com.nike.nrc.room*',),
         "output_types": "all",
         "artifact_icon": "activity",
+        "sample_data": {
+            "samsunga53_a14": "Android 14 | com.nike.plusgps vc 1717605525 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/OneDrive_Metadata.py
+++ b/scripts/artifacts/OneDrive_Metadata.py
@@ -13,6 +13,13 @@ __artifacts_v2__ = {
         "paths": ('*/com.microsoft.skydrive/files/QTMetadata.db*'),
         "output_types": "standard",
         "artifact_icon": "cloud",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.microsoft.skydrive vc 2027390102 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.microsoft.skydrive vc 2026998332 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.microsoft.skydrive vc 2027440202 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.microsoft.skydrive | 0 rows",
+            "sharon_a14": "Android 14 | com.microsoft.skydrive vc 2027110002 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/SamsungDeviceHealthManagement.py
+++ b/scripts/artifacts/SamsungDeviceHealthManagement.py
@@ -11,7 +11,14 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.sec.android.sdhms/databases/anomaly.db*'),
         "output_types": "all",
-        "artifact_icon": "settings"
+        "artifact_icon": "settings",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.sec.android.sdhms | 29 rows",
+            "galaxys10_a10": "Android 10 | com.sec.android.sdhms | 11 rows",
+            "samsunga53_a14": "Android 14 | com.sec.android.sdhms | 9 rows",
+            "samsungs20_a13": "Android 13 | com.sec.android.sdhms | 28 rows",
+            "sharon_a14": "Android 14 | com.sec.android.sdhms | 100 rows",
+        }
     },
     "sdhms_netstat": {
         "name": "SDHMS Netstat",
@@ -24,7 +31,14 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.sec.android.sdhms/databases/thermal_log*'),
         "output_types": "all",
-        "artifact_icon": "chart-bar-popular"
+        "artifact_icon": "chart-bar-popular",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.sec.android.sdhms | 1582 rows",
+            "galaxys10_a10": "Android 10 | com.sec.android.sdhms | 0 rows",
+            "samsunga53_a14": "Android 14 | com.sec.android.sdhms | 1154 rows",
+            "samsungs20_a13": "Android 13 | com.sec.android.sdhms | 324 rows",
+            "sharon_a14": "Android 14 | com.sec.android.sdhms | 1160 rows",
+        }
     },
     "sdhms_temperature": {
         "name": "SDHMS Temperature Logs",
@@ -37,7 +51,14 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.sec.android.sdhms/databases/thermal_log*'),
         "output_types": "all",
-        "artifact_icon": "thermometer"
+        "artifact_icon": "thermometer",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.sec.android.sdhms | 567 rows",
+            "galaxys10_a10": "Android 10 | com.sec.android.sdhms | 0 rows",
+            "samsunga53_a14": "Android 14 | com.sec.android.sdhms | 0 rows",
+            "samsungs20_a13": "Android 13 | com.sec.android.sdhms | 0 rows",
+            "sharon_a14": "Android 14 | com.sec.android.sdhms | 0 rows",
+        }
     },
     "sdhms_cpustats": {
         "name": "SDHMS CPU Stats",
@@ -50,7 +71,14 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.sec.android.sdhms/databases/thermal_log*'),
         "output_types": "all",
-        "artifact_icon": "cpu"
+        "artifact_icon": "cpu",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.sec.android.sdhms | 963 rows",
+            "galaxys10_a10": "Android 10 | com.sec.android.sdhms | 1045 rows",
+            "samsunga53_a14": "Android 14 | com.sec.android.sdhms | 491 rows",
+            "samsungs20_a13": "Android 13 | com.sec.android.sdhms | 595 rows",
+            "sharon_a14": "Android 14 | com.sec.android.sdhms | 483 rows",
+        }
     }
 
 }

--- a/scripts/artifacts/SamsungHoneyboard.py
+++ b/scripts/artifacts/SamsungHoneyboard.py
@@ -11,6 +11,12 @@ __artifacts_v2__ = {
         "paths": ('*/com.samsung.android.honeyboard/databases/ClipItem*',),
         "output_types": "standard",
         "artifact_icon": "clipboard",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.samsung.android.honeyboard vc 590202300 | 8 rows",
+            "samsunga53_a14": "Android 14 | com.samsung.android.honeyboard | 3 rows",
+            "samsungs20_a13": "Android 13 | com.samsung.android.honeyboard | 11 rows",
+            "sharon_a14": "Android 14 | com.samsung.android.honeyboard vc 560051300 | 19 rows",
+        },
     },
     "get_honeyboard_screenshot": {
         "name": "Samsung Honeyboard - Clipboard Screenshot",
@@ -24,6 +30,12 @@ __artifacts_v2__ = {
         "paths": ('*/com.samsung.android.honeyboard/clipboard/*/clip',),
         "output_types": "standard",
         "artifact_icon": "clipboard",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.samsung.android.honeyboard vc 590202300 | 3 rows",
+            "samsunga53_a14": "Android 14 | com.samsung.android.honeyboard | 3 rows",
+            "samsungs20_a13": "Android 13 | com.samsung.android.honeyboard | 1 row",
+            "sharon_a14": "Android 14 | com.samsung.android.honeyboard vc 560051300 | 17 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/SamsungNotes.py
+++ b/scripts/artifacts/SamsungNotes.py
@@ -12,7 +12,12 @@ __artifacts_v2__ = {
         "output_types": ["standard"],
         "paths": (  '*/com.samsung.android.app.notes/databases/sdoc.db*',
                     '*/user/*/com.samsung.android.app.notes/SDocData/*/media/*'),
-        "artifact_icon": "edit"
+        "artifact_icon": "edit",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.samsung.android.app.notes vc 443081000 | 2 rows",
+            "samsungs20_a13": "Android 13 | com.samsung.android.app.notes vc 442923000 | 7 rows",
+            "sharon_a14": "Android 14 | com.samsung.android.app.notes vc 441305000 | 1 row",
+        }
     }
 
 }

--- a/scripts/artifacts/SamsungTrash.py
+++ b/scripts/artifacts/SamsungTrash.py
@@ -15,6 +15,11 @@ __artifacts_v2__ = {
         ),
         "output_types": "standard",
         "artifact_icon": "trash",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.samsung.android.providers.trash | 3 rows",
+            "samsunga53_a14": "Android 14 | com.samsung.android.providers.trash | 0 rows",
+            "sharon_a14": "Android 14 | com.samsung.android.providers.trash | 29 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/SimpleStorage_applaunch.py
+++ b/scripts/artifacts/SimpleStorage_applaunch.py
@@ -13,6 +13,10 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.as/databases/SimpleStorage*'),
         "output_types": "standard",
         "artifact_icon": "loader",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.as vc 14926349 | 10 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.as vc 10790541 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/TorBrowser.py
+++ b/scripts/artifacts/TorBrowser.py
@@ -24,7 +24,10 @@ __artifacts_v2__ = {
         "notes": "Tested on version 15.0 (140.4.0esr (Oct 28th, 2025)",
         "paths": ('*/org.torproject.torbrowser/files/places.sqlite'),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "bookmark"
+        "artifact_icon": "bookmark",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | org.torproject.torbrowser vc 2016164570 | 1 row",
+        }
     },
     "torbrowser_usageinfo": {
         "name": "Tor Browser - Usage Info",
@@ -37,7 +40,10 @@ __artifacts_v2__ = {
         "notes": "Tested on version 15.0 (140.4.0esr (Oct 28th, 2025)",
         "paths": ('*/org.torproject.torbrowser/shared_prefs/fenix_preferences.xml'),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "info-circle"
+        "artifact_icon": "info-circle",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | org.torproject.torbrowser vc 2016164570 | 3 rows",
+        }
     },
 }
 

--- a/scripts/artifacts/Twitter.py
+++ b/scripts/artifacts/Twitter.py
@@ -12,6 +12,11 @@ __artifacts_v2__ = {
         "paths": ('*/com.twitter.android/databases/*-search.db*',),
         "output_types": "standard",
         "artifact_icon": "users",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.twitter.android vc 310480000 | 2 rows",
+            "samsungs20_a13": "Android 13 | com.twitter.android vc 311550000 | 2 rows",
+            "sharon_a14": "Android 14 | com.twitter.android vc 310542000 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/Viber.py
+++ b/scripts/artifacts/Viber.py
@@ -12,6 +12,11 @@ __artifacts_v2__ = {
         "paths": ('*/com.viber.voip/databases/*',),
         "output_types": "standard",
         "artifact_icon": "phone-call",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.viber.voip vc 1281010 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.viber.voip vc 1231070 | 0 rows",
+            "sharon_a14": "Android 14 | com.viber.voip vc 1233020 | 0 rows",
+        },
     },
     "get_Viber_contacts": {
         "name": "Viber - Contacts",
@@ -25,6 +30,11 @@ __artifacts_v2__ = {
         "paths": ('*/com.viber.voip/databases/*',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "users",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.viber.voip vc 1281010 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.viber.voip vc 1231070 | 0 rows",
+            "sharon_a14": "Android 14 | com.viber.voip vc 1233020 | 0 rows",
+        },
     },
     "get_Viber_messages": {
         "name": "Viber - Messages",
@@ -38,6 +48,11 @@ __artifacts_v2__ = {
         "paths": ('*/com.viber.voip/databases/*',),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.viber.voip vc 1281010 | 17 rows",
+            "pixel7a_a14": "Android 14 | com.viber.voip vc 1231070 | 34 rows",
+            "sharon_a14": "Android 14 | com.viber.voip vc 1233020 | 5051 rows",
+        },
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Thread ID",
@@ -61,6 +76,11 @@ __artifacts_v2__ = {
         "paths": ('*/com.viber.voip/databases/*',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "lock",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.viber.voip vc 1281010 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.viber.voip vc 1231070 | 0 rows",
+            "sharon_a14": "Android 14 | com.viber.voip vc 1233020 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/WhatsApp.py
+++ b/scripts/artifacts/WhatsApp.py
@@ -12,6 +12,14 @@ __artifacts_v2__ = {
         "paths": ('*/com.whatsapp/databases/wa.db*',),
         "output_types": "standard",
         "artifact_icon": "users",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.whatsapp vc 252573000 | 268 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.whatsapp vc 262307413 | 14 rows",
+            "kevin_pocox7_a15": "Android 15 | com.whatsapp vc 252674000 | 295 rows",
+            "pixel7a_a14": "Android 14 | com.whatsapp vc 241481004 | 92 rows",
+            "samsungs20_a13": "Android 13 | com.whatsapp vc 253776000 | 28 rows",
+            "sharon_a14": "Android 14 | com.whatsapp vc 241676004 | 638 rows",
+        },
     },
     "get_whatsapp_call_logs": {
         "name": "WhatsApp - Call Logs",
@@ -25,6 +33,14 @@ __artifacts_v2__ = {
         "paths": ('*/com.whatsapp/databases/msgstore.db*', '*/com.whatsapp/databases/wa.db*'),
         "output_types": "standard",
         "artifact_icon": "phone",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.whatsapp vc 252573000 | 1 row",
+            "hc_pixel8pro_a16": "Android 16 | com.whatsapp vc 262307413 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.whatsapp vc 252674000 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.whatsapp vc 241481004 | 4 rows",
+            "samsungs20_a13": "Android 13 | com.whatsapp vc 253776000 | 0 rows",
+            "sharon_a14": "Android 14 | com.whatsapp vc 241676004 | 3 rows",
+        },
     },
     "get_whatsapp_messages": {
         "name": "WhatsApp - Messages",
@@ -38,6 +54,14 @@ __artifacts_v2__ = {
         "paths": ('*/com.whatsapp/databases/msgstore.db*', '*/com.whatsapp/databases/wa.db*'),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.whatsapp vc 252573000 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.whatsapp vc 262307413 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.whatsapp vc 252674000 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.whatsapp vc 241481004 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.whatsapp vc 253776000 | 0 rows",
+            "sharon_a14": "Android 14 | com.whatsapp vc 241676004 | 0 rows",
+        },
     },
     "get_whatsapp_one_to_one_messages": {
         "name": "WhatsApp - One To One Messages",
@@ -53,6 +77,14 @@ __artifacts_v2__ = {
                   '*/Android/media/com.whatsapp/WhatsApp/Media/*'),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.whatsapp vc 252573000 | 29 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.whatsapp vc 262307413 | 7 rows",
+            "kevin_pocox7_a15": "Android 15 | com.whatsapp vc 252674000 | 3877 rows",
+            "pixel7a_a14": "Android 14 | com.whatsapp vc 241481004 | 73 rows",
+            "samsungs20_a13": "Android 13 | com.whatsapp vc 253776000 | 195 rows",
+            "sharon_a14": "Android 14 | com.whatsapp vc 241676004 | 781 rows",
+        },
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Other Participant WA User Name",
@@ -80,6 +112,14 @@ __artifacts_v2__ = {
                   '*/Android/media/com.whatsapp/WhatsApp/Media/*'),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.whatsapp vc 252573000 | 7 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.whatsapp vc 262307413 | 39 rows",
+            "kevin_pocox7_a15": "Android 15 | com.whatsapp vc 252674000 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.whatsapp vc 241481004 | 156 rows",
+            "samsungs20_a13": "Android 13 | com.whatsapp vc 253776000 | 0 rows",
+            "sharon_a14": "Android 14 | com.whatsapp vc 241676004 | 4730 rows",
+        },
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Conversation Name",
@@ -105,6 +145,14 @@ __artifacts_v2__ = {
                   '*/com.whatsapp/files/Avatars/*'),
         "output_types": "standard",
         "artifact_icon": "users",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.whatsapp vc 252573000 | 1 row",
+            "hc_pixel8pro_a16": "Android 16 | com.whatsapp vc 262307413 | 1 row",
+            "kevin_pocox7_a15": "Android 15 | com.whatsapp vc 252674000 | 10 rows",
+            "pixel7a_a14": "Android 14 | com.whatsapp vc 241481004 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.whatsapp vc 253776000 | 3 rows",
+            "sharon_a14": "Android 14 | com.whatsapp vc 241676004 | 0 rows",
+        },
     },
     "get_whatsapp_user_profile": {
         "name": "WhatsApp - User Profile",
@@ -119,6 +167,14 @@ __artifacts_v2__ = {
                   '*/com.whatsapp/shared_prefs/startup_prefs.xml'),
         "output_types": "standard",
         "artifact_icon": "user",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.whatsapp vc 252573000 | 1 row",
+            "hc_pixel8pro_a16": "Android 16 | com.whatsapp vc 262307413 | 1 row",
+            "kevin_pocox7_a15": "Android 15 | com.whatsapp vc 252674000 | 1 row",
+            "pixel7a_a14": "Android 14 | com.whatsapp vc 241481004 | 1 row",
+            "samsungs20_a13": "Android 13 | com.whatsapp vc 253776000 | 1 row",
+            "sharon_a14": "Android 14 | com.whatsapp vc 241676004 | 1 row",
+        },
     }
 }
 

--- a/scripts/artifacts/accounts_ce.py
+++ b/scripts/artifacts/accounts_ce.py
@@ -1,3 +1,4 @@
+# pylint: disable=W0613
 __artifacts_v2__ = {
     "accounts_ce": {
         "name": "Accounts_ce",
@@ -10,7 +11,17 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/system_ce/*/accounts_ce.db*'),
         "output_types": ["html", "lava", "tsv"],
-        "artifact_icon": "user"
+        "artifact_icon": "user",
+        "sample_data": {
+            "anne_a15": "Android 15 | 9 rows",
+            "galaxys10_a10": "Android 10 | 4 rows",
+            "hc_pixel8pro_a16": "Android 16 | 9 rows",
+            "kevin_pocox7_a15": "Android 15 | 8 rows",
+            "pixel7a_a14": "Android 14 | 20 rows",
+            "samsunga53_a14": "Android 14 | 8 rows",
+            "samsungs20_a13": "Android 13 | 16 rows",
+            "sharon_a14": "Android 14 | 14 rows",
+        }
     },
     "accounts_ce_authtokens": {
         "name": "Authentication tokens",
@@ -23,7 +34,17 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/system_ce/*/accounts_ce.db*'),
         "output_types": ["html", "lava", "tsv"],
-        "artifact_icon": "key"
+        "artifact_icon": "key",
+        "sample_data": {
+            "anne_a15": "Android 15 | 75 rows",
+            "galaxys10_a10": "Android 10 | 78 rows",
+            "hc_pixel8pro_a16": "Android 16 | 160 rows",
+            "kevin_pocox7_a15": "Android 15 | 122 rows",
+            "pixel7a_a14": "Android 14 | 162 rows",
+            "samsunga53_a14": "Android 14 | 130 rows",
+            "samsungs20_a13": "Android 13 | 107 rows",
+            "sharon_a14": "Android 14 | 107 rows",
+        }
     }
 }
 

--- a/scripts/artifacts/accounts_de.py
+++ b/scripts/artifacts/accounts_de.py
@@ -11,7 +11,17 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/system_de/*/accounts_de.db*'),
         "output_types": "standard",
-        "artifact_icon": "user"
+        "artifact_icon": "user",
+        "sample_data": {
+            "anne_a15": "Android 15 | 11 rows",
+            "galaxys10_a10": "Android 10 | 5 rows",
+            "hc_pixel8pro_a16": "Android 16 | 10 rows",
+            "kevin_pocox7_a15": "Android 15 | 8 rows",
+            "pixel7a_a14": "Android 14 | 21 rows",
+            "samsunga53_a14": "Android 14 | 11 rows",
+            "samsungs20_a13": "Android 13 | 19 rows",
+            "sharon_a14": "Android 14 | 15 rows",
+        }
     }
 }
 

--- a/scripts/artifacts/adb_hosts.py
+++ b/scripts/artifacts/adb_hosts.py
@@ -1,3 +1,4 @@
+# pylint: disable=W0613,W0702
 __artifacts_v2__ = {
     "adb_hosts": {
         "name": "ADB Hosts",
@@ -11,7 +12,14 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/misc/adb/adb_keys'),
         "output_types": ["html", "lava", "tsv"],
-        "artifact_icon": "terminal"
+        "artifact_icon": "terminal",
+        "sample_data": {
+            "galaxys10_a10": "Android 10 | 1 row",
+            "hc_pixel8pro_a16": "Android 16 | 1 row",
+            "pixel7a_a14": "Android 14 | 0 rows",
+            "samsungs20_a13": "Android 13 | 1 row",
+            "sharon_a14": "Android 14 | 0 rows",
+        }
     }
 }
 

--- a/scripts/artifacts/airtagAndroid.py
+++ b/scripts/artifacts/airtagAndroid.py
@@ -11,7 +11,16 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": '*/com.google.android.gms/databases/personalsafety_db*',
         "output_types": "standard",
-        "artifact_icon": "alert-circle"
+        "artifact_icon": "alert-circle",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 4 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 2 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+        }
     },
     "airtagScans": {
         "name": "Android Airtag Scans",
@@ -24,7 +33,16 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": '*/com.google.android.gms/databases/personalsafety_db*',
         "output_types": "all",
-        "artifact_icon": "alert-circle"
+        "artifact_icon": "alert-circle",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 43 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 39 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 4 rows",
+        }
     },
     "airtagLastScan": {
         "name": "Android Airtag Last Scan",
@@ -37,7 +55,14 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": '*/files/personalsafety/shared/personalsafety_info.pb',
         "output_types": "standard",
-        "artifact_icon": "alert-circle"
+        "artifact_icon": "alert-circle",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 1 row",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 1 row",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 1 row",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 1 row",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 1 row",
+        }
     },
     "airtagPassiveScan": {
         "name": "Android Airtag Passive Scan",

--- a/scripts/artifacts/androidauto.py
+++ b/scripts/artifacts/androidauto.py
@@ -11,6 +11,13 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.projection.gearhead/databases/carservicedata.db*'),
         "output_types": "standard",
         "artifact_icon": "truck",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.projection.gearhead vc 151653424 | 1 row",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.projection.gearhead vc 152653624 | 3 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.projection.gearhead vc 123642624 | 1 row",
+            "samsunga53_a14": "Android 14 | com.google.android.projection.gearhead vc 156654484 | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.projection.gearhead vc 124642854 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/appSemloc.py
+++ b/scripts/artifacts/appSemloc.py
@@ -12,6 +12,15 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.gms/app_semanticlocation_rawsignal_db/*',),
         "output_types": "all",
         "artifact_icon": "map-pin",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 6651 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 1497 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 5033 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/appicons.py
+++ b/scripts/artifacts/appicons.py
@@ -1,3 +1,4 @@
+# pylint: disable=W0612,W0613,W0631
 __artifacts_v2__ = {
     "appIcons": {
         "name": "App Icon",
@@ -10,7 +11,11 @@ __artifacts_v2__ = {
         "notes": "Seems to be a google thing, on Nexus/Pixel devices only?",
         "paths": ('*/com.google.android.apps.nexuslauncher/databases/app_icons.db*'),
         "output_types": ["html", "lava"],
-        "artifact_icon": "package"
+        "artifact_icon": "package",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.nexuslauncher | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.nexuslauncher | 100 rows",
+        }
     }
 }
 

--- a/scripts/artifacts/appopSetupWiz.py
+++ b/scripts/artifacts/appopSetupWiz.py
@@ -12,6 +12,14 @@ __artifacts_v2__ = {
         "paths": ('*/system/appops.xml',),
         "output_types": "standard",
         "artifact_icon": "package",
+        "sample_data": {
+            "anne_a15": "Android 15 | 0 rows",
+            "galaxys10_a10": "Android 10 | 14 rows",
+            "pixel7a_a14": "Android 14 | 0 rows",
+            "samsunga53_a14": "Android 14 | 0 rows",
+            "samsungs20_a13": "Android 13 | 11 rows",
+            "sharon_a14": "Android 14 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/appops.py
+++ b/scripts/artifacts/appops.py
@@ -12,6 +12,14 @@ __artifacts_v2__ = {
         "paths": ('*/system/appops.xml',),
         "output_types": "standard",
         "artifact_icon": "package",
+        "sample_data": {
+            "anne_a15": "Android 15 | 0 rows",
+            "galaxys10_a10": "Android 10 | 922 rows",
+            "pixel7a_a14": "Android 14 | 0 rows",
+            "samsunga53_a14": "Android 14 | 0 rows",
+            "samsungs20_a13": "Android 13 | 1650 rows",
+            "sharon_a14": "Android 14 | 0 rows",
+        },
     },
     "get_appops_legacy": {
         "name": "App Ops Permissions - Legacy",
@@ -25,6 +33,14 @@ __artifacts_v2__ = {
         "paths": ('*/system/appops.xml',),
         "output_types": "standard",
         "artifact_icon": "package",
+        "sample_data": {
+            "anne_a15": "Android 15 | 0 rows",
+            "galaxys10_a10": "Android 10 | 0 rows",
+            "pixel7a_a14": "Android 14 | 0 rows",
+            "samsunga53_a14": "Android 14 | 0 rows",
+            "samsungs20_a13": "Android 13 | 0 rows",
+            "sharon_a14": "Android 14 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/battery_usage_v4.py
+++ b/scripts/artifacts/battery_usage_v4.py
@@ -12,6 +12,10 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.settings.intelligence/databases/battery-usage-db-v4*',),
         "output_types": "standard",
         "artifact_icon": "battery",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.settings.intelligence vc 1000282241 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.settings.intelligence vc 1000230247 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/battery_usage_v9.py
+++ b/scripts/artifacts/battery_usage_v9.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/user_de/*/com.android.settings/databases/battery-usage-db-v9',),
         "output_types": "standard",
         "artifact_icon": "battery",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.android.settings | 26561 rows",
+        },
     },
     "get_app_usage_events": {
         "name": "Settings Services - App Battery Usages v9 - App Battery Usage Events",
@@ -25,6 +28,9 @@ __artifacts_v2__ = {
         "paths": ('*/user_de/*/com.android.settings/databases/battery-usage-db-v9',),
         "output_types": "standard",
         "artifact_icon": "battery",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.android.settings | 3196 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/batterystats.py
+++ b/scripts/artifacts/batterystats.py
@@ -11,7 +11,17 @@ __artifacts_v2__ = {
         "notes": "",
         "output_types": ["standard"],
         "paths": (  '*/system/batterystats-daily.xml'),
-        "artifact_icon": "battery-charging"
+        "artifact_icon": "battery-charging",
+        "sample_data": {
+            "anne_a15": "Android 15 | 170 rows",
+            "galaxys10_a10": "Android 10 | 275 rows",
+            "hc_pixel8pro_a16": "Android 16 | 367 rows",
+            "kevin_pocox7_a15": "Android 15 | 586 rows",
+            "pixel7a_a14": "Android 14 | 727 rows",
+            "samsunga53_a14": "Android 14 | 335 rows",
+            "samsungs20_a13": "Android 13 | 148 rows",
+            "sharon_a14": "Android 14 | 230 rows",
+        }
     }
 }
 

--- a/scripts/artifacts/bluetoothConnections.py
+++ b/scripts/artifacts/bluetoothConnections.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/misc/bluedroid/bt_config.conf', '*/bt_config.conf'),
         "output_types": "standard",
         "artifact_icon": "bluetooth",
+        "sample_data": {
+            "anne_a15": "Android 15 | 2 rows",
+            "galaxys10_a10": "Android 10 | 1 row",
+            "hc_pixel8pro_a16": "Android 16 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | 4 rows",
+            "pixel7a_a14": "Android 14 | 4 rows",
+            "samsunga53_a14": "Android 14 | 1 row",
+            "samsungs20_a13": "Android 13 | 0 rows",
+            "sharon_a14": "Android 14 | 1 row",
+        },
     },
     "get_bluetoothAdapter": {
         "name": "Bluetooth Adapter Information",
@@ -25,6 +35,16 @@ __artifacts_v2__ = {
         "paths": ('*/misc/bluedroid/bt_config.conf', '*/bt_config.conf'),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "bluetooth",
+        "sample_data": {
+            "anne_a15": "Android 15 | 14 rows",
+            "galaxys10_a10": "Android 10 | 14 rows",
+            "hc_pixel8pro_a16": "Android 16 | 9 rows",
+            "kevin_pocox7_a15": "Android 15 | 11 rows",
+            "pixel7a_a14": "Android 14 | 10 rows",
+            "samsunga53_a14": "Android 14 | 14 rows",
+            "samsungs20_a13": "Android 13 | 14 rows",
+            "sharon_a14": "Android 14 | 14 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/browserCachechrome.py
+++ b/scripts/artifacts/browserCachechrome.py
@@ -11,6 +11,16 @@ __artifacts_v2__ = {
         "paths": ('*/data/com.android.chrome/cache/Cache/*_0',),
         "output_types": "standard",
         "artifact_icon": "globe",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.android.chrome vc 733915533 | 21956 rows",
+            "galaxys10_a10": "Android 10 | com.android.chrome vc 438910534 | 847 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.android.chrome vc 782711433 | 1289 rows",
+            "kevin_pocox7_a15": "Android 15 | com.android.chrome vc 733920733 | 39865 rows",
+            "pixel7a_a14": "Android 14 | com.android.chrome vc 616710133 | 3035 rows",
+            "samsunga53_a14": "Android 14 | com.android.chrome vc 744417133 | 1701 rows",
+            "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233 | 44 rows",
+            "sharon_a14": "Android 14 | com.android.chrome vc 653310333 | 13957 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/browserCachefirefox.py
+++ b/scripts/artifacts/browserCachefirefox.py
@@ -11,6 +11,9 @@ __artifacts_v2__ = {
         "paths": ('*/data/org.mozilla.firefox/cache/*/cache2/entries/**',),
         "output_types": "standard",
         "artifact_icon": "globe",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | org.mozilla.firefox vc 2016030615 | 3702 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/build.py
+++ b/scripts/artifacts/build.py
@@ -12,6 +12,14 @@ __artifacts_v2__ = {
         "paths": ('*/vendor/build.prop',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "info-circle",
+        "sample_data": {
+            "anne_a15": "Android 15 | 0 rows",
+            "galaxys10_a10": "Android 10 | 6 rows",
+            "hc_pixel8pro_a16": "Android 16 | 6 rows",
+            "pixel7a_a14": "Android 14 | 6 rows",
+            "samsunga53_a14": "Android 14 | 6 rows",
+            "sharon_a14": "Android 14 | 6 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/burnerContacts.py
+++ b/scripts/artifacts/burnerContacts.py
@@ -13,6 +13,9 @@ __artifacts_v2__ = {
         "paths": ('*/data/com.adhoclabs.burner/databases/burnerDatabase.db*',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "user",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.adhoclabs.burner vc 2104 | 1 row",
+        },
     }
 }
 

--- a/scripts/artifacts/burnerMessages.py
+++ b/scripts/artifacts/burnerMessages.py
@@ -13,6 +13,9 @@ __artifacts_v2__ = {
         "paths": ('*/data/com.adhoclabs.burner/databases/burnerDatabase.db*',),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.adhoclabs.burner vc 2104 | 1 row",
+        },
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Contact",

--- a/scripts/artifacts/burnerSubscription.py
+++ b/scripts/artifacts/burnerSubscription.py
@@ -13,6 +13,9 @@ __artifacts_v2__ = {
         "paths": ('*/data/com.adhoclabs.burner/databases/burnerDatabase.db*',),
         "output_types": "standard",
         "artifact_icon": "credit-card",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.adhoclabs.burner vc 2104 | 1 row",
+        },
     }
 }
 

--- a/scripts/artifacts/burnerUser.py
+++ b/scripts/artifacts/burnerUser.py
@@ -13,6 +13,9 @@ __artifacts_v2__ = {
         "paths": ('*/data/com.adhoclabs.burner/databases/burnerDatabase.db*',),
         "output_types": "standard",
         "artifact_icon": "user",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.adhoclabs.burner vc 2104 | 1 row",
+        },
     }
 }
 

--- a/scripts/artifacts/calllog.py
+++ b/scripts/artifacts/calllog.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.android.providers.contacts/databases/calllog.db*', '*/com.samsung.android.providers.contacts/databases/calllog.db*'),
         "output_types": "standard",
         "artifact_icon": "phone",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.samsung.android.providers.contacts | 11 rows",
+            "galaxys10_a10": "Android 10 | com.samsung.android.providers.contacts | 24 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.android.providers.contacts | 705 rows",
+            "kevin_pocox7_a15": "Android 15 | com.android.providers.contacts | 12 rows",
+            "pixel7a_a14": "Android 14 | com.android.providers.contacts | 2655 rows",
+            "samsunga53_a14": "Android 14 | com.samsung.android.providers.contacts | 69 rows",
+            "samsungs20_a13": "Android 13 | com.samsung.android.providers.contacts | 12 rows",
+            "sharon_a14": "Android 14 | com.samsung.android.providers.contacts | 397 rows",
+        },
         "html_columns": ['Type'],
     }
 }

--- a/scripts/artifacts/calllogs.py
+++ b/scripts/artifacts/calllogs.py
@@ -12,6 +12,11 @@ __artifacts_v2__ = {
         "paths": ('*/com.android.providers.contacts/databases/contact*', '*/com.sec.android.provider.logsprovider/databases/logs.db*'),
         "output_types": "standard",
         "artifact_icon": "phone",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.android.providers.contacts | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.android.providers.contacts | 0 rows",
+            "pixel7a_a14": "Android 14 | com.android.providers.contacts | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/chatgpt.py
+++ b/scripts/artifacts/chatgpt.py
@@ -11,6 +11,9 @@ __artifacts_v2__ = {
         "paths": ('**/com.openai.chatgpt/databases/*_conversations.db*',),
         "output_types": "standard",
         "artifact_icon": "message-circle",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.openai.chatgpt vc 2525902 | 2 rows",
+        },
     },
     "get_chatgpt_conversations": {
         "name": "ChatGPT - Messages (Legacy)",
@@ -37,6 +40,9 @@ __artifacts_v2__ = {
         "paths": ('**/com.openai.chatgpt/files/datastore/*_user.preferences_pb',),
         "output_types": "standard",
         "artifact_icon": "user",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.openai.chatgpt vc 2525902 | 1 row",
+        },
     },
     "get_chatgpt_accountstatus": {
         "name": "ChatGPT - Account Status",
@@ -50,6 +56,9 @@ __artifacts_v2__ = {
         "paths": ('**/com.openai.chatgpt/files/datastore/*_accountstatus.preferences_pb',),
         "output_types": "standard",
         "artifact_icon": "user-check",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.openai.chatgpt vc 2525902 | 2 rows",
+        },
     },
     "get_chatgpt_accountuserstate": {
         "name": "ChatGPT - Account User State",
@@ -63,6 +72,9 @@ __artifacts_v2__ = {
         "paths": ('**/com.openai.chatgpt/files/datastore/*_accountuser_state.preferences_pb',),
         "output_types": "standard",
         "artifact_icon": "users",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.openai.chatgpt vc 2525902 | 1 row",
+        },
     },
     "get_chatgpt_custominstructions": {
         "name": "ChatGPT - Custom Instructions",
@@ -76,6 +88,9 @@ __artifacts_v2__ = {
         "paths": ('**/com.openai.chatgpt/files/datastore/*_custom_instructions.preferences_pb',),
         "output_types": "standard",
         "artifact_icon": "edit",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.openai.chatgpt vc 2525902 | 1 row",
+        },
     },
     "get_chatgpt_usersettings": {
         "name": "ChatGPT - User Settings",
@@ -89,6 +104,9 @@ __artifacts_v2__ = {
         "paths": ('**/com.openai.chatgpt/files/datastore/*_user_settings.preferences_pb',),
         "output_types": "standard",
         "artifact_icon": "settings",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.openai.chatgpt vc 2525902 | 1 row",
+        },
     },
     "get_chatgpt_analytics": {
         "name": "ChatGPT - User Analytics",
@@ -102,6 +120,9 @@ __artifacts_v2__ = {
         "paths": ('**/com.openai.chatgpt/shared_prefs/analytics-android-oai.xml',),
         "output_types": "standard",
         "artifact_icon": "chart-bar",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.openai.chatgpt vc 2525902 | 1 row",
+        },
     },
     "get_chatgpt_media": {
         "name": "ChatGPT - Media Uploads",

--- a/scripts/artifacts/chrome.py
+++ b/scripts/artifacts/chrome.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/app_chrome/Default/History*', '*/app_sbrowser/Default/History*', '*/app_opera/History*', '*/app_webview/Default/History*'),
         "output_types": "standard",
         "artifact_icon": "globe",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.android.chrome vc 733915533, com.sec.android.app.sbrowser vc 1280509502 | 94 rows",
+            "galaxys10_a10": "Android 10 | com.android.chrome vc 438910534 | 191 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.android.chrome vc 782711433, com.brave.browser vc 429117204, com.sec.android.app.sbrowser vc 1300067502 | 20 rows",
+            "kevin_pocox7_a15": "Android 15 | com.android.chrome vc 733920733 | 46 rows",
+            "pixel7a_a14": "Android 14 | 76 rows",
+            "samsunga53_a14": "Android 14 | com.android.chrome vc 744417133, com.sec.android.app.sbrowser vc 1290059502 | 132 rows",
+            "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233, com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 65 rows",
+            "sharon_a14": "Android 14 | com.android.chrome vc 653310333, com.sec.android.app.sbrowser vc 1260103502 | 137 rows",
+        },
     },
     "get_chromeWebVisits": {
         "name": "Web Visits",
@@ -25,6 +35,16 @@ __artifacts_v2__ = {
         "paths": ('*/app_chrome/Default/History*', '*/app_sbrowser/Default/History*', '*/app_opera/History*', '*/app_webview/Default/History*'),
         "output_types": "standard",
         "artifact_icon": "globe",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.android.chrome vc 733915533, com.sec.android.app.sbrowser vc 1280509502 | 127 rows",
+            "galaxys10_a10": "Android 10 | com.android.chrome vc 438910534 | 291 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.android.chrome vc 782711433, com.brave.browser vc 429117204, com.sec.android.app.sbrowser vc 1300067502 | 39 rows",
+            "kevin_pocox7_a15": "Android 15 | com.android.chrome vc 733920733 | 71 rows",
+            "pixel7a_a14": "Android 14 | 89 rows",
+            "samsunga53_a14": "Android 14 | com.android.chrome vc 744417133, com.sec.android.app.sbrowser vc 1290059502 | 174 rows",
+            "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233, com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 86 rows",
+            "sharon_a14": "Android 14 | com.android.chrome vc 653310333, com.sec.android.app.sbrowser vc 1260103502 | 198 rows",
+        },
     },
     "get_chromeSearchTerms": {
         "name": "Search Terms",
@@ -38,6 +58,16 @@ __artifacts_v2__ = {
         "paths": ('*/app_chrome/Default/History*', '*/app_sbrowser/Default/History*', '*/app_opera/History*', '*/app_webview/Default/History*'),
         "output_types": "standard",
         "artifact_icon": "search",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.android.chrome vc 733915533, com.sec.android.app.sbrowser vc 1280509502 | 44 rows",
+            "galaxys10_a10": "Android 10 | com.android.chrome vc 438910534 | 20 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.android.chrome vc 782711433, com.brave.browser vc 429117204, com.sec.android.app.sbrowser vc 1300067502 | 1 row",
+            "kevin_pocox7_a15": "Android 15 | com.android.chrome vc 733920733 | 3 rows",
+            "pixel7a_a14": "Android 14 | 7 rows",
+            "samsunga53_a14": "Android 14 | com.android.chrome vc 744417133, com.sec.android.app.sbrowser vc 1290059502 | 39 rows",
+            "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233, com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 18 rows",
+            "sharon_a14": "Android 14 | com.android.chrome vc 653310333, com.sec.android.app.sbrowser vc 1260103502 | 18 rows",
+        },
     },
     "get_chromeDownloads": {
         "name": "Downloads",
@@ -51,6 +81,16 @@ __artifacts_v2__ = {
         "paths": ('*/app_chrome/Default/History*', '*/app_sbrowser/Default/History*', '*/app_opera/History*', '*/app_webview/Default/History*'),
         "output_types": "standard",
         "artifact_icon": "download",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.android.chrome vc 733915533, com.sec.android.app.sbrowser vc 1280509502 | 0 rows",
+            "galaxys10_a10": "Android 10 | com.android.chrome vc 438910534 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.android.chrome vc 782711433, com.brave.browser vc 429117204, com.sec.android.app.sbrowser vc 1300067502 | 1 row",
+            "kevin_pocox7_a15": "Android 15 | com.android.chrome vc 733920733 | 0 rows",
+            "pixel7a_a14": "Android 14 | 4 rows",
+            "samsunga53_a14": "Android 14 | com.android.chrome vc 744417133, com.sec.android.app.sbrowser vc 1290059502 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233, com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 2 rows",
+            "sharon_a14": "Android 14 | com.android.chrome vc 653310333, com.sec.android.app.sbrowser vc 1260103502 | 108 rows",
+        },
     },
     "get_chromeKeywordSearchTerms": {
         "name": "Keyword Search Terms",
@@ -64,6 +104,16 @@ __artifacts_v2__ = {
         "paths": ('*/app_chrome/Default/History*', '*/app_sbrowser/Default/History*', '*/app_opera/History*', '*/app_webview/Default/History*'),
         "output_types": "standard",
         "artifact_icon": "search",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.android.chrome vc 733915533, com.sec.android.app.sbrowser vc 1280509502 | 88 rows",
+            "galaxys10_a10": "Android 10 | com.android.chrome vc 438910534 | 15 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.android.chrome vc 782711433, com.brave.browser vc 429117204, com.sec.android.app.sbrowser vc 1300067502 | 4 rows",
+            "kevin_pocox7_a15": "Android 15 | com.android.chrome vc 733920733 | 3 rows",
+            "pixel7a_a14": "Android 14 | 7 rows",
+            "samsunga53_a14": "Android 14 | com.android.chrome vc 744417133, com.sec.android.app.sbrowser vc 1290059502 | 48 rows",
+            "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233, com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 18 rows",
+            "sharon_a14": "Android 14 | com.android.chrome vc 653310333, com.sec.android.app.sbrowser vc 1260103502 | 23 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/chromeAutofill.py
+++ b/scripts/artifacts/chromeAutofill.py
@@ -12,6 +12,11 @@ __artifacts_v2__ = {
         "paths": ('*/app_chrome/Default/Web Data*', '*/app_sbrowser/Default/Web Data*', '*/data/*/app_opera/Web Data*', '*/app_webview/Default/Web Data*'),
         "output_types": "standard",
         "artifact_icon": "globe",
+        "sample_data": {
+            "galaxys10_a10": "Android 10 | 6 rows",
+            "pixel7a_a14": "Android 14 | 4 rows",
+            "sharon_a14": "Android 14 | 4 rows",
+        },
     },
     "get_chromeAutofillProfiles": {
         "name": "Chrome Autofill - Profiles",
@@ -25,6 +30,16 @@ __artifacts_v2__ = {
         "paths": ('*/app_chrome/Default/Web Data*', '*/app_sbrowser/Default/Web Data*', '*/data/*/app_opera/Web Data*', '*/app_webview/Default/Web Data*'),
         "output_types": "standard",
         "artifact_icon": "globe",
+        "sample_data": {
+            "anne_a15": "Android 15 | 0 rows",
+            "galaxys10_a10": "Android 10 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | 0 rows",
+            "pixel7a_a14": "Android 14 | 0 rows",
+            "samsunga53_a14": "Android 14 | 0 rows",
+            "samsungs20_a13": "Android 13 | 0 rows",
+            "sharon_a14": "Android 14 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/chromeBookmarks.py
+++ b/scripts/artifacts/chromeBookmarks.py
@@ -12,6 +12,11 @@ __artifacts_v2__ = {
         "paths": ('*/app_chrome/Default/Bookmarks*', '*/app_sbrowser/Default/Bookmarks*', '*/app_opera/Bookmarks*', '*/app_webview/Default/Bookmarks*'),
         "output_types": "standard",
         "artifact_icon": "bookmark",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.android.chrome vc 616710133, com.microsoft.emmx vc 259210005, com.opera.browser vc 1908324306 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.microsoft.emmx vc 365012523 | 1 row",
+            "sharon_a14": "Android 14 | com.android.chrome vc 653310333 | 6 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/chromeCookies.py
+++ b/scripts/artifacts/chromeCookies.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/app_chrome/Default/Cookies*', '*/app_sbrowser/Default/Cookies*', '*/app_opera/Cookies*', '*/app_webview/Default/Cookies*'),
         "output_types": "standard",
         "artifact_icon": "globe",
+        "sample_data": {
+            "anne_a15": "Android 15 | 1777 rows",
+            "galaxys10_a10": "Android 10 | 800 rows",
+            "hc_pixel8pro_a16": "Android 16 | 474 rows",
+            "kevin_pocox7_a15": "Android 15 | 4170 rows",
+            "pixel7a_a14": "Android 14 | 1554 rows",
+            "samsunga53_a14": "Android 14 | 1491 rows",
+            "samsungs20_a13": "Android 13 | 670 rows",
+            "sharon_a14": "Android 14 | 1842 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/chromeDIPS.py
+++ b/scripts/artifacts/chromeDIPS.py
@@ -12,6 +12,12 @@ __artifacts_v2__ = {
         "paths": ('*/app_chrome/Default/DIPS*', '*/app_sbrowser/Default/DIPS*', '*/app_opera/DIPS*', '*/app_webview/Default/DIPS*'),
         "output_types": "standard",
         "artifact_icon": "globe",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.android.chrome vc 733915533 | 13 rows",
+            "kevin_pocox7_a15": "Android 15 | com.android.chrome vc 733920733 | 19 rows",
+            "pixel7a_a14": "Android 14 | com.android.chrome vc 616710133, com.microsoft.emmx vc 259210005 | 36 rows",
+            "sharon_a14": "Android 14 | com.android.chrome vc 653310333 | 19 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/chromeLoginData.py
+++ b/scripts/artifacts/chromeLoginData.py
@@ -12,6 +12,13 @@ __artifacts_v2__ = {
         "paths": ('*/app_chrome/Default/Login Data*', '*/app_sbrowser/Default/Login Data*', '*/app_opera/Login Data*', '*/app_webview/Default/Login Data*'),
         "output_types": "standard",
         "artifact_icon": "key",
+        "sample_data": {
+            "galaxys10_a10": "Android 10 | com.android.chrome vc 438910534 | 1 row",
+            "hc_pixel8pro_a16": "Android 16 | com.brave.browser vc 429117204, com.sec.android.app.sbrowser vc 1300067502 | 0 rows",
+            "pixel7a_a14": "Android 14 | 3 rows",
+            "samsungs20_a13": "Android 13 | com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 0 rows",
+            "sharon_a14": "Android 14 | com.android.chrome vc 653310333, com.sec.android.app.sbrowser vc 1260103502 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/chromeMediaHistory.py
+++ b/scripts/artifacts/chromeMediaHistory.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/app_chrome/Default/Media History*', '*/app_sbrowser/Default/Media History*', '*/app_opera/Media History*', '*/app_webview/Default/Media History*'),
         "output_types": "standard",
         "artifact_icon": "photo",
+        "sample_data": {
+            "galaxys10_a10": "Android 10 | com.android.chrome vc 438910534 | 0 rows",
+        },
     },
     "get_chromeMediaHistoryPlaybacks": {
         "name": "Media History - Playbacks",
@@ -25,6 +28,9 @@ __artifacts_v2__ = {
         "paths": ('*/app_chrome/Default/Media History*', '*/app_sbrowser/Default/Media History*', '*/app_opera/Media History*', '*/app_webview/Default/Media History*'),
         "output_types": "standard",
         "artifact_icon": "photo",
+        "sample_data": {
+            "galaxys10_a10": "Android 10 | com.android.chrome vc 438910534 | 0 rows",
+        },
     },
     "get_chromeMediaHistoryOrigins": {
         "name": "Media History - Origins",
@@ -38,6 +44,9 @@ __artifacts_v2__ = {
         "paths": ('*/app_chrome/Default/Media History*', '*/app_sbrowser/Default/Media History*', '*/app_opera/Media History*', '*/app_webview/Default/Media History*'),
         "output_types": "standard",
         "artifact_icon": "photo",
+        "sample_data": {
+            "galaxys10_a10": "Android 10 | com.android.chrome vc 438910534 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/chromeNetworkActionPredictor.py
+++ b/scripts/artifacts/chromeNetworkActionPredictor.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/app_Chrome/Default/Network Action Predictor*', '*/app_sbrowser/Default/Network Action Predictor*', '*/app_opera/Network Action Predicator*', '*/app_webview/Default/Network Action Predictor*'),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "wifi",
+        "sample_data": {
+            "sharon_a14": "Android 14 | com.sec.android.app.sbrowser vc 1260103502 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/chromeOfflinePages.py
+++ b/scripts/artifacts/chromeOfflinePages.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/app_chrome/Default/Offline Pages/metadata/OfflinePages.db*', '*/app_sbrowser/Default/Offline Pages/metadata/OfflinePages.db*', '*/app_webview/Default/Offline Pages/metadata/OfflinePages.db*'),
         "output_types": "standard",
         "artifact_icon": "cloud-download",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.android.chrome vc 733915533 | 7 rows",
+            "galaxys10_a10": "Android 10 | com.android.chrome vc 438910534 | 4 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.android.chrome vc 782711433, com.brave.browser vc 429117204 | 2 rows",
+            "kevin_pocox7_a15": "Android 15 | com.android.chrome vc 733920733 | 2 rows",
+            "pixel7a_a14": "Android 14 | com.android.chrome vc 616710133, com.brave.browser vc 426712324, com.microsoft.emmx vc 259210005 | 8 rows",
+            "samsunga53_a14": "Android 14 | com.android.chrome vc 744417133 | 12 rows",
+            "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233, com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 7 rows",
+            "sharon_a14": "Android 14 | com.android.chrome vc 653310333 | 38 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/chromeTopSites.py
+++ b/scripts/artifacts/chromeTopSites.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/app_chrome/Default/Top Sites*', '*/app_sbrowser/Default/Top Sites*', '*/app_opera/Top Sites*', '*/app_webview/Default/Top Sites*'),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "globe",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.android.chrome vc 733915533, com.sec.android.app.sbrowser vc 1280509502 | 0 rows",
+            "galaxys10_a10": "Android 10 | com.android.chrome vc 438910534 | 4 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.android.chrome vc 782711433, com.brave.browser vc 429117204, com.sec.android.app.sbrowser vc 1300067502 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.android.chrome vc 733920733 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.android.chrome vc 616710133, com.brave.browser vc 426712324, com.microsoft.emmx vc 259210005 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.android.chrome vc 744417133 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233, com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 0 rows",
+            "sharon_a14": "Android 14 | com.android.chrome vc 653310333, com.sec.android.app.sbrowser vc 1260103502 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/clipBoard.py
+++ b/scripts/artifacts/clipBoard.py
@@ -12,6 +12,13 @@ __artifacts_v2__ = {
         "paths": ('*/*clipboard/*/*'),
         "output_types": "standard",
         "artifact_icon": "clipboard",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.samsung.android.honeyboard vc 590202300 | 1 row",
+            "galaxys10_a10": "Android 10 | 10 rows",
+            "samsunga53_a14": "Android 14 | com.samsung.android.honeyboard | 3 rows",
+            "samsungs20_a13": "Android 13 | com.samsung.android.honeyboard | 0 rows",
+            "sharon_a14": "Android 14 | com.samsung.android.honeyboard vc 560051300 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/cmh.py
+++ b/scripts/artifacts/cmh.py
@@ -12,6 +12,12 @@ __artifacts_v2__ = {
         "paths": ('*/cmh.db',),
         "output_types": "all",
         "artifact_icon": "file",
+        "sample_data": {
+            "galaxys10_a10": "Android 10 | com.samsung.cmh | 32 rows",
+            "samsunga53_a14": "Android 14 | com.samsung.cmh | 2 rows",
+            "samsungs20_a13": "Android 13 | com.samsung.cmh | 15 rows",
+            "sharon_a14": "Android 14 | com.samsung.cmh | 1410 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/contacts.py
+++ b/scripts/artifacts/contacts.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.android.providers.contacts/databases/contact*', '*/com.sec.android.provider.logsprovider/databases/logs.db*', '*/com.samsung.android.providers.contacts/databases/contact*'),
         "output_types": ["html","tsv","lava"],
         "artifact_icon": "users",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.samsung.android.providers.contacts | 9 rows",
+            "galaxys10_a10": "Android 10 | com.samsung.android.providers.contacts | 3 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.android.providers.contacts | 2 rows",
+            "kevin_pocox7_a15": "Android 15 | com.android.providers.contacts | 19 rows",
+            "pixel7a_a14": "Android 14 | com.android.providers.contacts | 16 rows",
+            "samsunga53_a14": "Android 14 | com.samsung.android.providers.contacts | 12 rows",
+            "samsungs20_a13": "Android 13 | com.samsung.android.providers.contacts | 6 rows",
+            "sharon_a14": "Android 14 | com.samsung.android.providers.contacts | 31 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/deviceHealthServices_AppUsage.py
+++ b/scripts/artifacts/deviceHealthServices_AppUsage.py
@@ -12,6 +12,15 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.apps.turbo/shared_prefs/app_usage_stats.xml',),
         "output_types": "standard",
         "artifact_icon": "chart-bar",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.apps.turbo | 221 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.apps.turbo vc 10235989 | 744 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.turbo vc 10272287 | 794 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.turbo vc 10270262 | 1677 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.apps.turbo | 237 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.apps.turbo | 232 rows",
+            "sharon_a14": "Android 14 | com.google.android.apps.turbo vc 10261629 | 79 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/deviceHealthServices_Battery.py
+++ b/scripts/artifacts/deviceHealthServices_Battery.py
@@ -11,7 +11,16 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.google.android.apps.turbo/databases/turbo.db*',),
         "output_types": "all",
-        "artifact_icon": "battery-charging"
+        "artifact_icon": "battery-charging",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.apps.turbo | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.apps.turbo vc 10235989 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.turbo vc 10272287 | 397 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.turbo vc 10270262 | 1416 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.apps.turbo | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.apps.turbo | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.apps.turbo vc 10261629 | 0 rows",
+        }
     },
     "Turbo_Bluetooth": {
         "name": "Turbo - Bluetooth Device Info",
@@ -24,7 +33,12 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.google.android.apps.turbo/databases/bluetooth.db*',),
         "output_types": "all",
-        "artifact_icon": "bluetooth"
+        "artifact_icon": "bluetooth",
+        "sample_data": {
+            "galaxys10_a10": "Android 10 | com.google.android.apps.turbo vc 10235989 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.apps.turbo | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.apps.turbo vc 10261629 | 0 rows",
+        }
     }
 }
 

--- a/scripts/artifacts/discordChats.py
+++ b/scripts/artifacts/discordChats.py
@@ -12,6 +12,11 @@ __artifacts_v2__ = {
         "paths": ('*/data/com.discord/files/kv-storage/*/a*',),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.discord vc 333012 | 7 rows",
+            "pixel7a_a14": "Android 14 | com.discord vc 239015 | 47 rows",
+            "samsungs20_a13": "Android 13 | com.discord vc 310011 | 1 row",
+        },
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Channel ID",

--- a/scripts/artifacts/discreteNative.py
+++ b/scripts/artifacts/discreteNative.py
@@ -12,6 +12,14 @@ __artifacts_v2__ = {
         "paths": ('*/system/appops/discrete/**',),
         "output_types": "standard",
         "artifact_icon": "file",
+        "sample_data": {
+            "anne_a15": "Android 15 | 1886 rows",
+            "kevin_pocox7_a15": "Android 15 | 1720 rows",
+            "pixel7a_a14": "Android 14 | 1948 rows",
+            "samsunga53_a14": "Android 14 | 13 rows",
+            "samsungs20_a13": "Android 13 | 41 rows",
+            "sharon_a14": "Android 14 | 281 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/downloads.py
+++ b/scripts/artifacts/downloads.py
@@ -11,6 +11,16 @@ __artifacts_v2__ = {
         "paths": ('*/data/com.android.providers.downloads/databases/downloads.db*'),
         "output_types": "standard",
         "artifact_icon": "download",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.android.providers.downloads | 14 rows",
+            "galaxys10_a10": "Android 10 | com.android.providers.downloads | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.android.providers.downloads | 18 rows",
+            "kevin_pocox7_a15": "Android 15 | com.android.providers.downloads | 23 rows",
+            "pixel7a_a14": "Android 14 | com.android.providers.downloads | 6 rows",
+            "samsunga53_a14": "Android 14 | com.android.providers.downloads | 11 rows",
+            "samsungs20_a13": "Android 13 | com.android.providers.downloads | 2 rows",
+            "sharon_a14": "Android 14 | com.android.providers.downloads | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/emulatedSmeta.py
+++ b/scripts/artifacts/emulatedSmeta.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.providers.media.module/databases/external.db*', '*/com.android.providers.media/databases/external.db*'),
         "output_types": "standard",
         "artifact_icon": "download",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.providers.media.module | 0 rows",
+            "galaxys10_a10": "Android 10 | com.android.providers.media | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.providers.media.module | 12 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.providers.media.module | 30 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.providers.media.module | 74 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.providers.media.module | 1 row",
+            "samsungs20_a13": "Android 13 | com.google.android.providers.media.module | 5 rows",
+            "sharon_a14": "Android 14 | com.google.android.providers.media.module | 122 rows",
+        },
     },
     "get_emulatedSmeta_images": {
         "name": "Emulated Storage Metadata - Images",
@@ -25,6 +35,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.providers.media.module/databases/external.db*', '*/com.android.providers.media/databases/external.db*'),
         "output_types": "standard",
         "artifact_icon": "photo",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.providers.media.module | 212 rows",
+            "galaxys10_a10": "Android 10 | com.android.providers.media | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.providers.media.module | 18 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.providers.media.module | 330 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.providers.media.module | 193 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.providers.media.module | 2 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.providers.media.module | 15 rows",
+            "sharon_a14": "Android 14 | com.google.android.providers.media.module | 1410 rows",
+        },
     },
     "get_emulatedSmeta_files": {
         "name": "Emulated Storage Metadata - Files",
@@ -38,6 +58,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.providers.media.module/databases/external.db*', '*/com.android.providers.media/databases/external.db*'),
         "output_types": "standard",
         "artifact_icon": "file",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.providers.media.module | 369 rows",
+            "galaxys10_a10": "Android 10 | com.android.providers.media | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.providers.media.module | 207 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.providers.media.module | 660 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.providers.media.module | 364 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.providers.media.module | 26 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.providers.media.module | 133 rows",
+            "sharon_a14": "Android 14 | com.google.android.providers.media.module | 1938 rows",
+        },
     },
     "get_emulatedSmeta_videos": {
         "name": "Emulated Storage Metadata - Videos",
@@ -51,6 +81,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.providers.media.module/databases/external.db*', '*/com.android.providers.media/databases/external.db*'),
         "output_types": "standard",
         "artifact_icon": "video",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.providers.media.module | 11 rows",
+            "galaxys10_a10": "Android 10 | com.android.providers.media | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.providers.media.module | 3 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.providers.media.module | 90 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.providers.media.module | 9 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.providers.media.module | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.providers.media.module | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.providers.media.module | 29 rows",
+        },
     },
     "get_emulatedSmeta_audio": {
         "name": "Emulated Storage Metadata - Audio",
@@ -64,6 +104,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.providers.media.module/databases/external.db*', '*/com.android.providers.media/databases/external.db*'),
         "output_types": "standard",
         "artifact_icon": "music",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.providers.media.module | 2 rows",
+            "galaxys10_a10": "Android 10 | com.android.providers.media | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.providers.media.module | 1 row",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.providers.media.module | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.providers.media.module | 14 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.providers.media.module | 1 row",
+            "samsungs20_a13": "Android 13 | com.google.android.providers.media.module | 1 row",
+            "sharon_a14": "Android 14 | com.google.android.providers.media.module | 2 rows",
+        },
     },
     "get_emulatedSmeta_files_legacy": {
         "name": "Emulated Storage Metadata - Files (Legacy)",
@@ -77,6 +127,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.providers.media.module/databases/external.db*', '*/com.android.providers.media/databases/external.db*'),
         "output_types": "standard",
         "artifact_icon": "file",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.providers.media.module | 0 rows",
+            "galaxys10_a10": "Android 10 | com.android.providers.media | 64 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.providers.media.module | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.providers.media.module | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.providers.media.module | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.providers.media.module | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.providers.media.module | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.providers.media.module | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/etc_hosts.py
+++ b/scripts/artifacts/etc_hosts.py
@@ -12,6 +12,13 @@ __artifacts_v2__ = {
         "paths": ('*/system/etc/hosts',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "file",
+        "sample_data": {
+            "galaxys10_a10": "Android 10 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | 0 rows",
+            "pixel7a_a14": "Android 14 | 0 rows",
+            "samsunga53_a14": "Android 14 | 0 rows",
+            "sharon_a14": "Android 14 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/factory_reset.py
+++ b/scripts/artifacts/factory_reset.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/misc/bootstat/factory_reset'),
         "output_types": "standard",
         "artifact_icon": "loader",
+        "sample_data": {
+            "anne_a15": "Android 15 | 1 row",
+            "galaxys10_a10": "Android 10 | 1 row",
+            "hc_pixel8pro_a16": "Android 16 | 1 row",
+            "kevin_pocox7_a15": "Android 15 | 1 row",
+            "pixel7a_a14": "Android 14 | 1 row",
+            "samsunga53_a14": "Android 14 | 1 row",
+            "samsungs20_a13": "Android 13 | 1 row",
+            "sharon_a14": "Android 14 | 1 row",
+        },
     }
 }
 

--- a/scripts/artifacts/firefox.py
+++ b/scripts/artifacts/firefox.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/org.mozilla.firefox/files/places.sqlite*',),
         "output_types": "standard",
         "artifact_icon": "globe",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | org.mozilla.firefox vc 2016030615 | 7 rows",
+        },
     },
     "get_firefox_visits": {
         "name": "Firefox - Web Visits",
@@ -25,6 +28,9 @@ __artifacts_v2__ = {
         "paths": ('*/org.mozilla.firefox/files/places.sqlite*',),
         "output_types": "standard",
         "artifact_icon": "globe",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | org.mozilla.firefox vc 2016030615 | 8 rows",
+        },
     },
     "get_firefox_bookmarks": {
         "name": "Firefox - Bookmarks",
@@ -38,6 +44,9 @@ __artifacts_v2__ = {
         "paths": ('*/org.mozilla.firefox/files/places.sqlite*',),
         "output_types": "standard",
         "artifact_icon": "bookmark",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | org.mozilla.firefox vc 2016030615 | 5 rows",
+        },
     },
     "get_firefox_searches": {
         "name": "Firefox - Search Terms",
@@ -51,6 +60,9 @@ __artifacts_v2__ = {
         "paths": ('*/org.mozilla.firefox/files/places.sqlite*',),
         "output_types": "standard",
         "artifact_icon": "search",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | org.mozilla.firefox vc 2016030615 | 2 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/firefoxCookies.py
+++ b/scripts/artifacts/firefoxCookies.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/org.mozilla.firefox/files/mozilla/*.default/cookies.sqlite*',),
         "output_types": "standard",
         "artifact_icon": "globe",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | org.mozilla.firefox vc 2016030615 | 95 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/firefoxDownloads.py
+++ b/scripts/artifacts/firefoxDownloads.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/org.mozilla.firefox/databases/mozac_downloads_database*',),
         "output_types": "standard",
         "artifact_icon": "globe",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | org.mozilla.firefox vc 2016030615 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/firefoxFormHistory.py
+++ b/scripts/artifacts/firefoxFormHistory.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/org.mozilla.firefox/files/mozilla/*.default/formhistory.sqlite*',),
         "output_types": "standard",
         "artifact_icon": "globe",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | org.mozilla.firefox vc 2016030615 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/firefoxPermissions.py
+++ b/scripts/artifacts/firefoxPermissions.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/org.mozilla.firefox/files/mozilla/*.default/permissions.sqlite*',),
         "output_types": "standard",
         "artifact_icon": "globe",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | org.mozilla.firefox vc 2016030615 | 5 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/firefoxRecentlyClosedTabs.py
+++ b/scripts/artifacts/firefoxRecentlyClosedTabs.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/org.mozilla.firefox/databases/recently_closed_tabs*',),
         "output_types": "standard",
         "artifact_icon": "globe",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | org.mozilla.firefox vc 2016030615 | 1 row",
+        },
     }
 }
 

--- a/scripts/artifacts/firefoxTopSites.py
+++ b/scripts/artifacts/firefoxTopSites.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/org.mozilla.firefox/databases/top_sites*',),
         "output_types": "standard",
         "artifact_icon": "globe",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | org.mozilla.firefox vc 2016030615 | 3 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/frosting.py
+++ b/scripts/artifacts/frosting.py
@@ -11,7 +11,17 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.android.vending/databases/frosting.db*'),
         "output_types": "standard",
-        "artifact_icon": "package"
+        "artifact_icon": "package",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.android.vending vc 84801930 | 555 rows",
+            "galaxys10_a10": "Android 10 | com.android.vending vc 82481710 | 445 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.android.vending vc 85180930 | 428 rows",
+            "kevin_pocox7_a15": "Android 15 | com.android.vending vc 84812830 | 464 rows",
+            "pixel7a_a14": "Android 14 | com.android.vending vc 84191730 | 407 rows",
+            "samsunga53_a14": "Android 14 | com.android.vending vc 84913330 | 527 rows",
+            "samsungs20_a13": "Android 13 | com.android.vending vc 84962330 | 507 rows",
+            "sharon_a14": "Android 14 | com.android.vending vc 84222730 | 541 rows",
+        }
     }
 }
 

--- a/scripts/artifacts/galleryTrash.py
+++ b/scripts/artifacts/galleryTrash.py
@@ -13,6 +13,13 @@ __artifacts_v2__ = {
                   '*/data/com.sec.android.gallery3d/files/.Trash/**'),
         "output_types": "all",
         "artifact_icon": "photo",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.sec.android.gallery3d vc 1550500003 | 0 rows",
+            "galaxys10_a10": "Android 10 | com.sec.android.gallery3d | 0 rows",
+            "samsunga53_a14": "Android 14 | com.sec.android.gallery3d | 0 rows",
+            "samsungs20_a13": "Android 13 | com.sec.android.gallery3d vc 1450000033 | 0 rows",
+            "sharon_a14": "Android 14 | com.sec.android.gallery3d vc 1500100001 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/garmin.py
+++ b/scripts/artifacts/garmin.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/data/com.garmin.android.apps.connectmobile/databases/gcm_cache.db*',),
         "output_types": "all",
         "artifact_icon": "activity",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.garmin.android.apps.connectmobile vc 8806 | 0 rows",
+        },
     },
     "get_garmin_devices": {
         "name": "Garmin - Devices",
@@ -25,6 +28,9 @@ __artifacts_v2__ = {
         "paths": ('*/data/com.garmin.android.apps.connectmobile/databases/gcm_cache.db*',),
         "output_types": "standard",
         "artifact_icon": "device-watch",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.garmin.android.apps.connectmobile vc 8806 | 1 row",
+        },
     },
     "get_garmin_weather": {
         "name": "Garmin - Weather",
@@ -38,6 +44,9 @@ __artifacts_v2__ = {
         "paths": ('*/data/com.garmin.android.apps.connectmobile/databases/gcm_cache.db*',),
         "output_types": "all",
         "artifact_icon": "cloud",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.garmin.android.apps.connectmobile vc 8806 | 0 rows",
+        },
     },
     "get_garmin_notification_details": {
         "name": "Garmin - Notification Details",
@@ -53,6 +62,9 @@ __artifacts_v2__ = {
         "paths": ('*/data/com.garmin.android.apps.connectmobile/databases/notification-database*',),
         "output_types": "standard",
         "artifact_icon": "bell",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.garmin.android.apps.connectmobile vc 8806 | 45 rows",
+        },
     },
     "get_garmin_cache_db_activities": {
         "name": "Garmin - Cache DB Activities",
@@ -66,6 +78,9 @@ __artifacts_v2__ = {
         "paths": ('*/data/com.garmin.android.apps.connectmobile/databases/cache-database*',),
         "output_types": "all",
         "artifact_icon": "activity",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.garmin.android.apps.connectmobile vc 8806 | 0 rows",
+        },
     },
     "get_garmin_sleep_activities": {
         "name": "Garmin - Sleep Activities",
@@ -80,6 +95,9 @@ __artifacts_v2__ = {
         "paths": ('*/data/com.garmin.android.apps.connectmobile/databases/cache-database*',),
         "output_types": "standard",
         "artifact_icon": "moon",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.garmin.android.apps.connectmobile vc 8806 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/gboard.py
+++ b/scripts/artifacts/gboard.py
@@ -13,6 +13,11 @@ __artifacts_v2__ = {
                   '*/com.google.android.inputmethod.latin/files/clipboard_image/*'),
         "output_types": "standard",
         "artifact_icon": "clipboard",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.inputmethod.latin vc 175827782 | 4 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.inputmethod.latin vc 175401514 | 4 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.inputmethod.latin vc 128278094 | 4 rows",
+        },
     },
     "get_gboardCache_keystrokes": {
         "name": "Gboard - Keystroke Cache",
@@ -26,6 +31,11 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.inputmethod.latin/databases/trainingcache*.db',),
         "output_types": "standard",
         "artifact_icon": "brand-chrome",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.inputmethod.latin vc 175827782 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.inputmethod.latin vc 175401514 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.inputmethod.latin vc 128278094 | 0 rows",
+        },
     },
     "get_gboardCache_sessions": {
         "name": "Gboard - Sessions",
@@ -39,6 +49,11 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.inputmethod.latin/databases/trainingcachev3.db',),
         "output_types": "standard",
         "artifact_icon": "brand-chrome",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.inputmethod.latin vc 175827782 | 12 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.inputmethod.latin vc 175401514 | 359 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.inputmethod.latin vc 128278094 | 230 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/gmail.py
+++ b/scripts/artifacts/gmail.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.gm/shared_prefs/Gmail.xml',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "mail",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gm vc 65346694 | 1 row",
+            "galaxys10_a10": "Android 10 | com.google.android.gm vc 62632206 | 1 row",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gm vc 65800239 | 1 row",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gm vc 65346694 | 1 row",
+            "pixel7a_a14": "Android 14 | com.google.android.gm vc 64361093 | 1 row",
+            "samsunga53_a14": "Android 14 | com.google.android.gm vc 65429598 | 1 row",
+            "samsungs20_a13": "Android 13 | com.google.android.gm vc 65465122 | 1 row",
+            "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 1 row",
+        },
     }
 }
 

--- a/scripts/artifacts/gmailEmails.py
+++ b/scripts/artifacts/gmailEmails.py
@@ -13,6 +13,14 @@ __artifacts_v2__ = {
         "output_types": "standard",
         "html_columns": ["Message"],
         "artifact_icon": "inbox",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gm vc 65346694 | 200 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gm vc 65800239 | 201 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gm vc 65346694 | 206 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gm vc 64361093 | 206 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gm vc 65429598 | 112 rows",
+            "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 207 rows",
+        },
     },
     "gmailLabels": {
         "name": "Gmail - Label Details",
@@ -26,6 +34,16 @@ __artifacts_v2__ = {
         "paths": ('*/data/com.google.android.gm/databases/bigTopDataDB.*','*/data/com.google.android.gm/files/downloads/*/attachments/*/*.*'),
         "output_types": ["html","tsv","lava"],
         "artifact_icon": "mail",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gm vc 65346694 | 32 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gm vc 62632206 | 30 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gm vc 65800239 | 33 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gm vc 65346694 | 32 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gm vc 64361093 | 32 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gm vc 65429598 | 66 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gm vc 65465122 | 33 rows",
+            "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 32 rows",
+        },
     },
     "gmailDownloadRequests": {
         "name": "Gmail - Download Requests",
@@ -39,6 +57,12 @@ __artifacts_v2__ = {
         "paths": ('*/data/com.google.android.gm/databases/downloader.db*'),
         "output_types": "standard",
         "artifact_icon": "download",
+        "sample_data": {
+            "galaxys10_a10": "Android 10 | com.google.android.gm vc 62632206 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gm vc 64361093 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gm vc 65429598 | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/gmailIMAPEmails.py
+++ b/scripts/artifacts/gmailIMAPEmails.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "output_types": "standard",
         "html_columns": ["Body(HTML)"],
         "artifact_icon": "inbox",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gm vc 65346694 | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gm vc 62632206 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gm vc 65800239 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gm vc 65346694 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gm vc 64361093 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gm vc 65429598 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gm vc 65465122 | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 0 rows",
+        },
     },
     "gmailIMAPAccounts": {
         "name": "Gmail - IMAP Accounts",
@@ -24,7 +34,17 @@ __artifacts_v2__ = {
         "notes": "", 
         "paths": ('*/data/com.google.android.gm/databases/EmailProvider.*'), 
         "output_types": "standard",
-        "artifact_icon": "user", 
+        "artifact_icon": "user",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gm vc 65346694 | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gm vc 62632206 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gm vc 65800239 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gm vc 65346694 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gm vc 64361093 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gm vc 65429598 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gm vc 65465122 | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 0 rows",
+        }, 
     }
 }
 

--- a/scripts/artifacts/googleCalendar.py
+++ b/scripts/artifacts/googleCalendar.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.android.providers.calendar/databases/calendar.db*',),
         "output_types": "standard",
         "artifact_icon": "calendar",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.android.providers.calendar | 0 rows",
+            "galaxys10_a10": "Android 10 | com.android.providers.calendar | 1 row",
+            "hc_pixel8pro_a16": "Android 16 | com.android.providers.calendar | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.android.providers.calendar | 62 rows",
+            "pixel7a_a14": "Android 14 | com.android.providers.calendar | 0 rows",
+            "samsunga53_a14": "Android 14 | com.android.providers.calendar | 0 rows",
+            "samsungs20_a13": "Android 13 | com.android.providers.calendar | 1 row",
+            "sharon_a14": "Android 14 | com.android.providers.calendar | 0 rows",
+        },
     },
     "get_calendar_calendars": {
         "name": "Calendar - Calendars",
@@ -25,6 +35,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.android.providers.calendar/databases/calendar.db*',),
         "output_types": "standard",
         "artifact_icon": "calendar",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.android.providers.calendar | 4 rows",
+            "galaxys10_a10": "Android 10 | com.android.providers.calendar | 3 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.android.providers.calendar | 1 row",
+            "kevin_pocox7_a15": "Android 15 | com.android.providers.calendar | 4 rows",
+            "pixel7a_a14": "Android 14 | com.android.providers.calendar | 1 row",
+            "samsunga53_a14": "Android 14 | com.android.providers.calendar | 5 rows",
+            "samsungs20_a13": "Android 13 | com.android.providers.calendar | 3 rows",
+            "sharon_a14": "Android 14 | com.android.providers.calendar | 4 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/googleCallScreen.py
+++ b/scripts/artifacts/googleCallScreen.py
@@ -13,6 +13,11 @@ __artifacts_v2__ = {
                   '*/com.google.android.dialer/files/callscreenrecordings/*.*'),
         "output_types": "standard",
         "artifact_icon": "phone",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.dialer vc 19806568 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.dialer vc 19106378 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.dialer vc 15435008 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/googleCast.py
+++ b/scripts/artifacts/googleCast.py
@@ -11,6 +11,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.gms/databases/cast.db*'),
         "output_types": "standard",
         "artifact_icon": "cast",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 1 row",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/googleChat.py
+++ b/scripts/artifacts/googleChat.py
@@ -14,6 +14,16 @@ __artifacts_v2__ = {
                   '*/com.google.android.apps.dynamite/databases/user_accounts/*/dynamite.db*'),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gm vc 65346694 | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gm vc 62632206 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gm vc 65800239 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gm vc 65346694 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.dynamite vc 5349480, com.google.android.gm vc 64361093 | 37 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.apps.dynamite vc 6281014, com.google.android.gm vc 65429598 | 54 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gm vc 65465122 | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 0 rows",
+        },
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Group ID",
@@ -40,6 +50,16 @@ __artifacts_v2__ = {
                   '*/com.google.android.apps.dynamite/databases/user_accounts/*/dynamite.db*'),
         "output_types": "standard",
         "artifact_icon": "users",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gm vc 65346694 | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gm vc 62632206 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gm vc 65800239 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gm vc 65346694 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.dynamite vc 5349480, com.google.android.gm vc 64361093 | 2 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.apps.dynamite vc 6281014, com.google.android.gm vc 65429598 | 3 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gm vc 65465122 | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 0 rows",
+        },
     },
     "get_googleChat_drafts": {
         "name": "Google Chat - Drafts",
@@ -55,6 +75,16 @@ __artifacts_v2__ = {
                   '*/com.google.android.apps.dynamite/databases/user_accounts/*/dynamite.db*'),
         "output_types": "standard",
         "artifact_icon": "edit",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gm vc 65346694 | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gm vc 62632206 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gm vc 65800239 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gm vc 65346694 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.dynamite vc 5349480, com.google.android.gm vc 64361093 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.apps.dynamite vc 6281014, com.google.android.gm vc 65429598 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gm vc 65465122 | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 0 rows",
+        },
     },
     "get_googleChat_users": {
         "name": "Google Chat - Users",
@@ -70,6 +100,16 @@ __artifacts_v2__ = {
                   '*/com.google.android.apps.dynamite/databases/user_accounts/*/dynamite.db*'),
         "output_types": "standard",
         "artifact_icon": "user",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gm vc 65346694 | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gm vc 62632206 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gm vc 65800239 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gm vc 65346694 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.dynamite vc 5349480, com.google.android.gm vc 64361093 | 12 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.apps.dynamite vc 6281014, com.google.android.gm vc 65429598 | 6 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gm vc 65465122 | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/googleDuo.py
+++ b/scripts/artifacts/googleDuo.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.apps.tachyon/databases/tachyon.db*',),
         "output_types": "standard",
         "artifact_icon": "phone-call",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.apps.tachyon vc 6541446 | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.apps.tachyon vc 3048502 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.tachyon vc 7312843 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.apps.tachyon vc 6559219 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.tachyon vc 4857491 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.apps.tachyon vc 6691613 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.apps.tachyon vc 6745781 | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.apps.tachyon vc 5494470 | 0 rows",
+        },
     },
     "get_googleDuo_contacts": {
         "name": "Google Duo - Contacts",
@@ -25,6 +35,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.apps.tachyon/databases/tachyon.db*',),
         "output_types": "standard",
         "artifact_icon": "users",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.apps.tachyon vc 6541446 | 8 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.apps.tachyon vc 3048502 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.tachyon vc 7312843 | 2 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.apps.tachyon vc 6559219 | 13 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.tachyon vc 4857491 | 1 row",
+            "samsunga53_a14": "Android 14 | com.google.android.apps.tachyon vc 6691613 | 1 row",
+            "samsungs20_a13": "Android 13 | com.google.android.apps.tachyon vc 6745781 | 4 rows",
+            "sharon_a14": "Android 14 | com.google.android.apps.tachyon vc 5494470 | 26 rows",
+        },
     },
     "get_googleDuo_notes": {
         "name": "Google Duo - Notes",
@@ -39,6 +59,16 @@ __artifacts_v2__ = {
                   '*/com.google.android.apps.tachyon/files/media/*.*'),
         "output_types": "standard",
         "artifact_icon": "photo",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.apps.tachyon vc 6541446 | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.apps.tachyon vc 3048502 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.tachyon vc 7312843 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.apps.tachyon vc 6559219 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.tachyon vc 4857491 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.apps.tachyon vc 6691613 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.apps.tachyon vc 6745781 | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.apps.tachyon vc 5494470 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/googleFitGMS.py
+++ b/scripts/artifacts/googleFitGMS.py
@@ -11,6 +11,13 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.gms/databases/fitness.db.*'),
         "output_types": "standard",
         "artifact_icon": "activity",
+        "sample_data": {
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 33 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/googleInitiatedNav.py
+++ b/scripts/artifacts/googleInitiatedNav.py
@@ -13,6 +13,9 @@ __artifacts_v2__ = {
                   '*/new_recent_history_cache_navigated.cs'),
         "output_types": "standard",
         "artifact_icon": "map-pin",
+        "sample_data": {
+            "kevin_pocox7_a15": "Android 15 | com.google.android.apps.maps vc 1068243484 | 4 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/googleKeepNotes.py
+++ b/scripts/artifacts/googleKeepNotes.py
@@ -12,6 +12,11 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.keep/databases/keep.db*',),
         "output_types": "standard",
         "artifact_icon": "file-text",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.keep vc 220663535 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.keep vc 220627544 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.keep vc 220548335 | 0 rows",
+        },
     },
     "get_googleKeepNotes_sharing": {
         "name": "Google Keep - Notes Sharing",
@@ -25,6 +30,11 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.keep/databases/keep.db*',),
         "output_types": "standard",
         "artifact_icon": "share-2",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.keep vc 220663535 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.keep vc 220627544 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.keep vc 220548335 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/googleLastTrip.py
+++ b/scripts/artifacts/googleLastTrip.py
@@ -12,6 +12,13 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.apps.maps/files/saved_directions.data.cs',),
         "output_types": "all",
         "artifact_icon": "map-pin",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.apps.maps vc 1068243484 | 2 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.apps.maps vc 1064201040 | 2 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.apps.maps vc 1068243484 | 2 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.maps vc 1067620099 | 2 rows",
+            "sharon_a14": "Android 14 | com.google.android.apps.maps vc 1067648704 | 2 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/googleMapsGmm.py
+++ b/scripts/artifacts/googleMapsGmm.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.apps.maps/databases/gmm_storage.db',),
         "output_types": "standard",
         "artifact_icon": "map-pin",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.apps.maps vc 1068243484 | 13 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.apps.maps vc 1064201040 | 2 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.maps vc 1068624404 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.apps.maps vc 1068243484 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.maps vc 1067620099 | 4 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.apps.maps vc 1068326445 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.apps.maps vc 1068347331 | 1 row",
+            "sharon_a14": "Android 14 | com.google.android.apps.maps vc 1067648704 | 0 rows",
+        },
     },
     "get_googleMapsGmm_places": {
         "name": "Google Maps Label Places",
@@ -25,6 +35,15 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.apps.maps/databases/gmm_myplaces.db',),
         "output_types": "all",
         "artifact_icon": "map-pin",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.apps.maps vc 1068243484 | 1 row",
+            "galaxys10_a10": "Android 10 | com.google.android.apps.maps vc 1064201040 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.maps vc 1068624404 | 1 row",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.apps.maps vc 1068243484 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.maps vc 1067620099 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.apps.maps vc 1068347331 | 1 row",
+            "sharon_a14": "Android 14 | com.google.android.apps.maps vc 1067648704 | 1 row",
+        },
     }
 }
 

--- a/scripts/artifacts/googleMapsSearches.py
+++ b/scripts/artifacts/googleMapsSearches.py
@@ -12,6 +12,13 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.apps.maps/files/new_recent_history_cache_search.cs',),
         "output_types": "all",
         "artifact_icon": "map-pin",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.apps.maps vc 1068243484 | 7 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.apps.maps vc 1064201040 | 10 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.maps vc 1067620099 | 6 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.apps.maps vc 1068347331 | 1 row",
+            "sharon_a14": "Android 14 | com.google.android.apps.maps vc 1067648704 | 8 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/googleMessages.py
+++ b/scripts/artifacts/googleMessages.py
@@ -12,6 +12,15 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.apps.messaging/databases/bugle_db*',),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.apps.messaging vc 289151900 | 94 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.messaging vc 311755063 | 81 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.apps.messaging vc 289151063 | 243 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.messaging vc 238308063 | 1123 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.apps.messaging vc 292971900 | 135 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.apps.messaging vc 293261063 | 40 rows",
+            "sharon_a14": "Android 14 | com.google.android.apps.messaging vc 161637900 | 0 rows",
+        },
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Conversation ID",

--- a/scripts/artifacts/googlePhotos.py
+++ b/scripts/artifacts/googlePhotos.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.apps.photos/databases/gphotos*.db*',),
         "output_types": "all",
         "artifact_icon": "photo",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.apps.photos vc 50280016 | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.apps.photos vc 36652547 | 64 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.photos vc 51832862 | 25 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.apps.photos vc 50765150 | 468 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.photos vc 48906608 | 202 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.apps.photos vc 50989980 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.apps.photos vc 51079548 | 24 rows",
+            "sharon_a14": "Android 14 | com.google.android.apps.photos vc 48388495 | 336 rows",
+        },
     },
     "get_googlePhotos_remote": {
         "name": "Google Photos - Remote Media",
@@ -25,6 +35,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.apps.photos/databases/gphotos*.db*',),
         "output_types": "all",
         "artifact_icon": "photo",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.apps.photos vc 50280016 | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.apps.photos vc 36652547 | 24 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.photos vc 51832862 | 23 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.apps.photos vc 50765150 | 645 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.photos vc 48906608 | 204 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.apps.photos vc 50989980 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.apps.photos vc 51079548 | 7 rows",
+            "sharon_a14": "Android 14 | com.google.android.apps.photos vc 48388495 | 0 rows",
+        },
     },
     "get_googlePhotos_shared": {
         "name": "Google Photos - Shared Media",
@@ -38,6 +58,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.apps.photos/databases/gphotos*.db*',),
         "output_types": "standard",
         "artifact_icon": "photo",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.apps.photos vc 50280016 | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.apps.photos vc 36652547 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.photos vc 51832862 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.apps.photos vc 50765150 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.photos vc 48906608 | 6 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.apps.photos vc 50989980 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.apps.photos vc 51079548 | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.apps.photos vc 48388495 | 0 rows",
+        },
     },
     "get_googlePhotos_folders": {
         "name": "Google Photos - Backed Up Folders",
@@ -51,6 +81,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.apps.photos/databases/gphotos*.db*',),
         "output_types": "standard",
         "artifact_icon": "folder",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.apps.photos vc 50280016 | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.apps.photos vc 36652547 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.photos vc 51832862 | 1 row",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.apps.photos vc 50765150 | 8 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.photos vc 48906608 | 3 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.apps.photos vc 50989980 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.apps.photos vc 51079548 | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.apps.photos vc 48388495 | 0 rows",
+        },
     },
     "get_googlePhotos_cache": {
         "name": "Google Photos - Cache",
@@ -65,6 +105,16 @@ __artifacts_v2__ = {
                   '*/com.google.android.apps.photos/cache/glide_cache/*'),
         "output_types": "standard",
         "artifact_icon": "photo",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.apps.photos vc 50280016 | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.apps.photos vc 36652547 | 88 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.photos vc 51832862 | 166 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.apps.photos vc 50765150 | 1833 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.photos vc 48906608 | 1058 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.apps.photos vc 50989980 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.apps.photos vc 51079548 | 43 rows",
+            "sharon_a14": "Android 14 | com.google.android.apps.photos vc 48388495 | 68 rows",
+        },
     },
     "get_googlePhotos_trash": {
         "name": "Google Photos - Local Trash",
@@ -79,6 +129,16 @@ __artifacts_v2__ = {
                   '*/com.google.android.apps.photos/files/trash_files/*'),
         "output_types": "standard",
         "artifact_icon": "trash",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.apps.photos vc 50280016 | 0 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.apps.photos vc 36652547 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.photos vc 51832862 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.apps.photos vc 50765150 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.photos vc 48906608 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.apps.photos vc 50989980 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.apps.photos vc 51079548 | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.apps.photos vc 48388495 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/googlePlaySearches.py
+++ b/scripts/artifacts/googlePlaySearches.py
@@ -11,7 +11,17 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.android.vending/databases/suggestions.db*'),
         "output_types": "standard",
-        'artifact_icon': 'search'
+        'artifact_icon': 'search',
+        "sample_data": {
+            "anne_a15": "Android 15 | com.android.vending vc 84801930 | 4 rows",
+            "galaxys10_a10": "Android 10 | com.android.vending vc 82481710 | 5 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.android.vending vc 85180930 | 34 rows",
+            "kevin_pocox7_a15": "Android 15 | com.android.vending vc 84812830 | 23 rows",
+            "pixel7a_a14": "Android 14 | com.android.vending vc 84191730 | 48 rows",
+            "samsunga53_a14": "Android 14 | com.android.vending vc 84913330 | 26 rows",
+            "samsungs20_a13": "Android 13 | com.android.vending vc 84962330 | 21 rows",
+            "sharon_a14": "Android 14 | com.android.vending vc 84222730 | 25 rows",
+        }
     }
 }
 

--- a/scripts/artifacts/googleQuickSearchbox.py
+++ b/scripts/artifacts/googleQuickSearchbox.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.googlequicksearchbox/app_session/*.binarypb',),
         "output_types": "standard",
         "artifact_icon": "search",
+        "sample_data": {
+            "sharon_a14": "Android 14 | com.google.android.googlequicksearchbox vc 301381725 | 1 row",
+        },
     }
 }
 

--- a/scripts/artifacts/googleQuickSearchboxRecent.py
+++ b/scripts/artifacts/googleQuickSearchboxRecent.py
@@ -14,6 +14,13 @@ __artifacts_v2__ = {
                   '*/com.google.android.googlequicksearchbox/databases/accounts.notifications.db'),
         "output_types": "standard",
         "artifact_icon": "search",
+        "sample_data": {
+            "galaxys10_a10": "Android 10 | com.google.android.googlequicksearchbox vc 301139116 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.googlequicksearchbox vc 301302075 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.googlequicksearchbox vc 301639434 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.googlequicksearchbox vc 301671258 | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.googlequicksearchbox vc 301381725 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/googleVoice.py
+++ b/scripts/artifacts/googleVoice.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/data/com.google.android.apps.googlevoice/files/AccountData.pb', '*/data/com.google.android.apps.googlevoice/files/accounts/*/SqliteKeyValueCache:VoiceAccountCache.db*'),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "user",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.google.android.apps.googlevoice vc 3579017 | 1 row",
+        },
     },
     "googlevoice_calls": {
         "name": "Google Voice - Calls",
@@ -25,6 +28,9 @@ __artifacts_v2__ = {
         "paths": ('*/data/com.google.android.apps.googlevoice/files/accounts/*/LegacyMsgDbInstance.db*', '*/data/com.google.android.apps.googlevoice/cache/audio/*'),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "phone",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.google.android.apps.googlevoice vc 3579017 | 4 rows",
+        },
     },
     "googlevoice_voicemails": {
         "name": "Google Voice - Voicemails",
@@ -38,6 +44,9 @@ __artifacts_v2__ = {
         "paths": ('*/data/com.google.android.apps.googlevoice/files/accounts/*/LegacyMsgDbInstance.db*', '*/data/com.google.android.apps.googlevoice/cache/audio/*'),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "record-mail",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.google.android.apps.googlevoice vc 3579017 | 1 row",
+        },
     },
     "googlevoice_messages": {
         "name": "Google Voice - Messages",
@@ -51,6 +60,14 @@ __artifacts_v2__ = {
         "paths": ('*/data/com.google.android.apps.googlevoice/files/accounts/*/LegacyMsgDbInstance.db*', '*/data/com.google.android.apps.googlevoice/cache/Photo MMS images/*', '*/data/com.samsung.android.providers.contacts/databases/contact*'),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "user",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.samsung.android.providers.contacts | 0 rows",
+            "galaxys10_a10": "Android 10 | com.samsung.android.providers.contacts | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.googlevoice vc 3579017 | 14 rows",
+            "samsunga53_a14": "Android 14 | com.samsung.android.providers.contacts | 0 rows",
+            "samsungs20_a13": "Android 13 | com.samsung.android.providers.contacts | 0 rows",
+            "sharon_a14": "Android 14 | com.samsung.android.providers.contacts | 0 rows",
+        },
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Conversation ID",

--- a/scripts/artifacts/googlemapaudio.py
+++ b/scripts/artifacts/googlemapaudio.py
@@ -12,6 +12,13 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.apps.maps/app_tts-cache/*_*',),
         "output_types": "standard",
         "artifact_icon": "map-pin",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.apps.maps vc 1068243484 | 480 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.apps.maps vc 1064201040 | 25 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.apps.maps vc 1068243484 | 359 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.maps vc 1067620099 | 301 rows",
+            "sharon_a14": "Android 14 | com.google.android.apps.maps vc 1067648704 | 362 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/googlemapaudioTemp.py
+++ b/scripts/artifacts/googlemapaudioTemp.py
@@ -12,6 +12,13 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.apps.maps/app_tts-temp/**',),
         "output_types": "standard",
         "artifact_icon": "map-pin",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.apps.maps vc 1068243484 | 85 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.apps.maps vc 1064201040 | 7 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.apps.maps vc 1068243484 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.maps vc 1067620099 | 6 rows",
+            "sharon_a14": "Android 14 | com.google.android.apps.maps vc 1067648704 | 13 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/groupMe.py
+++ b/scripts/artifacts/groupMe.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.groupme.android/databases/groupme.db',),
         "output_types": "standard",
         "artifact_icon": "users",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.groupme.android vc 240460204 | 1 row",
+        },
     },
     "get_groupMe_chat": {
         "name": "GroupMe - Chat Information",
@@ -25,6 +28,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.groupme.android/databases/groupme.db',),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.groupme.android vc 240460204 | 86 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/imagemngCache.py
+++ b/scripts/artifacts/imagemngCache.py
@@ -11,6 +11,16 @@ __artifacts_v2__ = {
         "paths": ('*/cache/image_manager_disk_cache/*.*', '*/*.cnt'),
         "output_types": "standard",
         "artifact_icon": "photo",
+        "sample_data": {
+            "anne_a15": "Android 15 | 1895 rows",
+            "galaxys10_a10": "Android 10 | 1140 rows",
+            "hc_pixel8pro_a16": "Android 16 | 1219 rows",
+            "kevin_pocox7_a15": "Android 15 | 21306 rows",
+            "pixel7a_a14": "Android 14 | 6018 rows",
+            "samsunga53_a14": "Android 14 | 6610 rows",
+            "samsungs20_a13": "Android 13 | 3164 rows",
+            "sharon_a14": "Android 14 | 2597 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/imo.py
+++ b/scripts/artifacts/imo.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.imo.android.imous/databases/accountdb.db*',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "user",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.imo.android.imous vc 2043 | 1 row",
+        },
     },
     "get_imo_messages": {
         "name": "IMO - Messages",
@@ -25,6 +28,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.imo.android.imous/databases/imofriends.db*',),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.imo.android.imous vc 2043 | 22 rows",
+        },
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Chat Partner",

--- a/scripts/artifacts/installedappsGass.py
+++ b/scripts/artifacts/installedappsGass.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.gms/databases/gass.db*', '*/user/*/com.google.android.gms/databases/gass.db*'),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "package",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 408 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 81 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 696 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 1310 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 214 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 404 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 240 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 1585 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/installedappsLibrary.py
+++ b/scripts/artifacts/installedappsLibrary.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.android.vending/databases/library.db*',),
         "output_types": "standard",
         "artifact_icon": "package",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.android.vending vc 84801930 | 73 rows",
+            "galaxys10_a10": "Android 10 | com.android.vending vc 82481710 | 62 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.android.vending vc 85180930 | 116 rows",
+            "kevin_pocox7_a15": "Android 15 | com.android.vending vc 84812830 | 69 rows",
+            "pixel7a_a14": "Android 14 | com.android.vending vc 84191730 | 145 rows",
+            "samsunga53_a14": "Android 14 | com.android.vending vc 84913330 | 384 rows",
+            "samsungs20_a13": "Android 13 | com.android.vending vc 84962330 | 162 rows",
+            "sharon_a14": "Android 14 | com.android.vending vc 84222730 | 99 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/installedappsVending.py
+++ b/scripts/artifacts/installedappsVending.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.android.vending/databases/localappstate.db*',),
         "output_types": "standard",
         "artifact_icon": "package",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.android.vending vc 84801930 | 93 rows",
+            "galaxys10_a10": "Android 10 | com.android.vending vc 82481710 | 56 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.android.vending vc 85180930 | 147 rows",
+            "kevin_pocox7_a15": "Android 15 | com.android.vending vc 84812830 | 97 rows",
+            "pixel7a_a14": "Android 14 | com.android.vending vc 84191730 | 155 rows",
+            "samsunga53_a14": "Android 14 | com.android.vending vc 84913330 | 204 rows",
+            "samsungs20_a13": "Android 13 | com.android.vending vc 84962330 | 150 rows",
+            "sharon_a14": "Android 14 | com.android.vending vc 84222730 | 122 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/keepNotes.py
+++ b/scripts/artifacts/keepNotes.py
@@ -12,6 +12,11 @@ __artifacts_v2__ = {
         "paths": ('*/data/com.google.android.keep/databases/keep.db*',),
         "output_types": "standard",
         "artifact_icon": "file-text",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.keep vc 220663535 | 1 row",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.keep vc 220627544 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.keep vc 220548335 | 2 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/last_boot_time.py
+++ b/scripts/artifacts/last_boot_time.py
@@ -1,3 +1,4 @@
+# pylint: disable=W0611,W0613,W0621,W0631
 __artifacts_v2__ = {
     "last_boot_time": {
         "name": "Last Boot Time",
@@ -11,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/misc/bootstat/last_boot_time_utc'),
         "output_types": "standard",
         "artifact_icon": "power",
+        "sample_data": {
+            "anne_a15": "Android 15 | 1 row",
+            "galaxys10_a10": "Android 10 | 1 row",
+            "hc_pixel8pro_a16": "Android 16 | 1 row",
+            "kevin_pocox7_a15": "Android 15 | 1 row",
+            "pixel7a_a14": "Android 14 | 1 row",
+            "samsunga53_a14": "Android 14 | 1 row",
+            "samsungs20_a13": "Android 13 | 1 row",
+            "sharon_a14": "Android 14 | 1 row",
+        },
     }
 }
 

--- a/scripts/artifacts/lgRCS.py
+++ b/scripts/artifacts/lgRCS.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/mmssms.db*',),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.android.providers.telephony | 0 rows",
+            "galaxys10_a10": "Android 10 | com.android.providers.telephony | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.android.providers.telephony | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.android.providers.telephony | 0 rows",
+            "pixel7a_a14": "Android 14 | com.android.providers.telephony | 0 rows",
+            "samsunga53_a14": "Android 14 | com.android.providers.telephony | 0 rows",
+            "samsungs20_a13": "Android 13 | com.android.providers.telephony | 0 rows",
+            "sharon_a14": "Android 14 | com.android.providers.telephony | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/line.py
+++ b/scripts/artifacts/line.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/jp.naver.line.android/databases/**',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "users",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | jp.naver.line.android vc 141220285 | 0 rows",
+        },
     },
     "get_line_messages": {
         "name": "Line - Messages",
@@ -25,6 +28,9 @@ __artifacts_v2__ = {
         "paths": ('*/jp.naver.line.android/databases/**',),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | jp.naver.line.android vc 141220285 | 0 rows",
+        },
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Thread ID",
@@ -48,6 +54,9 @@ __artifacts_v2__ = {
         "paths": ('*/jp.naver.line.android/databases/**',),
         "output_types": "standard",
         "artifact_icon": "phone-call",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | jp.naver.line.android vc 141220285 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/mastodon.py
+++ b/scripts/artifacts/mastodon.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/org.joinmastodon.android/databases/*.db*',),
         "output_types": "standard",
         "artifact_icon": "search",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | org.joinmastodon.android vc 93 | 0 rows",
+        },
     },
     "get_mastodon_account_searches": {
         "name": "Mastodon - Account Searches",
@@ -25,6 +28,9 @@ __artifacts_v2__ = {
         "paths": ('*/org.joinmastodon.android/databases/*.db*',),
         "output_types": "standard",
         "artifact_icon": "search",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | org.joinmastodon.android vc 93 | 1 row",
+        },
     },
     "get_mastodon_notifications": {
         "name": "Mastodon - Notifications",
@@ -38,6 +44,9 @@ __artifacts_v2__ = {
         "paths": ('*/org.joinmastodon.android/databases/*.db*',),
         "output_types": "standard",
         "artifact_icon": "bell",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | org.joinmastodon.android vc 93 | 6 rows",
+        },
     },
     "get_mastodon_timeline": {
         "name": "Mastodon - Timeline",
@@ -51,6 +60,9 @@ __artifacts_v2__ = {
         "paths": ('*/org.joinmastodon.android/databases/*.db*',),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | org.joinmastodon.android vc 93 | 2 rows",
+        },
     },
     "get_mastodon_accounts": {
         "name": "Mastodon - Account Details",
@@ -64,6 +76,9 @@ __artifacts_v2__ = {
         "paths": ('*/org.joinmastodon.android/files/accounts.json',),
         "output_types": "standard",
         "artifact_icon": "user",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | org.joinmastodon.android vc 93 | 1 row",
+        },
     },
     "get_mastodon_instance": {
         "name": "Mastodon - Instance Details",
@@ -77,6 +92,9 @@ __artifacts_v2__ = {
         "paths": ('*/org.joinmastodon.android/files/instance*.json',),
         "output_types": "standard",
         "artifact_icon": "server",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | org.joinmastodon.android vc 93 | 1 row",
+        },
     }
 }
 

--- a/scripts/artifacts/mega.py
+++ b/scripts/artifacts/mega.py
@@ -12,6 +12,10 @@ __artifacts_v2__ = {
         "paths": ('*/mega.privacy.android.app/karere-*.db*',),
         "output_types": "standard",
         "artifact_icon": "download",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | mega.privacy.android.app vc 261630858 | 20 rows",
+            "pixel7a_a14": "Android 14 | mega.privacy.android.app vc 241780257 | 83 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/mega_transfers.py
+++ b/scripts/artifacts/mega_transfers.py
@@ -12,6 +12,10 @@ __artifacts_v2__ = {
         "paths": ('*/mega.privacy.android.app/databases/megapreferences',),
         "output_types": "standard",
         "artifact_icon": "download",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | mega.privacy.android.app vc 261630858 | 0 rows",
+            "pixel7a_a14": "Android 14 | mega.privacy.android.app vc 241780257 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/mewe.py
+++ b/scripts/artifacts/mewe.py
@@ -36,6 +36,10 @@ __artifacts_v2__ = {
         "paths": ('*/com.mewe/shared_prefs/SGSession.xml',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "key",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.mewe vc 90017000 | 27 rows",
+            "pixel7a_a14": "Android 14 | com.mewe vc 80116099 | 25 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/notificationHistory.py
+++ b/scripts/artifacts/notificationHistory.py
@@ -13,6 +13,11 @@ __artifacts_v2__ = {
         "paths": ('**/system_ce/*/notification_history/history/*',),
         "output_types": "standard",
         "artifact_icon": "bell",
+        "sample_data": {
+            "anne_a15": "Android 15 | 286 rows",
+            "samsunga53_a14": "Android 14 | 0 rows",
+            "sharon_a14": "Android 14 | 44 rows",
+        },
     },
     "get_notificationHistory_status": {
         "name": "Android Notification History - Status",
@@ -26,6 +31,16 @@ __artifacts_v2__ = {
         "paths": ('**/system/users/*/settings_secure.xml',),
         "output_types": "standard",
         "artifact_icon": "toggle-right",
+        "sample_data": {
+            "anne_a15": "Android 15 | 1 row",
+            "galaxys10_a10": "Android 10 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | 1 row",
+            "kevin_pocox7_a15": "Android 15 | 1 row",
+            "pixel7a_a14": "Android 14 | 1 row",
+            "samsunga53_a14": "Android 14 | 0 rows",
+            "samsungs20_a13": "Android 13 | 0 rows",
+            "sharon_a14": "Android 14 | 0 rows",
+        },
     },
     "get_notificationHistory_snoozed": {
         "name": "Android Notification History - Snoozed",
@@ -39,6 +54,16 @@ __artifacts_v2__ = {
         "paths": ('**/system/notification_policy.xml',),
         "output_types": "standard",
         "artifact_icon": "clock",
+        "sample_data": {
+            "anne_a15": "Android 15 | 0 rows",
+            "galaxys10_a10": "Android 10 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | 0 rows",
+            "pixel7a_a14": "Android 14 | 0 rows",
+            "samsunga53_a14": "Android 14 | 0 rows",
+            "samsungs20_a13": "Android 13 | 0 rows",
+            "sharon_a14": "Android 14 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/offlinePages.py
+++ b/scripts/artifacts/offlinePages.py
@@ -11,6 +11,16 @@ __artifacts_v2__ = {
         "paths": ('*/*.mhtml', '*/*.mht'),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.android.chrome vc 733915533 | 7 rows",
+            "galaxys10_a10": "Android 10 | com.android.chrome vc 438910534 | 4 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.android.chrome vc 782711433, com.brave.browser vc 429117204 | 2 rows",
+            "kevin_pocox7_a15": "Android 15 | com.android.chrome vc 733920733 | 2 rows",
+            "pixel7a_a14": "Android 14 | com.android.chrome vc 616710133, com.brave.browser vc 426712324, com.microsoft.emmx vc 259210005 | 8 rows",
+            "samsunga53_a14": "Android 14 | com.android.chrome vc 744417133 | 12 rows",
+            "samsungs20_a13": "Android 13 | com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 7 rows",
+            "sharon_a14": "Android 14 | com.android.chrome vc 653310333 | 37 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/oldpowerOffReset.py
+++ b/scripts/artifacts/oldpowerOffReset.py
@@ -12,6 +12,11 @@ __artifacts_v2__ = {
         "paths": ('*/log/power_off_reset_reason.txt', '*/log/power_off_reset_reason_backup.txt'),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "battery",
+        "sample_data": {
+            "galaxys10_a10": "Android 10 | 10 rows",
+            "samsungs20_a13": "Android 13 | 6 rows",
+            "sharon_a14": "Android 14 | 10 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/pSettings.py
+++ b/scripts/artifacts/pSettings.py
@@ -12,6 +12,13 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.gsf/databases/googlesettings.db*',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "settings",
+        "sample_data": {
+            "galaxys10_a10": "Android 10 | com.google.android.gsf | 13 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gsf | 18 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gsf | 57 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gsf | 33 rows",
+            "sharon_a14": "Android 14 | com.google.android.gsf | 18 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/packageGplinks.py
+++ b/scripts/artifacts/packageGplinks.py
@@ -12,6 +12,15 @@ __artifacts_v2__ = {
         "paths": ('*/system/packages.list',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "package",
+        "sample_data": {
+            "anne_a15": "Android 15 | 513 rows",
+            "galaxys10_a10": "Android 10 | 448 rows",
+            "hc_pixel8pro_a16": "Android 16 | 385 rows",
+            "kevin_pocox7_a15": "Android 15 | 426 rows",
+            "pixel7a_a14": "Android 14 | 369 rows",
+            "samsungs20_a13": "Android 13 | 506 rows",
+            "sharon_a14": "Android 14 | 499 rows",
+        },
         "html_columns": ['Possible Google Play Store Link'],
     }
 }

--- a/scripts/artifacts/packageInfo.py
+++ b/scripts/artifacts/packageInfo.py
@@ -12,6 +12,15 @@ __artifacts_v2__ = {
         "paths": ('*/system/packages.xml',),
         "output_types": "standard",
         "artifact_icon": "package",
+        "sample_data": {
+            "anne_a15": "Android 15 | 513 rows",
+            "galaxys10_a10": "Android 10 | 448 rows",
+            "hc_pixel8pro_a16": "Android 16 | 385 rows",
+            "kevin_pocox7_a15": "Android 15 | 426 rows",
+            "pixel7a_a14": "Android 14 | 369 rows",
+            "samsunga53_a14": "Android 14 | 486 rows",
+            "sharon_a14": "Android 14 | 499 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/permissions.py
+++ b/scripts/artifacts/permissions.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/system/packages.xml',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "settings",
+        "sample_data": {
+            "anne_a15": "Android 15 | 1 row",
+            "galaxys10_a10": "Android 10 | 1 row",
+            "hc_pixel8pro_a16": "Android 16 | 1 row",
+            "kevin_pocox7_a15": "Android 15 | 1 row",
+            "pixel7a_a14": "Android 14 | 1 row",
+            "samsunga53_a14": "Android 14 | 1 row",
+            "samsungs20_a13": "Android 13 | 0 rows",
+            "sharon_a14": "Android 14 | 1 row",
+        },
     },
     "get_permissions_list": {
         "name": "Permissions",
@@ -25,6 +35,16 @@ __artifacts_v2__ = {
         "paths": ('*/system/packages.xml',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "settings",
+        "sample_data": {
+            "anne_a15": "Android 15 | 3060 rows",
+            "galaxys10_a10": "Android 10 | 1784 rows",
+            "hc_pixel8pro_a16": "Android 16 | 1970 rows",
+            "kevin_pocox7_a15": "Android 15 | 2107 rows",
+            "pixel7a_a14": "Android 14 | 1629 rows",
+            "samsunga53_a14": "Android 14 | 2651 rows",
+            "samsungs20_a13": "Android 13 | 0 rows",
+            "sharon_a14": "Android 14 | 2793 rows",
+        },
     },
     "get_permissions_packages": {
         "name": "Package and Shared User",
@@ -38,6 +58,16 @@ __artifacts_v2__ = {
         "paths": ('*/system/packages.xml',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "settings",
+        "sample_data": {
+            "anne_a15": "Android 15 | 0 rows",
+            "galaxys10_a10": "Android 10 | 6388 rows",
+            "hc_pixel8pro_a16": "Android 16 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | 0 rows",
+            "pixel7a_a14": "Android 14 | 0 rows",
+            "samsunga53_a14": "Android 14 | 0 rows",
+            "samsungs20_a13": "Android 13 | 0 rows",
+            "sharon_a14": "Android 14 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/persistentProp.py
+++ b/scripts/artifacts/persistentProp.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/property/persistent_properties',),
         "output_types": "standard",
         "artifact_icon": "info-circle",
+        "sample_data": {
+            "anne_a15": "Android 15 | 0 rows",
+            "galaxys10_a10": "Android 10 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | 0 rows",
+            "pixel7a_a14": "Android 14 | 0 rows",
+            "samsunga53_a14": "Android 14 | 0 rows",
+            "samsungs20_a13": "Android 13 | 2 rows",
+            "sharon_a14": "Android 14 | 1 row",
+        },
     }
 }
 

--- a/scripts/artifacts/pkgPredictions.py
+++ b/scripts/artifacts/pkgPredictions.py
@@ -12,6 +12,13 @@ __artifacts_v2__ = {
         "paths": ('*/system/PkgPredictions.db*',),
         "output_types": "standard",
         "artifact_icon": "package",
+        "sample_data": {
+            "anne_a15": "Android 15 | 483 rows",
+            "galaxys10_a10": "Android 10 | 295 rows",
+            "samsunga53_a14": "Android 14 | 158 rows",
+            "samsungs20_a13": "Android 13 | 407 rows",
+            "sharon_a14": "Android 14 | 443 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/powerOffReset.py
+++ b/scripts/artifacts/powerOffReset.py
@@ -11,6 +11,11 @@ __artifacts_v2__ = {
         "paths": ('*/log/power_off_reset_reason.txt','*/log/power_off_reset_reason_backup.txt'),
         "output_types": "standard",
         "artifact_icon": "power",
+        "sample_data": {
+            "galaxys10_a10": "Android 10 | 9 rows",
+            "samsungs20_a13": "Android 13 | 8 rows",
+            "sharon_a14": "Android 14 | 10 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/recentactivity.py
+++ b/scripts/artifacts/recentactivity.py
@@ -16,6 +16,16 @@ __artifacts_v2__ = {
                   '*/system_ce/*/recent_images/*/*'),
         "output_types": "standard",
         "artifact_icon": "activity",
+        "sample_data": {
+            "anne_a15": "Android 15 | 35 rows",
+            "galaxys10_a10": "Android 10 | 38 rows",
+            "hc_pixel8pro_a16": "Android 16 | 4 rows",
+            "kevin_pocox7_a15": "Android 15 | 21 rows",
+            "pixel7a_a14": "Android 14 | 5 rows",
+            "samsunga53_a14": "Android 14 | 37 rows",
+            "samsungs20_a13": "Android 13 | 36 rows",
+            "sharon_a14": "Android 14 | 13 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/roles.py
+++ b/scripts/artifacts/roles.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/system/users/*/roles.xml', '*/misc_de/*/apexdata/com.android.permission/roles.xml'),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "package",
+        "sample_data": {
+            "anne_a15": "Android 15 | 40 rows",
+            "galaxys10_a10": "Android 10 | 8 rows",
+            "hc_pixel8pro_a16": "Android 16 | 44 rows",
+            "kevin_pocox7_a15": "Android 15 | 40 rows",
+            "pixel7a_a14": "Android 14 | 38 rows",
+            "samsunga53_a14": "Android 14 | 76 rows",
+            "samsungs20_a13": "Android 13 | 63 rows",
+            "sharon_a14": "Android 14 | 38 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/runtimePerms.py
+++ b/scripts/artifacts/runtimePerms.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/system/users/*/runtime-permissions.xml', '*/misc_de/*/apexdata/com.android.permission/runtime-permissions.xml'),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "activity",
+        "sample_data": {
+            "anne_a15": "Android 15 | 12258 rows",
+            "galaxys10_a10": "Android 10 | 1005 rows",
+            "hc_pixel8pro_a16": "Android 16 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | 0 rows",
+            "pixel7a_a14": "Android 14 | 6661 rows",
+            "samsunga53_a14": "Android 14 | 21634 rows",
+            "samsungs20_a13": "Android 13 | 19872 rows",
+            "sharon_a14": "Android 14 | 11562 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/sRecoveryhist.py
+++ b/scripts/artifacts/sRecoveryhist.py
@@ -12,6 +12,12 @@ __artifacts_v2__ = {
         "paths": ('*/efs/recovery/history',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "file",
+        "sample_data": {
+            "anne_a15": "Android 15 | 0 rows",
+            "galaxys10_a10": "Android 10 | 4 rows",
+            "samsunga53_a14": "Android 14 | 0 rows",
+            "sharon_a14": "Android 14 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/sWipehist.py
+++ b/scripts/artifacts/sWipehist.py
@@ -12,6 +12,12 @@ __artifacts_v2__ = {
         "paths": ('*/efs/recovery/history', '*/data/log/recovery_history.log'),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "file",
+        "sample_data": {
+            "anne_a15": "Android 15 | 6 rows",
+            "galaxys10_a10": "Android 10 | 4 rows",
+            "samsunga53_a14": "Android 14 | 5 rows",
+            "sharon_a14": "Android 14 | 4 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/samsungSecureFolderHistoryLog.py
+++ b/scripts/artifacts/samsungSecureFolderHistoryLog.py
@@ -28,6 +28,13 @@ __artifacts_v2__ = {
         ),
         "output_types": "standard",
         "artifact_icon": "lock",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.samsung.knox.securefolder vc 192100000 | 0 rows",
+            "galaxys10_a10": "Android 10 | com.samsung.knox.securefolder | 0 rows",
+            "samsunga53_a14": "Android 14 | com.samsung.knox.securefolder | 0 rows",
+            "samsungs20_a13": "Android 13 | com.samsung.knox.securefolder | 0 rows",
+            "sharon_a14": "Android 14 | com.samsung.knox.securefolder vc 191200000 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/samsungWeatherClock.py
+++ b/scripts/artifacts/samsungWeatherClock.py
@@ -12,6 +12,13 @@ __artifacts_v2__ = {
         "paths": ('*/com.sec.android.daemonapp/databases/WeatherClock*',),
         "output_types": "standard",
         "artifact_icon": "cloud",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.sec.android.daemonapp | 5 rows",
+            "galaxys10_a10": "Android 10 | com.sec.android.daemonapp | 1 row",
+            "samsunga53_a14": "Android 14 | com.sec.android.daemonapp | 1 row",
+            "samsungs20_a13": "Android 13 | com.sec.android.daemonapp | 1 row",
+            "sharon_a14": "Android 14 | com.sec.android.daemonapp | 1 row",
+        },
     },
     "get_samsungWeatherClockDaily": {
         "name": "Samsung Weather Clock - Daily",
@@ -25,6 +32,13 @@ __artifacts_v2__ = {
         "paths": ('*/com.sec.android.daemonapp/databases/WeatherClock*',),
         "output_types": "standard",
         "artifact_icon": "cloud",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.sec.android.daemonapp | 40 rows",
+            "galaxys10_a10": "Android 10 | com.sec.android.daemonapp | 8 rows",
+            "samsunga53_a14": "Android 14 | com.sec.android.daemonapp | 8 rows",
+            "samsungs20_a13": "Android 13 | com.sec.android.daemonapp | 8 rows",
+            "sharon_a14": "Android 14 | com.sec.android.daemonapp | 8 rows",
+        },
     },
     "get_samsungWeatherClockHourly": {
         "name": "Samsung Weather Clock - Hourly",
@@ -38,6 +52,13 @@ __artifacts_v2__ = {
         "paths": ('*/com.sec.android.daemonapp/databases/WeatherClock*',),
         "output_types": "standard",
         "artifact_icon": "cloud",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.sec.android.daemonapp | 120 rows",
+            "galaxys10_a10": "Android 10 | com.sec.android.daemonapp | 24 rows",
+            "samsunga53_a14": "Android 14 | com.sec.android.daemonapp | 24 rows",
+            "samsungs20_a13": "Android 13 | com.sec.android.daemonapp | 24 rows",
+            "sharon_a14": "Android 14 | com.sec.android.daemonapp | 24 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/sbbmobile.py
+++ b/scripts/artifacts/sbbmobile.py
@@ -11,7 +11,10 @@ __artifacts_v2__ = {
         "paths": ('*/data/ch.sbb.mobile.*/databases/SbbMobile.db*'),
         "output_types": "standard",
         "html_columns": ['location of places (link)'],
-        "artifact_icon": "search"
+        "artifact_icon": "search",
+        "sample_data": {
+            "galaxys10_a10": "Android 10 | ch.sbb.mobile.android.b2c vc 111004052 | 0 rows",
+        }
     },
     "cff_search_history": {
         "name": "SBB Mobile - Search History",
@@ -25,7 +28,10 @@ __artifacts_v2__ = {
         "paths": ('*/data/ch.sbb.mobile.*/databases/SbbMobile.db*'),
         "output_types": "standard",
         "html_columns": ['location of search (link)'],
-        "artifact_icon": "search"
+        "artifact_icon": "search",
+        "sample_data": {
+            "galaxys10_a10": "Android 10 | ch.sbb.mobile.android.b2c vc 111004052 | 4 rows",
+        }
     },
     "cff_travel_cards": {
         "name": "SBB Mobile - Travel Cards",
@@ -38,7 +44,10 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/data/ch.sbb.mobile.*/databases/SbbMobile.db*'),
         "output_types": "standard",
-        "artifact_icon": "user"
+        "artifact_icon": "user",
+        "sample_data": {
+            "galaxys10_a10": "Android 10 | ch.sbb.mobile.android.b2c vc 111004052 | 0 rows",
+        }
     },
         "cff_purchased_tickets": {
         "name": "SBB Mobile - Ticket Purchased recently",
@@ -51,7 +60,10 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/data/ch.sbb.mobile.*/databases/SbbMobile.db*'),
         "output_types": "standard",
-        "artifact_icon": "star"
+        "artifact_icon": "star",
+        "sample_data": {
+            "galaxys10_a10": "Android 10 | ch.sbb.mobile.android.b2c vc 111004052 | 0 rows",
+        }
     }
 }
 

--- a/scripts/artifacts/settingsSecure.py
+++ b/scripts/artifacts/settingsSecure.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/system/users/*/settings_secure.xml',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "settings",
+        "sample_data": {
+            "anne_a15": "Android 15 | 4 rows",
+            "galaxys10_a10": "Android 10 | 4 rows",
+            "hc_pixel8pro_a16": "Android 16 | 4 rows",
+            "kevin_pocox7_a15": "Android 15 | 4 rows",
+            "pixel7a_a14": "Android 14 | 4 rows",
+            "samsunga53_a14": "Android 14 | 4 rows",
+            "samsungs20_a13": "Android 13 | 2 rows",
+            "sharon_a14": "Android 14 | 8 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/setupWizardinfo.py
+++ b/scripts/artifacts/setupWizardinfo.py
@@ -12,6 +12,10 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.settings.intelligence/shared_prefs/setup_wizard_info.xml',),
         "output_types": "standard",
         "artifact_icon": "info-circle",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.settings.intelligence vc 1000282241 | 1 row",
+            "pixel7a_a14": "Android 14 | com.google.android.settings.intelligence vc 1000230247 | 1 row",
+        },
     }
 }
 

--- a/scripts/artifacts/sharedProto.py
+++ b/scripts/artifacts/sharedProto.py
@@ -12,6 +12,11 @@ __artifacts_v2__ = {
         "paths": ('*/data/com.sec.android.app.sbrowser/app_sbrowser/Default/shared_proto_db/*',),
         "output_types": "standard",
         "artifact_icon": "file",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.sec.android.app.sbrowser vc 1280509502 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.sec.android.app.sbrowser vc 1300067502 | 0 rows",
+            "sharon_a14": "Android 14 | com.sec.android.app.sbrowser vc 1260103502 | 261 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/shutdown_checkpoints.py
+++ b/scripts/artifacts/shutdown_checkpoints.py
@@ -11,6 +11,11 @@ __artifacts_v2__ = {
         "paths": ('*/system/shutdown-checkpoints/checkpoints-*'),
         "output_types": "standard",
         "artifact_icon": "power",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | 61 rows",
+            "kevin_pocox7_a15": "Android 15 | 31 rows",
+            "pixel7a_a14": "Android 14 | 41 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/siminfo.py
+++ b/scripts/artifacts/siminfo.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/user_de/*/com.android.providers.telephony/databases/telephony.db',),
         "output_types": "standard",
         "artifact_icon": "info-circle",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.android.providers.telephony | 1 row",
+            "galaxys10_a10": "Android 10 | com.android.providers.telephony | 1 row",
+            "hc_pixel8pro_a16": "Android 16 | com.android.providers.telephony | 2 rows",
+            "kevin_pocox7_a15": "Android 15 | com.android.providers.telephony | 3 rows",
+            "pixel7a_a14": "Android 14 | com.android.providers.telephony | 1 row",
+            "samsunga53_a14": "Android 14 | com.android.providers.telephony | 2 rows",
+            "samsungs20_a13": "Android 13 | com.android.providers.telephony | 2 rows",
+            "sharon_a14": "Android 14 | com.android.providers.telephony | 2 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/smsmms.py
+++ b/scripts/artifacts/smsmms.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.android.providers.telephony/databases/mmssms*',),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.android.providers.telephony | 25 rows",
+            "galaxys10_a10": "Android 10 | com.android.providers.telephony | 32 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.android.providers.telephony | 62 rows",
+            "kevin_pocox7_a15": "Android 15 | com.android.providers.telephony | 87 rows",
+            "pixel7a_a14": "Android 14 | com.android.providers.telephony | 1031 rows",
+            "samsunga53_a14": "Android 14 | com.android.providers.telephony | 123 rows",
+            "samsungs20_a13": "Android 13 | com.android.providers.telephony | 35 rows",
+            "sharon_a14": "Android 14 | com.android.providers.telephony | 308 rows",
+        },
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Thread ID",
@@ -38,6 +48,16 @@ __artifacts_v2__ = {
                   '*/com.android.providers.telephony/parts/*'),
         "output_types": "standard",
         "artifact_icon": "photo",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.android.providers.telephony | 67 rows",
+            "galaxys10_a10": "Android 10 | com.android.providers.telephony | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.android.providers.telephony | 17 rows",
+            "kevin_pocox7_a15": "Android 15 | com.android.providers.telephony | 219 rows",
+            "pixel7a_a14": "Android 14 | com.android.providers.telephony | 91 rows",
+            "samsunga53_a14": "Android 14 | com.android.providers.telephony | 12 rows",
+            "samsungs20_a13": "Android 13 | com.android.providers.telephony | 6 rows",
+            "sharon_a14": "Android 14 | com.android.providers.telephony | 20 rows",
+        },
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Thread ID",

--- a/scripts/artifacts/smyFiles2.py
+++ b/scripts/artifacts/smyFiles2.py
@@ -12,6 +12,13 @@ __artifacts_v2__ = {
         "paths": ('*/com.sec.android.app.myfiles/databases/FileInfo.db',),
         "output_types": "standard",
         "artifact_icon": "download",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.sec.android.app.myfiles vc 1520402000 | 0 rows",
+            "galaxys10_a10": "Android 10 | com.sec.android.app.myfiles vc 1150303551 | 13 rows",
+            "samsunga53_a14": "Android 14 | com.sec.android.app.myfiles vc 1520402000 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.sec.android.app.myfiles | 0 rows",
+            "sharon_a14": "Android 14 | com.sec.android.app.myfiles vc 1500405000 | 0 rows",
+        },
     },
     "get_smyFiles2_gdrive": {
         "name": "My Files - Google Drive",
@@ -26,6 +33,13 @@ __artifacts_v2__ = {
                   '*/com.sec.android.app.myfiles/cache/*.*'),
         "output_types": "standard",
         "artifact_icon": "cloud",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.sec.android.app.myfiles vc 1520402000 | 0 rows",
+            "galaxys10_a10": "Android 10 | com.sec.android.app.myfiles vc 1150303551 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.sec.android.app.myfiles vc 1520402000 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.sec.android.app.myfiles | 0 rows",
+            "sharon_a14": "Android 14 | com.sec.android.app.myfiles vc 1500405000 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/smyfilesOpHistory.py
+++ b/scripts/artifacts/smyfilesOpHistory.py
@@ -12,6 +12,10 @@ __artifacts_v2__ = {
         "paths": ('*/com.sec.android.app.myfiles/databases/OperationHistory.db*',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "clock",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.sec.android.app.myfiles vc 1520402000 | 0 rows",
+            "sharon_a14": "Android 14 | com.sec.android.app.myfiles vc 1500405000 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/smyfilesRecents.py
+++ b/scripts/artifacts/smyfilesRecents.py
@@ -12,6 +12,13 @@ __artifacts_v2__ = {
         "paths": ('*/com.sec.android.app.myfiles/databases/myfiles.db*', '*/com.sec.android.app.myfiles/databases/FileInfo.db*'),
         "output_types": "standard",
         "artifact_icon": "file",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.sec.android.app.myfiles vc 1520402000 | 0 rows",
+            "galaxys10_a10": "Android 10 | com.sec.android.app.myfiles vc 1150303551 | 13 rows",
+            "samsunga53_a14": "Android 14 | com.sec.android.app.myfiles vc 1520402000 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.sec.android.app.myfiles | 0 rows",
+            "sharon_a14": "Android 14 | com.sec.android.app.myfiles vc 1500405000 | 0 rows",
+        },
     },
     "get_smyfilesRecents_fileinfo": {
         "name": "My Files - Recent Files (FileInfo)",
@@ -25,6 +32,13 @@ __artifacts_v2__ = {
         "paths": ('*/com.sec.android.app.myfiles/databases/myfiles.db*', '*/com.sec.android.app.myfiles/databases/FileInfo.db*'),
         "output_types": "standard",
         "artifact_icon": "file",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.sec.android.app.myfiles vc 1520402000 | 97 rows",
+            "galaxys10_a10": "Android 10 | com.sec.android.app.myfiles vc 1150303551 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.sec.android.app.myfiles vc 1520402000 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.sec.android.app.myfiles | 0 rows",
+            "sharon_a14": "Android 14 | com.sec.android.app.myfiles vc 1500405000 | 102 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/smyfilesStored.py
+++ b/scripts/artifacts/smyfilesStored.py
@@ -12,6 +12,12 @@ __artifacts_v2__ = {
         "paths": ('*/com.sec.android.app.myfiles/databases/FileCache.db*',),
         "output_types": "standard",
         "artifact_icon": "file",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.sec.android.app.myfiles vc 1520402000 | 2048 rows",
+            "galaxys10_a10": "Android 10 | com.sec.android.app.myfiles vc 1150303551 | 1024 rows",
+            "samsungs20_a13": "Android 13 | com.sec.android.app.myfiles | 2048 rows",
+            "sharon_a14": "Android 14 | com.sec.android.app.myfiles vc 1500405000 | 2048 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/smyfilescache.py
+++ b/scripts/artifacts/smyfilescache.py
@@ -13,6 +13,13 @@ __artifacts_v2__ = {
                   '*/com.sec.android.app.myfiles/cache/*.*'),
         "output_types": "standard",
         "artifact_icon": "file",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.sec.android.app.myfiles vc 1520402000 | 2048 rows",
+            "galaxys10_a10": "Android 10 | com.sec.android.app.myfiles vc 1150303551 | 1024 rows",
+            "samsunga53_a14": "Android 14 | com.sec.android.app.myfiles vc 1520402000 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.sec.android.app.myfiles | 2048 rows",
+            "sharon_a14": "Android 14 | com.sec.android.app.myfiles vc 1500405000 | 2048 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/snapchat.py
+++ b/scripts/artifacts/snapchat.py
@@ -7,6 +7,13 @@ __artifacts_v2__ = {
         "requirements": "none", "category": "Snapchat", "notes": "",
         "paths": ('*/com.snapchat.android/databases/main.db*', '*/com.snapchat.android/databases/tcspahn.db*'),
         "output_types": "standard", "artifact_icon": "rss",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.snapchat.android vc 295722 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.snapchat.android vc 238022 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.snapchat.android vc 147872 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.snapchat.android vc 260222 | 0 rows",
+            "sharon_a14": "Android 14 | com.snapchat.android vc 151972 | 0 rows",
+        },
     },
     "get_snapchat_friends": {
         "name": "Snapchat - Friends",
@@ -15,6 +22,13 @@ __artifacts_v2__ = {
         "requirements": "none", "category": "Snapchat", "notes": "",
         "paths": ('*/com.snapchat.android/databases/main.db*', '*/com.snapchat.android/databases/tcspahn.db*'),
         "output_types": "standard", "artifact_icon": "users",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.snapchat.android vc 295722 | 4 rows",
+            "kevin_pocox7_a15": "Android 15 | com.snapchat.android vc 238022 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.snapchat.android vc 147872 | 4 rows",
+            "samsungs20_a13": "Android 13 | com.snapchat.android vc 260222 | 0 rows",
+            "sharon_a14": "Android 14 | com.snapchat.android vc 151972 | 6 rows",
+        },
     },
     "get_snapchat_messages": {
         "name": "Snapchat - Messages",
@@ -23,6 +37,13 @@ __artifacts_v2__ = {
         "requirements": "none", "category": "Snapchat", "notes": "",
         "paths": ('*/com.snapchat.android/databases/main.db*', '*/com.snapchat.android/databases/tcspahn.db*'),
         "output_types": "standard", "artifact_icon": "message",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.snapchat.android vc 295722 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.snapchat.android vc 238022 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.snapchat.android vc 147872 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.snapchat.android vc 260222 | 0 rows",
+            "sharon_a14": "Android 14 | com.snapchat.android vc 151972 | 0 rows",
+        },
     },
     "get_snapchat_memories": {
         "name": "Snapchat - Memories",
@@ -31,6 +52,11 @@ __artifacts_v2__ = {
         "requirements": "none", "category": "Snapchat", "notes": "",
         "paths": ('*/com.snapchat.android/databases/memories.db*',),
         "output_types": "standard", "artifact_icon": "photo",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.snapchat.android vc 295722 | 4 rows",
+            "pixel7a_a14": "Android 14 | com.snapchat.android vc 147872 | 1 row",
+            "sharon_a14": "Android 14 | com.snapchat.android vc 151972 | 3 rows",
+        },
     },
     "get_snapchat_meo": {
         "name": "Snapchat - MEO My Eyes Only",
@@ -40,6 +66,11 @@ __artifacts_v2__ = {
         "notes": "Passcode recovery brute-forces the 4-digit MEO code (bcrypt); can be slow.",
         "paths": ('*/com.snapchat.android/databases/memories.db*',),
         "output_types": "standard", "artifact_icon": "eye-off",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.snapchat.android vc 295722 | 1 row",
+            "pixel7a_a14": "Android 14 | com.snapchat.android vc 147872 | 1 row",
+            "sharon_a14": "Android 14 | com.snapchat.android vc 151972 | 0 rows",
+        },
     },
     "get_snapchat_snap_media": {
         "name": "Snapchat - Snap Media",
@@ -48,6 +79,11 @@ __artifacts_v2__ = {
         "requirements": "none", "category": "Snapchat", "notes": "",
         "paths": ('*/com.snapchat.android/databases/memories.db*',),
         "output_types": "all", "artifact_icon": "photo",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.snapchat.android vc 295722 | 5 rows",
+            "pixel7a_a14": "Android 14 | com.snapchat.android vc 147872 | 1 row",
+            "sharon_a14": "Android 14 | com.snapchat.android vc 151972 | 3 rows",
+        },
     },
     "get_snapchat_identity": {
         "name": "Snapchat - Identity Persistent Store",
@@ -56,6 +92,13 @@ __artifacts_v2__ = {
         "requirements": "none", "category": "Snapchat", "notes": "",
         "paths": ('*/com.snapchat.android/shared_prefs/identity_persistent_store.xml',),
         "output_types": "standard", "artifact_icon": "user",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.snapchat.android vc 295722 | 12 rows",
+            "kevin_pocox7_a15": "Android 15 | com.snapchat.android vc 238022 | 10 rows",
+            "pixel7a_a14": "Android 14 | com.snapchat.android vc 147872 | 12 rows",
+            "samsungs20_a13": "Android 13 | com.snapchat.android vc 260222 | 13 rows",
+            "sharon_a14": "Android 14 | com.snapchat.android vc 151972 | 12 rows",
+        },
     },
     "get_snapchat_login_signup": {
         "name": "Snapchat - Login Signup Store",
@@ -64,6 +107,13 @@ __artifacts_v2__ = {
         "requirements": "none", "category": "Snapchat", "notes": "",
         "paths": ('*/com.snapchat.android/shared_prefs/LoginSignupStore.xml',),
         "output_types": "standard", "artifact_icon": "login-2",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.snapchat.android vc 295722 | 2 rows",
+            "kevin_pocox7_a15": "Android 15 | com.snapchat.android vc 238022 | 2 rows",
+            "pixel7a_a14": "Android 14 | com.snapchat.android vc 147872 | 3 rows",
+            "samsungs20_a13": "Android 13 | com.snapchat.android vc 260222 | 2 rows",
+            "sharon_a14": "Android 14 | com.snapchat.android vc 151972 | 1 row",
+        },
     }
 }
 

--- a/scripts/artifacts/suggestions.py
+++ b/scripts/artifacts/suggestions.py
@@ -12,6 +12,10 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.settings.intelligence/shared_prefs/suggestions.xml',),
         "output_types": "standard",
         "artifact_icon": "clock",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.settings.intelligence vc 1000282241 | 2 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.settings.intelligence vc 1000230247 | 3 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/swellbeing.py
+++ b/scripts/artifacts/swellbeing.py
@@ -12,6 +12,13 @@ __artifacts_v2__ = {
         "paths": ('*/com.samsung.android.forest/databases/dwbCommon.db*',),
         "output_types": "standard",
         "artifact_icon": "battery",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.samsung.android.forest | 2410 rows",
+            "galaxys10_a10": "Android 10 | com.samsung.android.forest | 11382 rows",
+            "samsunga53_a14": "Android 14 | com.samsung.android.forest | 6921 rows",
+            "samsungs20_a13": "Android 13 | com.samsung.android.forest | 554 rows",
+            "sharon_a14": "Android 14 | com.samsung.android.forest vc 510200008 | 3187 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/teams.py
+++ b/scripts/artifacts/teams.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.microsoft.teams/databases/SkypeTeams.db*',),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.microsoft.teams vc 2024132725 | 32 rows",
+        },
     },
     "get_teams_users": {
         "name": "Teams - Users",
@@ -25,6 +28,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.microsoft.teams/databases/SkypeTeams.db*',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "users",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.microsoft.teams vc 2024132725 | 3 rows",
+        },
     },
     "get_teams_calllog": {
         "name": "Teams - Call Log",
@@ -38,6 +44,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.microsoft.teams/databases/SkypeTeams.db*',),
         "output_types": "standard",
         "artifact_icon": "phone-call",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.microsoft.teams vc 2024132725 | 2 rows",
+        },
     },
     "get_teams_activity": {
         "name": "Teams - Activity Feed",
@@ -51,6 +60,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.microsoft.teams/databases/SkypeTeams.db*',),
         "output_types": "standard",
         "artifact_icon": "activity",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.microsoft.teams vc 2024132725 | 0 rows",
+        },
     },
     "get_teams_fileinfo": {
         "name": "Teams - File Info",
@@ -64,6 +76,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.microsoft.teams/databases/SkypeTeams.db*',),
         "output_types": "standard",
         "artifact_icon": "file",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.microsoft.teams vc 2024132725 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/teleguard.py
+++ b/scripts/artifacts/teleguard.py
@@ -13,6 +13,10 @@ __artifacts_v2__ = {
                   '*/data/ch.swisscows.messenger.teleguardapp/cache/**'),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | ch.swisscows.messenger.teleguardapp vc 176 | 2 rows",
+            "pixel7a_a14": "Android 14 | ch.swisscows.messenger.teleguardapp vc 162 | 42 rows",
+        },
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Chat ID",
@@ -37,6 +41,10 @@ __artifacts_v2__ = {
         "paths": ('*/data/ch.swisscows.messenger.teleguardapp/app_flutter/teleguard_database.db*',),
         "output_types": "standard",
         "artifact_icon": "file-text",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | ch.swisscows.messenger.teleguardapp vc 176 | 0 rows",
+            "pixel7a_a14": "Android 14 | ch.swisscows.messenger.teleguardapp vc 162 | 0 rows",
+        },
     },
     "get_teleguard_contacts": {
         "name": "Teleguard - Contacts",
@@ -50,6 +58,10 @@ __artifacts_v2__ = {
         "paths": ('*/data/ch.swisscows.messenger.teleguardapp/app_flutter/teleguard_database.db*',),
         "output_types": "standard",
         "artifact_icon": "users",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | ch.swisscows.messenger.teleguardapp vc 176 | 2 rows",
+            "pixel7a_a14": "Android 14 | ch.swisscows.messenger.teleguardapp vc 162 | 5 rows",
+        },
     },
     "get_teleguard_channels": {
         "name": "Teleguard - Channels",
@@ -63,6 +75,10 @@ __artifacts_v2__ = {
         "paths": ('*/data/ch.swisscows.messenger.teleguardapp/app_flutter/teleguard_database.db*',),
         "output_types": "standard",
         "artifact_icon": "radio",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | ch.swisscows.messenger.teleguardapp vc 176 | 0 rows",
+            "pixel7a_a14": "Android 14 | ch.swisscows.messenger.teleguardapp vc 162 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/tikTok.py
+++ b/scripts/artifacts/tikTok.py
@@ -12,6 +12,15 @@ __artifacts_v2__ = {
         "paths": ('*_im.db*', '*db_im_xx*'),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.zhiliaoapp.musically vc 2024108030 | 11 rows",
+            "galaxys10_a10": "Android 10 | com.zhiliaoapp.musically vc 2021809050 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.zhiliaoapp.musically vc 2024109030 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.zhiliaoapp.musically vc 2023507030 | 10 rows",
+            "samsunga53_a14": "Android 14 | com.bd.nproject vc 100203 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.zhiliaoapp.musically vc 2024301040 | 0 rows",
+            "sharon_a14": "Android 14 | com.zhiliaoapp.musically vc 2023600040 | 2 rows",
+        },
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Conversation ID",
@@ -35,6 +44,15 @@ __artifacts_v2__ = {
         "paths": ('*_im.db*', '*db_im_xx*'),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "users",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.zhiliaoapp.musically vc 2024108030 | 24 rows",
+            "galaxys10_a10": "Android 10 | com.zhiliaoapp.musically vc 2021809050 | 1 row",
+            "kevin_pocox7_a15": "Android 15 | com.zhiliaoapp.musically vc 2024109030 | 94 rows",
+            "pixel7a_a14": "Android 14 | com.zhiliaoapp.musically vc 2023507030 | 2 rows",
+            "samsunga53_a14": "Android 14 | com.bd.nproject vc 100203 | 0 rows",
+            "samsungs20_a13": "Android 13 | com.zhiliaoapp.musically vc 2024301040 | 2 rows",
+            "sharon_a14": "Android 14 | com.zhiliaoapp.musically vc 2023600040 | 8 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/ulrUserprefs.py
+++ b/scripts/artifacts/ulrUserprefs.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.gms/shared_prefs/ULR_USER_PREFS.xml',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "map-pin",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 15 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 13 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 15 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 15 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 14 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 81 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 28 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 15 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/usageapps.py
+++ b/scripts/artifacts/usageapps.py
@@ -13,6 +13,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.as/databases/reflection_gel_events.db*',),
         "output_types": "standard",
         "artifact_icon": "package",
+        "sample_data": {
+            "galaxys10_a10": "Android 10 | com.google.android.as vc 1353029 | 1063 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/usagestats.py
+++ b/scripts/artifacts/usagestats.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/system/usagestats/*', '*/system_ce/*/usagestats*'),
         "output_types": "standard",
         "artifact_icon": "battery",
+        "sample_data": {
+            "anne_a15": "Android 15 | 15346 rows",
+            "galaxys10_a10": "Android 10 | 11333 rows",
+            "hc_pixel8pro_a16": "Android 16 | 6843 rows",
+            "kevin_pocox7_a15": "Android 15 | 14995 rows",
+            "pixel7a_a14": "Android 14 | 35075 rows",
+            "samsunga53_a14": "Android 14 | 4954 rows",
+            "samsungs20_a13": "Android 13 | 15053 rows",
+            "sharon_a14": "Android 14 | 13398 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/usagestatsVersion.py
+++ b/scripts/artifacts/usagestatsVersion.py
@@ -10,7 +10,17 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/system/usagestats/*/version', '*/system_ce/*/usagestats/version'),
         "output_types": ["html", "tsv", "lava"],
-        "artifact_icon": "chart-bar"
+        "artifact_icon": "chart-bar",
+        "sample_data": {
+            "anne_a15": "Android 15 | 4 rows",
+            "galaxys10_a10": "Android 10 | 4 rows",
+            "hc_pixel8pro_a16": "Android 16 | 3 rows",
+            "kevin_pocox7_a15": "Android 15 | 3 rows",
+            "pixel7a_a14": "Android 14 | 3 rows",
+            "samsunga53_a14": "Android 14 | 4 rows",
+            "samsungs20_a13": "Android 13 | 4 rows",
+            "sharon_a14": "Android 14 | 4 rows",
+        }
     }
 }
 

--- a/scripts/artifacts/userDict.py
+++ b/scripts/artifacts/userDict.py
@@ -12,6 +12,15 @@ __artifacts_v2__ = {
         "paths": ('*/com.android.providers.userdictionary/databases/user_dict.db*',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "user",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.android.providers.userdictionary | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.android.providers.userdictionary | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.android.providers.userdictionary | 0 rows",
+            "pixel7a_a14": "Android 14 | com.android.providers.userdictionary | 0 rows",
+            "samsunga53_a14": "Android 14 | com.android.providers.userdictionary | 0 rows",
+            "samsungs20_a13": "Android 13 | com.android.providers.userdictionary | 0 rows",
+            "sharon_a14": "Android 14 | com.android.providers.userdictionary | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/walStrings.py
+++ b/scripts/artifacts/walStrings.py
@@ -11,6 +11,10 @@ __artifacts_v2__ = {
         "paths": ('*/*-wal', '*/*-journal'),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "file",
+        "sample_data": {
+            "galaxys10_a10": "Android 10 | 721 rows",
+            "samsunga53_a14": "Android 14 | 1916 rows",
+        },
         "html_columns": ['Report'],
     }
 }

--- a/scripts/artifacts/waze.py
+++ b/scripts/artifacts/waze.py
@@ -21,7 +21,11 @@ __artifacts_v2__ = {
                   "*/com.waze/waze/cached_data*"),
         "output_types": [ "standard" ],
         "html_columns": [ "Profile Picture URL" ],
-        "artifact_icon": "user"
+        "artifact_icon": "user",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.waze vc 1030478 | 2 rows",
+            "sharon_a14": "Android 14 | com.waze vc 1030483 | 2 rows",
+        }
     },
     "waze_session_info": {
         "name": "Waze - Session Info",
@@ -34,7 +38,11 @@ __artifacts_v2__ = {
         "notes": "https://djangofaiola.blogspot.com",
         "paths": ("*/com.waze/session"),
         "output_types": [ "all" ],
-        "artifact_icon": "navigation"
+        "artifact_icon": "navigation",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.waze vc 1030478 | 24 rows",
+            "sharon_a14": "Android 14 | com.waze vc 1030483 | 24 rows",
+        }
     },
     "waze_track_gps_quality": {
         "name": "Waze - Track GPS Quality",
@@ -49,7 +57,11 @@ __artifacts_v2__ = {
                   "*/com.waze/waze_log.txt",
                   "*/com.waze/*spdlog.logdata.gz"),
         "output_types": [ "all" ],
-        "artifact_icon": "navigation"
+        "artifact_icon": "navigation",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.waze vc 1030478 | 0 rows",
+            "sharon_a14": "Android 14 | com.waze vc 1030483 | 0 rows",
+        }
     },
     "waze_search_history": {
         "name": "Waze - Search History",
@@ -62,7 +74,11 @@ __artifacts_v2__ = {
         "notes": "https://djangofaiola.blogspot.com",
         "paths": ("*/com.waze/user.db*"),
         "output_types": [ "all" ],
-        "artifact_icon": "search"
+        "artifact_icon": "search",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.waze vc 1030478 | 4 rows",
+            "sharon_a14": "Android 14 | com.waze vc 1030483 | 3 rows",
+        }
     },
     "waze_recent_locations": {
         "name": "Waze - Recent Locations",
@@ -75,7 +91,11 @@ __artifacts_v2__ = {
         "notes": "https://djangofaiola.blogspot.com",
         "paths": ("*/com.waze/user.db*"),
         "output_types": [ "all" ],
-        "artifact_icon": "map-pin"
+        "artifact_icon": "map-pin",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.waze vc 1030478 | 4 rows",
+            "sharon_a14": "Android 14 | com.waze vc 1030483 | 3 rows",
+        }
     },
     "waze_favorite_locations": {
         "name": "Waze - Favorite Locations",
@@ -89,7 +109,11 @@ __artifacts_v2__ = {
         "paths": ("*/com.waze/user.db*",
                   "*/com.waze/waze/cached_data*"),                  
         "output_types": [ "all" ],
-        "artifact_icon": "star"
+        "artifact_icon": "star",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.waze vc 1030478 | 0 rows",
+            "sharon_a14": "Android 14 | com.waze vc 1030483 | 0 rows",
+        }
     },
     "waze_shared_locations": {
         "name": "Waze - Shared Locations",
@@ -102,7 +126,11 @@ __artifacts_v2__ = {
         "notes": "https://djangofaiola.blogspot.com",
         "paths": ("*/com.waze/user.db*"),
         "output_types": [ "all" ],
-        "artifact_icon": "map-pin"
+        "artifact_icon": "map-pin",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.waze vc 1030478 | 0 rows",
+            "sharon_a14": "Android 14 | com.waze vc 1030483 | 0 rows",
+        }
     },
     "waze_planned_events": {
         "name": "Waze - Planned Events",
@@ -116,7 +144,11 @@ __artifacts_v2__ = {
         "paths": ("*/com.waze/user.db*"),
         "output_types": [ "all" ],
         "html_columns": [ "Image URL" ],
-        "artifact_icon": "calendar"
+        "artifact_icon": "calendar",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.waze vc 1030478 | 0 rows",
+            "sharon_a14": "Android 14 | com.waze vc 1030483 | 0 rows",
+        }
     },
     "waze_tts": {
         "name": "Waze - Text-To-Speech Navigation",
@@ -129,7 +161,11 @@ __artifacts_v2__ = {
         "notes": "https://djangofaiola.blogspot.com",
         "paths": ("*/com.waze/waze/tts/tts.db*"),
         "output_types": [ "standard" ],
-        "artifact_icon": "volume-2"
+        "artifact_icon": "volume-2",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.waze vc 1030478 | 400 rows",
+            "sharon_a14": "Android 14 | com.waze vc 1030483 | 574 rows",
+        }
     }
 }
 

--- a/scripts/artifacts/wellbeing.py
+++ b/scripts/artifacts/wellbeing.py
@@ -12,6 +12,11 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.apps.wellbeing/databases/app_usage*',),
         "output_types": "standard",
         "artifact_icon": "heart",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.wellbeing vc 839927 | 4556 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.apps.wellbeing vc 762847 | 18070 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.wellbeing vc 550467 | 44715 rows",
+        },
     },
     "get_wellbeing_url": {
         "name": "Digital Wellbeing - URL Events",
@@ -25,6 +30,11 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.apps.wellbeing/databases/app_usage*',),
         "output_types": "standard",
         "artifact_icon": "globe",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.wellbeing vc 839927 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.apps.wellbeing vc 762847 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.wellbeing vc 550467 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/wellbeingaccount.py
+++ b/scripts/artifacts/wellbeingaccount.py
@@ -12,6 +12,11 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.android.apps.wellbeing/files/AccountData.pb',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "battery",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.wellbeing vc 839927 | 1 row",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.apps.wellbeing vc 762847 | 1 row",
+            "pixel7a_a14": "Android 14 | com.google.android.apps.wellbeing vc 550467 | 1 row",
+        },
         "html_columns": ['Protobuf Parsed Data'],
     }
 }

--- a/scripts/artifacts/wifiConfigstore2.py
+++ b/scripts/artifacts/wifiConfigstore2.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/misc/wifi/WifiConfigStore.xml', '*/misc**/apexdata/com.android.wifi/WifiConfigStore.xml'),
         "output_types": "standard",
         "artifact_icon": "wifi",
+        "sample_data": {
+            "anne_a15": "Android 15 | 12 rows",
+            "galaxys10_a10": "Android 10 | 4 rows",
+            "hc_pixel8pro_a16": "Android 16 | 1 row",
+            "kevin_pocox7_a15": "Android 15 | 20 rows",
+            "pixel7a_a14": "Android 14 | 11 rows",
+            "samsunga53_a14": "Android 14 | 2 rows",
+            "samsungs20_a13": "Android 13 | 2 rows",
+            "sharon_a14": "Android 14 | 18 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/wifiHotspot.py
+++ b/scripts/artifacts/wifiHotspot.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/misc/wifi/softap.conf', '*/misc**/apexdata/com.android.wifi/WifiConfigStoreSoftAp.xml'),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "wifi",
+        "sample_data": {
+            "anne_a15": "Android 15 | 1 row",
+            "galaxys10_a10": "Android 10 | 1 row",
+            "hc_pixel8pro_a16": "Android 16 | 1 row",
+            "kevin_pocox7_a15": "Android 15 | 1 row",
+            "pixel7a_a14": "Android 14 | 1 row",
+            "samsunga53_a14": "Android 14 | 1 row",
+            "samsungs20_a13": "Android 13 | 1 row",
+            "sharon_a14": "Android 14 | 1 row",
+        },
     }
 }
 

--- a/scripts/artifacts/wifiProfiles.py
+++ b/scripts/artifacts/wifiProfiles.py
@@ -12,6 +12,16 @@ __artifacts_v2__ = {
         "paths": ('*/misc/wifi/WifiConfigStore.xml', '*/misc**/apexdata/com.android.wifi/WifiConfigStore.xml'),
         "output_types": "standard",
         "artifact_icon": "wifi",
+        "sample_data": {
+            "anne_a15": "Android 15 | 12 rows",
+            "galaxys10_a10": "Android 10 | 4 rows",
+            "hc_pixel8pro_a16": "Android 16 | 2 rows",
+            "kevin_pocox7_a15": "Android 15 | 20 rows",
+            "pixel7a_a14": "Android 14 | 11 rows",
+            "samsunga53_a14": "Android 14 | 2 rows",
+            "samsungs20_a13": "Android 13 | 2 rows",
+            "sharon_a14": "Android 14 | 18 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/wireMessenger.py
+++ b/scripts/artifacts/wireMessenger.py
@@ -12,6 +12,10 @@ __artifacts_v2__ = {
         "paths": ('*/com.wire/**',),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.wire vc 100206242 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.wire vc 9369190 | 0 rows",
+        },
     },
     "get_wire_contacts": {
         "name": "Wire Contacts",
@@ -25,6 +29,10 @@ __artifacts_v2__ = {
         "paths": ('*/com.wire/**',),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.wire vc 100206242 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.wire vc 9369190 | 0 rows",
+        },
     },
     "get_wire_messages": {
         "name": "Wire Messages",
@@ -38,6 +46,10 @@ __artifacts_v2__ = {
         "paths": ('*/com.wire/**',),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.wire vc 100206242 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.wire vc 9369190 | 0 rows",
+        },
     }
 }
 


### PR DESCRIPTION
Fills the `sample_data` metadata key across **185 artifact files** with auto-generated coverage notes from batch-leapp runs over **8 test images spanning Android 10 → 16**. Each entry records the image's OS version, the owning app's `versionCode` (when the artifact is app-linked), and the rows produced:

```python
"sample_data": {
    "galaxys10_a10": "Android 10 | 88 rows",
    "pixel7a_a14": "Android 14 | com.viber.voip vc 1231070 | 34 rows",
    "sharon_a14": "Android 14 | com.viber.voip vc 1233020 | 5051 rows",
},
```

## Registered images

| key | image | Android |
|---|---|---|
| `galaxys10_a10` | Galaxy S10 SM-G973F | 10 |
| `samsungs20_a13` | Samsung S20 FFS (build props report 13) | 13 |
| `pixel7a_a14` | Android 14 public image, UFED Pixel 7a | 14 |
| `samsunga53_a14` | Samsung A53 files_full | 14 |
| `sharon_a14` | Sharon, Galaxy S21 SM-G991B | 14 |
| `anne_a15` | Anne, Samsung SM-S911U1 | 15 |
| `kevin_pocox7_a15` | Kevin, Xiaomi Poco X7 Pro | 15 |
| `hc_pixel8pro_a16` | HC, Pixel 8 Pro | 16 |

## Semantics

- Entry wherever the artifact's search patterns **matched ≥1 file** in an image — including **`0 rows`** (source present but empty) and **`files found`** (no LAVA output).
- Artifacts that **errored** on a given image (30 image×artifact pairs, e.g. `gmailEmails`, `OneDrive_Metadata`) are skipped with a warning rather than recorded as a false "0 rows".
- `fitbit.py` builds its metadata via a factory function (non-literal dicts) — not editable by the generator, so its artifacts carry no entries.
- Android app versions are integer **`versionCode`s** (from Play-services gass.db) — no Android source yields the marketing version string.
- 4 touched files with pre-existing pylint warnings get **file-scoped zero-behavior pragmas** (`accounts_ce`, `adb_hosts`, `appicons`, `last_boot_time`). **No parser logic changed anywhere.**

## Verification

- All 185 files re-parsed, `sample_data` verified equal to computed values, compiled
- `PluginLoader` loads **583** plugins (unchanged)
- `PYTHONPATH=. pylint <all 185 changed files> --disable=C,R` exits 0 at **10.00/10**
- Idempotent: an immediate second `--apply` reports **0 changes**

Companion to iLEAPP #1689 (iOS corpus). Generated by batch-leapp's `sample_data_update.py`; runbook in its `docs/sample-data.md`.