### PR TITLE
Fix artifact crashes surfaced by the 8-image Android coverage run

### DIFF
--- a/scripts/artifacts/GarminActivities.py
+++ b/scripts/artifacts/GarminActivities.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
         "description": "Get Information related to Garmin activities from the cache-database",
         "author": "Fabian Nunes {fabiannunes12@gmail.com}",
         "creation_date": "2023-02-24",
-        "last_update_date": "2023-02-24",
+        "last_update_date": "2026-07-10",
         "requirements": "Python 3.7 or higher",
         "category": "Garmin",
         "notes": "",
@@ -17,6 +17,7 @@ __artifacts_v2__ = {
 
 import datetime
 import json
+import sqlite3
 
 from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
@@ -35,20 +36,25 @@ def get_garmin_activities(files_found, report_folder, seeker, wrap_text):
     db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
     # Combine activity_details and activity_summaries (grouped by activityId to drop duplicates)
-    cursor.execute('''
-    Select *
-    from (
-        SELECT activity_details.activityId, abd.json, lastUpdated, lastUpdate, calendarDate, activityName, activity_details.startTimeGMT, activityTypeKey, distance, duration, movingDuration, elevationGain, elevationLoss, averageSpeed, maxSpeed, startLatitude, startLongitude, ownerId, ownerProfileImageUrlLarge, calories, averageHR, maxHR, averageRunningCadenceInStepsPerMinute, maxRunningCadenceInStepsPerMinute, steps
-        from activity_details
-        LEFT JOIN activity_summaries abd on activity_details.activityId = abd.activityId
-        UNION
-        SELECT activity_summaries.activityId, json, lastUpdated, lastUpdate, calendarDate, activityName, acd.startTimeGMT, activityTypeKey, distance, duration, movingDuration, elevationGain, elevationLoss, averageSpeed, maxSpeed, startLatitude, startLongitude, ownerId, ownerProfileImageUrlLarge, calories, averageHR, maxHR, averageRunningCadenceInStepsPerMinute, maxRunningCadenceInStepsPerMinute, steps
-        from activity_summaries
-        LEFT JOIN activity_details acd on activity_summaries.activityId = acd.activityId
-    ) as t
-    group by activityId;
-    ''')
-    all_rows = cursor.fetchall()
+    try:
+        cursor.execute('''
+        Select *
+        from (
+            SELECT activity_details.activityId, abd.json, lastUpdated, lastUpdate, calendarDate, activityName, activity_details.startTimeGMT, activityTypeKey, distance, duration, movingDuration, elevationGain, elevationLoss, averageSpeed, maxSpeed, startLatitude, startLongitude, ownerId, ownerProfileImageUrlLarge, calories, averageHR, maxHR, averageRunningCadenceInStepsPerMinute, maxRunningCadenceInStepsPerMinute, steps
+            from activity_details
+            LEFT JOIN activity_summaries abd on activity_details.activityId = abd.activityId
+            UNION
+            SELECT activity_summaries.activityId, json, lastUpdated, lastUpdate, calendarDate, activityName, acd.startTimeGMT, activityTypeKey, distance, duration, movingDuration, elevationGain, elevationLoss, averageSpeed, maxSpeed, startLatitude, startLongitude, ownerId, ownerProfileImageUrlLarge, calories, averageHR, maxHR, averageRunningCadenceInStepsPerMinute, maxRunningCadenceInStepsPerMinute, steps
+            from activity_summaries
+            LEFT JOIN activity_details acd on activity_summaries.activityId = acd.activityId
+        ) as t
+        group by activityId;
+        ''')
+        all_rows = cursor.fetchall()
+    except sqlite3.OperationalError as ex:
+        # Newer Garmin Connect versions restructured the cache-database
+        logfunc(f'Unable to query the Garmin cache-database (unsupported schema version?): {ex}')
+        all_rows = []
     db.close()
     logfunc(f"Found {len(all_rows)} Garmin Activities")
 

--- a/scripts/artifacts/GarminChart.py
+++ b/scripts/artifacts/GarminChart.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
         "description": "Get Information from the table activity_charts and activity_details in the database cache-database from Garmin Connect",
         "author": "Fabian Nunes {fabiannunes12@gmail.com}",
         "creation_date": "2023-02-24",
-        "last_update_date": "2023-02-24",
+        "last_update_date": "2026-07-10",
         "requirements": "Python 3.7 or higher",
         "category": "Garmin",
         "notes": "",
@@ -16,6 +16,7 @@ __artifacts_v2__ = {
 }
 
 import datetime
+import sqlite3
 
 from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
@@ -33,25 +34,30 @@ def get_garmin_chart(files_found, report_folder, seeker, wrap_text):
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
-    cursor.execute('''
-        Select
-        activity_details.activityId,
-        activity_details.lastUpdated,
-        activityName,
-        startTimeGMT,
-        activityTypeKey,
-        round(distance, 0),
-        round(duration/60, 0),
-        steps,
-        acd.lastUpdated,
-        chartType,
-        chartXList,
-        chartYList
-        from activity_details
-        left join activity_chart_data acd on activity_details.activityId = acd.activityId
-        where activity_details.activityId = acd.activityId
-    ''')
-    all_rows = cursor.fetchall()
+    try:
+        cursor.execute('''
+            Select
+            activity_details.activityId,
+            activity_details.lastUpdated,
+            activityName,
+            startTimeGMT,
+            activityTypeKey,
+            round(distance, 0),
+            round(duration/60, 0),
+            steps,
+            acd.lastUpdated,
+            chartType,
+            chartXList,
+            chartYList
+            from activity_details
+            left join activity_chart_data acd on activity_details.activityId = acd.activityId
+            where activity_details.activityId = acd.activityId
+        ''')
+        all_rows = cursor.fetchall()
+    except sqlite3.OperationalError as ex:
+        # Newer Garmin Connect versions restructured the cache-database
+        logfunc(f'Unable to query the Garmin cache-database (unsupported schema version?): {ex}')
+        all_rows = []
     db.close()
     logfunc(f'Found {len(all_rows)} activity details')
 

--- a/scripts/artifacts/GarminDailies.py
+++ b/scripts/artifacts/GarminDailies.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
         "description": "Get Information from the table user_daily_summary from the cache-database in the Garmin Connect App",
         "author": "Fabian Nunes {fabiannunes12@gmail.com}",
         "creation_date": "2023-02-24",
-        "last_update_date": "2023-02-24",
+        "last_update_date": "2026-07-10",
         "requirements": "Python 3.7 or higher",
         "category": "Garmin",
         "notes": "",
@@ -14,6 +14,8 @@ __artifacts_v2__ = {
         "artifact_icon": "activity",
     }
 }
+
+import sqlite3
 
 from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
@@ -74,11 +76,16 @@ def get_garmin_dailies(files_found, report_folder, seeker, wrap_text):
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
-    cursor.execute(f'''
-        SELECT {", ".join(col for col, _ in FIELDS)}
-        from user_daily_summary
-    ''')
-    all_rows = cursor.fetchall()
+    try:
+        cursor.execute(f'''
+            SELECT {", ".join(col for col, _ in FIELDS)}
+            from user_daily_summary
+        ''')
+        all_rows = cursor.fetchall()
+    except sqlite3.OperationalError as ex:
+        # Newer Garmin Connect versions restructured the cache-database
+        logfunc(f'Unable to query the Garmin cache-database (unsupported schema version?): {ex}')
+        all_rows = []
     db.close()
     logfunc(f"Found {len(all_rows)} entries")
 

--- a/scripts/artifacts/GarminSPo2.py
+++ b/scripts/artifacts/GarminSPo2.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
         "description": "Get Information related to Garmin Pulse Ox from acclimation_pulse_ox_details table",
         "author": "Fabian Nunes {fabiannunes12@gmail.com}",
         "creation_date": "2023-02-24",
-        "last_update_date": "2023-02-24",
+        "last_update_date": "2026-07-10",
         "requirements": "Python 3.7 or higher",
         "category": "Garmin",
         "notes": "",
@@ -14,6 +14,8 @@ __artifacts_v2__ = {
         "artifact_icon": "activity",
     }
 }
+
+import sqlite3
 
 from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
@@ -25,18 +27,23 @@ def get_garmin_spo2(files_found, report_folder, seeker, wrap_text):
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
-    cursor.execute('''
-        SELECT
-        userProfilePk,
-        startTimestampGMT,
-        endTimestampGMT,
-        spo2Value,
-        spo2ValueAverage,
-        spo2ValuesArray
-        from acclimation_pulse_ox_details
-        where spo2Value is not null
-    ''')
-    all_rows = cursor.fetchall()
+    try:
+        cursor.execute('''
+            SELECT
+            userProfilePk,
+            startTimestampGMT,
+            endTimestampGMT,
+            spo2Value,
+            spo2ValueAverage,
+            spo2ValuesArray
+            from acclimation_pulse_ox_details
+            where spo2Value is not null
+        ''')
+        all_rows = cursor.fetchall()
+    except sqlite3.OperationalError as ex:
+        # Newer Garmin Connect versions restructured the cache-database
+        logfunc(f'Unable to query the Garmin cache-database (unsupported schema version?): {ex}')
+        all_rows = []
     db.close()
     logfunc(f'Found {len(all_rows)} Garmin Pulse Ox details')
 

--- a/scripts/artifacts/GarminSleep.py
+++ b/scripts/artifacts/GarminSleep.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
         "description": "Get Information relative to the sleep data in the database cache-database from the table sleep_detail in the Garmin Connect app",
         "author": "Fabian Nunes {fabiannunes12@gmail.com}",
         "creation_date": "2023-02-24",
-        "last_update_date": "2023-02-24",
+        "last_update_date": "2026-07-10",
         "requirements": "Python 3.7 or higher",
         "category": "Garmin",
         "notes": "",
@@ -16,6 +16,7 @@ __artifacts_v2__ = {
 }
 
 import datetime
+import sqlite3
 
 from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
@@ -33,20 +34,25 @@ def get_garmin_sleep(files_found, report_folder, seeker, wrap_text):
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
-    cursor.execute('''
-        SELECT
-        sleepStartTimeGMT,
-        sleepEndTimeGMT,
-        sleepTimeInSeconds,
-        deepSleepSeconds,
-        lightSleepSeconds,
-        remSleepSeconds,
-        awakeSleepSeconds,
-        averageSpO2Value,
-        averageSpO2HRSleep
-        from sleep_detail
-    ''')
-    all_rows = cursor.fetchall()
+    try:
+        cursor.execute('''
+            SELECT
+            sleepStartTimeGMT,
+            sleepEndTimeGMT,
+            sleepTimeInSeconds,
+            deepSleepSeconds,
+            lightSleepSeconds,
+            remSleepSeconds,
+            awakeSleepSeconds,
+            averageSpO2Value,
+            averageSpO2HRSleep
+            from sleep_detail
+        ''')
+        all_rows = cursor.fetchall()
+    except sqlite3.OperationalError as ex:
+        # Newer Garmin Connect versions restructured the cache-database
+        logfunc(f'Unable to query the Garmin cache-database (unsupported schema version?): {ex}')
+        all_rows = []
     db.close()
     logfunc(f"Found {len(all_rows)} sleep entries")
 

--- a/scripts/artifacts/GarminWeight.py
+++ b/scripts/artifacts/GarminWeight.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
         "description": "Get Information relative to the weight data in the database cache-database from the table weight in the Garmin Connect app",
         "author": "Fabian Nunes {fabiannunes12@gmail.com}",
         "creation_date": "2023-02-24",
-        "last_update_date": "2023-02-24",
+        "last_update_date": "2026-07-10",
         "requirements": "Python 3.7 or higher",
         "category": "Garmin",
         "notes": "",
@@ -16,6 +16,7 @@ __artifacts_v2__ = {
 }
 
 import datetime
+import sqlite3
 
 from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
@@ -27,11 +28,16 @@ def get_garmin_weight(files_found, report_folder, seeker, wrap_text):
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
-    cursor.execute('''
-        Select samplePk, "date", weight
-        from weight
-    ''')
-    all_rows = cursor.fetchall()
+    try:
+        cursor.execute('''
+            Select samplePk, "date", weight
+            from weight
+        ''')
+        all_rows = cursor.fetchall()
+    except sqlite3.OperationalError as ex:
+        # Newer Garmin Connect versions restructured the cache-database
+        logfunc(f'Unable to query the Garmin cache-database (unsupported schema version?): {ex}')
+        all_rows = []
     db.close()
     logfunc(f"Found {len(all_rows)} weight entries")
 

--- a/scripts/artifacts/LinkedIn.py
+++ b/scripts/artifacts/LinkedIn.py
@@ -6,7 +6,7 @@ __artifacts_v2__ = {
         "description": "Existing account in LinkedIn App. The Public Identifier can be used to visit the public profile on the LinkedIn Website (https://www.linkedin.com/in/[Public Identifier]).",
         "author": "Marco Neumann {kalinko@be-binary.de}",
         "creation_date": "2025-04-26",
-        'last_update_date': '2026-02-07',
+        'last_update_date': '2026-07-10',
         "requirements": "xml, json",
         "category": "LinkedIn",
         "notes": "",
@@ -91,16 +91,27 @@ def linkedin_account(files_found, _report_folder, _seeker, _wrap_text):
                 value = elem.attrib.get('value') if 'value' in elem.attrib else elem.text
                 xml_dict[name] = value
 
-    # Now get the data from the dict and put it into the data_list
-    last_login =  convert_unix_ts_to_utc(int(xml_dict['lastLoggedInTimestamp']))
-    account_mail = xml_dict['memberEmail']
-    temp_meModel = json.loads(xml_dict['meModel'])
-    member_id = temp_meModel['plainId']
-    last_name = temp_meModel['miniProfile']['lastName']
-    first_name = temp_meModel['miniProfile']['firstName']
-    headline = temp_meModel['miniProfile']['occupation']
-    public_identifier = temp_meModel['miniProfile']['publicIdentifier']
-    data_list = [(last_login, member_id, account_mail, last_name, first_name, headline, public_identifier)]
+    # Now get the data from the dict and put it into the data_list.
+    # Not every install carries the account keys (e.g. never signed in).
+    last_login = xml_dict.get('lastLoggedInTimestamp')
+    last_login = convert_unix_ts_to_utc(int(last_login)) if last_login else ''
+    account_mail = xml_dict.get('memberEmail', '')
+    member_id = last_name = first_name = headline = public_identifier = ''
+    me_model = xml_dict.get('meModel')
+    if me_model:
+        temp_meModel = json.loads(me_model)
+        mini_profile = temp_meModel.get('miniProfile', {})
+        member_id = temp_meModel.get('plainId', '')
+        last_name = mini_profile.get('lastName', '')
+        first_name = mini_profile.get('firstName', '')
+        headline = mini_profile.get('occupation', '')
+        public_identifier = mini_profile.get('publicIdentifier', '')
+
+    data_list = []
+    if any((last_login, member_id, account_mail, last_name, first_name, headline, public_identifier)):
+        data_list = [(last_login, member_id, account_mail, last_name, first_name, headline, public_identifier)]
+    else:
+        logfunc('No LinkedIn account details found in linkedInPrefsName.xml')
 
     data_headers = (    
                         ('Last Login', 'datetime'),

--- a/scripts/artifacts/OneDrive_Metadata.py
+++ b/scripts/artifacts/OneDrive_Metadata.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
         "description": "Parses the QTMetadata.db from OneDrive",
         "author": "Matt Beers and Anthony Reince",
         "creation_date": "2025-04-17",
-        "last_update_date": "2025-04-17",
+        "last_update_date": "2026-07-10",
         "requirements": "none",
         "category": "Cloud Storage",
         "notes": "Inline base64 image previews replaced with checked-in media; cached image streams are "
@@ -27,7 +27,8 @@ import datetime
 import os
 import mimetypes
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, check_in_embedded_media
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly, check_in_embedded_media, \
+    does_column_exist_in_db
 
 
 def _ms_to_utc(value):
@@ -81,17 +82,22 @@ def get_onedrive(files_found, report_folder, seeker, wrap_text):
 
         if file_found.endswith('QTMetadata.db'):
             source = file_found
+            # Some OneDrive schema versions carry fileHash/fileHashType instead of sha1Hash
+            hash_column = 'items.sha1Hash'
+            if not does_column_exist_in_db(file_found, 'items', 'sha1Hash'):
+                hash_column = 'NULL'
+                logfunc(f'No items.sha1Hash column in {file_found}; hash values unavailable')
             db = open_sqlite_db_readonly(file_found)
             cursor = db.cursor()
 
-            cursor.execute('''
+            cursor.execute(f'''
             SELECT
                 items.itemDate,
                 items._id,
                 items.extension,
                 items.name,
                 items.ownerName,
-                items.sha1Hash,
+                {hash_column},
                 stream_cache.parentID,
                 stream_cache.stream_location
             FROM

--- a/scripts/artifacts/chatgpt.py
+++ b/scripts/artifacts/chatgpt.py
@@ -20,7 +20,7 @@ __artifacts_v2__ = {
         "description": "User messages with ChatGPT, older DBMessage.messageNode schema (see ChatGPT - Conversations / chatgpt2 for the newer DBMessageChunk schema)",
         "author": "Evangelos Dragonas (@theAtropos4n6)",
         "creation_date": "2024-07-09",
-        "last_update_date": "2024-07-09",
+        "last_update_date": "2026-07-10",
         "requirements": "",
         "category": "ChatGPT",
         "notes": "",
@@ -149,7 +149,8 @@ from pathlib import Path
 import blackboxprotobuf
 from PIL import Image, UnidentifiedImageError
 
-from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly, check_in_media
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly, check_in_media, \
+    does_column_exist_in_db
 
 
 def _iso_to_utc(value):
@@ -234,6 +235,10 @@ def get_chatgpt_conversations(context):
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('_conversations.db'):
+            continue
+        if not does_column_exist_in_db(file_found, 'DBMessage', 'messageNode'):
+            logfunc(f'Skipping {file_found}: no DBMessage.messageNode column '
+                    '(newer ChatGPT schema, parsed by ChatGPT - Conversations)')
             continue
         source_path = file_found
         account = _account(os.path.basename(file_found), '_conversations.db')

--- a/scripts/artifacts/chatgpt2.py
+++ b/scripts/artifacts/chatgpt2.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
         "description": "Android ChatGPT conversations",
         "author": "Alexis Brignoni",
         "creation_date": "2025-07-08",
-        "last_update_date": "2025-09-09",
+        "last_update_date": "2026-07-10",
         "requirements": "none",
         "category": "ChatGPT",
         "notes": "",
@@ -79,6 +79,9 @@ def get_chatpgt2(files_found, report_folder, seeker, wrap_text):
 
             # Print one result as a check
             for message_id, message in list(reconstructed_messages.items()):
+                if not isinstance(message, dict) or not isinstance(message.get('content'), dict):
+                    logfunc(f'Skipping ChatGPT message {message_id}: unrecognized message structure')
+                    continue
                 cdt = ''
                 mdt = ''
                 creationdate = message['content'].get('created_date','')
@@ -99,11 +102,17 @@ def get_chatpgt2(files_found, report_folder, seeker, wrap_text):
                         mdt = datetime.strptime(modificationdate, "%Y-%m-%dT%H:%M:%SZ")
                     mdt = mdt.replace(tzinfo=timezone.utc)
 
-                chunkdata = message['content']['content'].get('content')
-                if chunkdata == None:
-                    chunkdata = message['content']['content']
-
-                references = message['content']['content'].get('references')
+                # The nested content value is a dict in most messages but can
+                # also be a plain string (e.g. some tool/voice messages)
+                content = message['content'].get('content')
+                if isinstance(content, dict):
+                    chunkdata = content.get('content')
+                    if chunkdata == None:
+                        chunkdata = content
+                    references = content.get('references')
+                else:
+                    chunkdata = content
+                    references = ''
 
                 # Get conversation title
                 conversation_id = message['content'].get('conversation_id')

--- a/scripts/artifacts/chromeAutofill.py
+++ b/scripts/artifacts/chromeAutofill.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
         "description": "Parses Chrome autofill entries",
         "author": "",
         "creation_date": "2020-03-19",
-        "last_update_date": "2020-03-19",
+        "last_update_date": "2026-07-10",
         "requirements": "none",
         "category": "Chromium",
         "notes": "",
@@ -86,6 +86,12 @@ def get_chromeAutofill(files_found, report_folder, seeker, wrap_text):
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         columns = [i[1] for i in cursor.execute('PRAGMA table_info(autofill)')]
+
+        if not columns:
+            # Some Web Data databases (e.g. embedded WebViews) have no autofill table
+            logfunc(f'No {browser_name} autofill table available in {file_found}')
+            db.close()
+            continue
 
         if 'date_created' in columns:
             cursor.execute('select date_created, name, value, date_last_used, count from autofill')

--- a/scripts/artifacts/chromeDIPS.py
+++ b/scripts/artifacts/chromeDIPS.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
         "description": "Module Description: Parses Chromium DIPS (Detect Incidental Party State)",
         "author": "@KevinPagano3",
         "creation_date": "2023-04-07",
-        "last_update_date": "2023-04-07",
+        "last_update_date": "2026-07-10",
         "requirements": "none",
         "category": "Chromium",
         "notes": "",
@@ -33,6 +33,12 @@ def _webkit_to_utc(value):
     if value in (None, 0, ''):
         return ''
     return datetime.datetime(1601, 1, 1, tzinfo=datetime.timezone.utc) + datetime.timedelta(microseconds=int(value))
+
+
+def _first_column(columns, candidates):
+    """Returns the first candidate column present in the table, or NULL —
+    the bounces schema varies between Chromium versions."""
+    return next((column for column in candidates if column in columns), 'NULL')
 
 
 @artifact_processor
@@ -77,23 +83,25 @@ def get_chromeDIPS(files_found, report_folder, seeker, wrap_text):
         cursor = db.cursor()
         columns = [i[1] for i in cursor.execute('PRAGMA table_info(bounces)')]
 
-        stateless = 'first_stateless_bounce_time' in columns
-        first_user_col = 'first_user_interaction_time' if 'first_user_interaction_time' in columns else 'first_user_activation_time'
-        last_user_col = 'last_user_interaction_time' if 'last_user_interaction_time' in columns else 'last_user_activation_time'
-        if stateless:
-            first_bounce_col, last_bounce_col = 'first_stateless_bounce_time', 'last_stateless_bounce_time'
-        else:
-            first_bounce_col, last_bounce_col = 'first_bounce_time', 'last_bounce_time'
+        if not columns:
+            logfunc(f'No bounces table available in {file_found}')
+            db.close()
+            continue
+
+        first_user_col = _first_column(columns, ('first_user_interaction_time', 'first_user_activation_time'))
+        last_user_col = _first_column(columns, ('last_user_interaction_time', 'last_user_activation_time'))
+        first_bounce_col = _first_column(columns, ('first_stateless_bounce_time', 'first_bounce_time'))
+        last_bounce_col = _first_column(columns, ('last_stateless_bounce_time', 'last_bounce_time'))
 
         cursor.execute(f'''
             select
             site,
-            first_site_storage_time,
-            last_site_storage_time,
+            {_first_column(columns, ('first_site_storage_time',))},
+            {_first_column(columns, ('last_site_storage_time',))},
             {first_user_col},
             {last_user_col},
-            first_stateful_bounce_time,
-            last_stateful_bounce_time,
+            {_first_column(columns, ('first_stateful_bounce_time',))},
+            {_first_column(columns, ('last_stateful_bounce_time',))},
             {first_bounce_col},
             {last_bounce_col}
             from bounces

--- a/scripts/artifacts/chromeNetworkActionPredictor.py
+++ b/scripts/artifacts/chromeNetworkActionPredictor.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
         "description": "Parses the Network Action Predictor from Chromium Based Browsers",
         "author": "",
         "creation_date": "2020-03-19",
-        "last_update_date": "2020-03-19",
+        "last_update_date": "2026-07-10",
         "requirements": "none",
         "category": "Chromium",
         "notes": "",
@@ -45,6 +45,14 @@ def get_chromeNetworkActionPredictor(files_found, report_folder, seeker, wrap_te
 
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
+        columns = [i[1] for i in cursor.execute('PRAGMA table_info(network_action_predictor)')]
+
+        if not columns:
+            # Some browser variants keep only resource_prefetch_predictor tables here
+            logfunc(f'No network_action_predictor table available in {file_found}')
+            db.close()
+            continue
+
         cursor.execute('''
         select
         user_text,

--- a/scripts/artifacts/cmh.py
+++ b/scripts/artifacts/cmh.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
         "description": "Parses the Samsung CMH media store (image dates, title, bucket, latitude, longitude, address and path) from cmh.db.",
         "author": "",
         "creation_date": "2020-03-05",
-        "last_update_date": "2020-03-05",
+        "last_update_date": "2026-07-10",
         "requirements": "none",
         "category": "Samsung_CMH",
         "notes": "",
@@ -22,8 +22,11 @@ __artifacts_v2__ = {
 }
 
 import datetime
+import hashlib
+import sqlite3
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly, does_table_exist_in_db, \
+    does_view_exist_in_db
 
 
 def _ms_to_utc(value):
@@ -40,23 +43,51 @@ def _sec_to_utc(value):
 
 @artifact_processor
 def get_cmh(files_found, report_folder, seeker, wrap_text):
-    source_path = str(files_found[0])
-    db = open_sqlite_db_readonly(source_path)
-    cursor = db.cursor()
-    cursor.execute('''
-        SELECT
-        images.datetaken, images.date_added, images.date_modified, images.title,
-        images.bucket_display_name, images.latitude, images.longitude,
-        location_view.address_text, location_view.uri, images._data, images.isprivate
-        FROM images
-        left join location_view on location_view._id = images._id
-    ''')
-    all_rows = cursor.fetchall()
-    db.close()
-
+    # Extractions can hold several cmh.db copies (e.g. one per user profile);
+    # parse every distinct copy that carries the images view. The same
+    # database can appear under aliased paths (data/data vs data/user/0,
+    # tool mirror folders), so byte-identical copies are only parsed once.
     data_list = []
-    for r in all_rows:
-        data_list.append((_ms_to_utc(r[0]), _sec_to_utc(r[1]), _sec_to_utc(r[2]), r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10]))
+    sources = []
+    seen_hashes = set()
+    for file_found in files_found:
+        file_found = str(file_found)
+        if file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
+            continue  # Skip mirror, it should be duplicate data
 
+        with open(file_found, 'rb') as db_file:
+            file_hash = hashlib.sha256(db_file.read()).hexdigest()
+        if file_hash in seen_hashes:
+            continue
+        seen_hashes.add(file_hash)
+
+        # images is a view in most CMH versions; newer versions dropped it
+        if not (does_view_exist_in_db(file_found, 'images') or does_table_exist_in_db(file_found, 'images')):
+            logfunc(f'No images table/view in {file_found} (unsupported CMH schema version?)')
+            continue
+
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        try:
+            cursor.execute('''
+                SELECT
+                images.datetaken, images.date_added, images.date_modified, images.title,
+                images.bucket_display_name, images.latitude, images.longitude,
+                location_view.address_text, location_view.uri, images._data, images.isprivate
+                FROM images
+                left join location_view on location_view._id = images._id
+            ''')
+            all_rows = cursor.fetchall()
+        except sqlite3.OperationalError as ex:
+            logfunc(f'Unable to query {file_found} (unsupported CMH schema version?): {ex}')
+            all_rows = []
+        db.close()
+
+        if all_rows:
+            sources.append(file_found)
+        for r in all_rows:
+            data_list.append((_ms_to_utc(r[0]), _sec_to_utc(r[1]), _sec_to_utc(r[2]), r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10]))
+
+    source_path = ', '.join(sources) if sources else str(files_found[0])
     data_headers = (('Timestamp', 'datetime'), ('Date Added', 'datetime'), ('Date Modified', 'datetime'), 'Title', 'Bucket Name', 'Latitude', 'Longitude', 'Address', 'URI', 'Data Location', 'Is Private')
     return data_headers, data_list, source_path

--- a/scripts/artifacts/gmailEmails.py
+++ b/scripts/artifacts/gmailEmails.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
         "description": "Parses emails from Gmail",
         "author": "Alexis Brignoni, Patrick Dalla, @stark4n6",
         "creation_date": "2023-01-04",
-        "last_update_date": "2025-07-30",
+        "last_update_date": "2026-07-10",
         "requirements": "none",
         "category": "Email",
         "notes": "",
@@ -71,7 +71,8 @@ import blackboxprotobuf
 import os
 from datetime import datetime
 
-from scripts.ilapfuncs import open_sqlite_db_readonly, check_in_media, get_sqlite_db_records, artifact_processor
+from scripts.ilapfuncs import open_sqlite_db_readonly, check_in_media, get_sqlite_db_records, artifact_processor, \
+    logfunc
 
 @artifact_processor
 def gmailEmails(files_found, report_folder, seeker, wrap_text):
@@ -161,15 +162,20 @@ def gmailEmails(files_found, report_folder, seeker, wrap_text):
                     else:
                         subjectline = ''
                 
+                messagehtml = ''
                 messagetest = (message.get('6', '')) #HTML message
                 if messagetest != '':
                     messagetest = message['6'].get('2','')
                     if messagetest != '':
-                        if isinstance(message['6']['2'], list):
-                            for x in message['6']['2']:
-                                messagehtml = messagehtml + (x['3']['2'].decode())
-                        else:
-                            messagehtml = (message['6']['2']['3']['2'].decode()) 
+                        try:
+                            if isinstance(message['6']['2'], list):
+                                for x in message['6']['2']:
+                                    messagehtml = messagehtml + (x['3']['2'].decode())
+                            else:
+                                messagehtml = (message['6']['2']['3']['2'].decode())
+                        except (AttributeError, KeyError, TypeError, IndexError):
+                            # The body node nesting varies between app versions
+                            logfunc(f'Unrecognized Gmail message body structure for server id {serverid}; body omitted')
                
                 mailedby = (message.get('11', {}).get('8', b'')) #mailed by
                 if isinstance(message.get('11', {}).get('8', ''), bytes): 

--- a/scripts/artifacts/packageInfo.py
+++ b/scripts/artifacts/packageInfo.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
         "description": "Represents an app",
         "author": "",
         "creation_date": "2020-11-03",
-        "last_update_date": "2020-11-03",
+        "last_update_date": "2026-07-10",
         "requirements": "none",
         "category": "Installed Apps",
         "notes": "",
@@ -28,6 +28,7 @@ import datetime
 import os
 import xmltodict
 import xml.etree.ElementTree as etree
+from xml.parsers.expat import ExpatError
 
 from scripts.ilapfuncs import artifact_processor, logfunc, is_platform_windows, abxread, checkabx
 
@@ -74,14 +75,20 @@ def get_package_info(files_found, report_folder, seeker, wrap_text):
             continue
 
         source_path = file_found
-        if (checkabx(file_found)):
-            multi_root = False
-            tree = abxread(file_found, multi_root)
-            xlmstring = (etree.tostring(tree.getroot()).decode())
-            doc = xmltodict.parse(xlmstring)
-        else:
-            with open(file_found, encoding='utf-8', errors='replace') as fd:
-                doc = xmltodict.parse(fd.read())
+        try:
+            if (checkabx(file_found)):
+                multi_root = False
+                tree = abxread(file_found, multi_root)
+                xlmstring = (etree.tostring(tree.getroot()).decode())
+                doc = xmltodict.parse(xlmstring)
+            else:
+                with open(file_found, encoding='utf-8', errors='replace') as fd:
+                    doc = xmltodict.parse(fd.read())
+        except ExpatError as ex:
+            # Some extractions carry a packages.xml that is neither plain XML
+            # nor ABX (e.g. encrypted or partially recovered content)
+            logfunc(f'Unable to parse {file_found} (not valid XML/ABX): {ex}')
+            continue
 
         package_dict = doc.get('packages', {}).get('package', {})
         for package in package_dict:

--- a/scripts/artifacts/walStrings.py
+++ b/scripts/artifacts/walStrings.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "If  we only want ascii, use 'ascii_chars_re' below",
         "author": "",
         "creation_date": "2020-04-17",
-        "last_update_date": "2020-04-17",
+        "last_update_date": "2026-07-10",
         "requirements": "none",
         "category": "SQLite Journaling",
         "notes": "",
@@ -40,7 +40,10 @@ def get_walStrings(context):
     x = 1
     data_list = []
     for file_found in files_found:
-        if Path(file_found).stat().st_size == 0:
+        # The seeker can list files it could not extract (e.g. zero-byte
+        # archive members), so the path may not exist on disk.
+        path = Path(file_found)
+        if not path.is_file() or path.stat().st_size == 0:
             continue
 
         journalName = os.path.basename(file_found)


### PR DESCRIPTION
## Summary

The 2026-07-10 batch-leapp coverage run over the 8-image Android test corpus (Android 10–16) surfaced **30 image×artifact crashes** across **17 artifacts**. The framework swallows these as `Reading <key> artifact had errors!`, so they had never been triaged. This PR extracts every distinct traceback, groups them by root cause, and fixes each one — all changes are inside `scripts/artifacts/` (companion to the iOS pass in abrignoni/iLEAPP#1691).

## Root causes and fixes

| Artifact(s) | Crash | Root cause | Fix |
|---|---|---|---|
| `get_chatgpt_conversations` | `no such column: DBMessage.messageNode` (Anne A15) | Newer ChatGPT app moved message content to `DBMessageChunk` | Skip the new-schema DB with a log (it is parsed by `get_chatpgt2`) |
| `get_chatpgt2` | `'str' object has no attribute 'get'` (Anne A15) | The nested content value can be a plain string, and unparseable chunk JSON is kept as a string message | Handle string/dict variants; skip unrecognized message structures with a log |
| `get_chromeAutofill` | `no such table: autofill` (5 images) | Web Data DBs without an autofill table (embedded WebViews) fell through into the legacy-schema query branch | Skip table-less databases per file |
| `get_chromeDIPS` | `no such column: first_site_storage_time` (3 images) | Newer Chromium `bounces` schema dropped the site_storage/stateful_bounce columns (new: `*_user_activation_time`, `*_bounce_time`, web_authn) | Column-dynamic SELECT — each column used only when present, NULL otherwise |
| `get_chromeNetworkActionPredictor` | `no such table: network_action_predictor` (2 images) | Some browser variants keep only `resource_prefetch_predictor_*` tables | Table guard + skip with log |
| `get_cmh` | `no such table: images` (Anne A15) | Newer Samsung CMH dropped the `images` view | View/table guard; **also** parse every *distinct* `cmh.db` copy instead of only `files_found[0]` — per-user-profile databases are real evidence, while byte-identical aliased/mirrored copies (`data/data` vs `data/user/0` vs `data_mirror`) are deduplicated by content hash |
| `get_garmin_activities` / `chart` / `dailies` / `sleep` / `spo2` / `weight` | `no such table: …` (Pixel 7a A14) | Newer Garmin Connect restructured `cache-database` (only `activity_summaries`/`activity_polyline`/`response_cache` remain) | Guard each query; log the unsupported schema and return no rows |
| `get_onedrive` | `no such column: items.sha1Hash` (Galaxy S10 A10) | Schema variant carries `fileHash`/`fileHashType` instead | Select the hash column only when present (the S10 `items` table is empty anyway) |
| `get_package_info` | `ExpatError` (S20 A13) | That `packages.xml` is neither plain XML nor ABX (content appears encrypted) | Parse guard; log and continue to the next candidate file |
| `get_walStrings` | `FileNotFoundError` on `wa.db-wal` (6 images) | The seeker can list archive members it could not extract, so `files_found` may contain paths that don't exist on disk | `is_file()` check before `stat()` |
| `gmailEmails` | `UnboundLocalError: messagehtml` (2 images) + `'dict' object has no attribute 'decode'` (S20, second layer) | `messagehtml` only assigned inside some branches and carried across rows; the body node nesting varies between app versions | Initialize per row; guard the body extraction and omit the body with a log when unrecognized |
| `linkedin_account` | `KeyError: 'memberEmail'` (Anne A15) | Installs without account data lack the account keys in `linkedInPrefsName.xml` | `.get()` with defaults; emit no row when no account details exist |

## Verification

All against the real corpus extractions:

1. **Crash re-runs**: every one of the 30 crashed image×artifact combinations re-run via `aleapp.py` (fs seeker + `.alprofile` selection) → **zero "had errors"**, with real data recovered (Anne `get_chatpgt2` 12 rows, `linkedin_account` 1 row, `get_chromeAutofill` 1–18 rows per image, `get_chromeDIPS` 3–15 rows from the **new** Chromium schema, `get_walStrings` 508–899 rows per image, Galaxy S10 `gmailEmails` 28 rows, S20 `gmailEmails` 109 rows).
2. **Regression runs**: 27 previously-working image×artifact pairs re-run → row counts match their `sample_data` baselines exactly (e.g. `gmailEmails` 200/201/206/207/112, `get_package_info` 369–513, `get_chromeDIPS` 13/19/36 on the old schema, `get_walStrings` 721/1916, `get_cmh` 1410/32/2). Two intentional differences: `get_cmh` on the S20 reports 16 rows instead of 15 because the second user profile's database (1 row) is now parsed as well, and A53's three byte-identical `cmh.db` path aliases are parsed once instead of the count depending on seeker file order.
3. `PYTHONPATH=. pylint --disable=C,R` on all 17 changed files: **10.00/10**; PluginLoader smoke test: 583 plugins load.

## Follow-ups (out of scope)

- Newer Garmin Connect keeps its data in `response_cache` JSON blobs — parsing that is a research task that would restore Garmin coverage on current app versions.
- Newer Samsung CMH (Anne) keeps media records in a `files` table — same story.
- The S20 `system/packages.xml` content appears encrypted; nothing parseable there.
- OneDrive `fileHash`/`fileHashType` support (hash type varies) could replace the NULL fallback.
- Fixed artifacts will pick up `sample_data` entries automatically on the next corpus refresh.