### PR TITLE
Parse Samsung CMH from the files table; document modern Garmin storage

### DIFF
--- a/scripts/artifacts/GarminActivities.py
+++ b/scripts/artifacts/GarminActivities.py
@@ -8,7 +8,7 @@ __artifacts_v2__ = {
         "last_update_date": "2026-07-10",
         "requirements": "Python 3.7 or higher",
         "category": "Garmin",
-        "notes": "",
+        "notes": "Newer Garmin Connect versions no longer populate cache-database; current app data lives in gcm_cache.db and garmin.api files (parsed by the GarminJson, GarminGcmJsonActivities, garmin and Garmin*API artifacts).",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
         "output_types": "standard",
         "artifact_icon": "activity",

--- a/scripts/artifacts/GarminChart.py
+++ b/scripts/artifacts/GarminChart.py
@@ -8,7 +8,7 @@ __artifacts_v2__ = {
         "last_update_date": "2026-07-10",
         "requirements": "Python 3.7 or higher",
         "category": "Garmin",
-        "notes": "",
+        "notes": "Newer Garmin Connect versions no longer populate cache-database; current app data lives in gcm_cache.db and garmin.api files (parsed by the GarminJson, GarminGcmJsonActivities, garmin and Garmin*API artifacts).",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
         "output_types": "standard",
         "artifact_icon": "activity",

--- a/scripts/artifacts/GarminDailies.py
+++ b/scripts/artifacts/GarminDailies.py
@@ -8,7 +8,7 @@ __artifacts_v2__ = {
         "last_update_date": "2026-07-10",
         "requirements": "Python 3.7 or higher",
         "category": "Garmin",
-        "notes": "",
+        "notes": "Newer Garmin Connect versions no longer populate cache-database; current app data lives in gcm_cache.db and garmin.api files (parsed by the GarminJson, GarminGcmJsonActivities, garmin and Garmin*API artifacts).",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
         "output_types": "standard",
         "artifact_icon": "activity",

--- a/scripts/artifacts/GarminSPo2.py
+++ b/scripts/artifacts/GarminSPo2.py
@@ -8,7 +8,7 @@ __artifacts_v2__ = {
         "last_update_date": "2026-07-10",
         "requirements": "Python 3.7 or higher",
         "category": "Garmin",
-        "notes": "",
+        "notes": "Newer Garmin Connect versions no longer populate cache-database; current app data lives in gcm_cache.db and garmin.api files (parsed by the GarminJson, GarminGcmJsonActivities, garmin and Garmin*API artifacts).",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "activity",

--- a/scripts/artifacts/GarminSleep.py
+++ b/scripts/artifacts/GarminSleep.py
@@ -8,7 +8,7 @@ __artifacts_v2__ = {
         "last_update_date": "2026-07-10",
         "requirements": "Python 3.7 or higher",
         "category": "Garmin",
-        "notes": "",
+        "notes": "Newer Garmin Connect versions no longer populate cache-database; current app data lives in gcm_cache.db and garmin.api files (parsed by the GarminJson, GarminGcmJsonActivities, garmin and Garmin*API artifacts).",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
         "output_types": "standard",
         "artifact_icon": "activity",

--- a/scripts/artifacts/GarminWeight.py
+++ b/scripts/artifacts/GarminWeight.py
@@ -8,7 +8,7 @@ __artifacts_v2__ = {
         "last_update_date": "2026-07-10",
         "requirements": "Python 3.7 or higher",
         "category": "Garmin",
-        "notes": "",
+        "notes": "Newer Garmin Connect versions no longer populate cache-database; current app data lives in gcm_cache.db and garmin.api files (parsed by the GarminJson, GarminGcmJsonActivities, garmin and Garmin*API artifacts).",
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
         "output_types": "standard",
         "artifact_icon": "activity",

--- a/scripts/artifacts/cmh.py
+++ b/scripts/artifacts/cmh.py
@@ -5,10 +5,10 @@ __artifacts_v2__ = {
         "description": "Parses the Samsung CMH media store (image dates, title, bucket, latitude, longitude, address and path) from cmh.db.",
         "author": "",
         "creation_date": "2020-03-05",
-        "last_update_date": "2026-07-10",
+        "last_update_date": "2026-07-11",
         "requirements": "none",
         "category": "Samsung_CMH",
-        "notes": "",
+        "notes": "Queries the files table directly (media_type 1 = images), which matches the images view older CMH versions defined over it; newer CMH versions dropped that view.",
         "paths": ('*/cmh.db',),
         "output_types": "all",
         "artifact_icon": "file",
@@ -25,8 +25,7 @@ import datetime
 import hashlib
 import sqlite3
 
-from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly, does_table_exist_in_db, \
-    does_view_exist_in_db
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly, does_table_exist_in_db
 
 
 def _ms_to_utc(value):
@@ -44,7 +43,7 @@ def _sec_to_utc(value):
 @artifact_processor
 def get_cmh(files_found, report_folder, seeker, wrap_text):
     # Extractions can hold several cmh.db copies (e.g. one per user profile);
-    # parse every distinct copy that carries the images view. The same
+    # parse every distinct copy that carries the files table. The same
     # database can appear under aliased paths (data/data vs data/user/0,
     # tool mirror folders), so byte-identical copies are only parsed once.
     data_list = []
@@ -61,21 +60,24 @@ def get_cmh(files_found, report_folder, seeker, wrap_text):
             continue
         seen_hashes.add(file_hash)
 
-        # images is a view in most CMH versions; newer versions dropped it
-        if not (does_view_exist_in_db(file_found, 'images') or does_table_exist_in_db(file_found, 'images')):
-            logfunc(f'No images table/view in {file_found} (unsupported CMH schema version?)')
+        if not does_table_exist_in_db(file_found, 'files'):
+            logfunc(f'No files table in {file_found} (unsupported CMH schema version?)')
             continue
 
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         try:
+            # Older CMH versions defined an images view as exactly
+            # "SELECT ... FROM files WHERE media_type=1"; newer versions
+            # dropped the view, so query the files table directly.
             cursor.execute('''
                 SELECT
-                images.datetaken, images.date_added, images.date_modified, images.title,
-                images.bucket_display_name, images.latitude, images.longitude,
-                location_view.address_text, location_view.uri, images._data, images.isprivate
-                FROM images
-                left join location_view on location_view._id = images._id
+                files.datetaken, files.date_added, files.date_modified, files.title,
+                files.bucket_display_name, files.latitude, files.longitude,
+                location_view.address_text, location_view.uri, files._data, files.isprivate
+                FROM files
+                left join location_view on location_view._id = files._id
+                WHERE files.media_type = 1
             ''')
             all_rows = cursor.fetchall()
         except sqlite3.OperationalError as ex:


### PR DESCRIPTION
## Samsung CMH — real recovery

Follow-up to #945's schema guard. Research on the corpus shows the newer CMH schema (Anne, Android 15) didn't move the data — it **dropped the `images` view** while keeping the underlying `files` table unchanged. The old view was literally:

```sql
CREATE VIEW images AS SELECT ... FROM files WHERE media_type=1
```

So `get_cmh` now queries the `files` table directly with that exact filter, which works on every schema generation:

- **Old-schema equivalence proven**: the files-direct query returns **byte-identical rows** to the images-view query on Sharon (all 1,410 rows compared), and matching counts on S20 (16), Galaxy S10 (32), A53 (2).
- **New-schema recovery**: Anne (Android 15) goes from 0 rows (schema-guard skip) to **212 image records** — dates, title, bucket, lat/long, address, path, private flag.
- `location_view` is unchanged across generations, so the address join works everywhere.

## Garmin — documented, no code change warranted

The six legacy Garmin artifacts (Activities/Chart/Dailies/Sleep/SPo2/Weight) target `cache-database` tables that modern Garmin Connect no longer populates. Findings from the Pixel 7a (Android 14) sample:

- `cache-database` is effectively empty: `activity_summaries` 0 rows, `activity_polyline` 0 rows, `response_cache` 1 row — there is **nothing unrecovered** for the legacy parsers to read.
- The modern app stores its data in **`gcm_cache.db`** (`json`, `json_activities`, `devices`, …) and `garmin.api` files — which the existing `GarminJson` (4 rows on this image), `GarminGcmJsonActivities` (3), `garmin.py` (device), `GarminResponse` (1), and `Garmin*API` artifacts already parse. Even the cached activity-segment entries on this image are empty lists — the device simply held minimal Garmin data.
- Added a `notes` line to each of the six legacy artifacts stating where current app versions keep their data, so empty results on modern extractions are understood. Adding speculative new-format parsers without sample data to validate against would be guesswork, so none were added.

## Verification

- `PYTHONPATH=. pylint --disable=C,R` on all 7 changed files: 10.00/10; PluginLoader loads 583 plugins.
- Artifact-level runs on all five Samsung images: Anne 212 (new), Sharon 1,410 / S20 16 / S10 32 / A53 2 (unchanged from #945 behavior).
- Note for the pending sample_data refresh: the fresh Android coverage run was executed with this branch's cmh change, so its Anne value (212) matches this PR — merging this before applying the Android sample_data refresh keeps those numbers consistent.