### PR TITLE
Update sample_data from the refreshed 8-image Android corpus

### DIFF
--- a/scripts/artifacts/GarminActivities.py
+++ b/scripts/artifacts/GarminActivities.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
         "output_types": "standard",
         "artifact_icon": "activity",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.garmin.android.apps.connectmobile vc 8806 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/GarminChart.py
+++ b/scripts/artifacts/GarminChart.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
         "output_types": "standard",
         "artifact_icon": "activity",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.garmin.android.apps.connectmobile vc 8806 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/GarminDailies.py
+++ b/scripts/artifacts/GarminDailies.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
         "output_types": "standard",
         "artifact_icon": "activity",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.garmin.android.apps.connectmobile vc 8806 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/GarminSPo2.py
+++ b/scripts/artifacts/GarminSPo2.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "activity",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.garmin.android.apps.connectmobile vc 8806 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/GarminSleep.py
+++ b/scripts/artifacts/GarminSleep.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
         "output_types": "standard",
         "artifact_icon": "activity",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.garmin.android.apps.connectmobile vc 8806 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/GarminWeight.py
+++ b/scripts/artifacts/GarminWeight.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.garmin.android.apps.connectmobile/databases/cache-database*',),
         "output_types": "standard",
         "artifact_icon": "activity",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | com.garmin.android.apps.connectmobile vc 8806 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/LinkedIn.py
+++ b/scripts/artifacts/LinkedIn.py
@@ -12,7 +12,10 @@ __artifacts_v2__ = {
         "notes": "",
         "paths": ('*/com.linkedin.android/shared_prefs/linkedInPrefsName.xml'),
         "output_types": "standard",
-        "artifact_icon": "user"
+        "artifact_icon": "user",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.linkedin.android vc 198600 | 1 row",
+        }
     },
     "linkedin_messages": {
         "name": "LinkedIn - Messages",

--- a/scripts/artifacts/OneDrive_Metadata.py
+++ b/scripts/artifacts/OneDrive_Metadata.py
@@ -19,6 +19,7 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.microsoft.skydrive vc 2027440202 | 0 rows",
             "samsungs20_a13": "Android 13 | com.microsoft.skydrive | 0 rows",
             "sharon_a14": "Android 14 | com.microsoft.skydrive vc 2027110002 | 0 rows",
+            "galaxys10_a10": "Android 10 | com.microsoft.skydrive vc 2026280402 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/chatgpt.py
+++ b/scripts/artifacts/chatgpt.py
@@ -27,6 +27,9 @@ __artifacts_v2__ = {
         "paths": ('**/com.openai.chatgpt/databases/*_conversations.db*',),
         "output_types": "standard",
         "artifact_icon": "message-circle",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.openai.chatgpt vc 2525902 | 0 rows",
+        },
     },
     "get_chatgpt_user": {
         "name": "ChatGPT - User",

--- a/scripts/artifacts/chatgpt2.py
+++ b/scripts/artifacts/chatgpt2.py
@@ -13,6 +13,9 @@ __artifacts_v2__ = {
         "html_columns": ['Content'],
         "output_types": "standard",
         "artifact_icon": "loader",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.openai.chatgpt vc 2525902 | 12 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/chromeAutofill.py
+++ b/scripts/artifacts/chromeAutofill.py
@@ -16,6 +16,11 @@ __artifacts_v2__ = {
             "galaxys10_a10": "Android 10 | 6 rows",
             "pixel7a_a14": "Android 14 | 4 rows",
             "sharon_a14": "Android 14 | 4 rows",
+            "anne_a15": "Android 15 | 2 rows",
+            "hc_pixel8pro_a16": "Android 16 | 1 row",
+            "kevin_pocox7_a15": "Android 15 | 1 row",
+            "samsunga53_a14": "Android 14 | 18 rows",
+            "samsungs20_a13": "Android 13 | 4 rows",
         },
     },
     "get_chromeAutofillProfiles": {

--- a/scripts/artifacts/chromeDIPS.py
+++ b/scripts/artifacts/chromeDIPS.py
@@ -17,6 +17,9 @@ __artifacts_v2__ = {
             "kevin_pocox7_a15": "Android 15 | com.android.chrome vc 733920733 | 19 rows",
             "pixel7a_a14": "Android 14 | com.android.chrome vc 616710133, com.microsoft.emmx vc 259210005 | 36 rows",
             "sharon_a14": "Android 14 | com.android.chrome vc 653310333 | 19 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.android.chrome vc 782711433, com.brave.browser vc 429117204, com.sec.android.app.sbrowser vc 1300067502 | 3 rows",
+            "samsunga53_a14": "Android 14 | com.android.chrome vc 744417133 | 15 rows",
+            "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233, com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 13 rows",
         },
     }
 }

--- a/scripts/artifacts/chromeNetworkActionPredictor.py
+++ b/scripts/artifacts/chromeNetworkActionPredictor.py
@@ -14,6 +14,8 @@ __artifacts_v2__ = {
         "artifact_icon": "wifi",
         "sample_data": {
             "sharon_a14": "Android 14 | com.sec.android.app.sbrowser vc 1260103502 | 0 rows",
+            "anne_a15": "Android 15 | com.sec.android.app.sbrowser vc 1280509502 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.sec.android.app.sbrowser vc 1300067502 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/cmh.py
+++ b/scripts/artifacts/cmh.py
@@ -15,8 +15,9 @@ __artifacts_v2__ = {
         "sample_data": {
             "galaxys10_a10": "Android 10 | com.samsung.cmh | 32 rows",
             "samsunga53_a14": "Android 14 | com.samsung.cmh | 2 rows",
-            "samsungs20_a13": "Android 13 | com.samsung.cmh | 15 rows",
+            "samsungs20_a13": "Android 13 | com.samsung.cmh | 16 rows",
             "sharon_a14": "Android 14 | com.samsung.cmh | 1410 rows",
+            "anne_a15": "Android 15 | com.samsung.cmh | 212 rows",
         },
     }
 }

--- a/scripts/artifacts/gmailEmails.py
+++ b/scripts/artifacts/gmailEmails.py
@@ -20,6 +20,8 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | com.google.android.gm vc 64361093 | 206 rows",
             "samsunga53_a14": "Android 14 | com.google.android.gm vc 65429598 | 112 rows",
             "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 207 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gm vc 62632206 | 28 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gm vc 65465122 | 109 rows",
         },
     },
     "gmailLabels": {

--- a/scripts/artifacts/packageInfo.py
+++ b/scripts/artifacts/packageInfo.py
@@ -20,6 +20,7 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | 369 rows",
             "samsunga53_a14": "Android 14 | 486 rows",
             "sharon_a14": "Android 14 | 499 rows",
+            "samsungs20_a13": "Android 13 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/walStrings.py
+++ b/scripts/artifacts/walStrings.py
@@ -14,6 +14,12 @@ __artifacts_v2__ = {
         "sample_data": {
             "galaxys10_a10": "Android 10 | 721 rows",
             "samsunga53_a14": "Android 14 | 1916 rows",
+            "anne_a15": "Android 15 | 869 rows",
+            "hc_pixel8pro_a16": "Android 16 | 527 rows",
+            "kevin_pocox7_a15": "Android 15 | 519 rows",
+            "pixel7a_a14": "Android 14 | 510 rows",
+            "samsungs20_a13": "Android 13 | 791 rows",
+            "sharon_a14": "Android 14 | 900 rows",
         },
         "html_columns": ['Report'],
     }


### PR DESCRIPTION
## Summary

Metadata-only refresh of `sample_data` after the crash fixes in #945 and #946. The full 8-image corpus (Android 10–16) was re-run with current main — **9/9 archives processed, zero artifact errors** — and the updater recorded coverage for the 17 artifacts that previously crashed and therefore had no entries.

Highlights:

- **Recovered data now documented**: `get_cmh` 212 rows on Android 15 (via #946's files-table query) and 16 on the S20 (second user profile included); `gmailEmails` 28 rows on the Galaxy S10 and 109 on the S20; `get_chromeAutofill` and `get_chromeDIPS` entries on every image (including the new Chromium DIPS schema); `get_walStrings` on six more images; `get_chatpgt2` 12 conversations and `linkedin_account` 1 row on Android 15.
- **Honest "0 rows" entries** where the source exists but holds nothing parseable: the six legacy Garmin artifacts on the Pixel 7a (modern Garmin Connect keeps data in gcm_cache.db — see their notes), `get_chatgpt_conversations` on the new ChatGPT schema (deferring to chatgpt2), and `get_package_info` on the S20's unparseable packages.xml.
- Hand-written notes preserved; managed keys only. A second `--apply` reports **zero changes** (idempotent).
- `PYTHONPATH=. pylint --disable=C,R` on all 17 files: 10.00/10; PluginLoader smoke passes (583 plugins).

The iOS counterpart will follow once its corpus re-run completes.