### PR TITLE
Fix googlemapaudioTemp crash on archives with file/directory name collisions

### DIFF
--- a/scripts/artifacts/googlemapaudioTemp.py
+++ b/scripts/artifacts/googlemapaudioTemp.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
         "description": "Google Maps text-to-speech voice guidance audio (app_tts-temp)",
         "author": "",
         "creation_date": "2023-04-27",
-        "last_update_date": "2023-04-27",
+        "last_update_date": "2026-07-12",
         "requirements": "none",
         "category": "Google Maps Voice Guidance",
         "notes": "",
@@ -44,7 +44,9 @@ def get_googlemapaudioTemp(files_found, report_folder, seeker, wrap_text):
     source_path = ''
     for file_found in files_found:
         file_found = str(file_found)
-        if os.path.isdir(file_found):
+        # Some archives hold a file and a directory under the same name, so a
+        # matched path may exist only in the archive listing, never on disk.
+        if not os.path.isfile(file_found):
             continue
         file_size = os.path.getsize(file_found)
         if file_size == 0:


### PR DESCRIPTION
## Summary
- `get_googlemapaudioTemp` crashed with `NotADirectoryError` on an Android 13 test image whose tar stores an `app_tts-temp/tts-<id>` entry as both a regular file and a directory prefix. The seeker matches the child paths from the archive listing but cannot extract them, so `os.path.getsize()` hits a path whose parent component is a file.
- Replaced the `isdir` guard with `os.path.isfile()`, which also skips matches that were never extracted (missing paths and file-as-parent collisions). Real audio files parse exactly as before.

## Verification
- Full ALEAPP re-run of the affected image: artifact completes with 4 files matched / 3 audio rows, corpus-wide artifact error count back to 0 (11 extractions).
- pylint 10.00/10 on the touched file.