### PR TITLE
Populate sample_data from 2 new Android 13 test images

### DIFF
--- a/scripts/artifacts/Cello.py
+++ b/scripts/artifacts/Cello.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.apps.docs vc 214258185 | 51 rows",
             "samsungs20_a13": "Android 13 | com.google.android.apps.docs vc 214207580 | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.docs vc 213692448 | 20 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.docs vc 213183212 | 1 row",
+            "userb2_a13": "Android 13 | com.google.android.apps.docs vc 213806576 | 8 rows",
         },
     }
 }

--- a/scripts/artifacts/DocList.py
+++ b/scripts/artifacts/DocList.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.apps.docs vc 214258185 | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.apps.docs vc 214207580 | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.docs vc 213692448 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.docs vc 213183212 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.docs vc 213806576 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/FCMQueuedMessageKik.py
+++ b/scripts/artifacts/FCMQueuedMessageKik.py
@@ -22,6 +22,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
         },
     },
     "fcm_kik_blanks": {
@@ -46,6 +48,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/FCMQueuedMessageOutlook.py
+++ b/scripts/artifacts/FCMQueuedMessageOutlook.py
@@ -22,6 +22,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/FCMQueuedMessagesDump.py
+++ b/scripts/artifacts/FCMQueuedMessagesDump.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 5010 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 3914 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 36746 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 11408 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 2016 rows",
         },
     },
     "get_fcm_dump_verizon": {
@@ -44,6 +46,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
         },
     },
     "get_fcm_dump_tiktok": {
@@ -67,6 +71,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 102 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 40 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 391 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 86 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 142 rows",
         },
     },
     "get_fcm_dump_instagram": {
@@ -90,6 +96,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 33 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
         },
     },
     "get_fcm_dump_gqsb": {
@@ -113,6 +121,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 53 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 54 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/FCMQueuedMessagesJungrammer.py
+++ b/scripts/artifacts/FCMQueuedMessagesJungrammer.py
@@ -42,6 +42,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/FCMQueuedMessagesSkype.py
+++ b/scripts/artifacts/FCMQueuedMessagesSkype.py
@@ -42,6 +42,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
         },
     },
     "get_fcm_skype_notifications": {
@@ -65,6 +67,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/FCMQueuedMessagesTumblr.py
+++ b/scripts/artifacts/FCMQueuedMessagesTumblr.py
@@ -42,6 +42,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
         },
     },
     "get_fcm_tumblr_flagged": {
@@ -65,6 +67,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
         },
     },
     "get_fcm_tumblr_notifications": {
@@ -88,6 +92,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
         },
     },
     "get_fcm_tumblr_logs": {
@@ -111,6 +117,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/FCMQueuedMessagesTwitter.py
+++ b/scripts/artifacts/FCMQueuedMessagesTwitter.py
@@ -42,6 +42,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/FCMQueuedMessagesXbox.py
+++ b/scripts/artifacts/FCMQueuedMessagesXbox.py
@@ -42,6 +42,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
         },
     },
     "get_fcm_xbox_party": {
@@ -65,6 +67,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
         },
     },
     "get_fcm_xbox_presence": {
@@ -88,6 +92,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/FilesByGoogle.py
+++ b/scripts/artifacts/FilesByGoogle.py
@@ -15,6 +15,8 @@ __artifacts_v2__ = {
             "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.nbu.files vc 1849879 | 71 rows",
             "kevin_pocox7_a15": "Android 15 | com.google.android.apps.nbu.files vc 1508395 | 434 rows",
             "pixel7a_a14": "Android 14 | com.google.android.apps.nbu.files vc 695143 | 228 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.nbu.files vc 492527 | 95 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.nbu.files vc 1107071 | 16 rows",
         }
     },
     "fbg_searchhistory": {

--- a/scripts/artifacts/NikeAMoments.py
+++ b/scripts/artifacts/NikeAMoments.py
@@ -15,6 +15,7 @@ __artifacts_v2__ = {
         "artifact_icon": "activity",
         "sample_data": {
             "samsunga53_a14": "Android 14 | com.nike.plusgps vc 1717605525 | 0 rows",
+            "userb2_a13": "Android 13 | com.nike.plusgps vc 1717303105 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/NikeActivities.py
+++ b/scripts/artifacts/NikeActivities.py
@@ -14,6 +14,7 @@ __artifacts_v2__ = {
         "artifact_icon": "activity",
         "sample_data": {
             "samsunga53_a14": "Android 14 | com.nike.plusgps vc 1717605525 | 0 rows",
+            "userb2_a13": "Android 13 | com.nike.plusgps vc 1717303105 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/NikeNotifications.py
+++ b/scripts/artifacts/NikeNotifications.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.nike.plusgps/databases/ns_inbox.db*',),
         "output_types": "standard",
         "artifact_icon": "activity",
+        "sample_data": {
+            "userb2_a13": "Android 13 | com.nike.plusgps vc 1717303105 | 0 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/NikePolyline.py
+++ b/scripts/artifacts/NikePolyline.py
@@ -15,6 +15,7 @@ __artifacts_v2__ = {
         "artifact_icon": "activity",
         "sample_data": {
             "samsunga53_a14": "Android 14 | com.nike.plusgps vc 1717605525 | 0 rows",
+            "userb2_a13": "Android 13 | com.nike.plusgps vc 1717303105 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/SimpleStorage_applaunch.py
+++ b/scripts/artifacts/SimpleStorage_applaunch.py
@@ -16,6 +16,8 @@ __artifacts_v2__ = {
         "sample_data": {
             "hc_pixel8pro_a16": "Android 16 | com.google.android.as vc 14926349 | 10 rows",
             "pixel7a_a14": "Android 14 | com.google.android.as vc 10790541 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.as vc 8828817 | 38 rows",
+            "userb2_a13": "Android 13 | com.google.android.as vc 8997612 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/TorBrowser.py
+++ b/scripts/artifacts/TorBrowser.py
@@ -27,6 +27,7 @@ __artifacts_v2__ = {
         "artifact_icon": "bookmark",
         "sample_data": {
             "hc_pixel8pro_a16": "Android 16 | org.torproject.torbrowser vc 2016164570 | 1 row",
+            "russell_pixel6a_a13": "Android 13 | org.torproject.torbrowser vc 2015960779 | 0 rows",
         }
     },
     "torbrowser_usageinfo": {
@@ -43,6 +44,7 @@ __artifacts_v2__ = {
         "artifact_icon": "info-circle",
         "sample_data": {
             "hc_pixel8pro_a16": "Android 16 | org.torproject.torbrowser vc 2016164570 | 3 rows",
+            "russell_pixel6a_a13": "Android 13 | org.torproject.torbrowser vc 2015960779 | 1 row",
         }
     },
 }

--- a/scripts/artifacts/WhatsApp.py
+++ b/scripts/artifacts/WhatsApp.py
@@ -19,6 +19,7 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | com.whatsapp vc 241481004 | 92 rows",
             "samsungs20_a13": "Android 13 | com.whatsapp vc 253776000 | 28 rows",
             "sharon_a14": "Android 14 | com.whatsapp vc 241676004 | 638 rows",
+            "russell_pixel6a_a13": "Android 13 | com.whatsapp vc 231278007 | 2 rows",
         },
     },
     "get_whatsapp_call_logs": {
@@ -40,6 +41,7 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | com.whatsapp vc 241481004 | 4 rows",
             "samsungs20_a13": "Android 13 | com.whatsapp vc 253776000 | 0 rows",
             "sharon_a14": "Android 14 | com.whatsapp vc 241676004 | 3 rows",
+            "russell_pixel6a_a13": "Android 13 | com.whatsapp vc 231278007 | 0 rows",
         },
     },
     "get_whatsapp_messages": {
@@ -61,6 +63,7 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | com.whatsapp vc 241481004 | 0 rows",
             "samsungs20_a13": "Android 13 | com.whatsapp vc 253776000 | 0 rows",
             "sharon_a14": "Android 14 | com.whatsapp vc 241676004 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.whatsapp vc 231278007 | 0 rows",
         },
     },
     "get_whatsapp_one_to_one_messages": {
@@ -84,6 +87,7 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | com.whatsapp vc 241481004 | 73 rows",
             "samsungs20_a13": "Android 13 | com.whatsapp vc 253776000 | 195 rows",
             "sharon_a14": "Android 14 | com.whatsapp vc 241676004 | 781 rows",
+            "russell_pixel6a_a13": "Android 13 | com.whatsapp vc 231278007 | 71 rows",
         },
         "data_views": {
             "conversation": {
@@ -119,6 +123,7 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | com.whatsapp vc 241481004 | 156 rows",
             "samsungs20_a13": "Android 13 | com.whatsapp vc 253776000 | 0 rows",
             "sharon_a14": "Android 14 | com.whatsapp vc 241676004 | 4730 rows",
+            "russell_pixel6a_a13": "Android 13 | com.whatsapp vc 231278007 | 0 rows",
         },
         "data_views": {
             "conversation": {
@@ -152,6 +157,7 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | com.whatsapp vc 241481004 | 0 rows",
             "samsungs20_a13": "Android 13 | com.whatsapp vc 253776000 | 3 rows",
             "sharon_a14": "Android 14 | com.whatsapp vc 241676004 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.whatsapp vc 231278007 | 0 rows",
         },
     },
     "get_whatsapp_user_profile": {
@@ -174,6 +180,7 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | com.whatsapp vc 241481004 | 1 row",
             "samsungs20_a13": "Android 13 | com.whatsapp vc 253776000 | 1 row",
             "sharon_a14": "Android 14 | com.whatsapp vc 241676004 | 1 row",
+            "russell_pixel6a_a13": "Android 13 | com.whatsapp vc 231278007 | 1 row",
         },
     }
 }

--- a/scripts/artifacts/accounts_ce.py
+++ b/scripts/artifacts/accounts_ce.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 8 rows",
             "samsungs20_a13": "Android 13 | 16 rows",
             "sharon_a14": "Android 14 | 14 rows",
+            "russell_pixel6a_a13": "Android 13 | 8 rows",
+            "userb2_a13": "Android 13 | 2 rows",
         }
     },
     "accounts_ce_authtokens": {
@@ -44,6 +46,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 130 rows",
             "samsungs20_a13": "Android 13 | 107 rows",
             "sharon_a14": "Android 14 | 107 rows",
+            "russell_pixel6a_a13": "Android 13 | 227 rows",
+            "userb2_a13": "Android 13 | 108 rows",
         }
     }
 }

--- a/scripts/artifacts/accounts_de.py
+++ b/scripts/artifacts/accounts_de.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 11 rows",
             "samsungs20_a13": "Android 13 | 19 rows",
             "sharon_a14": "Android 14 | 15 rows",
+            "russell_pixel6a_a13": "Android 13 | 11 rows",
+            "userb2_a13": "Android 13 | 3 rows",
         }
     }
 }

--- a/scripts/artifacts/adb_hosts.py
+++ b/scripts/artifacts/adb_hosts.py
@@ -19,6 +19,8 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | 0 rows",
             "samsungs20_a13": "Android 13 | 1 row",
             "sharon_a14": "Android 14 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | 1 row",
+            "userb2_a13": "Android 13 | 1 row",
         }
     }
 }

--- a/scripts/artifacts/airGuard.py
+++ b/scripts/artifacts/airGuard.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/de.seemoo.at_tracking_detection.release/databases/attd_db*',),
         "output_types": "all",
         "artifact_icon": "shield",
+        "sample_data": {
+            "russell_pixel6a_a13": "Android 13 | de.seemoo.at_tracking_detection.release vc 37 | 1960 rows",
+        },
     },
     "get_airGuard_scans": {
         "name": "AirGuard AirTag Scans",
@@ -25,6 +28,9 @@ __artifacts_v2__ = {
         "paths": ('*/de.seemoo.at_tracking_detection.release/databases/attd_db*',),
         "output_types": "standard",
         "artifact_icon": "search",
+        "sample_data": {
+            "russell_pixel6a_a13": "Android 13 | de.seemoo.at_tracking_detection.release vc 37 | 805 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/airtagAndroid.py
+++ b/scripts/artifacts/airtagAndroid.py
@@ -20,6 +20,7 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
         }
     },
     "airtagScans": {
@@ -42,6 +43,7 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 4 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
         }
     },
     "airtagLastScan": {
@@ -62,6 +64,7 @@ __artifacts_v2__ = {
             "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 1 row",
             "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 1 row",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 1 row",
+            "userb2_a13": "Android 13 | com.google.android.gms | 1 row",
         }
     },
     "airtagPassiveScan": {

--- a/scripts/artifacts/androidauto.py
+++ b/scripts/artifacts/androidauto.py
@@ -17,6 +17,8 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | com.google.android.projection.gearhead vc 123642624 | 1 row",
             "samsunga53_a14": "Android 14 | com.google.android.projection.gearhead vc 156654484 | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.projection.gearhead vc 124642854 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.projection.gearhead vc 97632214 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.projection.gearhead vc 132644464 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/appSemloc.py
+++ b/scripts/artifacts/appSemloc.py
@@ -20,6 +20,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 1324 rows",
         },
     }
 }

--- a/scripts/artifacts/appicons.py
+++ b/scripts/artifacts/appicons.py
@@ -15,6 +15,8 @@ __artifacts_v2__ = {
         "sample_data": {
             "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.nexuslauncher | 0 rows",
             "pixel7a_a14": "Android 14 | com.google.android.apps.nexuslauncher | 100 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.nexuslauncher | 293 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.nexuslauncher | 88 rows",
         }
     }
 }

--- a/scripts/artifacts/appopSetupWiz.py
+++ b/scripts/artifacts/appopSetupWiz.py
@@ -19,6 +19,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 0 rows",
             "samsungs20_a13": "Android 13 | 11 rows",
             "sharon_a14": "Android 14 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | 26 rows",
+            "userb2_a13": "Android 13 | 12 rows",
         },
     }
 }

--- a/scripts/artifacts/appops.py
+++ b/scripts/artifacts/appops.py
@@ -19,6 +19,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 0 rows",
             "samsungs20_a13": "Android 13 | 1650 rows",
             "sharon_a14": "Android 14 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | 2391 rows",
+            "userb2_a13": "Android 13 | 1015 rows",
         },
     },
     "get_appops_legacy": {
@@ -40,6 +42,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 0 rows",
             "samsungs20_a13": "Android 13 | 0 rows",
             "sharon_a14": "Android 14 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | 0 rows",
+            "userb2_a13": "Android 13 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/battery_usage_v4.py
+++ b/scripts/artifacts/battery_usage_v4.py
@@ -15,6 +15,8 @@ __artifacts_v2__ = {
         "sample_data": {
             "hc_pixel8pro_a16": "Android 16 | com.google.android.settings.intelligence vc 1000282241 | 0 rows",
             "pixel7a_a14": "Android 14 | com.google.android.settings.intelligence vc 1000230247 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.settings.intelligence vc 1000217934 | 98857 rows",
+            "userb2_a13": "Android 13 | com.google.android.settings.intelligence vc 1000232695 | 216 rows",
         },
     }
 }

--- a/scripts/artifacts/batterystats.py
+++ b/scripts/artifacts/batterystats.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 335 rows",
             "samsungs20_a13": "Android 13 | 148 rows",
             "sharon_a14": "Android 14 | 230 rows",
+            "russell_pixel6a_a13": "Android 13 | 714 rows",
+            "userb2_a13": "Android 13 | 325 rows",
         }
     }
 }

--- a/scripts/artifacts/bluetoothConnections.py
+++ b/scripts/artifacts/bluetoothConnections.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 1 row",
             "samsungs20_a13": "Android 13 | 0 rows",
             "sharon_a14": "Android 14 | 1 row",
+            "russell_pixel6a_a13": "Android 13 | 4 rows",
+            "userb2_a13": "Android 13 | 1 row",
         },
     },
     "get_bluetoothAdapter": {
@@ -44,6 +46,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 14 rows",
             "samsungs20_a13": "Android 13 | 14 rows",
             "sharon_a14": "Android 14 | 14 rows",
+            "russell_pixel6a_a13": "Android 13 | 10 rows",
+            "userb2_a13": "Android 13 | 10 rows",
         },
     }
 }

--- a/scripts/artifacts/browserCachechrome.py
+++ b/scripts/artifacts/browserCachechrome.py
@@ -20,6 +20,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.android.chrome vc 744417133 | 1701 rows",
             "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233 | 44 rows",
             "sharon_a14": "Android 14 | com.android.chrome vc 653310333 | 13957 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.chrome vc 573513033 | 11054 rows",
+            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 1257 rows",
         },
     }
 }

--- a/scripts/artifacts/build.py
+++ b/scripts/artifacts/build.py
@@ -19,6 +19,7 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | 6 rows",
             "samsunga53_a14": "Android 14 | 6 rows",
             "sharon_a14": "Android 14 | 6 rows",
+            "russell_pixel6a_a13": "Android 13 | 6 rows",
         },
     }
 }

--- a/scripts/artifacts/calllog.py
+++ b/scripts/artifacts/calllog.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.samsung.android.providers.contacts | 69 rows",
             "samsungs20_a13": "Android 13 | com.samsung.android.providers.contacts | 12 rows",
             "sharon_a14": "Android 14 | com.samsung.android.providers.contacts | 397 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.providers.contacts | 42 rows",
+            "userb2_a13": "Android 13 | com.android.providers.contacts | 0 rows",
         },
         "html_columns": ['Type'],
     }

--- a/scripts/artifacts/calllogs.py
+++ b/scripts/artifacts/calllogs.py
@@ -16,6 +16,8 @@ __artifacts_v2__ = {
             "hc_pixel8pro_a16": "Android 16 | com.android.providers.contacts | 0 rows",
             "kevin_pocox7_a15": "Android 15 | com.android.providers.contacts | 0 rows",
             "pixel7a_a14": "Android 14 | com.android.providers.contacts | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.providers.contacts | 0 rows",
+            "userb2_a13": "Android 13 | com.android.providers.contacts | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/chrome.py
+++ b/scripts/artifacts/chrome.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.android.chrome vc 744417133, com.sec.android.app.sbrowser vc 1290059502 | 132 rows",
             "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233, com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 65 rows",
             "sharon_a14": "Android 14 | com.android.chrome vc 653310333, com.sec.android.app.sbrowser vc 1260103502 | 137 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.chrome vc 573513033, com.brave.browser vc 415212624 | 118 rows",
+            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 62 rows",
         },
     },
     "get_chromeWebVisits": {
@@ -44,6 +46,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.android.chrome vc 744417133, com.sec.android.app.sbrowser vc 1290059502 | 174 rows",
             "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233, com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 86 rows",
             "sharon_a14": "Android 14 | com.android.chrome vc 653310333, com.sec.android.app.sbrowser vc 1260103502 | 198 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.chrome vc 573513033, com.brave.browser vc 415212624 | 207 rows",
+            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 76 rows",
         },
     },
     "get_chromeSearchTerms": {
@@ -67,6 +71,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.android.chrome vc 744417133, com.sec.android.app.sbrowser vc 1290059502 | 39 rows",
             "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233, com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 18 rows",
             "sharon_a14": "Android 14 | com.android.chrome vc 653310333, com.sec.android.app.sbrowser vc 1260103502 | 18 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.chrome vc 573513033, com.brave.browser vc 415212624 | 37 rows",
+            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 16 rows",
         },
     },
     "get_chromeDownloads": {
@@ -90,6 +96,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.android.chrome vc 744417133, com.sec.android.app.sbrowser vc 1290059502 | 0 rows",
             "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233, com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 2 rows",
             "sharon_a14": "Android 14 | com.android.chrome vc 653310333, com.sec.android.app.sbrowser vc 1260103502 | 108 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.chrome vc 573513033, com.brave.browser vc 415212624 | 1 row",
+            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 2 rows",
         },
     },
     "get_chromeKeywordSearchTerms": {
@@ -113,6 +121,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.android.chrome vc 744417133, com.sec.android.app.sbrowser vc 1290059502 | 48 rows",
             "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233, com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 18 rows",
             "sharon_a14": "Android 14 | com.android.chrome vc 653310333, com.sec.android.app.sbrowser vc 1260103502 | 23 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.chrome vc 573513033, com.brave.browser vc 415212624 | 44 rows",
+            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 16 rows",
         },
     }
 }

--- a/scripts/artifacts/chromeAutofill.py
+++ b/scripts/artifacts/chromeAutofill.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "kevin_pocox7_a15": "Android 15 | 1 row",
             "samsunga53_a14": "Android 14 | 18 rows",
             "samsungs20_a13": "Android 13 | 4 rows",
+            "russell_pixel6a_a13": "Android 13 | 8 rows",
+            "userb2_a13": "Android 13 | 12 rows",
         },
     },
     "get_chromeAutofillProfiles": {
@@ -44,6 +46,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 0 rows",
             "samsungs20_a13": "Android 13 | 0 rows",
             "sharon_a14": "Android 14 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | 0 rows",
+            "userb2_a13": "Android 13 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/chromeBookmarks.py
+++ b/scripts/artifacts/chromeBookmarks.py
@@ -16,6 +16,7 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | com.android.chrome vc 616710133, com.microsoft.emmx vc 259210005, com.opera.browser vc 1908324306 | 0 rows",
             "samsungs20_a13": "Android 13 | com.microsoft.emmx vc 365012523 | 1 row",
             "sharon_a14": "Android 14 | com.android.chrome vc 653310333 | 6 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.chrome vc 573513033 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/chromeCookies.py
+++ b/scripts/artifacts/chromeCookies.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 1491 rows",
             "samsungs20_a13": "Android 13 | 670 rows",
             "sharon_a14": "Android 14 | 1842 rows",
+            "russell_pixel6a_a13": "Android 13 | 1420 rows",
+            "userb2_a13": "Android 13 | 632 rows",
         },
     }
 }

--- a/scripts/artifacts/chromeDIPS.py
+++ b/scripts/artifacts/chromeDIPS.py
@@ -20,6 +20,8 @@ __artifacts_v2__ = {
             "hc_pixel8pro_a16": "Android 16 | com.android.chrome vc 782711433, com.brave.browser vc 429117204, com.sec.android.app.sbrowser vc 1300067502 | 3 rows",
             "samsunga53_a14": "Android 14 | com.android.chrome vc 744417133 | 15 rows",
             "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233, com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 13 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.chrome vc 573513033 | 19 rows",
+            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 10 rows",
         },
     }
 }

--- a/scripts/artifacts/chromeLoginData.py
+++ b/scripts/artifacts/chromeLoginData.py
@@ -18,6 +18,7 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | 3 rows",
             "samsungs20_a13": "Android 13 | com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 0 rows",
             "sharon_a14": "Android 14 | com.android.chrome vc 653310333, com.sec.android.app.sbrowser vc 1260103502 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.chrome vc 573513033, com.brave.browser vc 415212624 | 1 row",
         },
     }
 }

--- a/scripts/artifacts/chromeOfflinePages.py
+++ b/scripts/artifacts/chromeOfflinePages.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.android.chrome vc 744417133 | 12 rows",
             "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233, com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 7 rows",
             "sharon_a14": "Android 14 | com.android.chrome vc 653310333 | 38 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.chrome vc 573513033, com.brave.browser vc 415212624 | 9 rows",
+            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 8 rows",
         },
     }
 }

--- a/scripts/artifacts/chromeTopSites.py
+++ b/scripts/artifacts/chromeTopSites.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.android.chrome vc 744417133 | 0 rows",
             "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233, com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 0 rows",
             "sharon_a14": "Android 14 | com.android.chrome vc 653310333, com.sec.android.app.sbrowser vc 1260103502 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.chrome vc 573513033, com.brave.browser vc 415212624 | 0 rows",
+            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/contacts.py
+++ b/scripts/artifacts/contacts.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.samsung.android.providers.contacts | 12 rows",
             "samsungs20_a13": "Android 13 | com.samsung.android.providers.contacts | 6 rows",
             "sharon_a14": "Android 14 | com.samsung.android.providers.contacts | 31 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.providers.contacts | 4 rows",
+            "userb2_a13": "Android 13 | com.android.providers.contacts | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/deviceHealthServices_AppUsage.py
+++ b/scripts/artifacts/deviceHealthServices_AppUsage.py
@@ -20,6 +20,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.apps.turbo | 237 rows",
             "samsungs20_a13": "Android 13 | com.google.android.apps.turbo | 232 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.turbo vc 10261629 | 79 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.turbo vc 10261629 | 928 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.turbo vc 10270697 | 2 rows",
         },
     }
 }

--- a/scripts/artifacts/deviceHealthServices_Battery.py
+++ b/scripts/artifacts/deviceHealthServices_Battery.py
@@ -20,6 +20,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.apps.turbo | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.apps.turbo | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.turbo vc 10261629 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.turbo vc 10261629 | 5604 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.turbo vc 10270697 | 1144 rows",
         }
     },
     "Turbo_Bluetooth": {
@@ -38,6 +40,8 @@ __artifacts_v2__ = {
             "galaxys10_a10": "Android 10 | com.google.android.apps.turbo vc 10235989 | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.apps.turbo | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.turbo vc 10261629 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.turbo vc 10261629 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.turbo vc 10270697 | 0 rows",
         }
     }
 }

--- a/scripts/artifacts/discordChats.py
+++ b/scripts/artifacts/discordChats.py
@@ -16,6 +16,7 @@ __artifacts_v2__ = {
             "hc_pixel8pro_a16": "Android 16 | com.discord vc 333012 | 7 rows",
             "pixel7a_a14": "Android 14 | com.discord vc 239015 | 47 rows",
             "samsungs20_a13": "Android 13 | com.discord vc 310011 | 1 row",
+            "userb2_a13": "Android 13 | com.discord vc 255014 | 25 rows",
         },
         "data_views": {
             "conversation": {

--- a/scripts/artifacts/discreteNative.py
+++ b/scripts/artifacts/discreteNative.py
@@ -19,6 +19,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 13 rows",
             "samsungs20_a13": "Android 13 | 41 rows",
             "sharon_a14": "Android 14 | 281 rows",
+            "russell_pixel6a_a13": "Android 13 | 41 rows",
+            "userb2_a13": "Android 13 | 13 rows",
         },
     }
 }

--- a/scripts/artifacts/downloads.py
+++ b/scripts/artifacts/downloads.py
@@ -20,6 +20,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.android.providers.downloads | 11 rows",
             "samsungs20_a13": "Android 13 | com.android.providers.downloads | 2 rows",
             "sharon_a14": "Android 14 | com.android.providers.downloads | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.providers.downloads | 16 rows",
+            "userb2_a13": "Android 13 | com.android.providers.downloads | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/emulatedSmeta.py
+++ b/scripts/artifacts/emulatedSmeta.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.providers.media.module | 1 row",
             "samsungs20_a13": "Android 13 | com.google.android.providers.media.module | 5 rows",
             "sharon_a14": "Android 14 | com.google.android.providers.media.module | 122 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.providers.media.module | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.providers.media.module | 2 rows",
         },
     },
     "get_emulatedSmeta_images": {
@@ -44,6 +46,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.providers.media.module | 2 rows",
             "samsungs20_a13": "Android 13 | com.google.android.providers.media.module | 15 rows",
             "sharon_a14": "Android 14 | com.google.android.providers.media.module | 1410 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.providers.media.module | 55 rows",
+            "userb2_a13": "Android 13 | com.google.android.providers.media.module | 4 rows",
         },
     },
     "get_emulatedSmeta_files": {
@@ -67,6 +71,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.providers.media.module | 26 rows",
             "samsungs20_a13": "Android 13 | com.google.android.providers.media.module | 133 rows",
             "sharon_a14": "Android 14 | com.google.android.providers.media.module | 1938 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.providers.media.module | 149 rows",
+            "userb2_a13": "Android 13 | com.google.android.providers.media.module | 26 rows",
         },
     },
     "get_emulatedSmeta_videos": {
@@ -90,6 +96,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.providers.media.module | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.providers.media.module | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.providers.media.module | 29 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.providers.media.module | 5 rows",
+            "userb2_a13": "Android 13 | com.google.android.providers.media.module | 0 rows",
         },
     },
     "get_emulatedSmeta_audio": {
@@ -113,6 +121,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.providers.media.module | 1 row",
             "samsungs20_a13": "Android 13 | com.google.android.providers.media.module | 1 row",
             "sharon_a14": "Android 14 | com.google.android.providers.media.module | 2 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.providers.media.module | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.providers.media.module | 0 rows",
         },
     },
     "get_emulatedSmeta_files_legacy": {
@@ -136,6 +146,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.providers.media.module | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.providers.media.module | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.providers.media.module | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.providers.media.module | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.providers.media.module | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/etc_hosts.py
+++ b/scripts/artifacts/etc_hosts.py
@@ -18,6 +18,7 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | 0 rows",
             "samsunga53_a14": "Android 14 | 0 rows",
             "sharon_a14": "Android 14 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/factory_reset.py
+++ b/scripts/artifacts/factory_reset.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 1 row",
             "samsungs20_a13": "Android 13 | 1 row",
             "sharon_a14": "Android 14 | 1 row",
+            "russell_pixel6a_a13": "Android 13 | 1 row",
+            "userb2_a13": "Android 13 | 1 row",
         },
     }
 }

--- a/scripts/artifacts/frosting.py
+++ b/scripts/artifacts/frosting.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.android.vending vc 84913330 | 527 rows",
             "samsungs20_a13": "Android 13 | com.android.vending vc 84962330 | 507 rows",
             "sharon_a14": "Android 14 | com.android.vending vc 84222730 | 541 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.vending vc 83631220 | 324 rows",
+            "userb2_a13": "Android 13 | com.android.vending vc 84371930 | 333 rows",
         }
     }
 }

--- a/scripts/artifacts/gboard.py
+++ b/scripts/artifacts/gboard.py
@@ -17,6 +17,8 @@ __artifacts_v2__ = {
             "hc_pixel8pro_a16": "Android 16 | com.google.android.inputmethod.latin vc 175827782 | 4 rows",
             "kevin_pocox7_a15": "Android 15 | com.google.android.inputmethod.latin vc 175401514 | 4 rows",
             "pixel7a_a14": "Android 14 | com.google.android.inputmethod.latin vc 128278094 | 4 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.inputmethod.latin vc 114763994 | 4 rows",
+            "userb2_a13": "Android 13 | com.google.android.inputmethod.latin vc 155404870 | 8 rows",
         },
     },
     "get_gboardCache_keystrokes": {
@@ -35,6 +37,8 @@ __artifacts_v2__ = {
             "hc_pixel8pro_a16": "Android 16 | com.google.android.inputmethod.latin vc 175827782 | 0 rows",
             "kevin_pocox7_a15": "Android 15 | com.google.android.inputmethod.latin vc 175401514 | 0 rows",
             "pixel7a_a14": "Android 14 | com.google.android.inputmethod.latin vc 128278094 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.inputmethod.latin vc 114763994 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.inputmethod.latin vc 155404870 | 0 rows",
         },
     },
     "get_gboardCache_sessions": {
@@ -53,6 +57,8 @@ __artifacts_v2__ = {
             "hc_pixel8pro_a16": "Android 16 | com.google.android.inputmethod.latin vc 175827782 | 12 rows",
             "kevin_pocox7_a15": "Android 15 | com.google.android.inputmethod.latin vc 175401514 | 359 rows",
             "pixel7a_a14": "Android 14 | com.google.android.inputmethod.latin vc 128278094 | 230 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.inputmethod.latin vc 114763994 | 357 rows",
+            "userb2_a13": "Android 13 | com.google.android.inputmethod.latin vc 155404870 | 140 rows",
         },
     }
 }

--- a/scripts/artifacts/gmail.py
+++ b/scripts/artifacts/gmail.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gm vc 65429598 | 1 row",
             "samsungs20_a13": "Android 13 | com.google.android.gm vc 65465122 | 1 row",
             "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 1 row",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gm vc 63927733 | 1 row",
+            "userb2_a13": "Android 13 | com.google.android.gm vc 64855928 | 1 row",
         },
     }
 }

--- a/scripts/artifacts/gmailEmails.py
+++ b/scripts/artifacts/gmailEmails.py
@@ -22,6 +22,8 @@ __artifacts_v2__ = {
             "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 207 rows",
             "galaxys10_a10": "Android 10 | com.google.android.gm vc 62632206 | 28 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gm vc 65465122 | 109 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gm vc 63927733 | 32 rows",
+            "userb2_a13": "Android 13 | com.google.android.gm vc 64855928 | 186 rows",
         },
     },
     "gmailLabels": {
@@ -45,6 +47,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gm vc 65429598 | 66 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gm vc 65465122 | 33 rows",
             "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 32 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gm vc 63927733 | 31 rows",
+            "userb2_a13": "Android 13 | com.google.android.gm vc 64855928 | 32 rows",
         },
     },
     "gmailDownloadRequests": {

--- a/scripts/artifacts/gmailIMAPEmails.py
+++ b/scripts/artifacts/gmailIMAPEmails.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gm vc 65429598 | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gm vc 65465122 | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gm vc 63927733 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gm vc 64855928 | 0 rows",
         },
     },
     "gmailIMAPAccounts": {
@@ -44,6 +46,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gm vc 65429598 | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gm vc 65465122 | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gm vc 63927733 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gm vc 64855928 | 0 rows",
         }, 
     }
 }

--- a/scripts/artifacts/googleCalendar.py
+++ b/scripts/artifacts/googleCalendar.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.android.providers.calendar | 0 rows",
             "samsungs20_a13": "Android 13 | com.android.providers.calendar | 1 row",
             "sharon_a14": "Android 14 | com.android.providers.calendar | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.providers.calendar | 79 rows",
+            "userb2_a13": "Android 13 | com.android.providers.calendar | 0 rows",
         },
     },
     "get_calendar_calendars": {
@@ -44,6 +46,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.android.providers.calendar | 5 rows",
             "samsungs20_a13": "Android 13 | com.android.providers.calendar | 3 rows",
             "sharon_a14": "Android 14 | com.android.providers.calendar | 4 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.providers.calendar | 3 rows",
+            "userb2_a13": "Android 13 | com.android.providers.calendar | 1 row",
         },
     }
 }

--- a/scripts/artifacts/googleCallScreen.py
+++ b/scripts/artifacts/googleCallScreen.py
@@ -17,6 +17,8 @@ __artifacts_v2__ = {
             "hc_pixel8pro_a16": "Android 16 | com.google.android.dialer vc 19806568 | 0 rows",
             "kevin_pocox7_a15": "Android 15 | com.google.android.dialer vc 19106378 | 0 rows",
             "pixel7a_a14": "Android 14 | com.google.android.dialer vc 15435008 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.dialer vc 11945968 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.dialer vc 18101788 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/googleCast.py
+++ b/scripts/artifacts/googleCast.py
@@ -20,6 +20,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 2 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/googleChat.py
+++ b/scripts/artifacts/googleChat.py
@@ -23,6 +23,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.apps.dynamite vc 6281014, com.google.android.gm vc 65429598 | 54 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gm vc 65465122 | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gm vc 63927733 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gm vc 64855928 | 0 rows",
         },
         "data_views": {
             "conversation": {
@@ -59,6 +61,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.apps.dynamite vc 6281014, com.google.android.gm vc 65429598 | 3 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gm vc 65465122 | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gm vc 63927733 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gm vc 64855928 | 0 rows",
         },
     },
     "get_googleChat_drafts": {
@@ -84,6 +88,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.apps.dynamite vc 6281014, com.google.android.gm vc 65429598 | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gm vc 65465122 | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gm vc 63927733 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gm vc 64855928 | 0 rows",
         },
     },
     "get_googleChat_users": {
@@ -109,6 +115,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.apps.dynamite vc 6281014, com.google.android.gm vc 65429598 | 6 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gm vc 65465122 | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gm vc 63927733 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gm vc 64855928 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/googleDuo.py
+++ b/scripts/artifacts/googleDuo.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.apps.tachyon vc 6691613 | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.apps.tachyon vc 6745781 | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.tachyon vc 5494470 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.tachyon vc 4350816 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.tachyon vc 5753132 | 0 rows",
         },
     },
     "get_googleDuo_contacts": {
@@ -44,6 +46,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.apps.tachyon vc 6691613 | 1 row",
             "samsungs20_a13": "Android 13 | com.google.android.apps.tachyon vc 6745781 | 4 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.tachyon vc 5494470 | 26 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.tachyon vc 4350816 | 2 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.tachyon vc 5753132 | 0 rows",
         },
     },
     "get_googleDuo_notes": {
@@ -68,6 +72,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.apps.tachyon vc 6691613 | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.apps.tachyon vc 6745781 | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.tachyon vc 5494470 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.tachyon vc 4350816 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.tachyon vc 5753132 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/googleFitGMS.py
+++ b/scripts/artifacts/googleFitGMS.py
@@ -17,6 +17,7 @@ __artifacts_v2__ = {
             "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 0 rows",
             "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 33 rows",
             "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/googleInitiatedNav.py
+++ b/scripts/artifacts/googleInitiatedNav.py
@@ -15,6 +15,7 @@ __artifacts_v2__ = {
         "artifact_icon": "map-pin",
         "sample_data": {
             "kevin_pocox7_a15": "Android 15 | com.google.android.apps.maps vc 1068243484 | 4 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.maps vc 1067057900 | 14 rows",
         },
     }
 }

--- a/scripts/artifacts/googleKeepNotes.py
+++ b/scripts/artifacts/googleKeepNotes.py
@@ -16,6 +16,8 @@ __artifacts_v2__ = {
             "hc_pixel8pro_a16": "Android 16 | com.google.android.keep vc 220663535 | 0 rows",
             "kevin_pocox7_a15": "Android 15 | com.google.android.keep vc 220627544 | 0 rows",
             "pixel7a_a14": "Android 14 | com.google.android.keep vc 220548335 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.keep vc 220522207 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.keep vc 220589177 | 0 rows",
         },
     },
     "get_googleKeepNotes_sharing": {
@@ -34,6 +36,8 @@ __artifacts_v2__ = {
             "hc_pixel8pro_a16": "Android 16 | com.google.android.keep vc 220663535 | 0 rows",
             "kevin_pocox7_a15": "Android 15 | com.google.android.keep vc 220627544 | 0 rows",
             "pixel7a_a14": "Android 14 | com.google.android.keep vc 220548335 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.keep vc 220522207 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.keep vc 220589177 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/googleLastTrip.py
+++ b/scripts/artifacts/googleLastTrip.py
@@ -18,6 +18,8 @@ __artifacts_v2__ = {
             "kevin_pocox7_a15": "Android 15 | com.google.android.apps.maps vc 1068243484 | 2 rows",
             "pixel7a_a14": "Android 14 | com.google.android.apps.maps vc 1067620099 | 2 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.maps vc 1067648704 | 2 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.maps vc 1067057900 | 2 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.maps vc 1067804533 | 4 rows",
         },
     }
 }

--- a/scripts/artifacts/googleMapsGmm.py
+++ b/scripts/artifacts/googleMapsGmm.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.apps.maps vc 1068326445 | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.apps.maps vc 1068347331 | 1 row",
             "sharon_a14": "Android 14 | com.google.android.apps.maps vc 1067648704 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.maps vc 1067057900 | 6 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.maps vc 1067804533 | 6 rows",
         },
     },
     "get_googleMapsGmm_places": {
@@ -43,6 +45,8 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | com.google.android.apps.maps vc 1067620099 | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.apps.maps vc 1068347331 | 1 row",
             "sharon_a14": "Android 14 | com.google.android.apps.maps vc 1067648704 | 1 row",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.maps vc 1067057900 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.maps vc 1067804533 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/googleMapsSearches.py
+++ b/scripts/artifacts/googleMapsSearches.py
@@ -18,6 +18,8 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | com.google.android.apps.maps vc 1067620099 | 6 rows",
             "samsungs20_a13": "Android 13 | com.google.android.apps.maps vc 1068347331 | 1 row",
             "sharon_a14": "Android 14 | com.google.android.apps.maps vc 1067648704 | 8 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.maps vc 1067057900 | 7 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.maps vc 1067804533 | 6 rows",
         },
     }
 }

--- a/scripts/artifacts/googleMessages.py
+++ b/scripts/artifacts/googleMessages.py
@@ -20,6 +20,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.apps.messaging vc 292971900 | 135 rows",
             "samsungs20_a13": "Android 13 | com.google.android.apps.messaging vc 293261063 | 40 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.messaging vc 161637900 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.messaging vc 186597063 | 36 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.messaging vc 259818063 | 42 rows",
         },
         "data_views": {
             "conversation": {

--- a/scripts/artifacts/googleNowPlaying.py
+++ b/scripts/artifacts/googleNowPlaying.py
@@ -12,6 +12,9 @@ __artifacts_v2__ = {
         "paths": ('*/com.google.intelligence.sense/db/history_db*', '*/com.google.android.as/databases/history_db*'),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "music",
+        "sample_data": {
+            "userb2_a13": "Android 13 | com.google.android.as vc 8997612 | 470 rows",
+        },
         "html_columns": ['Timestamp'],
     }
 }

--- a/scripts/artifacts/googlePhotos.py
+++ b/scripts/artifacts/googlePhotos.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.apps.photos vc 50989980 | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.apps.photos vc 51079548 | 24 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.photos vc 48388495 | 336 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.photos vc 48388511 | 204 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.photos vc 49358716 | 16 rows",
         },
     },
     "get_googlePhotos_remote": {
@@ -44,6 +46,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.apps.photos vc 50989980 | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.apps.photos vc 51079548 | 7 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.photos vc 48388495 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.photos vc 48388511 | 98 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.photos vc 49358716 | 6 rows",
         },
     },
     "get_googlePhotos_shared": {
@@ -67,6 +71,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.apps.photos vc 50989980 | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.apps.photos vc 51079548 | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.photos vc 48388495 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.photos vc 48388511 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.photos vc 49358716 | 0 rows",
         },
     },
     "get_googlePhotos_folders": {
@@ -90,6 +96,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.apps.photos vc 50989980 | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.apps.photos vc 51079548 | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.photos vc 48388495 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.photos vc 48388511 | 2 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.photos vc 49358716 | 0 rows",
         },
     },
     "get_googlePhotos_cache": {
@@ -114,6 +122,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.apps.photos vc 50989980 | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.apps.photos vc 51079548 | 43 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.photos vc 48388495 | 68 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.photos vc 48388511 | 704 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.photos vc 49358716 | 10 rows",
         },
     },
     "get_googlePhotos_trash": {
@@ -138,6 +148,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.apps.photos vc 50989980 | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.apps.photos vc 51079548 | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.photos vc 48388495 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.photos vc 48388511 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.photos vc 49358716 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/googlePlaySearches.py
+++ b/scripts/artifacts/googlePlaySearches.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.android.vending vc 84913330 | 26 rows",
             "samsungs20_a13": "Android 13 | com.android.vending vc 84962330 | 21 rows",
             "sharon_a14": "Android 14 | com.android.vending vc 84222730 | 25 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.vending vc 83631220 | 12 rows",
+            "userb2_a13": "Android 13 | com.android.vending vc 84371930 | 9 rows",
         }
     }
 }

--- a/scripts/artifacts/googleQuickSearchbox.py
+++ b/scripts/artifacts/googleQuickSearchbox.py
@@ -14,6 +14,7 @@ __artifacts_v2__ = {
         "artifact_icon": "search",
         "sample_data": {
             "sharon_a14": "Android 14 | com.google.android.googlequicksearchbox vc 301381725 | 1 row",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.googlequicksearchbox vc 301246250 | 2 rows",
         },
     }
 }

--- a/scripts/artifacts/googleQuickSearchboxRecent.py
+++ b/scripts/artifacts/googleQuickSearchboxRecent.py
@@ -20,6 +20,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.googlequicksearchbox vc 301639434 | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.googlequicksearchbox vc 301671258 | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.googlequicksearchbox vc 301381725 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.googlequicksearchbox vc 301246250 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.googlequicksearchbox vc 301427619 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/googlemapaudio.py
+++ b/scripts/artifacts/googlemapaudio.py
@@ -18,6 +18,8 @@ __artifacts_v2__ = {
             "kevin_pocox7_a15": "Android 15 | com.google.android.apps.maps vc 1068243484 | 359 rows",
             "pixel7a_a14": "Android 14 | com.google.android.apps.maps vc 1067620099 | 301 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.maps vc 1067648704 | 362 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.maps vc 1067057900 | 252 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.maps vc 1067804533 | 26 rows",
         },
     }
 }

--- a/scripts/artifacts/googlemapaudioTemp.py
+++ b/scripts/artifacts/googlemapaudioTemp.py
@@ -18,6 +18,8 @@ __artifacts_v2__ = {
             "kevin_pocox7_a15": "Android 15 | com.google.android.apps.maps vc 1068243484 | 0 rows",
             "pixel7a_a14": "Android 14 | com.google.android.apps.maps vc 1067620099 | 6 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.maps vc 1067648704 | 13 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.maps vc 1067057900 | 9 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.maps vc 1067804533 | 3 rows",
         },
     }
 }

--- a/scripts/artifacts/groupMe.py
+++ b/scripts/artifacts/groupMe.py
@@ -14,6 +14,7 @@ __artifacts_v2__ = {
         "artifact_icon": "users",
         "sample_data": {
             "pixel7a_a14": "Android 14 | com.groupme.android vc 240460204 | 1 row",
+            "russell_pixel6a_a13": "Android 13 | com.groupme.android vc 231500204 | 1 row",
         },
     },
     "get_groupMe_chat": {
@@ -30,6 +31,7 @@ __artifacts_v2__ = {
         "artifact_icon": "message",
         "sample_data": {
             "pixel7a_a14": "Android 14 | com.groupme.android vc 240460204 | 86 rows",
+            "russell_pixel6a_a13": "Android 13 | com.groupme.android vc 231500204 | 1 row",
         },
     }
 }

--- a/scripts/artifacts/imagemngCache.py
+++ b/scripts/artifacts/imagemngCache.py
@@ -20,6 +20,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 6610 rows",
             "samsungs20_a13": "Android 13 | 3164 rows",
             "sharon_a14": "Android 14 | 2597 rows",
+            "russell_pixel6a_a13": "Android 13 | 7123 rows",
+            "userb2_a13": "Android 13 | 757 rows",
         },
     }
 }

--- a/scripts/artifacts/installedappsGass.py
+++ b/scripts/artifacts/installedappsGass.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 404 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 240 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 1585 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 532 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 513 rows",
         },
     }
 }

--- a/scripts/artifacts/installedappsLibrary.py
+++ b/scripts/artifacts/installedappsLibrary.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.android.vending vc 84913330 | 384 rows",
             "samsungs20_a13": "Android 13 | com.android.vending vc 84962330 | 162 rows",
             "sharon_a14": "Android 14 | com.android.vending vc 84222730 | 99 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.vending vc 83631220 | 160 rows",
+            "userb2_a13": "Android 13 | com.android.vending vc 84371930 | 178 rows",
         },
     }
 }

--- a/scripts/artifacts/installedappsVending.py
+++ b/scripts/artifacts/installedappsVending.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.android.vending vc 84913330 | 204 rows",
             "samsungs20_a13": "Android 13 | com.android.vending vc 84962330 | 150 rows",
             "sharon_a14": "Android 14 | com.android.vending vc 84222730 | 122 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.vending vc 83631220 | 204 rows",
+            "userb2_a13": "Android 13 | com.android.vending vc 84371930 | 214 rows",
         },
     }
 }

--- a/scripts/artifacts/keepNotes.py
+++ b/scripts/artifacts/keepNotes.py
@@ -16,6 +16,8 @@ __artifacts_v2__ = {
             "hc_pixel8pro_a16": "Android 16 | com.google.android.keep vc 220663535 | 1 row",
             "kevin_pocox7_a15": "Android 15 | com.google.android.keep vc 220627544 | 0 rows",
             "pixel7a_a14": "Android 14 | com.google.android.keep vc 220548335 | 2 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.keep vc 220522207 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.keep vc 220589177 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/last_boot_time.py
+++ b/scripts/artifacts/last_boot_time.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 1 row",
             "samsungs20_a13": "Android 13 | 1 row",
             "sharon_a14": "Android 14 | 1 row",
+            "russell_pixel6a_a13": "Android 13 | 1 row",
+            "userb2_a13": "Android 13 | 1 row",
         },
     }
 }

--- a/scripts/artifacts/lgRCS.py
+++ b/scripts/artifacts/lgRCS.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.android.providers.telephony | 0 rows",
             "samsungs20_a13": "Android 13 | com.android.providers.telephony | 0 rows",
             "sharon_a14": "Android 14 | com.android.providers.telephony | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.providers.telephony | 0 rows",
+            "userb2_a13": "Android 13 | com.android.providers.telephony | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/notificationHistory.py
+++ b/scripts/artifacts/notificationHistory.py
@@ -40,6 +40,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 0 rows",
             "samsungs20_a13": "Android 13 | 0 rows",
             "sharon_a14": "Android 14 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | 1 row",
+            "userb2_a13": "Android 13 | 1 row",
         },
     },
     "get_notificationHistory_snoozed": {
@@ -63,6 +65,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 0 rows",
             "samsungs20_a13": "Android 13 | 0 rows",
             "sharon_a14": "Android 14 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | 0 rows",
+            "userb2_a13": "Android 13 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/offlinePages.py
+++ b/scripts/artifacts/offlinePages.py
@@ -20,6 +20,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.android.chrome vc 744417133 | 12 rows",
             "samsungs20_a13": "Android 13 | com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 7 rows",
             "sharon_a14": "Android 14 | com.android.chrome vc 653310333 | 37 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.chrome vc 573513033, com.brave.browser vc 415212624 | 9 rows",
+            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 8 rows",
         },
     }
 }

--- a/scripts/artifacts/pSettings.py
+++ b/scripts/artifacts/pSettings.py
@@ -18,6 +18,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gsf | 57 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gsf | 33 rows",
             "sharon_a14": "Android 14 | com.google.android.gsf | 18 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gsf | 30 rows",
+            "userb2_a13": "Android 13 | com.google.android.gsf | 36 rows",
         },
     }
 }

--- a/scripts/artifacts/packageGplinks.py
+++ b/scripts/artifacts/packageGplinks.py
@@ -20,6 +20,8 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | 369 rows",
             "samsungs20_a13": "Android 13 | 506 rows",
             "sharon_a14": "Android 14 | 499 rows",
+            "russell_pixel6a_a13": "Android 13 | 303 rows",
+            "userb2_a13": "Android 13 | 303 rows",
         },
         "html_columns": ['Possible Google Play Store Link'],
     }

--- a/scripts/artifacts/packageInfo.py
+++ b/scripts/artifacts/packageInfo.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 486 rows",
             "sharon_a14": "Android 14 | 499 rows",
             "samsungs20_a13": "Android 13 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | 303 rows",
+            "userb2_a13": "Android 13 | 303 rows",
         },
     }
 }

--- a/scripts/artifacts/permissions.py
+++ b/scripts/artifacts/permissions.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 1 row",
             "samsungs20_a13": "Android 13 | 0 rows",
             "sharon_a14": "Android 14 | 1 row",
+            "russell_pixel6a_a13": "Android 13 | 1 row",
+            "userb2_a13": "Android 13 | 1 row",
         },
     },
     "get_permissions_list": {
@@ -44,6 +46,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 2651 rows",
             "samsungs20_a13": "Android 13 | 0 rows",
             "sharon_a14": "Android 14 | 2793 rows",
+            "russell_pixel6a_a13": "Android 13 | 1260 rows",
+            "userb2_a13": "Android 13 | 1263 rows",
         },
     },
     "get_permissions_packages": {
@@ -67,6 +71,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 0 rows",
             "samsungs20_a13": "Android 13 | 0 rows",
             "sharon_a14": "Android 14 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | 0 rows",
+            "userb2_a13": "Android 13 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/persistentProp.py
+++ b/scripts/artifacts/persistentProp.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 0 rows",
             "samsungs20_a13": "Android 13 | 2 rows",
             "sharon_a14": "Android 14 | 1 row",
+            "russell_pixel6a_a13": "Android 13 | 1 row",
+            "userb2_a13": "Android 13 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/recentactivity.py
+++ b/scripts/artifacts/recentactivity.py
@@ -25,6 +25,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 37 rows",
             "samsungs20_a13": "Android 13 | 36 rows",
             "sharon_a14": "Android 14 | 13 rows",
+            "russell_pixel6a_a13": "Android 13 | 15 rows",
+            "userb2_a13": "Android 13 | 4 rows",
         },
     }
 }

--- a/scripts/artifacts/roles.py
+++ b/scripts/artifacts/roles.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 76 rows",
             "samsungs20_a13": "Android 13 | 63 rows",
             "sharon_a14": "Android 14 | 38 rows",
+            "russell_pixel6a_a13": "Android 13 | 66 rows",
+            "userb2_a13": "Android 13 | 33 rows",
         },
     }
 }

--- a/scripts/artifacts/runtimePerms.py
+++ b/scripts/artifacts/runtimePerms.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 21634 rows",
             "samsungs20_a13": "Android 13 | 19872 rows",
             "sharon_a14": "Android 14 | 11562 rows",
+            "russell_pixel6a_a13": "Android 13 | 9423 rows",
+            "userb2_a13": "Android 13 | 4528 rows",
         },
     }
 }

--- a/scripts/artifacts/settingsSecure.py
+++ b/scripts/artifacts/settingsSecure.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 4 rows",
             "samsungs20_a13": "Android 13 | 2 rows",
             "sharon_a14": "Android 14 | 8 rows",
+            "russell_pixel6a_a13": "Android 13 | 6 rows",
+            "userb2_a13": "Android 13 | 4 rows",
         },
     }
 }

--- a/scripts/artifacts/setupWizardinfo.py
+++ b/scripts/artifacts/setupWizardinfo.py
@@ -15,6 +15,8 @@ __artifacts_v2__ = {
         "sample_data": {
             "hc_pixel8pro_a16": "Android 16 | com.google.android.settings.intelligence vc 1000282241 | 1 row",
             "pixel7a_a14": "Android 14 | com.google.android.settings.intelligence vc 1000230247 | 1 row",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.settings.intelligence vc 1000217934 | 2 rows",
+            "userb2_a13": "Android 13 | com.google.android.settings.intelligence vc 1000232695 | 2 rows",
         },
     }
 }

--- a/scripts/artifacts/shutdown_checkpoints.py
+++ b/scripts/artifacts/shutdown_checkpoints.py
@@ -15,6 +15,8 @@ __artifacts_v2__ = {
             "hc_pixel8pro_a16": "Android 16 | 61 rows",
             "kevin_pocox7_a15": "Android 15 | 31 rows",
             "pixel7a_a14": "Android 14 | 41 rows",
+            "russell_pixel6a_a13": "Android 13 | 21 rows",
+            "userb2_a13": "Android 13 | 17 rows",
         },
     }
 }

--- a/scripts/artifacts/siminfo.py
+++ b/scripts/artifacts/siminfo.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.android.providers.telephony | 2 rows",
             "samsungs20_a13": "Android 13 | com.android.providers.telephony | 2 rows",
             "sharon_a14": "Android 14 | com.android.providers.telephony | 2 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.providers.telephony | 2 rows",
+            "userb2_a13": "Android 13 | com.android.providers.telephony | 1 row",
         },
     }
 }

--- a/scripts/artifacts/smsmms.py
+++ b/scripts/artifacts/smsmms.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.android.providers.telephony | 123 rows",
             "samsungs20_a13": "Android 13 | com.android.providers.telephony | 35 rows",
             "sharon_a14": "Android 14 | com.android.providers.telephony | 308 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.providers.telephony | 12 rows",
+            "userb2_a13": "Android 13 | com.android.providers.telephony | 38 rows",
         },
         "data_views": {
             "conversation": {
@@ -57,6 +59,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.android.providers.telephony | 12 rows",
             "samsungs20_a13": "Android 13 | com.android.providers.telephony | 6 rows",
             "sharon_a14": "Android 14 | com.android.providers.telephony | 20 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.providers.telephony | 6 rows",
+            "userb2_a13": "Android 13 | com.android.providers.telephony | 4 rows",
         },
         "data_views": {
             "conversation": {

--- a/scripts/artifacts/snapchat.py
+++ b/scripts/artifacts/snapchat.py
@@ -13,6 +13,7 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | com.snapchat.android vc 147872 | 0 rows",
             "samsungs20_a13": "Android 13 | com.snapchat.android vc 260222 | 0 rows",
             "sharon_a14": "Android 14 | com.snapchat.android vc 151972 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.snapchat.android vc 101539 | 0 rows",
         },
     },
     "get_snapchat_friends": {
@@ -28,6 +29,7 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | com.snapchat.android vc 147872 | 4 rows",
             "samsungs20_a13": "Android 13 | com.snapchat.android vc 260222 | 0 rows",
             "sharon_a14": "Android 14 | com.snapchat.android vc 151972 | 6 rows",
+            "russell_pixel6a_a13": "Android 13 | com.snapchat.android vc 101539 | 5 rows",
         },
     },
     "get_snapchat_messages": {
@@ -43,6 +45,7 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | com.snapchat.android vc 147872 | 0 rows",
             "samsungs20_a13": "Android 13 | com.snapchat.android vc 260222 | 0 rows",
             "sharon_a14": "Android 14 | com.snapchat.android vc 151972 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.snapchat.android vc 101539 | 0 rows",
         },
     },
     "get_snapchat_memories": {
@@ -56,6 +59,7 @@ __artifacts_v2__ = {
             "hc_pixel8pro_a16": "Android 16 | com.snapchat.android vc 295722 | 4 rows",
             "pixel7a_a14": "Android 14 | com.snapchat.android vc 147872 | 1 row",
             "sharon_a14": "Android 14 | com.snapchat.android vc 151972 | 3 rows",
+            "russell_pixel6a_a13": "Android 13 | com.snapchat.android vc 101539 | 0 rows",
         },
     },
     "get_snapchat_meo": {
@@ -70,6 +74,7 @@ __artifacts_v2__ = {
             "hc_pixel8pro_a16": "Android 16 | com.snapchat.android vc 295722 | 1 row",
             "pixel7a_a14": "Android 14 | com.snapchat.android vc 147872 | 1 row",
             "sharon_a14": "Android 14 | com.snapchat.android vc 151972 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.snapchat.android vc 101539 | 0 rows",
         },
     },
     "get_snapchat_snap_media": {
@@ -83,6 +88,7 @@ __artifacts_v2__ = {
             "hc_pixel8pro_a16": "Android 16 | com.snapchat.android vc 295722 | 5 rows",
             "pixel7a_a14": "Android 14 | com.snapchat.android vc 147872 | 1 row",
             "sharon_a14": "Android 14 | com.snapchat.android vc 151972 | 3 rows",
+            "russell_pixel6a_a13": "Android 13 | com.snapchat.android vc 101539 | 0 rows",
         },
     },
     "get_snapchat_identity": {
@@ -98,6 +104,7 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | com.snapchat.android vc 147872 | 12 rows",
             "samsungs20_a13": "Android 13 | com.snapchat.android vc 260222 | 13 rows",
             "sharon_a14": "Android 14 | com.snapchat.android vc 151972 | 12 rows",
+            "russell_pixel6a_a13": "Android 13 | com.snapchat.android vc 101539 | 12 rows",
         },
     },
     "get_snapchat_login_signup": {
@@ -113,6 +120,7 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | com.snapchat.android vc 147872 | 3 rows",
             "samsungs20_a13": "Android 13 | com.snapchat.android vc 260222 | 2 rows",
             "sharon_a14": "Android 14 | com.snapchat.android vc 151972 | 1 row",
+            "russell_pixel6a_a13": "Android 13 | com.snapchat.android vc 101539 | 3 rows",
         },
     }
 }

--- a/scripts/artifacts/suggestions.py
+++ b/scripts/artifacts/suggestions.py
@@ -15,6 +15,8 @@ __artifacts_v2__ = {
         "sample_data": {
             "hc_pixel8pro_a16": "Android 16 | com.google.android.settings.intelligence vc 1000282241 | 2 rows",
             "pixel7a_a14": "Android 14 | com.google.android.settings.intelligence vc 1000230247 | 3 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.settings.intelligence vc 1000217934 | 5 rows",
+            "userb2_a13": "Android 13 | com.google.android.settings.intelligence vc 1000232695 | 6 rows",
         },
     }
 }

--- a/scripts/artifacts/tikTok.py
+++ b/scripts/artifacts/tikTok.py
@@ -20,6 +20,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.bd.nproject vc 100203 | 0 rows",
             "samsungs20_a13": "Android 13 | com.zhiliaoapp.musically vc 2024301040 | 0 rows",
             "sharon_a14": "Android 14 | com.zhiliaoapp.musically vc 2023600040 | 2 rows",
+            "russell_pixel6a_a13": "Android 13 | com.zhiliaoapp.musically vc 2023000030 | 0 rows",
+            "userb2_a13": "Android 13 | com.zhiliaoapp.musically vc 2023705030 | 0 rows",
         },
         "data_views": {
             "conversation": {
@@ -52,6 +54,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.bd.nproject vc 100203 | 0 rows",
             "samsungs20_a13": "Android 13 | com.zhiliaoapp.musically vc 2024301040 | 2 rows",
             "sharon_a14": "Android 14 | com.zhiliaoapp.musically vc 2023600040 | 8 rows",
+            "russell_pixel6a_a13": "Android 13 | com.zhiliaoapp.musically vc 2023000030 | 5 rows",
+            "userb2_a13": "Android 13 | com.zhiliaoapp.musically vc 2023705030 | 1 row",
         },
     }
 }

--- a/scripts/artifacts/ulrUserprefs.py
+++ b/scripts/artifacts/ulrUserprefs.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 81 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 28 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 15 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 25 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 30 rows",
         },
     }
 }

--- a/scripts/artifacts/usagestats.py
+++ b/scripts/artifacts/usagestats.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 4954 rows",
             "samsungs20_a13": "Android 13 | 15053 rows",
             "sharon_a14": "Android 14 | 13398 rows",
+            "russell_pixel6a_a13": "Android 13 | 23654 rows",
+            "userb2_a13": "Android 13 | 3115 rows",
         },
     }
 }

--- a/scripts/artifacts/usagestatsVersion.py
+++ b/scripts/artifacts/usagestatsVersion.py
@@ -20,6 +20,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 4 rows",
             "samsungs20_a13": "Android 13 | 4 rows",
             "sharon_a14": "Android 14 | 4 rows",
+            "russell_pixel6a_a13": "Android 13 | 3 rows",
+            "userb2_a13": "Android 13 | 3 rows",
         }
     }
 }

--- a/scripts/artifacts/userDict.py
+++ b/scripts/artifacts/userDict.py
@@ -20,6 +20,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.android.providers.userdictionary | 0 rows",
             "samsungs20_a13": "Android 13 | com.android.providers.userdictionary | 0 rows",
             "sharon_a14": "Android 14 | com.android.providers.userdictionary | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.android.providers.userdictionary | 0 rows",
+            "userb2_a13": "Android 13 | com.android.providers.userdictionary | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/walStrings.py
+++ b/scripts/artifacts/walStrings.py
@@ -20,6 +20,8 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | 510 rows",
             "samsungs20_a13": "Android 13 | 791 rows",
             "sharon_a14": "Android 14 | 900 rows",
+            "russell_pixel6a_a13": "Android 13 | 455 rows",
+            "userb2_a13": "Android 13 | 527 rows",
         },
         "html_columns": ['Report'],
     }

--- a/scripts/artifacts/wellbeing.py
+++ b/scripts/artifacts/wellbeing.py
@@ -16,6 +16,8 @@ __artifacts_v2__ = {
             "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.wellbeing vc 839927 | 4556 rows",
             "kevin_pocox7_a15": "Android 15 | com.google.android.apps.wellbeing vc 762847 | 18070 rows",
             "pixel7a_a14": "Android 14 | com.google.android.apps.wellbeing vc 550467 | 44715 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.wellbeing vc 495937 | 11663 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.wellbeing vc 668567 | 1723 rows",
         },
     },
     "get_wellbeing_url": {
@@ -34,6 +36,8 @@ __artifacts_v2__ = {
             "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.wellbeing vc 839927 | 0 rows",
             "kevin_pocox7_a15": "Android 15 | com.google.android.apps.wellbeing vc 762847 | 0 rows",
             "pixel7a_a14": "Android 14 | com.google.android.apps.wellbeing vc 550467 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.wellbeing vc 495937 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.wellbeing vc 668567 | 0 rows",
         },
     }
 }

--- a/scripts/artifacts/wellbeingaccount.py
+++ b/scripts/artifacts/wellbeingaccount.py
@@ -16,6 +16,8 @@ __artifacts_v2__ = {
             "hc_pixel8pro_a16": "Android 16 | com.google.android.apps.wellbeing vc 839927 | 1 row",
             "kevin_pocox7_a15": "Android 15 | com.google.android.apps.wellbeing vc 762847 | 1 row",
             "pixel7a_a14": "Android 14 | com.google.android.apps.wellbeing vc 550467 | 1 row",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.wellbeing vc 495937 | 1 row",
+            "userb2_a13": "Android 13 | com.google.android.apps.wellbeing vc 668567 | 1 row",
         },
         "html_columns": ['Protobuf Parsed Data'],
     }

--- a/scripts/artifacts/wifiConfigstore2.py
+++ b/scripts/artifacts/wifiConfigstore2.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 2 rows",
             "samsungs20_a13": "Android 13 | 2 rows",
             "sharon_a14": "Android 14 | 18 rows",
+            "russell_pixel6a_a13": "Android 13 | 8 rows",
+            "userb2_a13": "Android 13 | 1 row",
         },
     }
 }

--- a/scripts/artifacts/wifiHotspot.py
+++ b/scripts/artifacts/wifiHotspot.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 1 row",
             "samsungs20_a13": "Android 13 | 1 row",
             "sharon_a14": "Android 14 | 1 row",
+            "russell_pixel6a_a13": "Android 13 | 1 row",
+            "userb2_a13": "Android 13 | 1 row",
         },
     }
 }

--- a/scripts/artifacts/wifiProfiles.py
+++ b/scripts/artifacts/wifiProfiles.py
@@ -21,6 +21,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 2 rows",
             "samsungs20_a13": "Android 13 | 2 rows",
             "sharon_a14": "Android 14 | 18 rows",
+            "russell_pixel6a_a13": "Android 13 | 9 rows",
+            "userb2_a13": "Android 13 | 1 row",
         },
     }
 }


### PR DESCRIPTION
## Summary
- Adds `sample_data` entries from two newly registered Android 13 corpus images: a Google Pixel 6a full file system extraction and a data-partition tar, both processed with the incremental batch flow (`--skip-existing`).
- 178 artifacts across 112 files gain per-image OS version, app version, and row-count entries. Pure additions: `git diff` contains zero removed lines, so every existing entry is untouched.

## Verification
- Corpus-wide coverage run is at 0 artifact errors across all 11 extractions (includes the fix from #948, verified on the image that surfaced it).
- Apply gates passed: AST re-parse + py_compile on all 112 files, PluginLoader smoke (583 plugins), pylint 10.00/10 on every changed file.
- Updater re-run after apply reports 0 pending actions (idempotent).