### PR TITLE
C2PA: case-insensitive media paths (catch uppercase iOS extensions)

### DIFF
--- a/scripts/artifacts/c2paProvenance.py
+++ b/scripts/artifacts/c2paProvenance.py
@@ -24,8 +24,14 @@ __artifacts_v2__ = {
                  "findings. JPEG (C2PA + XMP + signature) is validated against test files and real "
                  "Google/Gemini images; PNG and ISOBMFF (HEIC/AVIF/MP4/MOV) containers are handled "
                  "per the C2PA specification.",
-        "paths": ('*.jpg', '*.jpeg', '*.jpe', '*.png', '*.heic', '*.heif', '*.avif',
-                  '*.webp', '*.tif', '*.tiff', '*.dng', '*.mp4', '*.mov', '*.m4v'),
+        "paths": (  # case-insensitive extensions; fnmatch '*' already spans '/', so these
+                    # match media at ANY depth. Uppercase forms catch iOS defaults (.HEIC/.JPG/.MOV).
+            '*.[jJ][pP][gG]', '*.[jJ][pP][eE][gG]', '*.[jJ][pP][eE]',
+            '*.[pP][nN][gG]', '*.[hH][eE][iI][cC]', '*.[hH][eE][iI][fF]',
+            '*.[hH][iI][fF]', '*.[aA][vV][iI][fF]', '*.[wW][eE][bB][pP]',
+            '*.[jJ][xX][lL]', '*.[tT][iI][fF]', '*.[tT][iI][fF][fF]',
+            '*.[dD][nN][gG]', '*.[mM][pP]4', '*.[mM][oO][vV]', '*.[mM]4[vV]',
+        ),
         "output_types": "all",
         "artifact_icon": "certificate",
     }


### PR DESCRIPTION
The file seeker matches case-sensitively on macOS/Linux, so the lowercase-only extension globs (`*.jpg`, `*.heic`, ...) silently missed uppercase media — including the **iOS camera defaults** `.HEIC`, `.JPG`, `.MOV`. This switches to case-insensitive character-class globs so both cases are caught.

Depth is unaffected: `fnmatch`'s `*` already spans `/`, so media is matched at any path depth. Also adds `.hif` and `.jxl`. Mirrors the iLEAPP change. pylint 10.00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)