### PR TITLE
Security: escape evidence in html_columns report cells

### DIFF
--- a/scripts/artifacts/AdidasUser.py
+++ b/scripts/artifacts/AdidasUser.py
@@ -18,6 +18,7 @@ __artifacts_v2__ = {
 
 import datetime
 
+from scripts.html_safe import esc
 from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
 
@@ -75,7 +76,7 @@ def get_adidas_user(files_found, report_folder, seeker, wrap_text):
         elif key == 'lastV3SessionSyncAtLocalTime':
             last_sync = _ms_to_utc(val)
 
-    image_html = f'<img src="{image}" alt="{image}" width="50" height="50">' if image else ''
+    image_html = f'<img src="{esc(image)}" alt="{esc(image)}" width="50" height="50">' if image else ''
     data_list = [(user_id, name, height, weight, country, gender, email, created_at, image_html, my_fitness_pal, garmin_connect, polar, last_sync)]
 
     data_headers = ('ID', 'Name', 'Height', 'Weight', 'Country', 'Gender', 'Email', ('Created At', 'datetime'), 'Image', 'My Fitness Pal', 'Garmin Connect', 'Polar', ('LastSync', 'datetime'))

--- a/scripts/artifacts/BadooConnections.py
+++ b/scripts/artifacts/BadooConnections.py
@@ -18,6 +18,7 @@ __artifacts_v2__ = {
 
 import datetime
 
+from scripts.html_safe import esc
 from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
 
@@ -39,7 +40,7 @@ def get_badoo_conn(files_found, report_folder, seeker, wrap_text):
     data_list = []
     for row in all_rows:
         sort_timestamp = datetime.datetime.fromtimestamp(int(row[4]) / 1000, datetime.timezone.utc) if row[4] else ''
-        avatar_url = '<img src="' + row[5] + '" width="100" height="100">' if row[5] else ''
+        avatar_url = '<img src="' + esc(row[5]) + '" width="100" height="100">' if row[5] else ''
         data_list.append((row[0], row[1], row[2], row[3], sort_timestamp, avatar_url, row[6]))
 
     data_headers = ('ID', 'Name', 'Gender', 'Origin', ('Sort Timestamp', 'datetime'), 'Avatar URL', 'Display Message')

--- a/scripts/artifacts/Deepseek_ChatMessages.py
+++ b/scripts/artifacts/Deepseek_ChatMessages.py
@@ -7,6 +7,7 @@ from scripts.ilapfuncs import (
     artifact_processor,
     open_sqlite_db_readonly
 )
+from scripts.html_safe import safe_source
 
 __artifacts_v2__ = {
     "deepseek_chat_messages": {
@@ -165,7 +166,7 @@ def deepseek_chat_messages(files_found, _report_folder, _seeker, _wrap_text):
                             table_name,
                             inserted_at_utc,
                             role,
-                            content
+                            safe_source(content)
                         ))
 
                 except Exception as e:  # pylint: disable=broad-exception-caught

--- a/scripts/artifacts/FairEmail.py
+++ b/scripts/artifacts/FairEmail.py
@@ -55,6 +55,7 @@ __artifacts_v2__ = {
 import os
 
 from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records, check_in_media
+from scripts.html_safe import safe_source
 
 
 @artifact_processor
@@ -87,7 +88,7 @@ def get_fair_mail_accounts(files_found, _report_folder, _seeker, _wrap_text):
         creationdate = convert_unix_ts_to_utc(row[10]/1000)
         lastconnecteddate = convert_unix_ts_to_utc(row[11]/1000)
 
-        data_list.append(( creationdate, lastconnecteddate, account_id, name, email, display_name, signature, server, port, username, password, account_name))
+        data_list.append(( creationdate, lastconnecteddate, account_id, name, email, display_name, safe_source(signature), server, port, username, password, account_name))
 
     data_headers = ( 'Creation Date', 'Last Connected Date', 'Account ID', 'Name', 'E-Mail Address', 'Display Name', 'Signature', 'IMAP Server', 'IMAP Port', 'Username', 'Password', 'Account Name')
 

--- a/scripts/artifacts/MMWUsers.py
+++ b/scripts/artifacts/MMWUsers.py
@@ -18,6 +18,7 @@ __artifacts_v2__ = {
 
 import datetime
 
+from scripts.html_safe import esc
 from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
 
@@ -49,7 +50,7 @@ def get_map_users(files_found, report_folder, seeker, wrap_text):
         height = round(row[6], 2) if row[6] is not None else row[6]
         weight = round(row[7], 2) if row[7] is not None else row[7]
         if row[12]:
-            image = '<img src="' + row[12] + '" alt="' + str(row[10]) + '" width="50" height="50">'
+            image = '<img src="' + esc(row[12]) + '" alt="' + esc(str(row[10])) + '" width="50" height="50">'
         else:
             image = 'N/A'
         data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], height, weight, row[8],

--- a/scripts/artifacts/PumaUsers.py
+++ b/scripts/artifacts/PumaUsers.py
@@ -18,6 +18,7 @@ __artifacts_v2__ = {
 
 import datetime
 
+from scripts.html_safe import esc
 from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
 
@@ -42,7 +43,7 @@ def get_puma_users(files_found, report_folder, seeker, wrap_text):
     for row in all_rows:
         dob = datetime.datetime.fromtimestamp(int(row[4]) / 1000, datetime.timezone.utc) if row[4] else ''
         work_time = row[16] / 60 if row[16] else 'N/A'
-        image = '<img src="' + row[10] + '" alt="' + row[10] + '" width="50" height="50">' if row[10] else 'N/A'
+        image = '<img src="' + esc(row[10]) + '" alt="' + esc(row[10]) + '" width="50" height="50">' if row[10] else 'N/A'
         data_list.append((row[0], row[1], row[2], row[3], dob, row[5], row[6], row[7], row[8], row[9], image, row[11], row[12], row[13], row[14], row[15], work_time))
 
     data_headers = ('ID', 'Email', 'Name', 'Gender', ('Date of Birth', 'datetime'), 'Weight', 'Height', 'Country', 'Location', 'Interests', 'Profile Image URL', 'Total Score', 'Following Count', 'Followers Count', 'Goal', 'Workout Time of Day', 'Workout Duration')

--- a/scripts/artifacts/chatgpt2.py
+++ b/scripts/artifacts/chatgpt2.py
@@ -25,6 +25,7 @@ import json
 from datetime import datetime, timezone
 from collections import defaultdict
 from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
+from scripts.html_safe import safe_source
 
 @artifact_processor
 def get_chatpgt2(files_found, report_folder, seeker, wrap_text):
@@ -121,7 +122,7 @@ def get_chatpgt2(files_found, report_folder, seeker, wrap_text):
                 conversation_id = message['content'].get('conversation_id')
                 conversation_title = conversations.get(conversation_id, 'Unknown Conversation')
 
-                data_list.append((mdt, cdt, conversation_title, chunkdata, references, message_id, conversation_id))
+                data_list.append((mdt, cdt, conversation_title, safe_source(chunkdata), references, message_id, conversation_id))
 
     data_headers = (('Modified Time', 'datetime'), ('Creation Time', 'datetime'), 'Conversation Title', 'Content', 'Content References','Message ID','Conversation ID')
 

--- a/scripts/artifacts/gmailEmails.py
+++ b/scripts/artifacts/gmailEmails.py
@@ -79,6 +79,7 @@ from datetime import datetime
 
 from scripts.ilapfuncs import open_sqlite_db_readonly, check_in_media, get_sqlite_db_records, artifact_processor, \
     logfunc
+from scripts.html_safe import safe_source
 
 @artifact_processor
 def gmailEmails(files_found, report_folder, seeker, wrap_text):
@@ -207,7 +208,7 @@ def gmailEmails(files_found, report_folder, seeker, wrap_text):
                             if attachpath.endswith(attachname):
                                 attachment = check_in_media(attachpath, name=attachname) or ''
 
-                data_list.append((timestamp,serverid,messagehtml,attachment,attachname,to,toname,replyto,replytoname,subjectline,mailedby,signedby,bigTopDataDB))
+                data_list.append((timestamp,serverid,safe_source(messagehtml),attachment,attachname,to,toname,replyto,replytoname,subjectline,mailedby,signedby,bigTopDataDB))
 
     data_headers = (('Timestamp','datetime'),'Email ID','Message',('Attachment','media'),'Attachment Name','Recipient','Recipient Name','Reply To','Reply To Name','Subject Line','Mailed By','Signed by','Source File')
     return data_headers, data_list, 'See source file(s) below:'

--- a/scripts/artifacts/gmailIMAPEmails.py
+++ b/scripts/artifacts/gmailIMAPEmails.py
@@ -57,6 +57,7 @@ import urllib.parse
 
 from scripts.ilapfuncs import open_sqlite_db_readonly, artifact_processor, convert_unix_ts_to_utc, logfunc, check_in_media
 from scripts.context import Context
+from scripts.html_safe import safe_source
 
 @artifact_processor
 def gmailIMAPEmails(files_found, _report_folder, _seeker, _wrap_text):
@@ -179,7 +180,7 @@ def gmailIMAPEmails(files_found, _report_folder, _seeker, _wrap_text):
                 attachment_cell = AttachmentPaths
             else:
                 attachment_cell = ''
-            data_list.append((row[0], row[1], row[2], tBody, hBody, row[3], row[4], row[5], row[6], row[7], row[8], row[9], attachment_cell, row[11], Context.get_relative_path(emailProviderDB)))
+            data_list.append((row[0], row[1], row[2], tBody, safe_source(hBody), row[3], row[4], row[5], row[6], row[7], row[8], row[9], attachment_cell, row[11], Context.get_relative_path(emailProviderDB)))
 
     data_headers = (('Timestamp','datetime'),'_id','Snippet', 'Body(TXT)', 'Body(HTML)', 'Recipient','Reply To','Subject Line','Mailed By','Signed by', 'Read', 'AttachmentFlag', ('Attachments', 'media'), 'Mailbox Folder', 'Source File')
     return data_headers, data_list, 'See source file(s) below:'

--- a/scripts/artifacts/googleNowPlaying.py
+++ b/scripts/artifacts/googleNowPlaying.py
@@ -24,6 +24,7 @@ import blackboxprotobuf
 
 from html import escape
 from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly, is_platform_windows
+from scripts.html_safe import esc
 
 is_windows = is_platform_windows()
 slash = '\\' if is_windows else '/'
@@ -133,7 +134,7 @@ def get_googleNowPlaying(files_found, report_folder, seeker, wrap_text):
                     if last_data_set[0] == timestamp:  # exact duplicate, do not add
                         pass
                     else:
-                        last_data_set[0] += ',<br />' + timestamp
+                        last_data_set[0] += ',<br />' + esc(timestamp)
                 else:
                     data_list.append(last_data_set)
                     last_data_set = []

--- a/scripts/artifacts/libretorrentFR.py
+++ b/scripts/artifacts/libretorrentFR.py
@@ -19,6 +19,7 @@ __artifacts_v2__ = {
 import bencoding
 
 from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.html_safe import esc
 
 
 @artifact_processor
@@ -58,7 +59,7 @@ def get_libretorrentFR(files_found, report_folder, seeker, wrap_text):
                                         lenghtf = iivalue
                                     if iikey == b'path':
                                         pathf = iivalue[0].decode()
-                                aggf = aggf + f'Lenght: {lenghtf} Path: {pathf} <br>'
+                                aggf = aggf + f'Lenght: {esc(lenghtf)} Path: {esc(pathf)} <br>'
                 elif key == b'save_path':
                     spath = value.decode()
                 elif key == b'name':
@@ -78,7 +79,7 @@ def get_libretorrentFR(files_found, report_folder, seeker, wrap_text):
                         value = str(value)
                     else:
                         value = value.decode()
-                    agg = agg + f'{key.decode()}: {value} <br>'
+                    agg = agg + f'{esc(key.decode())}: {esc(value)} <br>'
 
             data_list.append((torrentihash, torrentname, spath, iname, tdown, tup, aggf, agg))
 

--- a/scripts/artifacts/packageGplinks.py
+++ b/scripts/artifacts/packageGplinks.py
@@ -27,6 +27,7 @@ __artifacts_v2__ = {
     }
 }
 
+from scripts.html_safe import esc
 from scripts.ilapfuncs import artifact_processor
 
 
@@ -46,7 +47,7 @@ def get_packageGplinks(files_found, report_folder, seeker, wrap_text):
 
         for x in values:
             bundleid = x.split(' ', 1)
-            url = f'<a href="https://play.google.com/store/apps/details?id={bundleid[0]}" target="_blank"><font color="blue">https://play.google.com/store/apps/details?id={bundleid[0]}</font></a>'
+            url = f'<a href="https://play.google.com/store/apps/details?id={esc(bundleid[0])}" target="_blank"><font color="blue">https://play.google.com/store/apps/details?id={esc(bundleid[0])}</font></a>'
             data_list.append((bundleid[0], url))
 
     data_headers = ('Bundle ID', 'Possible Google Play Store Link')

--- a/scripts/artifacts/pikpakCloudlist.py
+++ b/scripts/artifacts/pikpakCloudlist.py
@@ -18,6 +18,7 @@ __artifacts_v2__ = {
 
 import datetime
 
+from scripts.html_safe import safe_url
 from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
@@ -45,7 +46,7 @@ def get_pikpakCloudlist(files_found, report_folder, seeker, wrap_text):
 
         for row in all_rows:
             local_update = datetime.datetime.fromtimestamp(int(row[3]) / 1000, datetime.timezone.utc) if row[3] else ''
-            link = f'<a href="{row[8]}" target="_blank">{row[8]}</a>'
+            link = safe_url(row[8])
             data_list.append((row[0], row[1], row[2], local_update, row[4], row[5], row[6], row[7], link))
 
     data_headers = ('Create Time', 'Modify Time', 'Delete Time', ('Local Update Time', 'datetime'), 'User ID', 'Name', 'Kind', 'URL', 'Thumbnail Link')

--- a/scripts/artifacts/rarlabPreferences.py
+++ b/scripts/artifacts/rarlabPreferences.py
@@ -21,6 +21,7 @@ import re
 import xml.etree.ElementTree as ET
 
 from scripts.ilapfuncs import artifact_processor, abxread, checkabx, logfunc
+from scripts.html_safe import esc
 
 
 INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
@@ -67,10 +68,10 @@ def get_rarlabPreferences(files_found, report_folder, seeker, wrap_text):
                         items = json.loads(text)
                         agg = ''
                         for x in items:
-                            agg = agg + f'{x}<br>'
+                            agg = agg + f'{esc(x)}<br>'
                         data_list.append((name,agg,value))
                     else:
-                        data_list.append((name,text,value))
+                        data_list.append((name,esc(text),value))
 
     data_headers = ('Key', 'Text', 'Value')
     return data_headers, data_list, source_path

--- a/scripts/artifacts/sbbmobile.py
+++ b/scripts/artifacts/sbbmobile.py
@@ -69,6 +69,7 @@ __artifacts_v2__ = {
 
 from scripts.ilapfuncs import artifact_processor, get_file_path, \
     get_sqlite_db_records, logfunc
+from scripts.html_safe import esc
 
 @artifact_processor
 def cff_purchased_tickets(files_found, _report_folder, _seeker, _wrap_text):
@@ -207,5 +208,5 @@ def cff_travel_cards(files_found, _report_folder, _seeker, _wrap_text):
     else:
         logfunc('No Data')
 
-def coordinate_to_osm(lat, lon): 
-    return f"https://www.openstreetmap.org/?mlat={lat}&mlon={lon}&zoom=15"
+def coordinate_to_osm(lat, lon):
+    return f"https://www.openstreetmap.org/?mlat={esc(lat)}&mlon={esc(lon)}&zoom=15"

--- a/scripts/artifacts/swissmeteo.py
+++ b/scripts/artifacts/swissmeteo.py
@@ -31,6 +31,7 @@ __artifacts_v2__ = {
 
 from scripts.ilapfuncs import artifact_processor, get_file_path, \
     get_sqlite_db_records, logfunc, open_sqlite_db_readonly
+from scripts.html_safe import esc
 
 @artifact_processor
 def plz_interaction(files_found, _report_folder, _seeker, _wrap_text):
@@ -70,7 +71,7 @@ def plz_interaction(files_found, _report_folder, _seeker, _wrap_text):
                     cons_link = coordinate_to_osm(record[2], record[3])
                 data_list.append((record[0], local_data[0][4], meteo_link, cons_link))
             else:
-                data_list.append(record)
+                data_list.append((record[0], record[1], esc(record[2]), esc(record[3])))
 
         return data_headers, data_list, source_path
     else:
@@ -102,8 +103,8 @@ def swissmeteo_plz(files_found, _report_folder, _seeker, _wrap_text):
     else:
         logfunc('No plz_interaction')
 
-def coordinate_to_osm(lat, lon): 
-    return f"https://www.openstreetmap.org/?mlat={lat}&mlon={lon}&zoom=15"
+def coordinate_to_osm(lat, lon):
+    return f"https://www.openstreetmap.org/?mlat={esc(lat)}&mlon={esc(lon)}&zoom=15"
 
 def lv03_to_osm(E, N): 
     # based on https://github.com/ValentinMinder/Swisstopo-WGS84-LV03/blob/master/scripts/py/wgs84_ch1903.py

--- a/scripts/artifacts/thunderbird.py
+++ b/scripts/artifacts/thunderbird.py
@@ -44,6 +44,7 @@ import json
 
 from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records
 from scripts.context import Context
+from scripts.html_safe import safe_source
 
 def _map_uuid_to_account(file):
     # Helper method to get the mapping of the uuid to the set up accounts
@@ -186,7 +187,7 @@ def thunderbird_messages(files_found, _report_folder, _seeker, _wrap_text):
             content = row[14]
 
 
-            data_list.append((sent, stored, account, sender, receiver, cc, bcc, subject, preview, content, attachments, read, flagged, answered, forwarded, folder, Context.get_relative_path(str(file))))
+            data_list.append((sent, stored, account, sender, receiver, cc, bcc, subject, preview, safe_source(content), attachments, read, flagged, answered, forwarded, folder, Context.get_relative_path(str(file))))
 
     data_headers = ( 'Timestamp Sent', 'Timestamp Stored', 'Account', 'Sender', 'Receiver', 'CC', 'BCC', 'Subject', 'Preview', 'Content', 'Attachments', 'Read?', 'Flagged?', 'Answered?', 'Forwarded?', 'Folder Name', 'Source File')
 

--- a/scripts/artifacts/torrentData.py
+++ b/scripts/artifacts/torrentData.py
@@ -20,6 +20,7 @@ import hashlib
 import bencoding
 
 from scripts.ilapfuncs import artifact_processor
+from scripts.html_safe import esc
 
 
 @artifact_processor
@@ -64,7 +65,7 @@ def get_TorrentData(files_found, report_folder, seeker, wrap_text):
                                             filen = iivalue[0].decode()
                                         except:
                                             filen = iivalue[0]
-                            aggf = aggf + f'<tr><td>{dirr}</td><td>{filen}</td></tr>'
+                            aggf = aggf + f'<tr><td>{esc(dirr)}</td><td>{esc(filen)}</td></tr>'
                         aggf = aggf + '</table>'
 
         data_list.append((torrentname, info_hash, aggf))

--- a/scripts/artifacts/torrentResumeinfo.py
+++ b/scripts/artifacts/torrentResumeinfo.py
@@ -22,6 +22,7 @@ import datetime
 import textwrap
 
 from scripts.ilapfuncs import artifact_processor
+from scripts.html_safe import esc
 
 
 def timestampcalc(timevalue):
@@ -54,13 +55,14 @@ def get_torrentResumeinfo(files_found, report_folder, seeker, wrap_text):
                     if x == b'pieces':
                         pass
                     else:
-                        aggregate = aggregate + f'{x.decode()}: {y} <br>'
+                        xs = x.decode()
+                        aggregate = aggregate + f'{esc(xs)}: {esc(y)} <br>'
             elif key.decode() == 'pieces':
                 pass
             elif key.decode() == 'creation date':
                 aggregate = aggregate + f'{key.decode()}: {timestampcalc(value)} <br>'
             else:
-                aggregate = aggregate + f'{key.decode()}: {value} <br>' #add if value is binary decode
+                aggregate = aggregate + f'{esc(key.decode())}: {esc(value)} <br>' #add if value is binary decode
 
         data_list.append((textwrap.fill(file_found, width=25),infohash,aggregate.strip()))
 

--- a/scripts/artifacts/torrentinfo.py
+++ b/scripts/artifacts/torrentinfo.py
@@ -22,6 +22,7 @@ import datetime
 import textwrap
 
 from scripts.ilapfuncs import artifact_processor, logfunc
+from scripts.html_safe import esc
 
 
 def timestampcalc(timevalue):
@@ -60,16 +61,16 @@ def get_torrentinfo(files_found, report_folder, seeker, wrap_text):
                                     for y in itemvalue:
                                         if len(y[b'path']) == 1:
                                             file = (y[b'path'][0].decode())
-                                            aggregate = aggregate + f'Files: {file} <br>'
+                                            aggregate = aggregate + f'Files: {esc(file)} <br>'
                         else:
-                            aggregate = aggregate + f'{x.decode()}: {y.decode()} <br>'
+                            aggregate = aggregate + f'{esc(x.decode())}: {esc(y.decode())} <br>'
 
                 elif key.decode() == 'pieces':
                     pass
                 elif key.decode() == 'creation date':
                     aggregate = aggregate + f'{key.decode()}: {timestampcalc(value)} <br>'
                 else:
-                    aggregate = aggregate + f'{key.decode()}: {value.decode()} <br>' #add if value is binary decode
+                    aggregate = aggregate + f'{esc(key.decode())}: {esc(value.decode())} <br>' #add if value is binary decode
 
             data_list.append((textwrap.fill(file_found.strip(), width=25),infohash,aggregate))
         except Exception as e: logfunc(str(e))

--- a/scripts/artifacts/wellbeingaccount.py
+++ b/scripts/artifacts/wellbeingaccount.py
@@ -27,6 +27,7 @@ import json
 
 from scripts.ilapfuncs import artifact_processor
 from scripts.parse3 import ParseProto
+from scripts.html_safe import esc
 
 
 @artifact_processor
@@ -38,7 +39,7 @@ def get_wellbeingaccount(files_found, report_folder, seeker, wrap_text):
     parsedContent = str(content_json_dump).encode(encoding='UTF-8',errors='ignore')
 
     data_list = []
-    data_list.append(('<pre id=\"json\">'+str(parsedContent).replace("\\n", "<br>")+'</pre>', str(content)))
+    data_list.append(('<pre id=\"json\">'+esc(str(parsedContent)).replace("\\n", "<br>")+'</pre>', str(content)))
 
     data_headers = ('Protobuf Parsed Data', 'Protobuf Data')
     return data_headers, data_list, source_path

--- a/scripts/html_safe.py
+++ b/scripts/html_safe.py
@@ -1,0 +1,74 @@
+"""Helpers for safely emitting evidence-derived values into ``html_columns`` cells.
+
+Columns listed in an artifact's ``__artifacts_v2__`` ``html_columns`` are written to
+the HTML report **without** the framework's ``html.escape`` (see
+``scripts/artifact_report.py`` ``write_artifact_data_table`` -- the ``html_no_escape``
+branch). Any evidence-derived text placed in such a cell is therefore an
+HTML/JavaScript injection sink: malicious content in a parsed return renders live in
+the examiner's report (stored XSS, CWE-79).
+
+Route every evidence-derived value in an ``html_columns`` cell through these helpers so
+the dynamic parts are escaped while the tool's own structural markup (``<a>``, ``<br>``,
+``<table>``) is preserved.
+"""
+
+import html
+from urllib.parse import urlparse
+
+# Schemes we are willing to turn into a live <a href>. Anything else (notably
+# javascript: and data:) is rendered as escaped text, never as a clickable link.
+ALLOWED_URL_SCHEMES = ('http', 'https', 'mailto', 'tel', 'ftp', 'ftps')
+
+
+def esc(value):
+    """HTML-escape a single evidence value for safe use in text or an attribute.
+
+    ``None`` becomes ``''``. ``quote=True`` escapes ``"`` and ``'`` as well, so the
+    result is safe in both element-text and double-quoted-attribute contexts.
+    """
+    if value is None:
+        return ''
+    return html.escape(str(value), quote=True)
+
+
+def safe_url(url, text=None, target='_blank'):
+    """Build an ``<a href>`` anchor with an escaped, scheme-checked href.
+
+    Returns the escaped visible text with **no** anchor when the URL is empty or its
+    scheme is not allowlisted, so ``javascript:``/``data:`` URLs never become live
+    links. ``text`` (the visible label) defaults to the URL itself.
+    """
+    url = '' if url is None else str(url).strip()
+    label = esc(text if text is not None else url)
+    if not url:
+        return label
+    try:
+        scheme = urlparse(url).scheme.lower()
+    except ValueError:
+        return label
+    if scheme not in ALLOWED_URL_SCHEMES:
+        return label
+    rel = ' rel="noopener noreferrer"' if target == '_blank' else ''
+    return f'<a href="{esc(url)}" target="{esc(target)}"{rel}>{label}</a>'
+
+
+def safe_join(values, sep='<br>'):
+    """Escape each evidence value and join with a tool-controlled separator.
+
+    The separator is emitted verbatim (it is tool-owned markup, default ``<br>``);
+    every joined value is escaped.
+    """
+    return sep.join(esc(v) for v in values)
+
+
+def safe_source(text):
+    """Escape an evidence text/document body for display as source.
+
+    Real newlines become ``<br>`` for readability *after* escaping, so any markup in
+    the evidence (including a literal ``<br>``) is shown inert as text. Use for
+    Tier-1 raw bodies -- message/email bodies, whole return pages, notes -- per the
+    escape-to-source policy.
+    """
+    if text is None:
+        return ''
+    return esc(text).replace('\n', '<br>')


### PR DESCRIPTION
Fixes stored HTML/JS injection (CWE-79, **GHSA-9xqw-4qrc-5qp5**) in ALEAPP `html_columns` cells — sibling of RLEAPP #374 / iLEAPP #1730, same shared `scripts/html_safe.py` pattern.

## What
21 modules routed through `html_safe` (esc / safe_url / safe_source):
- **Tier 1 (escape-to-source):** gmailEmails, gmailIMAPEmails, FairEmail account Signature, thunderbird message Content, Deepseek_ChatMessages, chatgpt2, rarlabPreferences — full email/chat bodies now shown as escaped source.
- **Tier 2 (escape dynamic parts, keep structure):** AdidasUser/BadooConnections/MMWUsers/PumaUsers (`<img src>`/alt), pikpakCloudlist (`<a href>`→safe_url), packageGplinks (Play Store link id), torrentData/torrentResumeinfo/torrentinfo + libretorrentFR (bencode k/v), wellbeingaccount (`<pre>` protobuf), googleNowPlaying (Timestamp), sbbmobile + swissmeteo (raw DB coords in the OSM link, incl. the postal-code fallback).

ALEAPP artifacts return a single `data_list`, so the escape wraps the html_columns value directly. `safe_url` allowlists schemes (no live `javascript:`/`data:`).

## Not touched
waze, FairEmail message Content/Attachments + RandoChat (media-typed), calllog Type (fixed enum), swissmeteo `lv03_to_osm` (numeric-coerced floats).

## Validation
pylint `--disable=C,R` = **10.00** on all changed files; py_compile clean; PluginLoader loads **585**; payload tests confirm the coordinate helpers escape raw values and the inline `<img>`/body/`<pre>` edits escape evidence while keeping structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)