### PR TITLE
ALEAPP context-form migration — batch 1: Garmin family (24 files)

### DIFF
--- a/scripts/artifacts/GarminActAPI.py
+++ b/scripts/artifacts/GarminActAPI.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_act_api": {
         "name": "GarminActAPI",
@@ -27,7 +26,8 @@ def _round2(value):
 
 
 @artifact_processor
-def get_act_api(files_found, report_folder, seeker, wrap_text):
+def get_act_api(context):
+    files_found = context.get_files_found()
     logfunc("Processing data for Garmin Activity API")
     data_list = []
     source_path = ''

--- a/scripts/artifacts/GarminActivities.py
+++ b/scripts/artifacts/GarminActivities.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_garmin_activities": {
         "name": "GarminActivities",
@@ -32,7 +31,8 @@ def _ms_to_utc(value):
 
 
 @artifact_processor
-def get_garmin_activities(files_found, report_folder, seeker, wrap_text):
+def get_garmin_activities(context):
+    files_found = context.get_files_found()
     logfunc("Processing data for Garmin Activities")
     files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
     source_path = str(files_found[0])

--- a/scripts/artifacts/GarminChart.py
+++ b/scripts/artifacts/GarminChart.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_garmin_chart": {
         "name": "GarminCharts",
@@ -31,7 +30,8 @@ def _ms_to_utc(value):
 
 
 @artifact_processor
-def get_garmin_chart(files_found, report_folder, seeker, wrap_text):
+def get_garmin_chart(context):
+    files_found = context.get_files_found()
     logfunc("Processing data for Garmin Chart")
     files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
     source_path = str(files_found[0])

--- a/scripts/artifacts/GarminDailies.py
+++ b/scripts/artifacts/GarminDailies.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_garmin_dailies": {
         "name": "GarminDailies",
@@ -73,7 +72,8 @@ FIELDS = [
 
 
 @artifact_processor
-def get_garmin_dailies(files_found, report_folder, seeker, wrap_text):
+def get_garmin_dailies(context):
+    files_found = context.get_files_found()
     logfunc("Processing data for Garmin User Dailies")
     files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
     source_path = str(files_found[0])

--- a/scripts/artifacts/GarminDailiesAPI.py
+++ b/scripts/artifacts/GarminDailiesAPI.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_dailies_api": {
         "name": "GarminDailiesAPI",
@@ -71,7 +70,8 @@ FIELDS = [
 
 
 @artifact_processor
-def get_dailies_api(files_found, report_folder, seeker, wrap_text):
+def get_dailies_api(context):
+    files_found = context.get_files_found()
     logfunc("Processing data for Dailies API")
     data_list = []
     source_path = ''

--- a/scripts/artifacts/GarminFacebook.py
+++ b/scripts/artifacts/GarminFacebook.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_garminFB": {
         "name": "Garmin - Facebook Account",
@@ -52,7 +51,8 @@ def _s(value):
 
 
 @artifact_processor
-def get_garminFB(files_found, report_folder, seeker, wrap_text):
+def get_garminFB(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/GarminGcmJsonActivities.py
+++ b/scripts/artifacts/GarminGcmJsonActivities.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_garmin_gcm_json_activities": {
         "name": "GarminGcmJsonActivities",
@@ -41,7 +40,8 @@ def _pretty_json(raw):
 
 
 @artifact_processor
-def get_garmin_gcm_json_activities(files_found, report_folder, seeker, wrap_text):
+def get_garmin_gcm_json_activities(context):
+    files_found = context.get_files_found()
     logfunc("Processing data for Garmin GCM JSON Activities")
     files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm') and not str(x).endswith('journal')]
     source_path = str(files_found[0])

--- a/scripts/artifacts/GarminHRAPI.py
+++ b/scripts/artifacts/GarminHRAPI.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_hr_api": {
         "name": "GarminHRAPI",
@@ -23,7 +22,8 @@ from scripts.ilapfuncs import artifact_processor, logfunc
 
 
 @artifact_processor
-def get_hr_api(files_found, report_folder, seeker, wrap_text):
+def get_hr_api(context):
+    files_found = context.get_files_found()
     logfunc("Processing data for Heart Rate API")
     data_list = []
     source_path = ''

--- a/scripts/artifacts/GarminJson.py
+++ b/scripts/artifacts/GarminJson.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_garmin_json": {
         "name": "GarminJson",
@@ -41,7 +40,8 @@ def _pretty_json(raw):
 
 
 @artifact_processor
-def get_garmin_json(files_found, report_folder, seeker, wrap_text):
+def get_garmin_json(context):
+    files_found = context.get_files_found()
     logfunc("Processing data for Garmin JSON")
     files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm') and not str(x).endswith('journal')]
     source_path = str(files_found[0])

--- a/scripts/artifacts/GarminLog.py
+++ b/scripts/artifacts/GarminLog.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_log": {
         "name": "GarminLog",
@@ -22,7 +21,8 @@ from scripts.ilapfuncs import artifact_processor, logfunc
 
 
 @artifact_processor
-def get_log(files_found, report_folder, seeker, wrap_text):
+def get_log(context):
+    files_found = context.get_files_found()
     user_info = {}
     attribute = ["access_token", "expires_in", "refresh_token", "token_type", "id_token", "Authorization"]
     auth = False

--- a/scripts/artifacts/GarminNotifications.py
+++ b/scripts/artifacts/GarminNotifications.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_garmin_notifications": {
         "name": "Garmin - Notifications",
@@ -28,7 +27,8 @@ from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readon
 
 
 @artifact_processor
-def get_garmin_notifications(files_found, report_folder, seeker, wrap_text):
+def get_garmin_notifications(context):
+    files_found = context.get_files_found()
     logfunc("Processing data for Garmin Notifications")
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)

--- a/scripts/artifacts/GarminPersistent.py
+++ b/scripts/artifacts/GarminPersistent.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_presisted": {
         "name": "Garmin - Persistent",
@@ -30,7 +29,8 @@ from scripts.ilapfuncs import artifact_processor, logfunc
 
 
 @artifact_processor
-def get_presisted(files_found, report_folder, seeker, wrap_text):
+def get_presisted(context):
+    files_found = context.get_files_found()
     # Dictionary to store the user information
     user_info = {}
     # Attributes to be extracted from the json file

--- a/scripts/artifacts/GarminPolyAPI.py
+++ b/scripts/artifacts/GarminPolyAPI.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_poly_api": {
         "name": "Garmin - API Activities",
@@ -34,7 +34,8 @@ def _ms_to_utc(value):
 
 
 @artifact_processor
-def get_poly_api(files_found, report_folder, seeker, wrap_text):
+def get_poly_api(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/GarminPolyline.py
+++ b/scripts/artifacts/GarminPolyline.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_garmin_polyline": {
         "name": "Garmin - Polyline Activities",
@@ -46,7 +46,8 @@ def _db(files_found):
 
 
 @artifact_processor
-def get_garmin_polyline(files_found, report_folder, seeker, wrap_text):
+def get_garmin_polyline(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found)
     data_list = []
     if source_path:

--- a/scripts/artifacts/GarminResponse.py
+++ b/scripts/artifacts/GarminResponse.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_garmin_response": {
         "name": "GarminResponse",
@@ -41,7 +40,8 @@ def _pretty_json(raw):
 
 
 @artifact_processor
-def get_garmin_response(files_found, report_folder, seeker, wrap_text):
+def get_garmin_response(context):
+    files_found = context.get_files_found()
     logfunc("Processing data for Garmin Response")
     files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
     source_path = str(files_found[0])

--- a/scripts/artifacts/GarminSPo2.py
+++ b/scripts/artifacts/GarminSPo2.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_garmin_spo2": {
         "name": "GarminSPO2",
@@ -24,7 +23,8 @@ from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readon
 
 
 @artifact_processor
-def get_garmin_spo2(files_found, report_folder, seeker, wrap_text):
+def get_garmin_spo2(context):
+    files_found = context.get_files_found()
     logfunc("Processing data for Garmin Pulse Ox details")
     files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
     source_path = str(files_found[0])

--- a/scripts/artifacts/GarminSleep.py
+++ b/scripts/artifacts/GarminSleep.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_garmin_sleep": {
         "name": "GarminSleep",
@@ -31,7 +30,8 @@ def _ms_to_utc(value):
 
 
 @artifact_processor
-def get_garmin_sleep(files_found, report_folder, seeker, wrap_text):
+def get_garmin_sleep(context):
+    files_found = context.get_files_found()
     logfunc("Processing data for Garmin Sleep")
     files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
     source_path = str(files_found[0])

--- a/scripts/artifacts/GarminSleepAPI.py
+++ b/scripts/artifacts/GarminSleepAPI.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_sleep_api": {
         "name": "GarminSleepAPI",
@@ -36,7 +35,8 @@ def _ms_to_time(value):
 
 
 @artifact_processor
-def get_sleep_api(files_found, report_folder, seeker, wrap_text):
+def get_sleep_api(context):
+    files_found = context.get_files_found()
     logfunc("Processing data for Garmin Sleep API")
     source_path = str(files_found[0])
     logfunc("Processing file: " + source_path)

--- a/scripts/artifacts/GarminStepsAPI.py
+++ b/scripts/artifacts/GarminStepsAPI.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_steps_api": {
         "name": "GarminStepsAPI",
@@ -23,7 +22,8 @@ from scripts.ilapfuncs import artifact_processor, logfunc
 
 
 @artifact_processor
-def get_steps_api(files_found, report_folder, seeker, wrap_text):
+def get_steps_api(context):
+    files_found = context.get_files_found()
     logfunc("Processing data for Steps API")
     data_list = []
     source_path = ''

--- a/scripts/artifacts/GarminStressAPI.py
+++ b/scripts/artifacts/GarminStressAPI.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_stress_api": {
         "name": "GarminStressAPI",
@@ -23,7 +22,8 @@ from scripts.ilapfuncs import artifact_processor, logfunc
 
 
 @artifact_processor
-def get_stress_api(files_found, report_folder, seeker, wrap_text):
+def get_stress_api(context):
+    files_found = context.get_files_found()
     logfunc("Processing data for Stress API")
     data_list = []
     source_path = ''

--- a/scripts/artifacts/GarminSync.py
+++ b/scripts/artifacts/GarminSync.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_garmin_sync": {
         "name": "Garmin - Sync",
@@ -28,7 +27,8 @@ from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readon
 
 
 @artifact_processor
-def get_garmin_sync(files_found, report_folder, seeker, wrap_text):
+def get_garmin_sync(context):
+    files_found = context.get_files_found()
     logfunc("Processing data for Garmin Sync")
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)

--- a/scripts/artifacts/GarminUser.py
+++ b/scripts/artifacts/GarminUser.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_garminUP": {
         "name": "Garmin - User Preferences",
@@ -58,7 +57,8 @@ def _parse_xml(file_found):
 
 
 @artifact_processor
-def get_garminUP(files_found, report_folder, seeker, wrap_text):
+def get_garminUP(context):
+    files_found = context.get_files_found()
     # Dictionary to store the user information
     user_info = {}
     # Attributes to be extracted from the xml file

--- a/scripts/artifacts/GarminWeight.py
+++ b/scripts/artifacts/GarminWeight.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_garmin_weight": {
         "name": "GarminWeight",
@@ -25,7 +24,8 @@ from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readon
 
 
 @artifact_processor
-def get_garmin_weight(files_found, report_folder, seeker, wrap_text):
+def get_garmin_weight(context):
+    files_found = context.get_files_found()
     logfunc("Processing data for Garmin Weight")
     files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
     source_path = str(files_found[0])

--- a/scripts/artifacts/garmin.py
+++ b/scripts/artifacts/garmin.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_garmin_gcm_cache_activities": {
         "name": "Garmin - GCM Cache Activities",
@@ -156,7 +155,8 @@ def _q(cursor, sql):
 
 
 @artifact_processor
-def get_garmin_gcm_cache_activities(files_found, report_folder, seeker, wrap_text):
+def get_garmin_gcm_cache_activities(context):
+    files_found = context.get_files_found()
     source = _find(files_found, 'gcm_cache.db')
     data_list = []
     if source:
@@ -203,7 +203,8 @@ def get_garmin_gcm_cache_activities(files_found, report_folder, seeker, wrap_tex
 
 
 @artifact_processor
-def get_garmin_devices(files_found, report_folder, seeker, wrap_text):
+def get_garmin_devices(context):
+    files_found = context.get_files_found()
     source = _find(files_found, 'gcm_cache.db')
     data_list = []
     if source:
@@ -226,7 +227,8 @@ def get_garmin_devices(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_garmin_weather(files_found, report_folder, seeker, wrap_text):
+def get_garmin_weather(context):
+    files_found = context.get_files_found()
     source = _find(files_found, 'gcm_cache.db')
     data_list = []
     if source:
@@ -266,7 +268,8 @@ def get_garmin_weather(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_garmin_notification_details(files_found, report_folder, seeker, wrap_text):
+def get_garmin_notification_details(context):
+    files_found = context.get_files_found()
     source = _find(files_found, 'notification-database')
     data_list = []
     if source:
@@ -293,7 +296,8 @@ def get_garmin_notification_details(files_found, report_folder, seeker, wrap_tex
 
 
 @artifact_processor
-def get_garmin_cache_db_activities(files_found, report_folder, seeker, wrap_text):
+def get_garmin_cache_db_activities(context):
+    files_found = context.get_files_found()
     source = _find(files_found, 'cache-database')
     data_list = []
     if source:
@@ -343,7 +347,8 @@ def get_garmin_cache_db_activities(files_found, report_folder, seeker, wrap_text
 
 
 @artifact_processor
-def get_garmin_sleep_activities(files_found, report_folder, seeker, wrap_text):
+def get_garmin_sleep_activities(context):
+    files_found = context.get_files_found()
     source = _find(files_found, 'cache-database')
     data_list = []
     if source:


### PR DESCRIPTION
First batch of the ALEAPP-wide **4-arg → context** signature migration, bringing ALEAPP in line with iLEAPP/RLEAPP/VLEAPP (already 100% context-form).

## What
Converts the **Garmin family — 29 functions across 24 files** from `def f(files_found, report_folder, seeker, wrap_text)` to `def f(context):` + `files_found = context.get_files_found()`. All are **pure signature swaps** (no body used report_folder/seeker/wrap_text). Also drops the now-redundant `# pylint: disable=W0613` these files carried only to silence the unused 4-arg params (`W0718` retained where still needed).

## Why
ALEAPP got the LAVA (`@artifact_processor`) conversion but never the context-form migration the other three LEAPPs received — 488 funcs / 278 files remain on the legacy signature. This is batch 1; the rest will follow by category.

## Validation
- pylint `--disable=C,R` = **10.00** on all 24 changed files
- `py_compile` clean
- `PluginLoader` loads **585** (unchanged); all 29 Garmin methods confirmed single-`context` signature
- Original author attribution and creation dates preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)