### PR TITLE
ALEAPP context-form migration — batch 2: FCM family (8 files)

### DIFF
--- a/scripts/artifacts/FCMQueuedMessageKik.py
+++ b/scripts/artifacts/FCMQueuedMessageKik.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "fcm_kik": {
         "name": "FCM-KIK Notifications",
@@ -81,7 +80,8 @@ from scripts.ilapfuncs import artifact_processor
 
 
 @artifact_processor
-def fcm_kik(files_found, report_folder, seeker, wrap_text):
+def fcm_kik(context):
+    files_found = context.get_files_found()
     # we only need the input data dirs not every matching file
     in_dirs = set(pathlib.Path(x).parent for x in files_found)
     rows = []
@@ -107,7 +107,8 @@ def fcm_kik(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def fcm_kik_blanks(files_found, report_folder, seeker, wrap_text):
+def fcm_kik_blanks(context):
+    files_found = context.get_files_found()
     # we only need the input data dirs not every matching file
     in_dirs = set(pathlib.Path(x).parent for x in files_found)
     rows = []

--- a/scripts/artifacts/FCMQueuedMessageOutlook.py
+++ b/scripts/artifacts/FCMQueuedMessageOutlook.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "fcm_outlook": {
         "name": "FCM-Outlook Notifications",
@@ -64,7 +63,8 @@ __contact__ = "Alex Caithness (research [at] cclsolutionsgroup.com)"
 from scripts.ilapfuncs import logfunc, artifact_processor
 
 @artifact_processor
-def fcm_outlook(files_found, report_folder, seeker, wrap_text):
+def fcm_outlook(context):
+    files_found = context.get_files_found()
     # we only need the input data dirs not every matching file
     in_dirs = set(pathlib.Path(x).parent for x in files_found)
     rows = []

--- a/scripts/artifacts/FCMQueuedMessagesDump.py
+++ b/scripts/artifacts/FCMQueuedMessagesDump.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_fcm_dump": {
         "name": "FCM Dump",
@@ -173,7 +173,8 @@ def _load_packages(files_found):
 
 
 @artifact_processor
-def get_fcm_dump(files_found, report_folder, seeker, wrap_text):
+def get_fcm_dump(context):
+    files_found = context.get_files_found()
     package_tables, source = _load_packages(files_found)
     data_list = []
     for package, rows in package_tables.items():
@@ -184,7 +185,8 @@ def get_fcm_dump(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fcm_dump_verizon(files_found, report_folder, seeker, wrap_text):
+def get_fcm_dump_verizon(context):
+    files_found = context.get_files_found()
     package_tables, source = _load_packages(files_found)
     data_list = []
     for data in package_tables.get('com.verizon.messaging.vzmsgs', []):
@@ -200,7 +202,8 @@ def get_fcm_dump_verizon(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fcm_dump_tiktok(files_found, report_folder, seeker, wrap_text):
+def get_fcm_dump_tiktok(context):
+    files_found = context.get_files_found()
     package_tables, source = _load_packages(files_found)
     data_list = []
     for data in package_tables.get('com.zhiliaoapp.musically', []):
@@ -217,7 +220,8 @@ def get_fcm_dump_tiktok(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fcm_dump_instagram(files_found, report_folder, seeker, wrap_text):
+def get_fcm_dump_instagram(context):
+    files_found = context.get_files_found()
     package_tables, source = _load_packages(files_found)
     data_list = []
     for data in package_tables.get('com.instagram.android', []):
@@ -241,7 +245,8 @@ def get_fcm_dump_instagram(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fcm_dump_gqsb(files_found, report_folder, seeker, wrap_text):
+def get_fcm_dump_gqsb(context):
+    files_found = context.get_files_found()
     package_tables, source = _load_packages(files_found)
     data_list = []
     for data in package_tables.get('com.google.android.googlequicksearchbox', []):

--- a/scripts/artifacts/FCMQueuedMessagesJungrammer.py
+++ b/scripts/artifacts/FCMQueuedMessagesJungrammer.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 """
 Copyright 2022, CCL Forensics
 
@@ -80,7 +79,8 @@ def _annotation(kv):
 
 
 @artifact_processor
-def get_fcm_jungrammer(files_found, report_folder, seeker, wrap_text):
+def get_fcm_jungrammer(context):
+    files_found = context.get_files_found()
     in_dirs = set(pathlib.Path(str(x)).parent for x in files_found)
     source = " ".join(str(x) for x in in_dirs)
     conversations = {}  # conv_key -> {package, from_token, parties: [], messages: [(ts, type, text)]}

--- a/scripts/artifacts/FCMQueuedMessagesSkype.py
+++ b/scripts/artifacts/FCMQueuedMessagesSkype.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 """
 Copyright 2022, CCL Forensics
 
@@ -273,7 +272,8 @@ def _load(files_found):
 
 
 @artifact_processor
-def get_fcm_skype(files_found, report_folder, seeker, wrap_text):
+def get_fcm_skype(context):
+    files_found = context.get_files_found()
     messages, _notifications, source = _load(files_found)
     data_headers = (('FCM Timestamp', 'datetime'), 'App', 'Original Timestamp', 'Conversation ID',
                     'Recipient', 'Sender', 'Content', 'Metadata')
@@ -281,7 +281,8 @@ def get_fcm_skype(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fcm_skype_notifications(files_found, report_folder, seeker, wrap_text):
+def get_fcm_skype_notifications(context):
+    files_found = context.get_files_found()
     _messages, notifications, source = _load(files_found)
     data_headers = (('Timestamp', 'datetime'), 'App', 'Title', 'Message', 'Recipient', 'Link')
     return data_headers, notifications, source

--- a/scripts/artifacts/FCMQueuedMessagesTumblr.py
+++ b/scripts/artifacts/FCMQueuedMessagesTumblr.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 """
 Copyright 2022, CCL Forensics
 
@@ -185,7 +184,8 @@ def _load(files_found):
 
 
 @artifact_processor
-def get_fcm_tumblr(files_found, report_folder, seeker, wrap_text):
+def get_fcm_tumblr(context):
+    files_found = context.get_files_found()
     messages, _flagged, _notifications, _logs, source = _load(files_found)
     data_headers = (('Timestamp', 'datetime'), 'FCM Key', 'Title', 'Body', 'Notification',
                     'Recipient', 'Uuid', 'Unread Count')
@@ -193,21 +193,24 @@ def get_fcm_tumblr(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fcm_tumblr_flagged(files_found, report_folder, seeker, wrap_text):
+def get_fcm_tumblr_flagged(context):
+    files_found = context.get_files_found()
     _messages, flagged, _notifications, _logs, source = _load(files_found)
     data_headers = (('Timestamp', 'datetime'), 'FCM Key', 'Blog Name', 'Post ID', 'Type')
     return data_headers, flagged, source
 
 
 @artifact_processor
-def get_fcm_tumblr_notifications(files_found, report_folder, seeker, wrap_text):
+def get_fcm_tumblr_notifications(context):
+    files_found = context.get_files_found()
     _messages, _flagged, notifications, _logs, source = _load(files_found)
     data_headers = (('Timestamp', 'datetime'), 'FCM Key', 'Notification')
     return data_headers, notifications, source
 
 
 @artifact_processor
-def get_fcm_tumblr_logs(files_found, report_folder, seeker, wrap_text):
+def get_fcm_tumblr_logs(context):
+    files_found = context.get_files_found()
     _messages, _flagged, _notifications, logs, source = _load(files_found)
     data_headers = (('Timestamp', 'datetime'), 'FCM Key', 'Push ID', 'Push Type')
     return data_headers, logs, source

--- a/scripts/artifacts/FCMQueuedMessagesTwitter.py
+++ b/scripts/artifacts/FCMQueuedMessagesTwitter.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 """
 Copyright 2022, CCL Forensics
 
@@ -101,7 +100,8 @@ def _process_dm(rec):
 
 
 @artifact_processor
-def get_fcm_twitter(files_found, report_folder, seeker, wrap_text):
+def get_fcm_twitter(context):
+    files_found = context.get_files_found()
     in_dirs = set(pathlib.Path(str(x)).parent for x in files_found)
     source = " ".join(str(x) for x in in_dirs)
     data_list = []

--- a/scripts/artifacts/FCMQueuedMessagesXbox.py
+++ b/scripts/artifacts/FCMQueuedMessagesXbox.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 """
 Copyright 2022, CCL Forensics
 
@@ -188,7 +187,8 @@ def _load(files_found):
 
 
 @artifact_processor
-def get_fcm_xbox(files_found, report_folder, seeker, wrap_text):
+def get_fcm_xbox(context):
+    files_found = context.get_files_found()
     messages, _parties, _presence, source = _load(files_found)
     data_headers = ('FCM Key', ('FCM Timestamp', 'datetime'), 'Conversation ID',
                     ('Message Timestamp', 'datetime'), 'Sender', 'Text', 'Content')
@@ -196,14 +196,16 @@ def get_fcm_xbox(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fcm_xbox_party(files_found, report_folder, seeker, wrap_text):
+def get_fcm_xbox_party(context):
+    files_found = context.get_files_found()
     _messages, parties, _presence, source = _load(files_found)
     data_headers = ('FCM Key', ('FCM Timestamp', 'datetime'), 'Sender')
     return data_headers, parties, source
 
 
 @artifact_processor
-def get_fcm_xbox_presence(files_found, report_folder, seeker, wrap_text):
+def get_fcm_xbox_presence(context):
+    files_found = context.get_files_found()
     _messages, _parties, presence, source = _load(files_found)
     data_headers = ('FCM Key', ('FCM Timestamp', 'datetime'), 'User')
     return data_headers, presence, source


### PR DESCRIPTION
Batch 2 of the ALEAPP-wide **4-arg → context** migration (batch 1 Garmin = #963, merged).

**What:** converts the FCM Queued Messages family — **19 functions across 8 files** (Kik, Outlook, Dump, Jungrammer, Skype, Tumblr, Twitter, Xbox) — to `def f(context):` + `files_found = context.get_files_found()`. All pure signature swaps. Drops the now-redundant `# pylint: disable=W0613` (`W0718` retained where a file still catches broad exceptions).

**Validation:** pylint `--disable=C,R` = **10.00** on all 8 files; `py_compile` clean; `PluginLoader` **585** (unchanged); all FCM methods confirmed single-`context`; attribution/dates preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)