### PR TITLE
ALEAPP context-form migration — batch 3: browsers (17 files)

### DIFF
--- a/scripts/artifacts/TorBrowser.py
+++ b/scripts/artifacts/TorBrowser.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "torbrowser_thumbnails": {
         "name": "Tor Browser Tab Thumnails",
@@ -75,7 +75,8 @@ def _parse_xml(file_found):
             return ET.Element('empty')
 
 @artifact_processor
-def torbrowser_thumbnails(files_found, report_folder, seeker, wrap_text):
+def torbrowser_thumbnails(context):
+    files_found = context.get_files_found()
     data_list = []
 
     for file_found in files_found:
@@ -102,7 +103,8 @@ def torbrowser_thumbnails(files_found, report_folder, seeker, wrap_text):
     return data_headers, data_list, 'See source path(s) below'
 
 @artifact_processor
-def torbrowser_bookmarks(files_found, report_folder, seeker, wrap_text):
+def torbrowser_bookmarks(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for source_path in files_found:
@@ -150,7 +152,8 @@ def torbrowser_bookmarks(files_found, report_folder, seeker, wrap_text):
     return data_headers, data_list, source_path
     
 @artifact_processor
-def torbrowser_usageinfo(files_found, report_folder, seeker, wrap_text):
+def torbrowser_usageinfo(context):
+    files_found = context.get_files_found()
 
     usage_keys = {
         "pref_key_last_browse_activity_time",

--- a/scripts/artifacts/chrome.py
+++ b/scripts/artifacts/chrome.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_chrome": {
         "name": "Web History",
@@ -177,7 +177,8 @@ def _history_files(files_found):
 
 
 @artifact_processor
-def get_chrome(files_found, report_folder, seeker, wrap_text):
+def get_chrome(context):
+    files_found = context.get_files_found()
     all_data = []
     data_headers = ['Last Visit Time', 'URL', 'Title', 'Visit Count', 'Typed Count', 'ID', 'Hidden']
     lava_data_headers = data_headers.copy()
@@ -207,7 +208,8 @@ def get_chrome(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_chromeWebVisits(files_found, report_folder, seeker, wrap_text):
+def get_chromeWebVisits(context):
+    files_found = context.get_files_found()
     all_data = []
     data_headers = ['Visit Timestamp', 'URL', 'Title', 'Duration', 'Transition Type', 'Qualifier(s)', 'From Visit URL']
     lava_data_headers = data_headers.copy()
@@ -271,7 +273,8 @@ def get_chromeWebVisits(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_chromeSearchTerms(files_found, report_folder, seeker, wrap_text):
+def get_chromeSearchTerms(context):
+    files_found = context.get_files_found()
     all_data = []
     data_headers = ['Last Visit Time', 'Search Term', 'URL', 'Title', 'Visit Count']
     lava_data_headers = data_headers.copy()
@@ -306,7 +309,8 @@ def get_chromeSearchTerms(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_chromeDownloads(files_found, report_folder, seeker, wrap_text):
+def get_chromeDownloads(context):
+    files_found = context.get_files_found()
     all_data = []
     data_headers = ['Start Time', 'End Time', 'Last Access Time', 'URL', 'Target Path', 'State',
                     'Danger Type', 'Interrupt Reason', 'Opened?', 'Received Bytes', 'Total Bytes']
@@ -418,7 +422,8 @@ def get_chromeDownloads(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_chromeKeywordSearchTerms(files_found, report_folder, seeker, wrap_text):
+def get_chromeKeywordSearchTerms(context):
+    files_found = context.get_files_found()
     all_data = []
     data_headers = ['Last Visit Time', 'Term', 'URL']
     lava_data_headers = data_headers.copy()

--- a/scripts/artifacts/chromeAutofill.py
+++ b/scripts/artifacts/chromeAutofill.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_chromeAutofill": {
         "name": "Chrome Autofill - Entries",
@@ -73,7 +73,8 @@ def _browser_for(file_found):
 
 
 @artifact_processor
-def get_chromeAutofill(files_found, report_folder, seeker, wrap_text):
+def get_chromeAutofill(context):
+    files_found = context.get_files_found()
     all_data = []
     data_headers = ['Date Created', 'Field', 'Value', 'Date Last Used', 'Count']
     lava_data_headers = data_headers.copy()
@@ -125,7 +126,8 @@ def get_chromeAutofill(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_chromeAutofillProfiles(files_found, report_folder, seeker, wrap_text):
+def get_chromeAutofillProfiles(context):
+    files_found = context.get_files_found()
     all_data = []
     data_headers = ['Date Modified', 'GUID', 'First Name', 'Middle Name', 'Last Name', 'Email',
                     'Phone Number', 'Company Name', 'Address', 'City', 'State', 'Zip Code',

--- a/scripts/artifacts/chromeBookmarks.py
+++ b/scripts/artifacts/chromeBookmarks.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0612,W0613
+# pylint: disable=W0612
 __artifacts_v2__ = {
     "get_chromeBookmarks": {
         "name": "Bookmarks",
@@ -30,7 +30,8 @@ from scripts.artifacts.chrome import get_browser_name
 
 
 @artifact_processor
-def get_chromeBookmarks(files_found, report_folder, seeker, wrap_text):
+def get_chromeBookmarks(context):
+    files_found = context.get_files_found()
     # all_data is a consolidated list of all browsers with an extra column to discriminate the browser
     all_data = []
 

--- a/scripts/artifacts/chromeDIPS.py
+++ b/scripts/artifacts/chromeDIPS.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_chromeDIPS": {
         "name": "ChromeDIPS",
@@ -47,7 +46,8 @@ def _first_column(columns, candidates):
 
 
 @artifact_processor
-def get_chromeDIPS(files_found, report_folder, seeker, wrap_text):
+def get_chromeDIPS(context):
+    files_found = context.get_files_found()
     # all_data is a consolidated list of all browsers with an extra column to discriminate the browser
     all_data = []
 

--- a/scripts/artifacts/chromeLoginData.py
+++ b/scripts/artifacts/chromeLoginData.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_chromeLoginData": {
         "name": "Login Data",
@@ -69,7 +68,8 @@ def get_valid_date(d1, d2):
 
 
 @artifact_processor
-def get_chromeLoginData(files_found, report_folder, seeker, wrap_text):
+def get_chromeLoginData(context):
+    files_found = context.get_files_found()
     all_data = []
 
     data_headers = ['Created Time', 'Username', 'Password', 'Origin URL', 'Blacklisted by User']

--- a/scripts/artifacts/chromeMediaHistory.py
+++ b/scripts/artifacts/chromeMediaHistory.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_chromeMediaHistorySessions": {
         "name": "Media History - Sessions",
@@ -68,7 +67,8 @@ def _media_history_files(files_found):
 
 
 @artifact_processor
-def get_chromeMediaHistorySessions(files_found, report_folder, seeker, wrap_text):
+def get_chromeMediaHistorySessions(context):
+    files_found = context.get_files_found()
     all_data = []
     data_headers = ['Last Updated', 'Origin ID', 'URL', 'Position', 'Duration', 'Title', 'Artist', 'Album', 'Source Title']
     lava_data_headers = data_headers.copy()
@@ -110,7 +110,8 @@ def get_chromeMediaHistorySessions(files_found, report_folder, seeker, wrap_text
 
 
 @artifact_processor
-def get_chromeMediaHistoryPlaybacks(files_found, report_folder, seeker, wrap_text):
+def get_chromeMediaHistoryPlaybacks(context):
+    files_found = context.get_files_found()
     all_data = []
     data_headers = ['Last Updated', 'ID', 'Origin ID', 'URL', 'Watch Time', 'Has Audio', 'Has Video']
     lava_data_headers = data_headers.copy()
@@ -156,7 +157,8 @@ def get_chromeMediaHistoryPlaybacks(files_found, report_folder, seeker, wrap_tex
 
 
 @artifact_processor
-def get_chromeMediaHistoryOrigins(files_found, report_folder, seeker, wrap_text):
+def get_chromeMediaHistoryOrigins(context):
+    files_found = context.get_files_found()
     all_data = []
     data_headers = ['Last Updated', 'ID', 'Origin', 'Aggregate Watchtime']
     lava_data_headers = data_headers.copy()

--- a/scripts/artifacts/chromeNetworkActionPredictor.py
+++ b/scripts/artifacts/chromeNetworkActionPredictor.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_chromeNetworkActionPredictor": {
         "name": "Network Action Predictor",
@@ -25,7 +24,8 @@ from scripts.artifacts.chrome import get_browser_name
 
 
 @artifact_processor
-def get_chromeNetworkActionPredictor(files_found, report_folder, seeker, wrap_text):
+def get_chromeNetworkActionPredictor(context):
+    files_found = context.get_files_found()
     all_data = []
 
     data_headers = ['User Text', 'URL', 'Number of Hits', 'Number of Misses']

--- a/scripts/artifacts/chromeTopSites.py
+++ b/scripts/artifacts/chromeTopSites.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0702
+# pylint: disable=W0702
 __artifacts_v2__ = {
     "get_chromeTopSites": {
         "name": "Top Sites",
@@ -34,7 +34,8 @@ from scripts.artifacts.chrome import get_browser_name
 
 
 @artifact_processor
-def get_chromeTopSites(files_found, report_folder, seeker, wrap_text):
+def get_chromeTopSites(context):
+    files_found = context.get_files_found()
     all_data = []
 
     data_headers = ['URL', 'Rank', 'Title', 'Redirects']

--- a/scripts/artifacts/firefox.py
+++ b/scripts/artifacts/firefox.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_firefox_history": {
         "name": "Firefox - Web History",
@@ -105,7 +104,8 @@ def _run(source_path, sql):
 
 
 @artifact_processor
-def get_firefox_history(files_found, report_folder, seeker, wrap_text):
+def get_firefox_history(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found)
     rows = _run(source_path, '''
         SELECT moz_places.last_visit_date_local, moz_places.url, moz_places.title,
@@ -125,7 +125,8 @@ def get_firefox_history(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_firefox_visits(files_found, report_folder, seeker, wrap_text):
+def get_firefox_visits(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found)
     rows = _run(source_path, '''
         SELECT moz_historyvisits.visit_date, moz_places.url, moz_places.title,
@@ -148,7 +149,8 @@ def get_firefox_visits(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_firefox_bookmarks(files_found, report_folder, seeker, wrap_text):
+def get_firefox_bookmarks(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found)
     rows = _run(source_path, '''
         SELECT moz_bookmarks.dateAdded, moz_bookmarks.lastModified, moz_bookmarks.title, moz_places.url,
@@ -166,7 +168,8 @@ def get_firefox_bookmarks(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_firefox_searches(files_found, report_folder, seeker, wrap_text):
+def get_firefox_searches(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found)
     rows = _run(source_path, '''
         SELECT id, term FROM moz_places_metadata_search_queries ORDER BY id ASC

--- a/scripts/artifacts/firefoxCookies.py
+++ b/scripts/artifacts/firefoxCookies.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_firefoxCookies": {
         "name": "Firefox - Cookies",
@@ -24,7 +23,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, conve
 
 
 @artifact_processor
-def get_firefoxCookies(files_found, report_folder, seeker, wrap_text):
+def get_firefoxCookies(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/firefoxDownloads.py
+++ b/scripts/artifacts/firefoxDownloads.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_firefoxDownloads": {
         "name": "Firefox - Downloads",
@@ -24,7 +23,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, conve
 
 
 @artifact_processor
-def get_firefoxDownloads(files_found, report_folder, seeker, wrap_text):
+def get_firefoxDownloads(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/firefoxFormHistory.py
+++ b/scripts/artifacts/firefoxFormHistory.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_firefoxFormHistory": {
         "name": "Firefox - Form History",
@@ -24,7 +23,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, conve
 
 
 @artifact_processor
-def get_firefoxFormHistory(files_found, report_folder, seeker, wrap_text):
+def get_firefoxFormHistory(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/firefoxPermissions.py
+++ b/scripts/artifacts/firefoxPermissions.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_firefoxPermissions": {
         "name": "Firefox - Permissions",
@@ -24,7 +23,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, conve
 
 
 @artifact_processor
-def get_firefoxPermissions(files_found, report_folder, seeker, wrap_text):
+def get_firefoxPermissions(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/firefoxRecentlyClosedTabs.py
+++ b/scripts/artifacts/firefoxRecentlyClosedTabs.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_firefoxRecentlyClosedTabs": {
         "name": "Firefox - Recently Closed Tabs",
@@ -24,7 +23,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, conve
 
 
 @artifact_processor
-def get_firefoxRecentlyClosedTabs(files_found, report_folder, seeker, wrap_text):
+def get_firefoxRecentlyClosedTabs(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/firefoxTopSites.py
+++ b/scripts/artifacts/firefoxTopSites.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_firefoxTopSites": {
         "name": "Firefox - Top Sites",
@@ -24,7 +23,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, conve
 
 
 @artifact_processor
-def get_firefoxTopSites(files_found, report_folder, seeker, wrap_text):
+def get_firefoxTopSites(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/torThumbs.py
+++ b/scripts/artifacts/torThumbs.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_torThumbs": {
         "name": "TOR Thumbnails",
@@ -34,7 +33,8 @@ def _sec_to_utc(value):
 
 
 @artifact_processor
-def get_torThumbs(files_found, report_folder, seeker, wrap_text):
+def get_torThumbs(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:


### PR DESCRIPTION
Batch 3 of the ALEAPP **4-arg → context** migration (batches 1–2 = #963/#964, merged).

**What:** Chrome / Firefox / Tor browser artifacts — **29 functions across 17 files** — to `def f(context):`. Pure signature swaps; redundant `# pylint: disable=W0613` removed. `chromeCookies.py` and `chromeOfflinePages.py` are **deferred to the specials batch** (their bodies use `wrap_text`).

**Validation:** pylint `--disable=C,R` = **10.00**; `py_compile` clean; `PluginLoader` **585**; attribution/dates preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)