### PR TITLE
ALEAPP context-form migration — batch 4: bulk A–M (110 files)

### DIFF
--- a/scripts/artifacts/AVG.py
+++ b/scripts/artifacts/AVG.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_AVG": {
         "name": "AVG - Encryption Details",
@@ -214,14 +213,16 @@ def _compute_avg(files_found):
 
 
 @artifact_processor
-def get_AVG(files_found, report_folder, seeker, wrap_text):
+def get_AVG(context):
+    files_found = context.get_files_found()
     enc_details, _, source_path = _compute_avg(files_found)
     data_headers = ('Encryption Detail', 'Value')
     return data_headers, enc_details, source_path
 
 
 @artifact_processor
-def get_AVG_media(files_found, report_folder, seeker, wrap_text):
+def get_AVG_media(context):
+    files_found = context.get_files_found()
     _, media_list, source_path = _compute_avg(files_found)
     data_headers = (('Media', 'media'), 'Decrypted Filename', 'Original File Path',
                     ('Encrypted Date', 'datetime'), 'File Size', 'Decrypted Full Path')

--- a/scripts/artifacts/AdidasActivities.py
+++ b/scripts/artifacts/AdidasActivities.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_adidas_activities": {
         "name": "Adidas Running - Activities",
@@ -43,7 +43,8 @@ def _db(files_found):
 
 
 @artifact_processor
-def get_adidas_activities(files_found, report_folder, seeker, wrap_text):
+def get_adidas_activities(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found)
     data_list = []
     if source_path:

--- a/scripts/artifacts/AdidasGoals.py
+++ b/scripts/artifacts/AdidasGoals.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_adidas_goals": {
         "name": "AdidasGoals",
@@ -34,7 +33,8 @@ def _yyyymmdd(value):
 
 
 @artifact_processor
-def get_adidas_goals(files_found, report_folder, seeker, wrap_text):
+def get_adidas_goals(context):
+    files_found = context.get_files_found()
     logfunc("Processing data for Adidas Goals")
     files_found = [x for x in files_found if not str(x).endswith('-journal')]
     source_path = str(files_found[0])

--- a/scripts/artifacts/AdidasUser.py
+++ b/scripts/artifacts/AdidasUser.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_adidas_user": {
         "name": "AdidasUser",
@@ -29,7 +28,8 @@ def _ms_to_utc(value):
 
 
 @artifact_processor
-def get_adidas_user(files_found, report_folder, seeker, wrap_text):
+def get_adidas_user(context):
+    files_found = context.get_files_found()
     logfunc("Processing data for Adidas User")
     files_found = [x for x in files_found if not str(x).endswith('-journal')]
     source_path = str(files_found[0])

--- a/scripts/artifacts/BadooChat.py
+++ b/scripts/artifacts/BadooChat.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_badoo_chat": {
         "name": "Badoo - Users",
@@ -101,7 +100,8 @@ def _msg_text(ptype, raw):
 
 
 @artifact_processor
-def get_badoo_chat(files_found, report_folder, seeker, wrap_text):
+def get_badoo_chat(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found)
     rows = _run(source_path, '''
         SELECT user_id, gender, user_name, user_image_url, age, user_photos, work, education,
@@ -118,7 +118,8 @@ def get_badoo_chat(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_badoo_messages(files_found, report_folder, seeker, wrap_text):
+def get_badoo_messages(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found)
     users = {r[0]: r[1] for r in
              _run(source_path, 'SELECT encrypted_user_id, user_name FROM conversation_info')}

--- a/scripts/artifacts/BadooConnections.py
+++ b/scripts/artifacts/BadooConnections.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_badoo_conn": {
         "name": "BadooConnections",
@@ -23,7 +22,8 @@ from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readon
 
 
 @artifact_processor
-def get_badoo_conn(files_found, report_folder, seeker, wrap_text):
+def get_badoo_conn(context):
+    files_found = context.get_files_found()
 
     files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
     source_path = str(files_found[0])

--- a/scripts/artifacts/ChessComAccount.py
+++ b/scripts/artifacts/ChessComAccount.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_ChessComAccount": {
         "name": "Chess.com Account",
@@ -41,7 +40,8 @@ def _parse_xml(file_found):
 
 
 @artifact_processor
-def get_ChessComAccount(files_found, report_folder, seeker, wrap_text):
+def get_ChessComAccount(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/ChessComFriends.py
+++ b/scripts/artifacts/ChessComFriends.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_ChessComFriends": {
         "name": "ChessComFriends",
@@ -21,7 +20,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_ChessComFriends(files_found, report_folder, seeker, wrap_text):
+def get_ChessComFriends(context):
+    files_found = context.get_files_found()
 
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)

--- a/scripts/artifacts/ChessComGames.py
+++ b/scripts/artifacts/ChessComGames.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_ChessComGames": {
         "name": "Chess.com Games",
@@ -41,7 +40,8 @@ def _parse_xml(file_found):
 
 
 @artifact_processor
-def get_ChessComGames(files_found, report_folder, seeker, wrap_text):
+def get_ChessComGames(context):
+    files_found = context.get_files_found()
 
     # Username
     username = "None"

--- a/scripts/artifacts/ChessComMessages.py
+++ b/scripts/artifacts/ChessComMessages.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_ChessComMessages": {
         "name": "ChessComMessages",
@@ -21,7 +20,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_ChessComMessages(files_found, report_folder, seeker, wrap_text):
+def get_ChessComMessages(context):
+    files_found = context.get_files_found()
 
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)

--- a/scripts/artifacts/ChessWithFriends.py
+++ b/scripts/artifacts/ChessWithFriends.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_ChessWithFriends": {
         "name": "Chess With Friends",
@@ -19,7 +18,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_ChessWithFriends(files_found, report_folder, seeker, wrap_text):
+def get_ChessWithFriends(context):
+    files_found = context.get_files_found()
 
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)

--- a/scripts/artifacts/Deepseek_ChatMessages.py
+++ b/scripts/artifacts/Deepseek_ChatMessages.py
@@ -67,7 +67,8 @@ def extract_content_from_fragments(fragments):
 
 
 @artifact_processor
-def deepseek_chat_messages(files_found, _report_folder, _seeker, _wrap_text):
+def deepseek_chat_messages(context):
+    files_found = context.get_files_found()
 
     data_headers = (
         ('Timestamp', 'datetime'),

--- a/scripts/artifacts/DocList.py
+++ b/scripts/artifacts/DocList.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0702
+# pylint: disable=W0702
 __artifacts_v2__ = {
     "get_DocList": {
         "name": "DocList",
@@ -31,7 +31,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, conve
 
 
 @artifact_processor
-def get_DocList(files_found, report_folder, seeker, wrap_text):
+def get_DocList(context):
+    files_found = context.get_files_found()
 
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)

--- a/scripts/artifacts/FairEmail.py
+++ b/scripts/artifacts/FairEmail.py
@@ -59,7 +59,8 @@ from scripts.html_safe import safe_source
 
 
 @artifact_processor
-def get_fair_mail_accounts(files_found, _report_folder, _seeker, _wrap_text):
+def get_fair_mail_accounts(context):
+    files_found = context.get_files_found()
     files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
         
     query = ('''
@@ -95,7 +96,8 @@ def get_fair_mail_accounts(files_found, _report_folder, _seeker, _wrap_text):
     return data_headers, data_list, files_found[0]
 
 @artifact_processor
-def get_fair_mail_contacts(files_found, _report_folder, _seeker, _wrap_text):
+def get_fair_mail_contacts(context):
+    files_found = context.get_files_found()
     files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
     
     query = ('''
@@ -127,7 +129,8 @@ def get_fair_mail_contacts(files_found, _report_folder, _seeker, _wrap_text):
     return data_headers, data_list, files_found[0]
 
 @artifact_processor
-def get_fair_mail_messages(files_found, _report_folder, _seeker, _wrap_text):
+def get_fair_mail_messages(context):
+    files_found = context.get_files_found()
     
     # Get the different files found and store their pathes in corresponding lists to work with them
     main_db = ''

--- a/scripts/artifacts/Grok.py
+++ b/scripts/artifacts/Grok.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "grok_generatedvideos": {
         "name": "Grok - Videos",
@@ -56,7 +56,8 @@ def _parse_xml(file_found):
             return ET.Element('empty')
 
 @artifact_processor
-def grok_generatedvideos(files_found, report_folder, seeker, wrap_text):
+def grok_generatedvideos(context):
+    files_found = context.get_files_found()
     data_list = []
 
     db_path = None
@@ -282,7 +283,8 @@ def grok_generatedvideos(files_found, report_folder, seeker, wrap_text):
     return data_headers, data_list, source_path
 
 @artifact_processor
-def grok_useraccount(files_found, report_folder, seeker, wrap_text):
+def grok_useraccount(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ""
 

--- a/scripts/artifacts/HideX.py
+++ b/scripts/artifacts/HideX.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_HideX": {
         "name": "HideX",
@@ -19,7 +18,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_HideX(files_found, report_folder, seeker, wrap_text):
+def get_HideX(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/K9Mail.py
+++ b/scripts/artifacts/K9Mail.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_k9mail_accounts": {
         "name": "K-9 Mail - Accounts",
@@ -56,7 +56,8 @@ def _account_uuids(cursor):
 
 
 @artifact_processor
-def get_k9mail_accounts(files_found, report_folder, seeker, wrap_text):
+def get_k9mail_accounts(context):
+    files_found = context.get_files_found()
     source_path = _prefs_db(files_found)
     data_list = []
     if source_path:
@@ -106,7 +107,8 @@ def _account_emails(files_found):
 
 
 @artifact_processor
-def get_k9mail_messages(files_found, report_folder, seeker, wrap_text):
+def get_k9mail_messages(context):
+    files_found = context.get_files_found()
     emails = _account_emails(files_found)
     data_list = []
     source_path = ''

--- a/scripts/artifacts/Life360.py
+++ b/scripts/artifacts/Life360.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_Life360_chat_messages": {
         "name": "Life360 - Chat Messages",
@@ -154,7 +153,8 @@ def _ble_events(file_found):
 
 
 @artifact_processor
-def get_Life360_chat_messages(files_found, report_folder, seeker, wrap_text):
+def get_Life360_chat_messages(context):
+    files_found = context.get_files_found()
     source = _find(files_found, 'messaging.db')
     data_list = []
     if source:
@@ -193,7 +193,8 @@ def get_Life360_chat_messages(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_Life360_places(files_found, report_folder, seeker, wrap_text):
+def get_Life360_places(context):
+    files_found = context.get_files_found()
     source = _find(files_found, 'L360LocalStoreRoomDatabase')
     data_list = []
     if source:
@@ -210,7 +211,8 @@ def get_Life360_places(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_Life360_locations(files_found, report_folder, seeker, wrap_text):
+def get_Life360_locations(context):
+    files_found = context.get_files_found()
     source = _find(files_found, 'L360EventStore.db')
     data_list = []
     if source:
@@ -227,7 +229,8 @@ def get_Life360_locations(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_Life360_device_battery(files_found, report_folder, seeker, wrap_text):
+def get_Life360_device_battery(context):
+    files_found = context.get_files_found()
     source = _find(files_found, 'L360EventStore.db')
     data_list = []
     if source:

--- a/scripts/artifacts/LinkedIn.py
+++ b/scripts/artifacts/LinkedIn.py
@@ -76,7 +76,8 @@ def _parse_xml(file_found):
 
 
 @artifact_processor
-def linkedin_account(files_found, _report_folder, _seeker, _wrap_text):
+def linkedin_account(context):
+    files_found = context.get_files_found()
     
     # Get data from xml into a dict to work with
     xml_dict = {}
@@ -131,7 +132,8 @@ def linkedin_account(files_found, _report_folder, _seeker, _wrap_text):
 
 
 @artifact_processor
-def linkedin_messages(files_found, _report_folder, _seeker, _wrap_text):
+def linkedin_messages(context):
+    files_found = context.get_files_found()
     files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
 
     query = ('''

--- a/scripts/artifacts/MMWActivities.py
+++ b/scripts/artifacts/MMWActivities.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_mmw_activities": {
         "name": "Map My Walk - Activities",
@@ -64,7 +64,8 @@ def _route_media(source, coords, title, subtitle, base):
 
 
 @artifact_processor
-def get_mmw_activities(files_found, report_folder, seeker, wrap_text):
+def get_mmw_activities(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found)
     data_list = []
     if source_path:

--- a/scripts/artifacts/MMWUsers.py
+++ b/scripts/artifacts/MMWUsers.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_map_users": {
         "name": "MapUsers",
@@ -29,7 +28,8 @@ def _ms_to_utc(value):
 
 
 @artifact_processor
-def get_map_users(files_found, report_folder, seeker, wrap_text):
+def get_map_users(context):
+    files_found = context.get_files_found()
 
     files_found = [x for x in files_found if not str(x).endswith('-journal')
                    and not str(x).endswith('_gear') and not str(x).endswith('_gear-journal')]

--- a/scripts/artifacts/MicrosoftAuthenticator.py
+++ b/scripts/artifacts/MicrosoftAuthenticator.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_MSAuth_accounts": {
         "name": "Microsoft Authenticator - Accounts",
@@ -19,7 +18,8 @@ from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readon
 
 
 @artifact_processor
-def get_MSAuth_accounts(files_found, report_folder, seeker, wrap_text):
+def get_MSAuth_accounts(context):
+    files_found = context.get_files_found()
     logfunc("Processing data for Microsoft Authenticator - Accounts")
 
     files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]

--- a/scripts/artifacts/accounts_ce.py
+++ b/scripts/artifacts/accounts_ce.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "accounts_ce": {
         "name": "Accounts_ce",
@@ -58,7 +57,8 @@ from scripts.ilapfuncs import artifact_processor, \
 
 
 @artifact_processor
-def accounts_ce(files_found, report_folder, seeker, wrap_text):
+def accounts_ce(context):
+    files_found = context.get_files_found()
     source_path_list = get_file_path_list_checking_uid(files_found, "accounts_ce.db", -2, "mirror")
     source_path = ""
     data_list = []
@@ -80,7 +80,8 @@ def accounts_ce(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def accounts_ce_authtokens(files_found, report_folder, seeker, wrap_text):
+def accounts_ce_authtokens(context):
+    files_found = context.get_files_found()
     source_path_list = get_file_path_list_checking_uid(files_found, "accounts_ce.db", -2, "mirror")
     source_path = ""
     data_list = []

--- a/scripts/artifacts/accounts_de.py
+++ b/scripts/artifacts/accounts_de.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "accounts_de": {
         "name": "Accounts_de",
@@ -34,7 +33,8 @@ from scripts.ilapfuncs import artifact_processor, \
 
 
 @artifact_processor
-def accounts_de(files_found, report_folder, seeker, wrap_text):
+def accounts_de(context):
+    files_found = context.get_files_found()
     source_path_list = get_file_path_list_checking_uid(files_found, "accounts_de.db", -2, "mirror")
     source_path = ""
     data_list = []

--- a/scripts/artifacts/airGuard.py
+++ b/scripts/artifacts/airGuard.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_airGuard": {
         "name": "AirGuard AirTag Tracker",
@@ -78,7 +77,8 @@ def _run(source_path, sql):
 
 
 @artifact_processor
-def get_airGuard(files_found, report_folder, seeker, wrap_text):
+def get_airGuard(context):
+    files_found = context.get_files_found()
     source_path = _attd_db(files_found)
     # Older databases keep latitude/longitude on the beacon table; newer ones use a location table
     if source_path and does_table_exist_in_db(source_path, 'location'):
@@ -103,7 +103,8 @@ def get_airGuard(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_airGuard_scans(files_found, report_folder, seeker, wrap_text):
+def get_airGuard_scans(context):
+    files_found = context.get_files_found()
     source_path = _attd_db(files_found)
     rows = _run(source_path, '''
         SELECT startDate, endDate, duration, noDevicesFound,

--- a/scripts/artifacts/airtagAndroid.py
+++ b/scripts/artifacts/airtagAndroid.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "airtagAlerts": {
         "name": "Android Airtag Alerts",
@@ -90,7 +89,8 @@ from scripts.ilapfuncs import artifact_processor, \
 
 
 @artifact_processor
-def airtagAlerts(files_found, report_folder, seeker, wrap_text):
+def airtagAlerts(context):
+    files_found = context.get_files_found()
     source_path = get_file_path(files_found, "personalsafety_db")
     data_list = []
     
@@ -130,7 +130,8 @@ def airtagAlerts(files_found, report_folder, seeker, wrap_text):
 
         
 @artifact_processor
-def airtagScans(files_found, report_folder, seeker, wrap_text):
+def airtagScans(context):
+    files_found = context.get_files_found()
     source_path = get_file_path(files_found, "personalsafety_db")
     data_list = []
     
@@ -177,7 +178,8 @@ def airtagScans(files_found, report_folder, seeker, wrap_text):
 
         
 @artifact_processor
-def airtagLastScan(files_found, report_folder, seeker, wrap_text):
+def airtagLastScan(context):
+    files_found = context.get_files_found()
     source_path = get_file_path(files_found, "personalsafety_info.pb")
     data_list = []
     
@@ -194,7 +196,8 @@ def airtagLastScan(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def airtagPassiveScan(files_found, report_folder, seeker, wrap_text):
+def airtagPassiveScan(context):
+    files_found = context.get_files_found()
     source_path = get_file_path(files_found, "personalsafety_optin.pb")
     data_list = []
     

--- a/scripts/artifacts/alex_live_data.py
+++ b/scripts/artifacts/alex_live_data.py
@@ -333,8 +333,9 @@ def split_dumpsys_log(dumpsys_file) -> dict:
 
 # Dumpsys - Wifi - Configured Networks
 @artifact_processor
-def alex_live_wifi_conf_net(files_found, _report_folder, _seeker, _wrap_text):
+def alex_live_wifi_conf_net(context):
     """Parses the dumpsys wifi dump for configured networks"""
+    files_found = context.get_files_found()
     source_path = files_found[0]
     data_list = []
     split_dumpsys_log(source_path)
@@ -457,8 +458,9 @@ def alex_live_wifi_conf_net(files_found, _report_folder, _seeker, _wrap_text):
 
 # Dumpsys - Usagestats - Events
 @artifact_processor
-def alex_live_usagestats_events(files_found, _report_folder, _seeker, _wrap_text):
+def alex_live_usagestats_events(context):
     """Parses the dumpsys usagestats dump for event logs"""
+    files_found = context.get_files_found()
     source_path = files_found[0]
     data_list = []
     split_dumpsys_log(source_path)
@@ -502,8 +504,9 @@ def alex_live_usagestats_events(files_found, _report_folder, _seeker, _wrap_text
 
 # Dumpsys - Usagestats - Packages (yearly)
 @artifact_processor
-def alex_live_usagestats_yearly(files_found, _report_folder, _seeker, _wrap_text):
+def alex_live_usagestats_yearly(context):
     """Parses the dumpsys usagestats dump for event logs"""
+    files_found = context.get_files_found()
     source_path = files_found[0]
     data_list = []
     data_headers = []
@@ -566,8 +569,9 @@ def alex_live_usagestats_yearly(files_found, _report_folder, _seeker, _wrap_text
 
 # Dumpsys - Bluetooth Manager - Bonded Devices
 @artifact_processor
-def alex_live_bt_bonded(files_found, _report_folder, _seeker, _wrap_text):
+def alex_live_bt_bonded(context):
     """Parses the dumpsys bluetooth_manager dump for bonded devices"""
+    files_found = context.get_files_found()
     source_path = files_found[0]
     data_list = []
     split_dumpsys_log(source_path)
@@ -613,8 +617,9 @@ def alex_live_bt_bonded(files_found, _report_folder, _seeker, _wrap_text):
 
 # Dumpsys - Companiondevice
 @artifact_processor
-def alex_live_companiondevice(files_found, _report_folder, _seeker, _wrap_text):
+def alex_live_companiondevice(context):
     """Parses the dumpsys companiondevice dump for entries"""
+    files_found = context.get_files_found()
 
     source_path = files_found[0]
     data_list = []
@@ -667,8 +672,9 @@ def alex_live_companiondevice(files_found, _report_folder, _seeker, _wrap_text):
 
 # Dumpsys - Role (Default Apps)
 @artifact_processor
-def alex_live_role(files_found, _report_folder, _seeker, _wrap_text):
+def alex_live_role(context):
     """Parses the dumpsys role dump for entries"""
+    files_found = context.get_files_found()
     source_path = files_found[0]
     data_list = []
     split_dumpsys_log(source_path)
@@ -703,8 +709,9 @@ def alex_live_role(files_found, _report_folder, _seeker, _wrap_text):
 
 # Dumpsys - Accounts
 @artifact_processor
-def alex_live_account(files_found, _report_folder, _seeker, _wrap_text):
+def alex_live_account(context):
     """Parses the dumpsys account dump for entires"""
+    files_found = context.get_files_found()
     source_path = files_found[0]
     data_list = []
     split_dumpsys_log(source_path)
@@ -732,8 +739,9 @@ def alex_live_account(files_found, _report_folder, _seeker, _wrap_text):
 
 # Dumpsys - Batterystats
 @artifact_processor
-def alex_live_batterystats(files_found, _report_folder, _seeker, _wrap_text):
+def alex_live_batterystats(context):
     """Parses the dumpsys batterystats dump for entires"""
+    files_found = context.get_files_found()
     source_path = ""
     alex_device = ""
     for file_found in files_found:
@@ -881,8 +889,9 @@ def alex_live_batterystats(files_found, _report_folder, _seeker, _wrap_text):
 
 # App Ops
 @artifact_processor
-def alex_live_appops(files_found, _report_folder, _seeker, _wrap_text):
+def alex_live_appops(context):
     """Parses the app_ops.json included in an ALEX PRFS Backup"""
+    files_found = context.get_files_found()
     source_path = get_file_path(files_found, "app_ops.json")
     data_list = []
     try:
@@ -932,8 +941,9 @@ def alex_live_appops(files_found, _report_folder, _seeker, _wrap_text):
 
 # Logcat (Android 10 and up as these allow the epoch-timestamps)
 @artifact_processor
-def alex_live_logcat(files_found, _report_folder, _seeker, _wrap_text):
+def alex_live_logcat(context):
     """Parses the logcat logs"""
+    files_found = context.get_files_found()
     source_path = get_file_path(files_found, "logcat.txt")
     data_list = []
     log_pattern = re.compile(

--- a/scripts/artifacts/appLockerfishingnetdb.py
+++ b/scripts/artifacts/appLockerfishingnetdb.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_appLockerfishingnetdb": {
         "name": "App Locker DB",
@@ -19,7 +18,8 @@ from scripts.ilapfuncs import artifact_processor
 
 
 @artifact_processor
-def get_appLockerfishingnetdb(files_found, report_folder, seeker, wrap_text):
+def get_appLockerfishingnetdb(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/appLockerfishingnetpat.py
+++ b/scripts/artifacts/appLockerfishingnetpat.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_appLockerfishingnetpat": {
         "name": "App Locker Pat",
@@ -23,7 +22,8 @@ from scripts.ilapfuncs import artifact_processor
 
 
 @artifact_processor
-def get_appLockerfishingnetpat(files_found, report_folder, seeker, wrap_text):
+def get_appLockerfishingnetpat(context):
+    files_found = context.get_files_found()
 
     standardKey = '526e7934384e693861506a59436e5549'
     standardIV = '526e7934384e693861506a59436e5549'

--- a/scripts/artifacts/appSemloc.py
+++ b/scripts/artifacts/appSemloc.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_appSemloc": {
         "name": "App Semantic Locations",
@@ -45,7 +45,8 @@ def _ms_to_utc(value):
 
 
 @artifact_processor
-def get_appSemloc(files_found, report_folder, seeker, wrap_text):
+def get_appSemloc(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     in_dirs = set(pathlib.Path(str(x)).parent for x in files_found)

--- a/scripts/artifacts/appopSetupWiz.py
+++ b/scripts/artifacts/appopSetupWiz.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_appopSetupWiz": {
         "name": "appopSetupWiz",
@@ -51,7 +50,8 @@ def _parse_xml(file_found):
 
 
 @artifact_processor
-def get_appopSetupWiz(files_found, report_folder, seeker, wrap_text):
+def get_appopSetupWiz(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/appops.py
+++ b/scripts/artifacts/appops.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_appops": {
         "name": "App Ops Permissions",
@@ -124,7 +123,8 @@ def _appops_file(files_found):
 
 
 @artifact_processor
-def get_appops(files_found, report_folder, seeker, wrap_text):
+def get_appops(context):
+    files_found = context.get_files_found()
     source_path = _appops_file(files_found)
     data_list = []
     if source_path:
@@ -145,7 +145,8 @@ def get_appops(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_appops_legacy(files_found, report_folder, seeker, wrap_text):
+def get_appops_legacy(context):
+    files_found = context.get_files_found()
     source_path = _appops_file(files_found)
     data_list = []
     if source_path:

--- a/scripts/artifacts/atrackerdetect.py
+++ b/scripts/artifacts/atrackerdetect.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_atrackerdetect": {
         "name": "atrackerdetect",
@@ -40,7 +39,8 @@ def _parse_xml(file_found):
 
 
 @artifact_processor
-def get_atrackerdetect(files_found, report_folder, seeker, wrap_text):
+def get_atrackerdetect(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/battery_usage_v4.py
+++ b/scripts/artifacts/battery_usage_v4.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_battery_usage_v4": {
         "name": "battery_usage_v4",
@@ -33,7 +32,8 @@ def _ms_to_utc(value):
 
 
 @artifact_processor
-def get_battery_usage_v4(files_found, report_folder, seeker, wrap_text):
+def get_battery_usage_v4(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/battery_usage_v9.py
+++ b/scripts/artifacts/battery_usage_v9.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_battery_usage_v9": {
         "name": "Settings Services - Battery Usages v9 - Battery States",
@@ -109,7 +108,8 @@ def _run(source_path, sql):
 
 
 @artifact_processor
-def get_battery_usage_v9(files_found, report_folder, seeker, wrap_text):
+def get_battery_usage_v9(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found)
     data_list = []
     rows = _run(source_path, '''
@@ -153,7 +153,8 @@ def get_battery_usage_v9(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_app_usage_events(files_found, report_folder, seeker, wrap_text):
+def get_app_usage_events(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found)
     rows = _run(source_path, '''
         SELECT uid, userId, timestamp,

--- a/scripts/artifacts/batterystats.py
+++ b/scripts/artifacts/batterystats.py
@@ -32,7 +32,8 @@ import xml.etree.ElementTree as etree
 from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, abxread, checkabx
 
 @artifact_processor
-def battery_stats_daily(files_found, _report_folder, _seeker, _wrap_text):
+def battery_stats_daily(context):
+    files_found = context.get_files_found()
     
     abx_file = ''
 

--- a/scripts/artifacts/bittorrentClientpref.py
+++ b/scripts/artifacts/bittorrentClientpref.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_bittorrentClientpref": {
         "name": "BitTorrent Prefs",
@@ -46,7 +45,8 @@ def _parse_xml(file_found):
 
 
 @artifact_processor
-def get_bittorrentClientpref(files_found, report_folder, seeker, wrap_text):
+def get_bittorrentClientpref(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/blueskymessages.py
+++ b/scripts/artifacts/blueskymessages.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_blueskymessages": {
         "name": "Bluesky - Messages",
@@ -120,7 +120,8 @@ def _build_actors(files_found):
 
 
 @artifact_processor
-def get_blueskymessages_actors(files_found, report_folder, seeker, wrap_text):
+def get_blueskymessages_actors(context):
+    files_found = context.get_files_found()
     actors = _build_actors(files_found)
     source_path = next((str(f) for f in files_found if not str(f).endswith('RKStorage')), '')
     data_headers = ('Created At', 'DID', 'Handle', 'Display Name', 'Avatar', 'Viewer', 'Labels',
@@ -129,7 +130,8 @@ def get_blueskymessages_actors(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_blueskymessages(files_found, report_folder, seeker, wrap_text):
+def get_blueskymessages(context):
+    files_found = context.get_files_found()
     actors = _build_actors(files_found)
     data_list = []
     seen = set()

--- a/scripts/artifacts/blueskyposts.py
+++ b/scripts/artifacts/blueskyposts.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_blueskyposts": {
         "name": "Bluesky - Posts",
@@ -44,7 +43,8 @@ def _extract_post(post, collection):
 
 
 @artifact_processor
-def get_blueskyposts(files_found, report_folder, seeker, wrap_text):
+def get_blueskyposts(context):
+    files_found = context.get_files_found()
     seen = set()
     data_list = []
     source_path = ''

--- a/scripts/artifacts/blueskysearches.py
+++ b/scripts/artifacts/blueskysearches.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_blueskysearches": {
         "name": "Bluesky - Searches",
@@ -21,7 +20,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_blueskysearches(files_found, report_folder, seeker, wrap_text):
+def get_blueskysearches(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/bluetoothConnections.py
+++ b/scripts/artifacts/bluetoothConnections.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_bluetoothConnections": {
         "name": "Bluetooth Connections",
@@ -61,7 +60,8 @@ MAC_RE = re.compile(r'(\[[0-9a-f]{2}(?::[0-9a-f]{2}){5}\])', re.IGNORECASE)
 
 
 @artifact_processor
-def get_bluetoothConnections(files_found, report_folder, seeker, wrap_text):
+def get_bluetoothConnections(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = str(files_found[0])
 
@@ -96,7 +96,8 @@ def get_bluetoothConnections(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_bluetoothAdapter(files_found, report_folder, seeker, wrap_text):
+def get_bluetoothAdapter(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = str(files_found[0])
 

--- a/scripts/artifacts/browserlocation.py
+++ b/scripts/artifacts/browserlocation.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_browserlocation": {
         "name": "Browser Location",
@@ -21,7 +21,8 @@ from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readon
 
 
 @artifact_processor
-def get_browserlocation(files_found, report_folder, seeker, wrap_text):
+def get_browserlocation(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/build.py
+++ b/scripts/artifacts/build.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_build": {
         "name": "Build",
@@ -30,7 +29,8 @@ from scripts.ilapfuncs import artifact_processor, logfunc, logdevinfo
 
 
 @artifact_processor
-def get_build(files_found, report_folder, seeker, wrap_text):
+def get_build(context):
+    files_found = context.get_files_found()
     data_list = []
     Androidversion = scripts.artifacts.artGlobals.versionf
 

--- a/scripts/artifacts/bumble.py
+++ b/scripts/artifacts/bumble.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_bumble": {
         "name": "Bumble - User Settings",
@@ -594,7 +594,8 @@ def _parse_settings(files_found):
 
 
 @artifact_processor
-def get_bumble(files_found, report_folder, seeker, wrap_text):
+def get_bumble(context):
+    files_found = context.get_files_found()
     info, source_path = _parse_settings(files_found)
     data_list = []
     if info:
@@ -607,7 +608,8 @@ def get_bumble(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_bumble_messages(files_found, report_folder, seeker, wrap_text):
+def get_bumble_messages(context):
+    files_found = context.get_files_found()
     info, _settings = _parse_settings(files_found)
     user_name = info.get('user_name', '') if info else ''
     local = f'{user_name} (local user)' if user_name else '(local user)'
@@ -636,7 +638,8 @@ def get_bumble_messages(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_bumble_matches(files_found, report_folder, seeker, wrap_text):
+def get_bumble_matches(context):
+    files_found = context.get_files_found()
     source_path = _chat_db(files_found)
     rows = _run(source_path, """
         SELECT user_name, age, gender,

--- a/scripts/artifacts/burner.py
+++ b/scripts/artifacts/burner.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_burner": {
         "name": "Burner - Numbers",
@@ -78,7 +77,8 @@ def _run(source_path, sql):
 
 
 @artifact_processor
-def get_burner(files_found, report_folder, seeker, wrap_text):
+def get_burner(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found)
     rows = _run(source_path, '''
         SELECT date_created, name, phone_number_id, last_updated_date, expiration_date,
@@ -96,7 +96,8 @@ def get_burner(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_burner_communications(files_found, report_folder, seeker, wrap_text):
+def get_burner_communications(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found)
     rows = _run(source_path, '''
         SELECT messages.date_created, messages.contact_phone_number, contacts.name,

--- a/scripts/artifacts/burnerContacts.py
+++ b/scripts/artifacts/burnerContacts.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_burnerContacts": {
         "name": "Burner - Contacts",
@@ -23,7 +22,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_burnerContacts(files_found, report_folder, seeker, wrap_text):
+def get_burnerContacts(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/burnerMessages.py
+++ b/scripts/artifacts/burnerMessages.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_burnerMessages": {
         "name": "Burner - Messages",
@@ -37,7 +36,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_burnerMessages(files_found, report_folder, seeker, wrap_text):
+def get_burnerMessages(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/burnerSubscription.py
+++ b/scripts/artifacts/burnerSubscription.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_burnerSubscription": {
         "name": "Burner - Subscription",
@@ -31,7 +30,8 @@ def _ms_to_utc(value):
 
 
 @artifact_processor
-def get_burnerSubscription(files_found, report_folder, seeker, wrap_text):
+def get_burnerSubscription(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/burnerUser.py
+++ b/scripts/artifacts/burnerUser.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_burnerUser": {
         "name": "Burner - User",
@@ -25,7 +24,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_burnerUser(files_found, report_folder, seeker, wrap_text):
+def get_burnerUser(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/cachelocation.py
+++ b/scripts/artifacts/cachelocation.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0612,W0613
+# pylint: disable=W0612
 __artifacts_v2__ = {
     "get_cachelocation": {
         "name": "Cache Location",
@@ -23,7 +23,8 @@ from scripts.ilapfuncs import artifact_processor
 
 
 @artifact_processor
-def get_cachelocation(files_found, report_folder, seeker, wrap_text):
+def get_cachelocation(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/callTranscription.py
+++ b/scripts/artifacts/callTranscription.py
@@ -1,4 +1,4 @@
-# pylint: disable=E0606,W0401,W0612,W0613,W0614
+# pylint: disable=E0606,W0401,W0612,W0614
 __artifacts_v2__ = {
     "get_callTranscription": {
         "name": "Android Call Transcriptions",
@@ -21,7 +21,8 @@ from datetime import *
 from scripts.ilapfuncs import artifact_processor
 
 @artifact_processor
-def get_callTranscription(files_found, report_folder, seeker, wrap_text):
+def get_callTranscription(context):
+    files_found = context.get_files_found()
 
     data_list = []
     for file_found in files_found:

--- a/scripts/artifacts/calllog.py
+++ b/scripts/artifacts/calllog.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_calllog": {
         "name": "Call logs ",
@@ -44,7 +43,8 @@ CALL_TYPE_ICONS = {
 
 
 @artifact_processor
-def get_calllog(files_found, report_folder, seeker, wrap_text):
+def get_calllog(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/calllogs.py
+++ b/scripts/artifacts/calllogs.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_calllogs": {
         "name": "Call Logs",
@@ -29,7 +29,8 @@ from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readon
 
 
 @artifact_processor
-def get_calllogs(files_found, report_folder, seeker, wrap_text):
+def get_calllogs(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/cashApp.py
+++ b/scripts/artifacts/cashApp.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0631
+# pylint: disable=W0631
 __artifacts_v2__ = {
     "get_cashApp": {
         "name": "Cash App",
@@ -19,7 +19,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, conve
 
 
 @artifact_processor
-def get_cashApp(files_found, report_folder, seeker, wrap_text):
+def get_cashApp(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/chatgpt2.py
+++ b/scripts/artifacts/chatgpt2.py
@@ -1,4 +1,4 @@
-# pylint: disable=E0606,E1120,E1123,W0611,W0613,W0702,W0718
+# pylint: disable=E0606,E1120,E1123,W0611,W0702,W0718
 __artifacts_v2__ = {
     "get_chatpgt2": {
         "name": "ChatGPT - Conversations",
@@ -28,7 +28,8 @@ from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readon
 from scripts.html_safe import safe_source
 
 @artifact_processor
-def get_chatpgt2(files_found, report_folder, seeker, wrap_text):
+def get_chatpgt2(context):
+    files_found = context.get_files_found()
 
     data_list = []
 

--- a/scripts/artifacts/citymapper.py
+++ b/scripts/artifacts/citymapper.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_citymapperLocationHistory" : {
         "name": "Citymapper - Location History",
@@ -77,7 +77,8 @@ def _parse_xml(file_found):
 
 
 @artifact_processor
-def get_citymapperLocationHistory(files_found, report_folder, _seeker, _wrap_text):
+def get_citymapperLocationHistory(context):
+    files_found = context.get_files_found()
 
     location_data_list = []
     source = ''
@@ -114,7 +115,8 @@ def get_citymapperLocationHistory(files_found, report_folder, _seeker, _wrap_tex
 
 
 @artifact_processor
-def get_citymapperSavedTrips(files_found, report_folder, _seeker, _wrap_text):
+def get_citymapperSavedTrips(context):
+    files_found = context.get_files_found()
 
     saved_trip_data_list = []
     source = ''
@@ -154,7 +156,8 @@ def get_citymapperSavedTrips(files_found, report_folder, _seeker, _wrap_text):
 
 
 @artifact_processor
-def get_citymapperAppPreferences(files_found, report_folder, _seeker, _wrap_text):
+def get_citymapperAppPreferences(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source = ''

--- a/scripts/artifacts/clipBoard.py
+++ b/scripts/artifacts/clipBoard.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0631
+# pylint: disable=W0631
 __artifacts_v2__ = {
     "clipboard": {
         "name": "Clipboard Data",
@@ -51,7 +51,8 @@ def triage_text(file_found):
     return str(output.rstrip())
 
 @artifact_processor
-def clipboard(files_found, report_folder, seeker, wrap_text):
+def clipboard(context):
+    files_found = context.get_files_found()
     data_list = []
     for file_found in files_found:
         if file_found.endswith('.DS_Store'):

--- a/scripts/artifacts/cmh.py
+++ b/scripts/artifacts/cmh.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_cmh": {
         "name": "cmh",
@@ -42,7 +41,8 @@ def _sec_to_utc(value):
 
 
 @artifact_processor
-def get_cmh(files_found, report_folder, seeker, wrap_text):
+def get_cmh(context):
+    files_found = context.get_files_found()
     # Extractions can hold several cmh.db copies (e.g. one per user profile);
     # parse every distinct copy that carries the files table. The same
     # database can appear under aliased paths (data/data vs data/user/0,

--- a/scripts/artifacts/deviceHealthServices_AppUsage.py
+++ b/scripts/artifacts/deviceHealthServices_AppUsage.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_Turbo_AppUsage": {
         "name": "Turbo_AppUsage",
@@ -52,7 +51,8 @@ def _parse_xml(file_found):
 
 
 @artifact_processor
-def get_Turbo_AppUsage(files_found, report_folder, seeker, wrap_text):
+def get_Turbo_AppUsage(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/discordChats.py
+++ b/scripts/artifacts/discordChats.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0612,W0613,W0631
+# pylint: disable=W0612,W0631
 __artifacts_v2__ = {
     "get_discordChats": {
         "name": "discordChats",
@@ -39,7 +39,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_discordChats(files_found, report_folder, seeker, wrap_text):
+def get_discordChats(context):
+    files_found = context.get_files_found()
 
     # build a table mapping all non-printable characters to None
     NOPRINT_TRANS_TABLE = {

--- a/scripts/artifacts/discreteNative.py
+++ b/scripts/artifacts/discreteNative.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0612,W0613
+# pylint: disable=W0612
 __artifacts_v2__ = {
     "get_discreteNative": {
         "name": "DiscreteNative",
@@ -71,7 +71,8 @@ def _parse_xml(file_found):
 
 
 @artifact_processor
-def get_discreteNative(files_found, report_folder, seeker, wrap_text):
+def get_discreteNative(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/emulatedSmeta.py
+++ b/scripts/artifacts/emulatedSmeta.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_emulatedSmeta": {
         "name": "Emulated Storage Metadata - Downloads",
@@ -208,7 +208,8 @@ def _run(source_path, sql):
 
 
 @artifact_processor
-def get_emulatedSmeta(files_found, report_folder, seeker, wrap_text):
+def get_emulatedSmeta(context):
+    files_found = context.get_files_found()
     source_path = _external_db(files_found, True)
     rows = _run(source_path, f'''
         SELECT date_added, date_modified, datetaken, _data, title, _display_name, _size,
@@ -228,7 +229,8 @@ def get_emulatedSmeta(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_emulatedSmeta_images(files_found, report_folder, seeker, wrap_text):
+def get_emulatedSmeta_images(context):
+    files_found = context.get_files_found()
     source_path = _external_db(files_found, True)
     rows = _run(source_path, f'''
         SELECT date_added, date_modified, datetaken, _data, title, _display_name, _size, latitude, longitude,
@@ -245,7 +247,8 @@ def get_emulatedSmeta_images(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_emulatedSmeta_files(files_found, report_folder, seeker, wrap_text):
+def get_emulatedSmeta_files(context):
+    files_found = context.get_files_found()
     source_path = _external_db(files_found, True)
     rows = _run(source_path, f'''
         SELECT date_added, date_modified, datetaken, _data, title, _display_name, _size, latitude, longitude,
@@ -262,7 +265,8 @@ def get_emulatedSmeta_files(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_emulatedSmeta_videos(files_found, report_folder, seeker, wrap_text):
+def get_emulatedSmeta_videos(context):
+    files_found = context.get_files_found()
     source_path = _external_db(files_found, True)
     rows = _run(source_path, f'''
         SELECT date_added, date_modified, datetaken, _data, title, _display_name, _size, latitude, longitude,
@@ -279,7 +283,8 @@ def get_emulatedSmeta_videos(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_emulatedSmeta_audio(files_found, report_folder, seeker, wrap_text):
+def get_emulatedSmeta_audio(context):
+    files_found = context.get_files_found()
     source_path = _external_db(files_found, True)
     rows = _run(source_path, f'''
         SELECT date_added, date_modified, datetaken, _data, title, _display_name, _size,
@@ -296,7 +301,8 @@ def get_emulatedSmeta_audio(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_emulatedSmeta_files_legacy(files_found, report_folder, seeker, wrap_text):
+def get_emulatedSmeta_files_legacy(context):
+    files_found = context.get_files_found()
     source_path = _external_db(files_found, False)
     rows = _run(source_path, f'''
         SELECT date_added, date_modified, datetaken, _data, title, _display_name, _size, latitude, longitude,

--- a/scripts/artifacts/errp.py
+++ b/scripts/artifacts/errp.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_errp": {
         "name": "Errp",
@@ -19,7 +18,8 @@ from scripts.ilapfuncs import artifact_processor, convert_local_to_utc
 
 
 @artifact_processor
-def get_errp(files_found, report_folder, seeker, wrap_text):
+def get_errp(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/factory_reset.py
+++ b/scripts/artifacts/factory_reset.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0631
+# pylint: disable=W0631
 __artifacts_v2__ = {
     "factory_reset": {
         "name": "Factory Reset",
@@ -33,7 +33,8 @@ import time
 from scripts.ilapfuncs import artifact_processor, logdevinfo
 
 @artifact_processor
-def factory_reset(files_found, report_folder, seeker, wrap_text):
+def factory_reset(context):
+    files_found = context.get_files_found()
 
     for file_found in files_found:
         file_found = str(file_found)

--- a/scripts/artifacts/fitbit.py
+++ b/scripts/artifacts/fitbit.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 _PATHS_PHONE_ACT = ('*/com.fitbit.FitbitMobile/databases/activity_db*',)
 _PATHS_PHONE_DEV = ('*/com.fitbit.FitbitMobile/databases/device_database*',)
 _PATHS_PHONE_EX = ('*/com.fitbit.FitbitMobile/databases/exercise_db*',)
@@ -99,7 +99,8 @@ def _route_media(source, coords, title, subtitle, base):
 
 
 @artifact_processor
-def get_fitbit_activity(files_found, report_folder, seeker, wrap_text):
+def get_fitbit_activity(context):
+    files_found = context.get_files_found()
     src = _find(files_found, 'activity_db')
     rows = _run(src, '''SELECT LOG_DATE, TIME_CREATED, NAME, LOG_TYPE, ACTIVE_DURATION, SPEED, PACE,
         ELEVATION_GAIN, AVERAGE_HEART_RATE, DISTANCE, DISTANCE_UNIT, DURATION, DURATION/60, STEPS,
@@ -118,7 +119,8 @@ def get_fitbit_activity(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fitbit_device(files_found, report_folder, seeker, wrap_text):
+def get_fitbit_device(context):
+    files_found = context.get_files_found()
     src = _find(files_found, 'device_database')
     rows = _run(src, '''SELECT lastsynctime, deviceName, bleMacAddress, batteryPercent, deviceType
         FROM core_device''')
@@ -134,7 +136,8 @@ def _phone_gps_rows(src):
 
 
 @artifact_processor
-def get_fitbit_exercise(files_found, report_folder, seeker, wrap_text):
+def get_fitbit_exercise(context):
+    files_found = context.get_files_found()
     src = _find(files_found, 'exercise_db')
     data_list = [(_ms_to_utc(r[0]), r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], src)
                  for r in _phone_gps_rows(src)]
@@ -144,7 +147,8 @@ def get_fitbit_exercise(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fitbit_routes(files_found, report_folder, seeker, wrap_text):
+def get_fitbit_routes(context):
+    files_found = context.get_files_found()
     src = _find(files_found, 'exercise_db')
     sessions = {}
     for r in _phone_gps_rows(src):
@@ -166,7 +170,8 @@ def get_fitbit_routes(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fitbit_heart(files_found, report_folder, seeker, wrap_text):
+def get_fitbit_heart(context):
+    files_found = context.get_files_found()
     src = _find(files_found, 'heart_rate_db')
     rows = _run(src, 'SELECT DATE_TIME, AVERAGE_HEART_RATE, RESTING_HEART_RATE FROM HEART_RATE_DAILY_SUMMARY')
     data_list = [(_ms_to_utc(r[0]), r[1], r[2], src) for r in rows]
@@ -175,7 +180,8 @@ def get_fitbit_heart(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fitbit_sleep_detail(files_found, report_folder, seeker, wrap_text):
+def get_fitbit_sleep_detail(context):
+    files_found = context.get_files_found()
     src = _find(files_found, 'sleep')
     rows = _run(src, 'SELECT DATE_TIME, SECONDS, LEVEL_STRING, LOG_ID FROM SLEEP_LEVEL_DATA')
     data_list = [(_ms_to_utc(r[0]), r[1], r[2], r[3], src) for r in rows]
@@ -184,7 +190,8 @@ def get_fitbit_sleep_detail(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fitbit_sleep_summary(files_found, report_folder, seeker, wrap_text):
+def get_fitbit_sleep_summary(context):
+    files_found = context.get_files_found()
     src = _find(files_found, 'sleep')
     rows = _run(src, '''SELECT DATE_OF_SLEEP, START_TIME, SYNC_STATUS_STRING, DURATION, DURATION/60000,
         MINUTES_AFTER_WAKEUP, MINUTES_ASLEEP, MINUTES_AWAKE, MINUTES_TO_FALL_ASLEEP, LOG_ID FROM SLEEP_LOG''')
@@ -197,7 +204,8 @@ def get_fitbit_sleep_summary(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fitbit_friends(files_found, report_folder, seeker, wrap_text):
+def get_fitbit_friends(context):
+    files_found = context.get_files_found()
     src = _find(files_found, 'social_db')
     rows = _run(src, 'SELECT OWNING_USER_ID, ENCODED_ID, DISPLAY_NAME, AVATAR_URL, FRIEND, CHILD FROM FRIEND')
     data_list = [(r[0], r[1], r[2], r[3], r[4], r[5], src) for r in rows]
@@ -207,7 +215,8 @@ def get_fitbit_friends(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fitbit_user(files_found, report_folder, seeker, wrap_text):
+def get_fitbit_user(context):
+    files_found = context.get_files_found()
     src = _find(files_found, 'social_db')
     rows = _run(src, '''SELECT LAST_UPDATED, DISPLAY_NAME, FULL_NAME, ABOUT_ME, AVATAR_URL,
         COVER_PHOTO_URL, CITY, STATE, COUNTRY, JOINED_DATE, DATE_OF_BIRTH, HEIGHT, WEIGHT, GENDER, COACH
@@ -221,7 +230,8 @@ def get_fitbit_user(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fitbit_steps(files_found, report_folder, seeker, wrap_text):
+def get_fitbit_steps(context):
+    files_found = context.get_files_found()
     src = _find(files_found, 'mobile_track_db')
     rows = _run(src, '''SELECT TIMESTAMP, STEPS_COUNT, METS_COUNT, TIME_CREATED, TIME_UPDATED
         FROM PEDOMETER_MINUTE_DATA''')
@@ -232,7 +242,8 @@ def get_fitbit_steps(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fitbit_wearos_profile(files_found, report_folder, seeker, wrap_text):
+def get_fitbit_wearos_profile(context):
+    files_found = context.get_files_found()
     src = _find(files_found, 'user.db')
     rows = _run(src, '''SELECT fullName, displayName, email, gender, dateOfBirth, height, weight,
         memberSince, userId FROM FitbitProfileEntity''')
@@ -243,7 +254,8 @@ def get_fitbit_wearos_profile(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fitbit_wearos_activity(files_found, report_folder, seeker, wrap_text):
+def get_fitbit_wearos_activity(context):
+    files_found = context.get_files_found()
     src = _find(files_found, 'user.db')
     rows = _run(src, '''SELECT startTime, name, duration/1000/60, distance, distanceUnit, steps,
         calories, averageHeartRate, elevationGain, activeZoneMinutes, logId FROM ActivityExerciseEntity
@@ -255,7 +267,8 @@ def get_fitbit_wearos_activity(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fitbit_wearos_daily(files_found, report_folder, seeker, wrap_text):
+def get_fitbit_wearos_daily(context):
+    files_found = context.get_files_found()
     src = _find(files_found, 'user.db')
     rows = _run(src, '''SELECT date, totalMinutesMoving, totalMinutesSedentary, longestDuration,
         longestStart FROM SedentaryDataEntity ORDER BY date DESC''')
@@ -266,7 +279,8 @@ def get_fitbit_wearos_daily(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fitbit_wearos_hourly(files_found, report_folder, seeker, wrap_text):
+def get_fitbit_wearos_hourly(context):
+    files_found = context.get_files_found()
     src = _find(files_found, 'user.db')
     data_list = []
     for r in _run(src, 'SELECT date, hourlyData FROM SedentaryDataEntity ORDER BY date DESC'):
@@ -284,7 +298,8 @@ def get_fitbit_wearos_hourly(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fitbit_wearos_sleep_logs(files_found, report_folder, seeker, wrap_text):
+def get_fitbit_wearos_sleep_logs(context):
+    files_found = context.get_files_found()
     src = _find(files_found, 'user.db')
     rows = _run(src, '''SELECT startTime, endTime, dateOfSleep, minutesAsleep, minutesAwake,
         minutesToFallAsleep, minutesAfterWakeup, type, isMainSleep FROM FitbitSleepDateEntity
@@ -297,7 +312,8 @@ def get_fitbit_wearos_sleep_logs(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fitbit_wearos_workouts(files_found, report_folder, seeker, wrap_text):
+def get_fitbit_wearos_workouts(context):
+    files_found = context.get_files_found()
     src = _find(files_found, 'passive_stats.db')
     rows = _run(src, '''SELECT time, sessionId, exerciseTypeId, totalDistanceMm/1000000.0, steps,
         caloriesBurned, avgHeartRate, elevationGainFt FROM ExerciseSummaryEntity ORDER BY time DESC''')
@@ -313,7 +329,8 @@ def _wearos_gps_rows(src):
 
 
 @artifact_processor
-def get_fitbit_wearos_gps(files_found, report_folder, seeker, wrap_text):
+def get_fitbit_wearos_gps(context):
+    files_found = context.get_files_found()
     src = _find(files_found, 'passive_stats.db')
     data_list = [(_ms_to_utc(r[0]), r[1], r[2], r[3], r[4], r[6]) for r in _wearos_gps_rows(src)]
     data_headers = (('Timestamp', 'datetime'), 'Latitude', 'Longitude', 'Altitude', 'Speed',
@@ -322,7 +339,8 @@ def get_fitbit_wearos_gps(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fitbit_wearos_gps_route(files_found, report_folder, seeker, wrap_text):
+def get_fitbit_wearos_gps_route(context):
+    files_found = context.get_files_found()
     src = _find(files_found, 'passive_stats.db')
     rows = _wearos_gps_rows(src)
     coords = [(r[1], r[2]) for r in rows if r[1] and r[2]]
@@ -340,7 +358,8 @@ def get_fitbit_wearos_gps_route(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fitbit_wearos_hr(files_found, report_folder, seeker, wrap_text):
+def get_fitbit_wearos_hr(context):
+    files_found = context.get_files_found()
     src = _find(files_found, 'passive_stats.db')
     rows = _run(src, 'SELECT startTime, endTime, value, accuracy FROM HeartRateStatEntity ORDER BY startTime DESC')
     data_list = [(_ms_to_utc(r[0]), _ms_to_utc(r[1]), r[2], r[3]) for r in rows]
@@ -349,7 +368,8 @@ def get_fitbit_wearos_hr(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fitbit_wearos_pace(files_found, report_folder, seeker, wrap_text):
+def get_fitbit_wearos_pace(context):
+    files_found = context.get_files_found()
     src = _find(files_found, 'passive_stats.db')
     rows = _run(src, 'SELECT timeSeconds, sessionId, statType, value FROM LivePaceEntity ORDER BY timeSeconds DESC')
     data_list = [(_ms_to_utc(r[0]), r[1], r[2], r[3]) for r in rows]
@@ -358,7 +378,8 @@ def get_fitbit_wearos_pace(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fitbit_wearos_sleep(files_found, report_folder, seeker, wrap_text):
+def get_fitbit_wearos_sleep(context):
+    files_found = context.get_files_found()
     src = _find(files_found, 'passive_stats.db')
     rows = _run(src, '''SELECT sleepStartTime, sleepEndTime, (sleepEndTime-sleepStartTime)/1000/60
         FROM LocalSleepPeriodsEntity ORDER BY sleepStartTime DESC''')
@@ -368,7 +389,8 @@ def get_fitbit_wearos_sleep(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fitbit_wearos_azm(files_found, report_folder, seeker, wrap_text):
+def get_fitbit_wearos_azm(context):
+    files_found = context.get_files_found()
     src = _find(files_found, 'passive_stats.db')
     rows = _run(src, 'SELECT startTime, endTime, activeZone, value, lastBpm FROM PassiveAzmEntity ORDER BY startTime DESC')
     data_list = [(_ms_to_utc(r[0]), _ms_to_utc(r[1]), r[2], r[3], r[4]) for r in rows]
@@ -377,7 +399,8 @@ def get_fitbit_wearos_azm(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fitbit_wearos_splits(files_found, report_folder, seeker, wrap_text):
+def get_fitbit_wearos_splits(context):
+    files_found = context.get_files_found()
     src = _find(files_found, 'passive_stats.db')
     rows = _run(src, '''SELECT time, sessionId, avgPaceMilliSecPerKm/1000/60.0, avgHeartRate, steps,
         caloriesBurned FROM ExerciseSplitAnnotationEntity ORDER BY time ASC''')
@@ -388,7 +411,8 @@ def get_fitbit_wearos_splits(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fitbit_wearos_opaque_hr(files_found, report_folder, seeker, wrap_text):
+def get_fitbit_wearos_opaque_hr(context):
+    files_found = context.get_files_found()
     src = _find(files_found, 'passive_stats.db')
     rows = _run(src, 'SELECT timestamp, baseHeartRate, confidence FROM OpaqueHeartRateEntity ORDER BY timestamp DESC')
     data_list = [(_ms_to_utc(r[0]), r[1], r[2]) for r in rows]

--- a/scripts/artifacts/frosting.py
+++ b/scripts/artifacts/frosting.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "frosting": {
         "name": "App Updates (Frosting.db)",
@@ -32,7 +31,8 @@ __artifacts_v2__ = {
 from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records
 
 @artifact_processor
-def frosting(files_found, report_folder, seeker, wrap_text):
+def frosting(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = get_file_path(files_found, "frosting.db")
     

--- a/scripts/artifacts/galleryTrash.py
+++ b/scripts/artifacts/galleryTrash.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_galleryTrash": {
         "name": "Gallery Trash",
@@ -40,7 +39,8 @@ def _ms_to_utc(value):
 
 
 @artifact_processor
-def get_galleryTrash(files_found, report_folder, seeker, wrap_text):
+def get_galleryTrash(context):
+    files_found = context.get_files_found()
     # Map basename -> path for the trashed media files so each row can resolve its thumbnail
     trash_files = {os.path.basename(str(f)): str(f) for f in files_found if '.Trash' in str(f)}
 

--- a/scripts/artifacts/gboard.py
+++ b/scripts/artifacts/gboard.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_gboardCache": {
         "name": "Gboard - Clipboard",
@@ -204,7 +203,8 @@ def _events_trainingcachev2(file_found):
 
 
 @artifact_processor
-def get_gboardCache(files_found, report_folder, seeker, wrap_text):
+def get_gboardCache(context):
+    files_found = context.get_files_found()
     source_path = ''
     data_list = []
     for file_found in files_found:
@@ -241,7 +241,8 @@ def get_gboardCache(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_gboardCache_keystrokes(files_found, report_folder, seeker, wrap_text):
+def get_gboardCache_keystrokes(context):
+    files_found = context.get_files_found()
     source_path = ''
     data_list = []
     for file_found in files_found:
@@ -265,7 +266,8 @@ def get_gboardCache_keystrokes(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_gboardCache_sessions(files_found, report_folder, seeker, wrap_text):
+def get_gboardCache_sessions(context):
+    files_found = context.get_files_found()
     source_path = ''
     data_list = []
     for file_found in files_found:

--- a/scripts/artifacts/gmail.py
+++ b/scripts/artifacts/gmail.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_gmailActive": {
         "name": "GmailActive",
@@ -52,7 +51,8 @@ def _parse_xml(file_found):
 
 
 @artifact_processor
-def get_gmailActive(files_found, report_folder, seeker, wrap_text):
+def get_gmailActive(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = str(files_found[0])

--- a/scripts/artifacts/gmailIMAPEmails.py
+++ b/scripts/artifacts/gmailIMAPEmails.py
@@ -60,7 +60,8 @@ from scripts.context import Context
 from scripts.html_safe import safe_source
 
 @artifact_processor
-def gmailIMAPEmails(files_found, _report_folder, _seeker, _wrap_text):
+def gmailIMAPEmails(context):
+    files_found = context.get_files_found()
     emailProviderDB = ''    
     emailProviderDB_found = []
 
@@ -186,7 +187,8 @@ def gmailIMAPEmails(files_found, _report_folder, _seeker, _wrap_text):
     return data_headers, data_list, 'See source file(s) below:'
     
 @artifact_processor
-def gmailIMAPAccounts(files_found, _report_folder, _seeker, _wrap_text):
+def gmailIMAPAccounts(context):
+    files_found = context.get_files_found()
     emailProviderDB = '' 
     emailProviderDB_found = []
 

--- a/scripts/artifacts/googleCalendar.py
+++ b/scripts/artifacts/googleCalendar.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_calendar": {
         "name": "Calendar - Events",
@@ -90,7 +89,8 @@ def _run(source_path, sql):
 
 
 @artifact_processor
-def get_calendar(files_found, report_folder, seeker, wrap_text):
+def get_calendar(context):
+    files_found = context.get_files_found()
     source_path = _calendar_db(files_found)
     rows = _run(source_path, '''
         SELECT Events.dtstart, Events.dtend, Events.eventTimezone, Events.title, Events.description,
@@ -109,7 +109,8 @@ def get_calendar(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_calendar_calendars(files_found, report_folder, seeker, wrap_text):
+def get_calendar_calendars(context):
+    files_found = context.get_files_found()
     source_path = _calendar_db(files_found)
     rows = _run(source_path, '''
         SELECT cal_sync8, name, calendar_displayName, account_name, account_type,

--- a/scripts/artifacts/googleCallScreen.py
+++ b/scripts/artifacts/googleCallScreen.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_googleCallScreen": {
         "name": "Google Call Screen",
@@ -51,7 +51,8 @@ def _ms_to_utc(value):
 
 
 @artifact_processor
-def get_googleCallScreen(files_found, report_folder, seeker, wrap_text):
+def get_googleCallScreen(context):
+    files_found = context.get_files_found()
     source_path = ''
     data_list = []
     for file_found in files_found:

--- a/scripts/artifacts/googleChat.py
+++ b/scripts/artifacts/googleChat.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_googleChat": {
         "name": "Google Chat - Messages",
@@ -194,7 +194,8 @@ def _parse_annotation(blob):
 
 
 @artifact_processor
-def get_googleChat(files_found, report_folder, seeker, wrap_text):
+def get_googleChat(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for source_path in _dbs(files_found):
@@ -230,7 +231,8 @@ def get_googleChat(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_googleChat_groups(files_found, report_folder, seeker, wrap_text):
+def get_googleChat_groups(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for source_path in _dbs(files_found):
@@ -249,7 +251,8 @@ def get_googleChat_groups(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_googleChat_drafts(files_found, report_folder, seeker, wrap_text):
+def get_googleChat_drafts(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for source_path in _dbs(files_found):
@@ -266,7 +269,8 @@ def get_googleChat_drafts(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_googleChat_users(files_found, report_folder, seeker, wrap_text):
+def get_googleChat_users(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for source_path in _dbs(files_found):

--- a/scripts/artifacts/googleDuo.py
+++ b/scripts/artifacts/googleDuo.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_googleDuo": {
         "name": "Google Duo - Call History",
@@ -126,7 +125,8 @@ def _run(source_path, sql):
 
 
 @artifact_processor
-def get_googleDuo(files_found, report_folder, seeker, wrap_text):
+def get_googleDuo(context):
+    files_found = context.get_files_found()
     source_path = _tachyon_db(files_found)
     rows = _run(source_path, '''
         SELECT timestamp_usec, substr(self_id, 0, instr(self_id, '|')),
@@ -144,7 +144,8 @@ def get_googleDuo(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_googleDuo_contacts(files_found, report_folder, seeker, wrap_text):
+def get_googleDuo_contacts(context):
+    files_found = context.get_files_found()
     source_path = _tachyon_db(files_found)
     rows = _run(source_path, '''
         SELECT system_contact_last_update_millis, contact_display_name, user_id,
@@ -158,7 +159,8 @@ def get_googleDuo_contacts(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_googleDuo_notes(files_found, report_folder, seeker, wrap_text):
+def get_googleDuo_notes(context):
+    files_found = context.get_files_found()
     source_path = _tachyon_db(files_found)
     rows = _run(source_path, '''
         SELECT sent_timestamp_millis, received_timestamp_millis, seen_timestamp_millis,

--- a/scripts/artifacts/googleInitiatedNav.py
+++ b/scripts/artifacts/googleInitiatedNav.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_googleInitiatedNav": {
         "name": "Google Initiated Navigation",
@@ -37,7 +37,8 @@ def _us_to_utc(value):
 
 
 @artifact_processor
-def get_googleInitiatedNav(files_found, report_folder, seeker, wrap_text):
+def get_googleInitiatedNav(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/googleKeepNotes.py
+++ b/scripts/artifacts/googleKeepNotes.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_googleKeepNotes": {
         "name": "Google Keep - Notes",
@@ -81,7 +80,8 @@ def _run(source_path, sql):
 
 
 @artifact_processor
-def get_googleKeepNotes(files_found, report_folder, seeker, wrap_text):
+def get_googleKeepNotes(context):
+    files_found = context.get_files_found()
     source_path = _keep_db(files_found)
     rows = _run(source_path, '''
         SELECT list_item.time_created, list_item.time_last_updated, list_parent_id, name, title, text,
@@ -99,7 +99,8 @@ def get_googleKeepNotes(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_googleKeepNotes_sharing(files_found, report_folder, seeker, wrap_text):
+def get_googleKeepNotes_sharing(context):
+    files_found = context.get_files_found()
     source_path = _keep_db(files_found)
     rows = _run(source_path, '''
         SELECT tree_entity.shared_timestamp, list_item.list_parent_id, account.name, sharing.email,

--- a/scripts/artifacts/googleLastTrip.py
+++ b/scripts/artifacts/googleLastTrip.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_googleLastTrip": {
         "name": "Google Maps Last Trip",
@@ -43,7 +43,8 @@ def _ms_to_utc(value):
 
 
 @artifact_processor
-def get_googleLastTrip(files_found, report_folder, seeker, wrap_text):
+def get_googleLastTrip(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/googleMapsGmm.py
+++ b/scripts/artifacts/googleMapsGmm.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_googleMapsGmm": {
         "name": "Google Search History Maps",
@@ -84,7 +84,8 @@ def _run(source_path, sql):
 
 
 @artifact_processor
-def get_googleMapsGmm(files_found, report_folder, seeker, wrap_text):
+def get_googleMapsGmm(context):
+    files_found = context.get_files_found()
     source_path = ''
     data_list = []
     for file_found in files_found:
@@ -125,7 +126,8 @@ def get_googleMapsGmm(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_googleMapsGmm_places(files_found, report_folder, seeker, wrap_text):
+def get_googleMapsGmm_places(context):
+    files_found = context.get_files_found()
     source_path = ''
     data_list = []
     for file_found in files_found:

--- a/scripts/artifacts/googleMapsSearches.py
+++ b/scripts/artifacts/googleMapsSearches.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_googleMapsSearches": {
         "name": "Google Maps Searches",
@@ -61,7 +61,8 @@ def _extract_search(item):
 
 
 @artifact_processor
-def get_googleMapsSearches(files_found, report_folder, seeker, wrap_text):
+def get_googleMapsSearches(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/googleMessages.py
+++ b/scripts/artifacts/googleMessages.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_googleMessages": {
         "name": "GoogleMessages",
@@ -43,7 +42,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_googleMessages(files_found, report_folder, seeker, wrap_text):
+def get_googleMessages(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/googleNowPlaying.py
+++ b/scripts/artifacts/googleNowPlaying.py
@@ -1,4 +1,4 @@
-# pylint: disable=E0606,W0612,W0613
+# pylint: disable=E0606,W0612
 __artifacts_v2__ = {
     "get_googleNowPlaying": {
         "name": "GoogleNowPlaying",
@@ -61,7 +61,8 @@ def AreContentsSame(last_data_set, timezones, songtitle, artist, duration, album
 
 
 @artifact_processor
-def get_googleNowPlaying(files_found, report_folder, seeker, wrap_text):
+def get_googleNowPlaying(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/googlePhotos.py
+++ b/scripts/artifacts/googlePhotos.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_googlePhotos": {
         "name": "Google Photos - Local Media",
@@ -194,7 +193,8 @@ def _find_media(files_found, key):
 
 
 @artifact_processor
-def get_googlePhotos(files_found, report_folder, seeker, wrap_text):
+def get_googlePhotos(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for db_path in _gphotos_dbs(files_found):
@@ -231,7 +231,8 @@ def get_googlePhotos(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_googlePhotos_remote(files_found, report_folder, seeker, wrap_text):
+def get_googlePhotos_remote(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for db_path in _gphotos_dbs(files_found):
@@ -266,7 +267,8 @@ def get_googlePhotos_remote(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_googlePhotos_shared(files_found, report_folder, seeker, wrap_text):
+def get_googlePhotos_shared(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for db_path in _gphotos_dbs(files_found):
@@ -295,7 +297,8 @@ def get_googlePhotos_shared(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_googlePhotos_folders(files_found, report_folder, seeker, wrap_text):
+def get_googlePhotos_folders(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for db_path in _gphotos_dbs(files_found):
@@ -324,7 +327,8 @@ def get_googlePhotos_folders(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_googlePhotos_cache(files_found, report_folder, seeker, wrap_text):
+def get_googlePhotos_cache(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:
@@ -352,7 +356,8 @@ def get_googlePhotos_cache(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_googlePhotos_trash(files_found, report_folder, seeker, wrap_text):
+def get_googlePhotos_trash(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/googlePlaySearches.py
+++ b/scripts/artifacts/googlePlaySearches.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "GooglePlaySearches": {
         "name": "Google Play Searches",
@@ -30,7 +29,8 @@ __artifacts_v2__ = {
 from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records
 
 @artifact_processor
-def GooglePlaySearches(files_found, report_folder, seeker, wrap_text):
+def GooglePlaySearches(context):
+    files_found = context.get_files_found()
     data_list = []
     
     source_path = get_file_path(files_found, "suggestions.db")

--- a/scripts/artifacts/googleTasks.py
+++ b/scripts/artifacts/googleTasks.py
@@ -1,4 +1,4 @@
-# pylint: disable=E0606,W0613
+# pylint: disable=E0606
 __artifacts_v2__ = {
     "get_googleTasks": {
         "name": "GoogleTasks",
@@ -48,7 +48,8 @@ def protobuf_parse_completed(data):
 
 
 @artifact_processor
-def get_googleTasks(files_found, report_folder, seeker, wrap_text):
+def get_googleTasks(context):
+    files_found = context.get_files_found()
     all_new_rows = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/googleVoice.py
+++ b/scripts/artifacts/googleVoice.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0612,W0613
+# pylint: disable=W0612
 __artifacts_v2__ = {
     "googlevoice_accounts": {
         "name": "Google Voice - User Accounts",
@@ -99,7 +99,8 @@ def _decode_text(value):
     return str(value)
 
 @artifact_processor
-def googlevoice_accounts(files_found, report_folder, seeker, wrap_text):
+def googlevoice_accounts(context):
+    files_found = context.get_files_found()
     data_headers = ('Account Number', 'Full Name', 'Email Address', 'Linked Phone Number', 'Current Google Voice Number')
     data_list = []
     source_path = ""
@@ -178,7 +179,8 @@ def googlevoice_accounts(files_found, report_folder, seeker, wrap_text):
     return data_headers, data_list, source_path
 
 @artifact_processor
-def googlevoice_calls(files_found, report_folder, seeker, wrap_text):
+def googlevoice_calls(context):
+    files_found = context.get_files_found()
     data_headers = (('Timestamp', 'datetime'), 'Account Number', 'Direction', 'Caller', 'Recipient', 'Call Status', 'Voicemail Left', 'Duration', ('Call Recording', 'media'))
     data_list = []
     source_path = ""
@@ -296,7 +298,8 @@ def googlevoice_calls(files_found, report_folder, seeker, wrap_text):
     return data_headers, data_list, source_path
 
 @artifact_processor
-def googlevoice_voicemails(files_found, report_folder, seeker, wrap_text):
+def googlevoice_voicemails(context):
+    files_found = context.get_files_found()
     data_headers = (('Timestamp', 'datetime'), 'Account Number', 'Caller', 'Recipient', 'Duration', 'Read Status', 'Transcript', ('Audio File', 'media'))
     data_list = []
     source_path = ""
@@ -406,7 +409,8 @@ def googlevoice_voicemails(files_found, report_folder, seeker, wrap_text):
     return data_headers, data_list, source_path
 
 @artifact_processor
-def googlevoice_messages(files_found, report_folder, seeker, wrap_text):
+def googlevoice_messages(context):
+    files_found = context.get_files_found()
     data_headers = (('Timestamp', 'datetime'), 'Account Number', 'Conversation ID', 'Direction', 'Sender', 'Recipient(s)', 'Read Status', 'Message', ('Image', 'media'))
     data_list = []
     source_path = ""

--- a/scripts/artifacts/googlemapaudio.py
+++ b/scripts/artifacts/googlemapaudio.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_googlemapaudio": {
         "name": "Google Maps Voice Guidance",
@@ -44,7 +43,8 @@ def _ms_to_utc(value):
 
 
 @artifact_processor
-def get_googlemapaudio(files_found, report_folder, seeker, wrap_text):
+def get_googlemapaudio(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/googlemapaudioTemp.py
+++ b/scripts/artifacts/googlemapaudioTemp.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_googlemapaudioTemp": {
         "name": "Google Maps Voice Guidance (Temp)",
@@ -41,7 +40,8 @@ def _sec_to_utc(value):
 
 
 @artifact_processor
-def get_googlemapaudioTemp(files_found, report_folder, seeker, wrap_text):
+def get_googlemapaudioTemp(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/googlemaplocation.py
+++ b/scripts/artifacts/googlemaplocation.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_googlemaplocation": {
         "name": "Googlemaplocation",
@@ -28,7 +28,8 @@ def convertGeo(s):
 
 
 @artifact_processor
-def get_googlemaplocation(files_found, report_folder, seeker, wrap_text):
+def get_googlemaplocation(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/groupMe.py
+++ b/scripts/artifacts/groupMe.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_groupMe": {
         "name": "GroupMe - Group Information",
@@ -48,7 +47,8 @@ def _sec_to_utc(value):
 
 
 @artifact_processor
-def get_groupMe(files_found, report_folder, seeker, wrap_text):
+def get_groupMe(context):
+    files_found = context.get_files_found()
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
@@ -82,7 +82,8 @@ def get_groupMe(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_groupMe_chat(files_found, report_folder, seeker, wrap_text):
+def get_groupMe_chat(context):
+    files_found = context.get_files_found()
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()

--- a/scripts/artifacts/hikvision.py
+++ b/scripts/artifacts/hikvision.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_hikvision": {
         "name": "Hikvision - CCTV Channels",
@@ -93,7 +92,8 @@ def _run(source_path, sql):
 
 
 @artifact_processor
-def get_hikvision(files_found, report_folder, seeker, wrap_text):
+def get_hikvision(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found, 'database.hik')
     rows = _run(source_path, '''
         SELECT nDeviceID, nChannelNo, chChannelName,
@@ -105,7 +105,8 @@ def get_hikvision(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_hikvision_info(files_found, report_folder, seeker, wrap_text):
+def get_hikvision_info(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found, 'database.hik')
     rows = _run(source_path, '''
         SELECT nDeviceID, chDeviceName, chDeviceSerialNo, nDevicePort, nChannelNum, nStartChan,
@@ -118,7 +119,8 @@ def get_hikvision_info(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_hikvision_activity(files_found, report_folder, seeker, wrap_text):
+def get_hikvision_activity(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found, 'ezvizlog.db')
     rows = _run(source_path, 'SELECT time, systemName, content FROM event')
     data_list = [(_ms_to_utc(r[0]), r[1], r[2]) for r in rows]
@@ -127,7 +129,8 @@ def get_hikvision_activity(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_hikvision_media(files_found, report_folder, seeker, wrap_text):
+def get_hikvision_media(context):
+    files_found = context.get_files_found()
     files_by_name = {os.path.basename(str(f)): str(f) for f in files_found}
     source_path = _db(files_found, 'image.db')
     rows = _run(source_path, '''

--- a/scripts/artifacts/imo.py
+++ b/scripts/artifacts/imo.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0702
+# pylint: disable=W0702
 __artifacts_v2__ = {
     "get_imo_account": {
         "name": "IMO - Account ID",
@@ -52,7 +52,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_imo_account(files_found, report_folder, seeker, wrap_text):
+def get_imo_account(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:
@@ -78,7 +79,8 @@ def get_imo_account(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_imo_messages(files_found, report_folder, seeker, wrap_text):
+def get_imo_messages(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/installedappsGass.py
+++ b/scripts/artifacts/installedappsGass.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_installedappsGass": {
         "name": "installedappsGass",
@@ -31,7 +30,8 @@ from scripts.ilapfuncs import artifact_processor, is_platform_windows, open_sqli
 
 
 @artifact_processor
-def get_installedappsGass(files_found, report_folder, seeker, wrap_text):
+def get_installedappsGass(context):
+    files_found = context.get_files_found()
 
     slash = '\\' if is_platform_windows() else '/'
     data_list = []

--- a/scripts/artifacts/installedappsLibrary.py
+++ b/scripts/artifacts/installedappsLibrary.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_installedappsLibrary": {
         "name": "InstalledappsLibrary",
@@ -34,7 +33,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_installedappsLibrary(files_found, report_folder, seeker, wrap_text):
+def get_installedappsLibrary(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/installedappsVending.py
+++ b/scripts/artifacts/installedappsVending.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_installedappsVending": {
         "name": "InstalledappsVending",
@@ -40,7 +39,8 @@ def _ms_to_utc(value):
 
 
 @artifact_processor
-def get_installedappsVending(files_found, report_folder, seeker, wrap_text):
+def get_installedappsVending(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/keepNotes.py
+++ b/scripts/artifacts/keepNotes.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_keepNotes": {
         "name": "Google Keep Notes",
@@ -28,7 +27,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, conve
 
 
 @artifact_processor
-def get_keepNotes(files_found, report_folder, seeker, wrap_text):
+def get_keepNotes(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/kijijiConversations.py
+++ b/scripts/artifacts/kijijiConversations.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_kijijiConversations": {
         "name": "kijijiConversations",
@@ -54,7 +53,8 @@ def AppendMessageRowsToDataList(data_list, conversationId, advertId, advertTitle
 
 
 @artifact_processor
-def get_kijijiConversations(files_found, report_folder, seeker, wrap_text):
+def get_kijijiConversations(context):
+    files_found = context.get_files_found()
     source_path = str(files_found[0])
     logfunc(f'Database file {source_path} is being interrogated...')
 

--- a/scripts/artifacts/kijijiLocalUserInfo.py
+++ b/scripts/artifacts/kijijiLocalUserInfo.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_kijijiLocalUserInfo": {
         "name": "kijijiLocalUserInfo",
@@ -54,7 +53,8 @@ def _parse_xml(file_found):
 
 
 @artifact_processor
-def get_kijijiLocalUserInfo(files_found, report_folder, seeker, wrap_text):
+def get_kijijiLocalUserInfo(context):
+    files_found = context.get_files_found()
     source_path = str(files_found[0])
     logfunc(f'XML file {source_path} is being interrogated...')
 

--- a/scripts/artifacts/kijijiRecentSearches.py
+++ b/scripts/artifacts/kijijiRecentSearches.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_kijijiRecentSearches": {
         "name": "kijijiRecentSearches",
@@ -38,7 +37,8 @@ recent_searches_query = '''
 
 
 @artifact_processor
-def get_kijijiRecentSearches(files_found, report_folder, seeker, wrap_text):
+def get_kijijiRecentSearches(context):
+    files_found = context.get_files_found()
     source_path = str(files_found[0])
     logfunc(f'Database file {source_path} is being interrogated...')
 

--- a/scripts/artifacts/kleinanzeigen.de.py
+++ b/scripts/artifacts/kleinanzeigen.de.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_kleinanzeigenaccount": {
         "name": "kleinanzeigen.de App - Account Details",
@@ -123,21 +123,24 @@ def _recent_searches(files_found, marker):
 
 
 @artifact_processor
-def get_kleinanzeigenrecentsearchescache(files_found, report_folder, seeker, wrap_text):
+def get_kleinanzeigenrecentsearchescache(context):
+    files_found = context.get_files_found()
     data_list, source_path = _recent_searches(files_found, 'RECENT_SEARCHES_CACHE')
     data_headers = ('Search Term', 'Category', ('Search Timestamp', 'datetime'))
     return data_headers, data_list, source_path
 
 
 @artifact_processor
-def get_kleinanzeigennonresettablerecentsearchescache(files_found, report_folder, seeker, wrap_text):
+def get_kleinanzeigennonresettablerecentsearchescache(context):
+    files_found = context.get_files_found()
     data_list, source_path = _recent_searches(files_found, 'NON_RESETTABLE_RECENT_SEARCHES_CACHE')
     data_headers = ('Search Term', 'Category', ('Search Timestamp', 'datetime'))
     return data_headers, data_list, source_path
 
 
 @artifact_processor
-def get_kleinanzeigenaccount(files_found, report_folder, seeker, wrap_text):
+def get_kleinanzeigenaccount(context):
+    files_found = context.get_files_found()
     keys = ['USERPROFILE_NAME_KEY', 'USERPROFILE_INITIALS', 'LAST_EMAIL_USED', 'AUTH_USER_EMAIL', 'AUTH_USER_ID',
             'USERPROFILE_PHONE_NUMBER_KEY', 'USERPROFILE_ACCOUNT_TYPE_KEY', 'USERPROFILE_USER_SINCE_DATE_KEY',
             'USERPROFILE_LOCATION_LONGITUDE_KEY', 'USERPROFILE_LOCATION_LATITUDE_KEY']
@@ -171,7 +174,8 @@ def _messagebox_db(files_found):
 
 
 @artifact_processor
-def get_kleinanzeigenmessagebox(files_found, report_folder, seeker, wrap_text):
+def get_kleinanzeigenmessagebox(context):
+    files_found = context.get_files_found()
     source_path = _messagebox_db(files_found)
     data_list = []
     if source_path:
@@ -200,7 +204,8 @@ def get_kleinanzeigenmessagebox(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_kleinanzeigenmessages(files_found, report_folder, seeker, wrap_text):
+def get_kleinanzeigenmessages(context):
+    files_found = context.get_files_found()
     source_path = _messagebox_db(files_found)
     data_list = []
     if source_path:

--- a/scripts/artifacts/last_boot_time.py
+++ b/scripts/artifacts/last_boot_time.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0613,W0621,W0631
+# pylint: disable=W0611,W0621,W0631
 __artifacts_v2__ = {
     "last_boot_time": {
         "name": "Last Boot Time",
@@ -32,7 +32,8 @@ import time
 from scripts.ilapfuncs import logfunc, logdevinfo, artifact_processor
 
 @artifact_processor
-def last_boot_time(files_found, report_folder, seeker, wrap_text):
+def last_boot_time(context):
+    files_found = context.get_files_found()
 
     data_list = []
 

--- a/scripts/artifacts/lgRCS.py
+++ b/scripts/artifacts/lgRCS.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_lgRCS": {
         "name": "LG RCS Chats",
@@ -55,7 +54,8 @@ def _rcs_db(files_found):
 
 
 @artifact_processor
-def get_lgRCS(files_found, report_folder, seeker, wrap_text):
+def get_lgRCS(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = _rcs_db(files_found)
     data_headers = (('Date', 'datetime'), 'Address', 'Body', 'Read?', 'Thread ID', 'Is File?',

--- a/scripts/artifacts/libretorrent.py
+++ b/scripts/artifacts/libretorrent.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_libretorrent": {
         "name": "Libretorrent",
@@ -21,7 +20,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_libretorrent(files_found, report_folder, seeker, wrap_text):
+def get_libretorrent(context):
+    files_found = context.get_files_found()
 
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/libretorrentFR.py
+++ b/scripts/artifacts/libretorrentFR.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_libretorrentFR": {
         "name": "LibretorrentFR",
@@ -23,7 +22,8 @@ from scripts.html_safe import esc
 
 
 @artifact_processor
-def get_libretorrentFR(files_found, report_folder, seeker, wrap_text):
+def get_libretorrentFR(context):
+    files_found = context.get_files_found()
 
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/life360DriverBehavior.py
+++ b/scripts/artifacts/life360DriverBehavior.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_TripEvents": {
         "name": "Life360 Driver Behavior - Trip Events",
@@ -64,7 +63,8 @@ def _iter_trip_files(files_found):
 
 
 @artifact_processor
-def get_TripEvents(files_found, report_folder, seeker, wrap_text):
+def get_TripEvents(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found, data in _iter_trip_files(files_found):
@@ -96,7 +96,8 @@ def get_TripEvents(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_TripWaypoints(files_found, report_folder, seeker, wrap_text):
+def get_TripWaypoints(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found, data in _iter_trip_files(files_found):

--- a/scripts/artifacts/line.py
+++ b/scripts/artifacts/line.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_line": {
         "name": "Line - Contacts",
@@ -83,7 +83,8 @@ def _line_dbs(files_found):
 
 
 @artifact_processor
-def get_line(files_found, report_folder, seeker, wrap_text):
+def get_line(context):
+    files_found = context.get_files_found()
     msg_db, _ = _line_dbs(files_found)
     data_list = []
     if msg_db:
@@ -101,7 +102,8 @@ def get_line(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_line_messages(files_found, report_folder, seeker, wrap_text):
+def get_line_messages(context):
+    files_found = context.get_files_found()
     msg_db, _ = _line_dbs(files_found)
     data_list = []
     if msg_db:
@@ -145,7 +147,8 @@ def get_line_messages(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_line_calls(files_found, report_folder, seeker, wrap_text):
+def get_line_calls(context):
+    files_found = context.get_files_found()
     msg_db, call_db = _line_dbs(files_found)
     data_list = []
     if call_db and msg_db:

--- a/scripts/artifacts/mastodon.py
+++ b/scripts/artifacts/mastodon.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_mastodon": {
         "name": "Mastodon - Hashtag Searches",
@@ -161,7 +161,8 @@ def _query(source_path, sql):
 
 
 @artifact_processor
-def get_mastodon(files_found, report_folder, seeker, wrap_text):
+def get_mastodon(context):
+    files_found = context.get_files_found()
     source_path = _mastodon_db(files_found)
     rows = _query(source_path, '''
         select time,
@@ -175,7 +176,8 @@ def get_mastodon(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_mastodon_account_searches(files_found, report_folder, seeker, wrap_text):
+def get_mastodon_account_searches(context):
+    files_found = context.get_files_found()
     source_path = _mastodon_db(files_found)
     rows = _query(source_path, '''
         select time,
@@ -191,7 +193,8 @@ def get_mastodon_account_searches(files_found, report_folder, seeker, wrap_text)
 
 
 @artifact_processor
-def get_mastodon_notifications(files_found, report_folder, seeker, wrap_text):
+def get_mastodon_notifications(context):
+    files_found = context.get_files_found()
     source_path = _mastodon_db(files_found)
     rows = _query(source_path, '''
         select
@@ -211,7 +214,8 @@ def get_mastodon_notifications(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_mastodon_timeline(files_found, report_folder, seeker, wrap_text):
+def get_mastodon_timeline(context):
+    files_found = context.get_files_found()
     source_path = _mastodon_db(files_found)
     rows = _query(source_path, '''
         select
@@ -244,7 +248,8 @@ def get_mastodon_timeline(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_mastodon_accounts(files_found, report_folder, seeker, wrap_text):
+def get_mastodon_accounts(context):
+    files_found = context.get_files_found()
     source_path = ''
     data_list = []
     for file_found in files_found:
@@ -271,7 +276,8 @@ def get_mastodon_accounts(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_mastodon_instance(files_found, report_folder, seeker, wrap_text):
+def get_mastodon_instance(context):
+    files_found = context.get_files_found()
     source_path = ''
     data_list = []
     for file_found in files_found:

--- a/scripts/artifacts/meetme.py
+++ b/scripts/artifacts/meetme.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0631
+# pylint: disable=W0631
 __artifacts_v2__ = {
     "get_meetmechats": {
         "name": "MeetMe Chats",
@@ -19,7 +19,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_meetmechats(files_found, report_folder, seeker, wrap_text):
+def get_meetmechats(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/mega.py
+++ b/scripts/artifacts/mega.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_mega": {
         "name": "mega",
@@ -32,7 +31,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, conve
 
 
 @artifact_processor
-def get_mega(files_found, report_folder, seeker, wrap_text):
+def get_mega(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
 

--- a/scripts/artifacts/mega_transfers.py
+++ b/scripts/artifacts/mega_transfers.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_mega_transfers": {
         "name": "mega_transfers",
@@ -53,7 +52,8 @@ def decrypt(cell):
 
 
 @artifact_processor
-def get_mega_transfers(files_found, report_folder, seeker, wrap_text):
+def get_mega_transfers(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/mewe.py
+++ b/scripts/artifacts/mewe.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0702
+# pylint: disable=W0702
 __artifacts_v2__ = {
     "get_mewe_chat": {
         "name": "MeWe - Chat",
@@ -90,7 +90,8 @@ def _parse_xml(file_found):
 
 
 @artifact_processor
-def get_mewe_chat(files_found, report_folder, seeker, wrap_text):
+def get_mewe_chat(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:
@@ -119,7 +120,8 @@ def get_mewe_chat(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_mewe_session(files_found, report_folder, seeker, wrap_text):
+def get_mewe_session(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:


### PR DESCRIPTION
Batch 4 of the ALEAPP **4-arg → context** migration (batches 1–3 = #963/#964/#965, merged).

**What:** all remaining pure-signature-swap artifacts A–M — **212 functions across 110 files** — to `def f(context):`. Docstring-safe transform (leading docstrings preserved); redundant `# pylint: disable=W0613` removed.

**Deferred, not in this PR:**
- 6 **special** files whose bodies use `seeker`/`report_folder`/`wrap_text` (need hoists / wrap_text removal) — coming in the specials batch.
- 4 files with **pre-existing lint debt** that ALEAPP's CI surfaces the moment a file is touched: `Deepseek_ChatInfo`/`Deepseek_UserInfo` (broad-except), `etc_hosts` (deprecated `open`), `alexDeviceInfo` (unspecified-encoding). Left 4-arg for a separate targeted cleanup rather than mixing debt fixes into a signature swap.

**Validation:** pylint `--disable=C,R` = **10.00** on all 110 files; `py_compile` clean; `PluginLoader` **585**; attribution/dates preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)