### PR TITLE
ALEAPP context-form migration — batch 5: bulk N–Z (104 files)

### DIFF
--- a/scripts/artifacts/NikeAMoments.py
+++ b/scripts/artifacts/NikeAMoments.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_nike_activMoments": {
         "name": "Nike - Activity Moments",
@@ -70,7 +69,8 @@ def _moment_desc(mtype, mvalue):
 
 
 @artifact_processor
-def get_nike_activMoments(files_found, report_folder, seeker, wrap_text):
+def get_nike_activMoments(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found)
     data_list = []
     if source_path:

--- a/scripts/artifacts/NikeActivities.py
+++ b/scripts/artifacts/NikeActivities.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_nike_activities": {
         "name": "Nike - Activities",
@@ -58,7 +57,8 @@ def _q(cursor, sql, params):
 
 
 @artifact_processor
-def get_nike_activities(files_found, report_folder, seeker, wrap_text):
+def get_nike_activities(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found)
     data_list = []
     if source_path:

--- a/scripts/artifacts/NikeNotifications.py
+++ b/scripts/artifacts/NikeNotifications.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_nike_notifications": {
         "name": "NikeNotifications",
@@ -24,7 +23,8 @@ from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readon
 
 
 @artifact_processor
-def get_nike_notifications(files_found, report_folder, seeker, wrap_text):
+def get_nike_notifications(context):
+    files_found = context.get_files_found()
 
     files_found = [x for x in files_found if not str(x).endswith('-journal')]
     source_path = str(files_found[0])

--- a/scripts/artifacts/NikePolyline.py
+++ b/scripts/artifacts/NikePolyline.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_nike_polyline": {
         "name": "Nike - Activity Route",
@@ -47,7 +47,8 @@ def _db(files_found):
 
 
 @artifact_processor
-def get_nike_polyline(files_found, report_folder, seeker, wrap_text):
+def get_nike_polyline(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found)
     data_list = []
     if source_path:

--- a/scripts/artifacts/Oruxmaps.py
+++ b/scripts/artifacts/Oruxmaps.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_Oruxmaps": {
         "name": "Oruxmaps - POI",
@@ -40,7 +39,8 @@ def _ms_to_utc(value):
 
 
 @artifact_processor
-def get_Oruxmaps(files_found, report_folder, seeker, wrap_text):
+def get_Oruxmaps(context):
+    files_found = context.get_files_found()
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()
@@ -57,7 +57,8 @@ def get_Oruxmaps(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_Oruxmaps_tracks(files_found, report_folder, seeker, wrap_text):
+def get_Oruxmaps_tracks(context):
+    files_found = context.get_files_found()
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()

--- a/scripts/artifacts/PodcastAddict.py
+++ b/scripts/artifacts/PodcastAddict.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_podcasts": {
         "name": "Podcast Addict",
@@ -19,7 +19,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, conve
 
 
 @artifact_processor
-def get_podcasts(files_found, report_folder, seeker, wrap_text):
+def get_podcasts(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
 

--- a/scripts/artifacts/ProtonDrive.py
+++ b/scripts/artifacts/ProtonDrive.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "protondrive_useraccount": {
         "name": "Proton Drive - User Account",
@@ -33,7 +32,8 @@ from pathlib import Path
 from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
 
 @artifact_processor
-def protondrive_useraccount(files_found, report_folder, seeker, wrap_text):
+def protondrive_useraccount(context):
+    files_found = context.get_files_found()
     data_list = []
     
     def is_sqlite_db(path):
@@ -85,7 +85,8 @@ def protondrive_useraccount(files_found, report_folder, seeker, wrap_text):
     return data_headers, data_list, source_path
 
 @artifact_processor
-def protondrive_fileinfo(files_found, report_folder, seeker, wrap_text):
+def protondrive_fileinfo(context):
+    files_found = context.get_files_found()
 
     data_list = []
     

--- a/scripts/artifacts/PumaActivities.py
+++ b/scripts/artifacts/PumaActivities.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_puma_activities": {
         "name": "Puma - Activities",
@@ -64,7 +64,8 @@ def _route_media(source, coords, title, subtitle, base):
 
 
 @artifact_processor
-def get_puma_activities(files_found, report_folder, seeker, wrap_text):
+def get_puma_activities(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found)
     data_list = []
     if source_path:

--- a/scripts/artifacts/PumaUsers.py
+++ b/scripts/artifacts/PumaUsers.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_puma_users": {
         "name": "PumaUsers",
@@ -23,7 +22,8 @@ from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readon
 
 
 @artifact_processor
-def get_puma_users(files_found, report_folder, seeker, wrap_text):
+def get_puma_users(context):
+    files_found = context.get_files_found()
 
     files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
     source_path = str(files_found[0])

--- a/scripts/artifacts/RandoChat.py
+++ b/scripts/artifacts/RandoChat.py
@@ -63,7 +63,8 @@ import os
 from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records, check_in_media
 
 @artifact_processor
-def randochat_messages(files_found, _report_folder, _seeker, _wrap_text):
+def randochat_messages(context):
+    files_found = context.get_files_found()
     files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]   
 
 
@@ -131,7 +132,8 @@ def randochat_messages(files_found, _report_folder, _seeker, _wrap_text):
 
 
 @artifact_processor
-def randochat_account(files_found, _report_folder, _seeker, _wrap_text):
+def randochat_account(context):
+    files_found = context.get_files_found()
     files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]   
 
 
@@ -189,7 +191,8 @@ def randochat_account(files_found, _report_folder, _seeker, _wrap_text):
 
 
 @artifact_processor
-def randochat_contacts(files_found, _report_folder, _seeker, _wrap_text):
+def randochat_contacts(context):
+    files_found = context.get_files_found()
     files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]   
     main_db = ''
 

--- a/scripts/artifacts/RomeoDatingApp.py
+++ b/scripts/artifacts/RomeoDatingApp.py
@@ -58,7 +58,8 @@ __artifacts_v2__ = {
 from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records
 
 @artifact_processor
-def romeo_dating_messages(files_found, _report_folder, _seeker, _wrap_text):
+def romeo_dating_messages(context):
+    files_found = context.get_files_found()
     files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
 
     main_db = ''
@@ -135,7 +136,8 @@ def romeo_dating_messages(files_found, _report_folder, _seeker, _wrap_text):
 
 
 @artifact_processor
-def romeo_dating_contacts(files_found, _report_folder, _seeker, _wrap_text):
+def romeo_dating_contacts(context):
+    files_found = context.get_files_found()
     files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
 
 
@@ -233,7 +235,8 @@ def romeo_dating_contacts(files_found, _report_folder, _seeker, _wrap_text):
 
 
 @artifact_processor
-def romeo_dating_accounts(files_found, _report_folder, _seeker, _wrap_text):
+def romeo_dating_accounts(context):
+    files_found = context.get_files_found()
     files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
     main_db = ''
 

--- a/scripts/artifacts/RunkeeperActivities.py
+++ b/scripts/artifacts/RunkeeperActivities.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_run_activities": {
         "name": "Runkeeper - Activities",
@@ -64,7 +64,8 @@ def _route_media(source, coords, title, subtitle, base):
 
 
 @artifact_processor
-def get_run_activities(files_found, report_folder, seeker, wrap_text):
+def get_run_activities(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found)
     data_list = []
     if source_path:

--- a/scripts/artifacts/RunkeeperUser.py
+++ b/scripts/artifacts/RunkeeperUser.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W1309
+# pylint: disable=W1309
 __artifacts_v2__ = {
     "get_run_user": {
         "name": "RunkeeperUser",
@@ -47,7 +47,8 @@ def _s_to_utc(value):
 
 
 @artifact_processor
-def get_run_user(files_found, report_folder, seeker, wrap_text):
+def get_run_user(context):
+    files_found = context.get_files_found()
     # Dictionary to store the user information
     user_info = {}
     # Attributes to be extracted from the xml file

--- a/scripts/artifacts/SamsungDeviceHealthManagement.py
+++ b/scripts/artifacts/SamsungDeviceHealthManagement.py
@@ -90,7 +90,8 @@ __artifacts_v2__ = {
 from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records
 
 @artifact_processor
-def sdhms_config_reloads(files_found, _report_folder, _seeker, _wrap_text):
+def sdhms_config_reloads(context):
+    files_found = context.get_files_found()
     files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
 
     query = ('''
@@ -124,7 +125,8 @@ def sdhms_config_reloads(files_found, _report_folder, _seeker, _wrap_text):
     return data_headers, data_list, files_found[0]
 
 @artifact_processor
-def sdhms_netstat(files_found, _report_folder, _seeker, _wrap_text):
+def sdhms_netstat(context):
+    files_found = context.get_files_found()
     files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
 
     query = ('''
@@ -164,7 +166,8 @@ def sdhms_netstat(files_found, _report_folder, _seeker, _wrap_text):
     return data_headers, data_list, files_found[0]
 
 @artifact_processor
-def sdhms_temperature(files_found, _report_folder, _seeker, _wrap_text):
+def sdhms_temperature(context):
+    files_found = context.get_files_found()
     files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
 
     query = ('''
@@ -218,7 +221,8 @@ def sdhms_temperature(files_found, _report_folder, _seeker, _wrap_text):
     return data_headers, data_list, files_found[0]
 
 @artifact_processor
-def sdhms_cpustats(files_found, _report_folder, _seeker, _wrap_text):
+def sdhms_cpustats(context):
+    files_found = context.get_files_found()
     files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
 
     query = ('''

--- a/scripts/artifacts/SamsungNotes.py
+++ b/scripts/artifacts/SamsungNotes.py
@@ -29,7 +29,8 @@ import os
 from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records, check_in_media
 
 @artifact_processor
-def snotes(files_found, _report_folder, _seeker, _wrap_text):
+def snotes(context):
+    files_found = context.get_files_found()
 
     main_db = ''
     medias = []

--- a/scripts/artifacts/SimpleStorage_applaunch.py
+++ b/scripts/artifacts/SimpleStorage_applaunch.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "SimpleStorage_applaunch": {
         "name": "SimpleStorage - App Launch",
@@ -26,7 +25,8 @@ from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_r
 from scripts.context import Context
 
 @artifact_processor
-def SimpleStorage_applaunch(files_found, report_folder, seeker, wrap_text):
+def SimpleStorage_applaunch(context):
+    files_found = context.get_files_found()
     data_list = []
     
     source_path = get_file_path(files_found, "SimpleStorage")

--- a/scripts/artifacts/StravaGPS.py
+++ b/scripts/artifacts/StravaGPS.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_gps": {
         "name": "Strava - Activities",
@@ -35,7 +35,8 @@ def _to_utc(value):
 
 
 @artifact_processor
-def get_gps(files_found, report_folder, seeker, wrap_text):
+def get_gps(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/Todoist.py
+++ b/scripts/artifacts/Todoist.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_Todoist": {
         "name": "Todoist - Items",
@@ -79,7 +78,8 @@ def _run(source_path, sql):
 
 
 @artifact_processor
-def get_Todoist(files_found, report_folder, seeker, wrap_text):
+def get_Todoist(context):
+    files_found = context.get_files_found()
     source_path = _todoist_db(files_found)
     rows = _run(source_path, '''
         SELECT items.date_added, items.added_by_uid, items.content, items.description, items.due_date,
@@ -100,7 +100,8 @@ def get_Todoist(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_Todoist_notes(files_found, report_folder, seeker, wrap_text):
+def get_Todoist_notes(context):
+    files_found = context.get_files_found()
     source_path = _todoist_db(files_found)
     rows = _run(source_path, '''
         SELECT notes.posted, notes.content, note_file_attachments.resource_type,
@@ -118,7 +119,8 @@ def get_Todoist_notes(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_Todoist_projects(files_found, report_folder, seeker, wrap_text):
+def get_Todoist_projects(context):
+    files_found = context.get_files_found()
     source_path = _todoist_db(files_found)
     rows = _run(source_path, '''
         SELECT name, color, view_style, child_order,

--- a/scripts/artifacts/Twitter.py
+++ b/scripts/artifacts/Twitter.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_Twitter": {
         "name": "twitter",
@@ -26,7 +25,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_Twitter(files_found, report_folder, seeker, wrap_text):
+def get_Twitter(context):
+    files_found = context.get_files_found()
     source_path = ''
     for file_found in files_found:
         file_found = str(file_found)

--- a/scripts/artifacts/VerizonRDDAnalytics.py
+++ b/scripts/artifacts/VerizonRDDAnalytics.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_rdd_analytics": {
         "name": "VerizonRDD-Battery",
@@ -21,7 +21,8 @@ from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readon
 
 
 @artifact_processor
-def get_rdd_analytics(files_found, report_folder, seeker, wrap_text):
+def get_rdd_analytics(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/VerizonRDDWIFI.py
+++ b/scripts/artifacts/VerizonRDDWIFI.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_rdd_wifi": {
         "name": "VerizonRDD-WIFI",
@@ -22,7 +22,8 @@ from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readon
 
 
 @artifact_processor
-def get_rdd_wifi(files_found, report_folder, seeker, wrap_text):
+def get_rdd_wifi(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/Viber.py
+++ b/scripts/artifacts/Viber.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_Viber": {
         "name": "Viber - Call Logs",
@@ -110,7 +110,8 @@ def _viber_dbs(files_found):
 
 
 @artifact_processor
-def get_Viber(files_found, report_folder, seeker, wrap_text):
+def get_Viber(context):
+    files_found = context.get_files_found()
     data_db, _, _ = _viber_dbs(files_found)
     data_list = []
     if data_db:
@@ -139,7 +140,8 @@ def get_Viber(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_Viber_contacts(files_found, report_folder, seeker, wrap_text):
+def get_Viber_contacts(context):
+    files_found = context.get_files_found()
     data_db, _, _ = _viber_dbs(files_found)
     data_list = []
     if data_db:
@@ -161,7 +163,8 @@ def get_Viber_contacts(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_Viber_messages(files_found, report_folder, seeker, wrap_text):
+def get_Viber_messages(context):
+    files_found = context.get_files_found()
     _, messages_db, _ = _viber_dbs(files_found)
     data_list = []
     if messages_db:
@@ -195,7 +198,8 @@ def get_Viber_messages(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_Viber_additional(files_found, report_folder, seeker, wrap_text):
+def get_Viber_additional(context):
+    files_found = context.get_files_found()
     _, _, prefs_db = _viber_dbs(files_found)
     data_list = []
     if prefs_db:

--- a/scripts/artifacts/WhatsApp.py
+++ b/scripts/artifacts/WhatsApp.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_whatsapp_contacts": {
         "name": "WhatsApp - Contacts",
@@ -264,7 +263,8 @@ def _run(cursor, sql):
 
 
 @artifact_processor
-def get_whatsapp_contacts(files_found, report_folder, seeker, wrap_text):
+def get_whatsapp_contacts(context):
+    files_found = context.get_files_found()
     source = _find(files_found, 'wa.db')
     data_list = []
     if source:
@@ -292,7 +292,8 @@ def get_whatsapp_contacts(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_whatsapp_call_logs(files_found, report_folder, seeker, wrap_text):
+def get_whatsapp_call_logs(context):
+    files_found = context.get_files_found()
     db, cursor, source, _wa = _open_msgstore(files_found)
     data_list = []
     if db:
@@ -324,7 +325,8 @@ def get_whatsapp_call_logs(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_whatsapp_messages(files_found, report_folder, seeker, wrap_text):
+def get_whatsapp_messages(context):
+    files_found = context.get_files_found()
     db, cursor, source, _wa = _open_msgstore(files_found)
     data_list = []
     if db:
@@ -358,7 +360,8 @@ def get_whatsapp_messages(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_whatsapp_one_to_one_messages(files_found, report_folder, seeker, wrap_text):
+def get_whatsapp_one_to_one_messages(context):
+    files_found = context.get_files_found()
     db, cursor, source, _wa = _open_msgstore(files_found)
     data_list = []
     if db:
@@ -403,7 +406,8 @@ def get_whatsapp_one_to_one_messages(files_found, report_folder, seeker, wrap_te
 
 
 @artifact_processor
-def get_whatsapp_group_messages(files_found, report_folder, seeker, wrap_text):
+def get_whatsapp_group_messages(context):
+    files_found = context.get_files_found()
     db, cursor, source, _wa = _open_msgstore(files_found)
     data_list = []
     if db:
@@ -449,7 +453,8 @@ def get_whatsapp_group_messages(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_whatsapp_group_details(files_found, report_folder, seeker, wrap_text):
+def get_whatsapp_group_details(context):
+    files_found = context.get_files_found()
     db, cursor, source, _wa = _open_msgstore(files_found)
     data_list = []
     if db:
@@ -488,7 +493,8 @@ def get_whatsapp_group_details(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_whatsapp_user_profile(files_found, report_folder, seeker, wrap_text):
+def get_whatsapp_user_profile(context):
+    files_found = context.get_files_found()
     keys = ('push_name', 'my_current_status', 'version', 'ph', 'cc')
     data = {k: '' for k in keys}
     source = ''

--- a/scripts/artifacts/WithingsHealthMate.py
+++ b/scripts/artifacts/WithingsHealthMate.py
@@ -109,7 +109,8 @@ import datetime
 from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records
 
 @artifact_processor
-def healthmate_accounts(files_found, _report_folder, _seeker, _wrap_text):
+def healthmate_accounts(context):
+    files_found = context.get_files_found()
     files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
     file_found = str(files_found[0])
 
@@ -184,7 +185,8 @@ def healthmate_accounts(files_found, _report_folder, _seeker, _wrap_text):
     return data_headers, data_list, file_found
 
 @artifact_processor
-def healthmate_trackings(files_found, _report_folder, _seeker, _wrap_text):
+def healthmate_trackings(context):
+    files_found = context.get_files_found()
     files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
     
     room_db = next((str(f) for f in files_found if 'room-healthmate' in str(f).lower()), None)
@@ -260,7 +262,8 @@ def healthmate_trackings(files_found, _report_folder, _seeker, _wrap_text):
     return data_headers, data_list, room_db
 
 @artifact_processor
-def healthmate_locations(files_found, _report_folder, _seeker, _wrap_text):
+def healthmate_locations(context):
+    files_found = context.get_files_found()
     files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
     
     file_found = str(files_found[0])
@@ -306,7 +309,8 @@ def healthmate_locations(files_found, _report_folder, _seeker, _wrap_text):
 
     return data_headers, data_list, file_found
 @artifact_processor
-def healthmate_messages(files_found, _report_folder, _seeker, _wrap_text):
+def healthmate_messages(context):
+    files_found = context.get_files_found()
     files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
 
     query = ('''
@@ -343,7 +347,8 @@ def healthmate_messages(files_found, _report_folder, _seeker, _wrap_text):
     return data_headers, data_list, files_found[0]
 
 @artifact_processor
-def healthmate_contacts(files_found, _report_folder, _seeker, _wrap_text):
+def healthmate_contacts(context):
+    files_found = context.get_files_found()
     files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
     
     query = ('''
@@ -388,7 +393,8 @@ def healthmate_contacts(files_found, _report_folder, _seeker, _wrap_text):
     return data_headers, data_list, files_found[0]
 
 @artifact_processor
-def healthmate_measurements(files_found, _report_folder, _seeker, _wrap_text):
+def healthmate_measurements(context):
+    files_found = context.get_files_found()
     files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
     
     query = ('''
@@ -465,7 +471,8 @@ def healthmate_measurements(files_found, _report_folder, _seeker, _wrap_text):
     return data_headers, data_list, files_found[0]
 
 @artifact_processor
-def healthmate_devices(files_found, _report_folder, _seeker, _wrap_text):
+def healthmate_devices(context):
+    files_found = context.get_files_found()
     files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
 
     query = ('''

--- a/scripts/artifacts/WordsWithFriends.py
+++ b/scripts/artifacts/WordsWithFriends.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_WordsWithFriends": {
         "name": "WordsWithFriends",
@@ -21,7 +20,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_WordsWithFriends(files_found, report_folder, seeker, wrap_text):
+def get_WordsWithFriends(context):
+    files_found = context.get_files_found()
 
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)

--- a/scripts/artifacts/Xender.py
+++ b/scripts/artifacts/Xender.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_Xender": {
         "name": "Xender - Contacts",
@@ -42,7 +42,8 @@ def _xender_db(files_found):
 
 
 @artifact_processor
-def get_Xender(files_found, report_folder, seeker, wrap_text):
+def get_Xender(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = _xender_db(files_found)
     if source_path:
@@ -63,7 +64,8 @@ def get_Xender(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_Xender_messages(files_found, report_folder, seeker, wrap_text):
+def get_Xender_messages(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = _xender_db(files_found)
     if source_path:

--- a/scripts/artifacts/ZangiChats.py
+++ b/scripts/artifacts/ZangiChats.py
@@ -37,7 +37,8 @@ from scripts.ilapfuncs import artifact_processor, \
     check_in_media
 
 @artifact_processor
-def zangichats(files_found, _report_folder, _seeker, _wrap_text):
+def zangichats(context):
+    files_found = context.get_files_found()
     source_path = ""
     data_list = []
     for file_found in files_found:

--- a/scripts/artifacts/Zapya.py
+++ b/scripts/artifacts/Zapya.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_Zapya": {
         "name": "Zapya",
@@ -21,7 +20,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_Zapya(files_found, report_folder, seeker, wrap_text):
+def get_Zapya(context):
+    files_found = context.get_files_found()
 
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)

--- a/scripts/artifacts/notificationHistory.py
+++ b/scripts/artifacts/notificationHistory.py
@@ -1,4 +1,4 @@
-# pylint: disable=E1101,W0613,W0718
+# pylint: disable=E1101,W0718
 __artifacts_v2__ = {
     "get_notificationHistory": {
         "name": "Android Notification History",
@@ -112,7 +112,8 @@ def _xml_root(file_found, multi_root):
 
 
 @artifact_processor
-def get_notificationHistory_status(files_found, report_folder, seeker, wrap_text):
+def get_notificationHistory_status(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:
@@ -133,7 +134,8 @@ def get_notificationHistory_status(files_found, report_folder, seeker, wrap_text
 
 
 @artifact_processor
-def get_notificationHistory_snoozed(files_found, report_folder, seeker, wrap_text):
+def get_notificationHistory_snoozed(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:
@@ -154,7 +156,8 @@ def get_notificationHistory_snoozed(files_found, report_folder, seeker, wrap_tex
 
 
 @artifact_processor
-def get_notificationHistory(files_found, report_folder, seeker, wrap_text):
+def get_notificationHistory(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     fields = ['uid', 'user_id', 'package_index', 'channel_name', 'channel_id',

--- a/scripts/artifacts/oldpowerOffReset.py
+++ b/scripts/artifacts/oldpowerOffReset.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_oldpowerOffReset": {
         "name": "oldpowerOffReset",
@@ -27,7 +26,8 @@ from scripts.ilapfuncs import artifact_processor
 
 
 @artifact_processor
-def get_oldpowerOffReset(files_found, report_folder, seeker, wrap_text):
+def get_oldpowerOffReset(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/pSettings.py
+++ b/scripts/artifacts/pSettings.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_pSettings": {
         "name": "pSettings",
@@ -28,7 +27,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_pSettings(files_found, report_folder, seeker, wrap_text):
+def get_pSettings(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/packageGplinks.py
+++ b/scripts/artifacts/packageGplinks.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_packageGplinks": {
         "name": "packageGplinks",
@@ -32,7 +31,8 @@ from scripts.ilapfuncs import artifact_processor
 
 
 @artifact_processor
-def get_packageGplinks(files_found, report_folder, seeker, wrap_text):
+def get_packageGplinks(context):
+    files_found = context.get_files_found()
 
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/packageInfo.py
+++ b/scripts/artifacts/packageInfo.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_package_info": {
         "name": "package_info",
@@ -66,7 +65,8 @@ def ReadUnixTimeMs(unix_time_ms):  # Unix timestamp is time epoch beginning 1970
 
 
 @artifact_processor
-def get_package_info(files_found, report_folder, seeker, wrap_text):
+def get_package_info(context):
+    files_found = context.get_files_found()
     packages = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/permissions.py
+++ b/scripts/artifacts/permissions.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_permissions_trees": {
         "name": "Permission Trees",
@@ -116,7 +115,8 @@ def _parse_xml(file_found):
 
 
 @artifact_processor
-def get_permissions_trees(files_found, report_folder, seeker, wrap_text):
+def get_permissions_trees(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for root, file_found in _iter_roots(files_found):
@@ -131,7 +131,8 @@ def get_permissions_trees(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_permissions_list(files_found, report_folder, seeker, wrap_text):
+def get_permissions_list(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for root, file_found in _iter_roots(files_found):
@@ -146,7 +147,8 @@ def get_permissions_list(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_permissions_packages(files_found, report_folder, seeker, wrap_text):
+def get_permissions_packages(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for root, file_found in _iter_roots(files_found):

--- a/scripts/artifacts/persistentProp.py
+++ b/scripts/artifacts/persistentProp.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_persistentProp": {
         "name": "persistentProp",
@@ -33,7 +32,8 @@ from scripts.ilapfuncs import artifact_processor
 
 
 @artifact_processor
-def get_persistentProp(files_found, report_folder, seeker, wrap_text):
+def get_persistentProp(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/pikpakCloudlist.py
+++ b/scripts/artifacts/pikpakCloudlist.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_pikpakCloudlist": {
         "name": "PikPak Cloud List",
@@ -23,7 +22,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_pikpakCloudlist(files_found, report_folder, seeker, wrap_text):
+def get_pikpakCloudlist(context):
+    files_found = context.get_files_found()
 
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/pikpakDownloads.py
+++ b/scripts/artifacts/pikpakDownloads.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_pikpakDownloads": {
         "name": "PikPak Downloads",
@@ -27,7 +26,8 @@ def _ms_to_utc(value):
 
 
 @artifact_processor
-def get_pikpakDownloads(files_found, report_folder, seeker, wrap_text):
+def get_pikpakDownloads(context):
+    files_found = context.get_files_found()
 
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/pikpakPlay.py
+++ b/scripts/artifacts/pikpakPlay.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_pikpakPlay": {
         "name": "PikPak Play",
@@ -21,7 +20,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_pikpakPlay(files_found, report_folder, seeker, wrap_text):
+def get_pikpakPlay(context):
+    files_found = context.get_files_found()
 
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/pkgPredictions.py
+++ b/scripts/artifacts/pkgPredictions.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_pkgPredictions": {
         "name": "pkgPredictions",
@@ -28,7 +27,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_pkgPredictions(files_found, report_folder, seeker, wrap_text):
+def get_pkgPredictions(context):
+    files_found = context.get_files_found()
 
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/protonVPN.py
+++ b/scripts/artifacts/protonVPN.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0702
+# pylint: disable=W0702
 __artifacts_v2__ = {
     "get_protonvpn_device_info": {
         "name": "ProtonVPN - Device Info",
@@ -68,7 +68,8 @@ def _parse_xml(file_found):
 
 
 @artifact_processor
-def get_protonvpn_device_info(files_found, report_folder, seeker, wrap_text):
+def get_protonvpn_device_info(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:
@@ -108,7 +109,8 @@ def get_protonvpn_device_info(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_protonvpn_connection_history(files_found, report_folder, seeker, wrap_text):
+def get_protonvpn_connection_history(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:
@@ -139,7 +141,8 @@ def get_protonvpn_connection_history(files_found, report_folder, seeker, wrap_te
 
 
 @artifact_processor
-def get_protonvpn_user_info(files_found, report_folder, seeker, wrap_text):
+def get_protonvpn_user_info(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/protonmail.py
+++ b/scripts/artifacts/protonmail.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_protonmail_messages": {
         "name": "ProtonMail - Messages",
@@ -32,7 +31,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, conve
 
 
 @artifact_processor
-def get_protonmail_messages(files_found, report_folder, seeker, wrap_text):
+def get_protonmail_messages(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:
@@ -118,7 +118,8 @@ def get_protonmail_messages(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_protonmail_contacts(files_found, report_folder, seeker, wrap_text):
+def get_protonmail_contacts(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/rarlabPreferences.py
+++ b/scripts/artifacts/rarlabPreferences.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_rarlabPreferences": {
         "name": "rarlabPreferences",
@@ -43,7 +42,8 @@ def _parse_xml(file_found):
 
 
 @artifact_processor
-def get_rarlabPreferences(files_found, report_folder, seeker, wrap_text):
+def get_rarlabPreferences(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
 

--- a/scripts/artifacts/recentactivity.py
+++ b/scripts/artifacts/recentactivity.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_recentactivity": {
         "name": "Recent Activity",
@@ -67,7 +66,8 @@ def _media(folder, *parts):
 
 
 @artifact_processor
-def get_recentactivity(files_found, report_folder, seeker, wrap_text):
+def get_recentactivity(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/roles.py
+++ b/scripts/artifacts/roles.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_roles": {
         "name": "roles",
@@ -52,7 +51,8 @@ def _parse_xml(file_found):
 
 
 @artifact_processor
-def get_roles(files_found, report_folder, seeker, wrap_text):
+def get_roles(context):
+    files_found = context.get_files_found()
 
     slash = '\\' if is_platform_windows() else '/'
     data_list = []

--- a/scripts/artifacts/runtimePerms.py
+++ b/scripts/artifacts/runtimePerms.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_runtimePerms": {
         "name": "runtimePerms",
@@ -52,7 +51,8 @@ def _parse_xml(file_found):
 
 
 @artifact_processor
-def get_runtimePerms(files_found, report_folder, seeker, wrap_text):
+def get_runtimePerms(context):
+    files_found = context.get_files_found()
 
     slash = '\\' if is_platform_windows() else '/'
     data_list = []

--- a/scripts/artifacts/sChats.py
+++ b/scripts/artifacts/sChats.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0631
+# pylint: disable=W0631
 __artifacts_v2__ = {
     "get_schats": {
         "name": "Sideline Chats and Calls",
@@ -19,7 +19,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, conve
 
 
 @artifact_processor
-def get_schats(files_found, report_folder, seeker, wrap_text):
+def get_schats(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/sRecoveryhist.py
+++ b/scripts/artifacts/sRecoveryhist.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_sRecoveryhist": {
         "name": "sRecoveryhist",
@@ -25,7 +24,8 @@ from scripts.ilapfuncs import artifact_processor
 
 
 @artifact_processor
-def get_sRecoveryhist(files_found, report_folder, seeker, wrap_text):
+def get_sRecoveryhist(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/sWipehist.py
+++ b/scripts/artifacts/sWipehist.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_sWipehist": {
         "name": "sWipehist",
@@ -25,7 +24,8 @@ from scripts.ilapfuncs import artifact_processor
 
 
 @artifact_processor
-def get_sWipehist(files_found, report_folder, seeker, wrap_text):
+def get_sWipehist(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/samsungSmartThings.py
+++ b/scripts/artifacts/samsungSmartThings.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_samsungSmartThings": {
         "name": "samsungSmartThings",
@@ -25,7 +24,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, conve
 
 
 @artifact_processor
-def get_samsungSmartThings(files_found, report_folder, seeker, wrap_text):
+def get_samsungSmartThings(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
 

--- a/scripts/artifacts/samsungWeatherClock.py
+++ b/scripts/artifacts/samsungWeatherClock.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_samsungWeatherClockInfo": {
         "name": "Samsung Weather Clock - Info",
@@ -74,7 +73,8 @@ def _weatherclock_db(files_found):
 
 
 @artifact_processor
-def get_samsungWeatherClockInfo(files_found, report_folder, seeker, wrap_text):
+def get_samsungWeatherClockInfo(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = _weatherclock_db(files_found) or ''
     if source_path:
@@ -117,7 +117,8 @@ def get_samsungWeatherClockInfo(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_samsungWeatherClockDaily(files_found, report_folder, seeker, wrap_text):
+def get_samsungWeatherClockDaily(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = _weatherclock_db(files_found) or ''
     if source_path:
@@ -150,7 +151,8 @@ def get_samsungWeatherClockDaily(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_samsungWeatherClockHourly(files_found, report_folder, seeker, wrap_text):
+def get_samsungWeatherClockHourly(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = _weatherclock_db(files_found) or ''
     if source_path:

--- a/scripts/artifacts/sbbmobile.py
+++ b/scripts/artifacts/sbbmobile.py
@@ -72,7 +72,8 @@ from scripts.ilapfuncs import artifact_processor, get_file_path, \
 from scripts.html_safe import esc
 
 @artifact_processor
-def cff_purchased_tickets(files_found, _report_folder, _seeker, _wrap_text):
+def cff_purchased_tickets(context):
+    files_found = context.get_files_found()
     source_path = get_file_path(files_found, "SbbMobile.db")
 
     if source_path:
@@ -102,7 +103,8 @@ def cff_purchased_tickets(files_found, _report_folder, _seeker, _wrap_text):
         logfunc('No Data')
 
 @artifact_processor
-def cff_searched_places(files_found, _report_folder, _seeker, _wrap_text):
+def cff_searched_places(context):
+    files_found = context.get_files_found()
     source_path = get_file_path(files_found, "SbbMobile.db")
     data_list = []
 
@@ -140,7 +142,8 @@ def cff_searched_places(files_found, _report_folder, _seeker, _wrap_text):
         logfunc('No Data')
 
 @artifact_processor
-def cff_search_history(files_found, _report_folder, _seeker, _wrap_text):
+def cff_search_history(context):
+    files_found = context.get_files_found()
     source_path = get_file_path(files_found, "SbbMobile.db")
     data_list = []
 
@@ -183,7 +186,8 @@ def cff_search_history(files_found, _report_folder, _seeker, _wrap_text):
         logfunc('No Data')
 
 @artifact_processor
-def cff_travel_cards(files_found, _report_folder, _seeker, _wrap_text):
+def cff_travel_cards(context):
+    files_found = context.get_files_found()
     source_path = get_file_path(files_found, "SbbMobile.db")
     data_list = []
 

--- a/scripts/artifacts/scontextLog.py
+++ b/scripts/artifacts/scontextLog.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_scontextLog": {
         "name": "scontextLog",
@@ -21,7 +20,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_scontextLog(files_found, report_folder, seeker, wrap_text):
+def get_scontextLog(context):
+    files_found = context.get_files_found()
 
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)

--- a/scripts/artifacts/settingsSecure.py
+++ b/scripts/artifacts/settingsSecure.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_settingsSecure": {
         "name": "settingsSecure",
@@ -66,7 +65,8 @@ def _parse_root(file_found):
 
 
 @artifact_processor
-def get_settingsSecure(files_found, report_folder, seeker, wrap_text):
+def get_settingsSecure(context):
+    files_found = context.get_files_found()
 
     slash = '\\' if is_platform_windows() else '/'
     data_list = []

--- a/scripts/artifacts/setupWizardinfo.py
+++ b/scripts/artifacts/setupWizardinfo.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_setupWizardinfo": {
         "name": "setupWizardinfo",
@@ -47,7 +46,8 @@ def _parse_xml(file_found):
 
 
 @artifact_processor
-def get_setupWizardinfo(files_found, report_folder, seeker, wrap_text):
+def get_setupWizardinfo(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/sharedProto.py
+++ b/scripts/artifacts/sharedProto.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_sharedProto": {
         "name": "Shared Proto Data",
@@ -45,7 +45,8 @@ def _txt(value):
 
 
 @artifact_processor
-def get_sharedProto(files_found, report_folder, seeker, wrap_text):
+def get_sharedProto(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     in_dirs = set(pathlib.Path(str(x)).parent for x in files_found)

--- a/scripts/artifacts/shareit.py
+++ b/scripts/artifacts/shareit.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_shareit": {
         "name": "shareit",
@@ -21,7 +21,8 @@ from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readon
 
 
 @artifact_processor
-def get_shareit(files_found, report_folder, seeker, wrap_text):
+def get_shareit(context):
+    files_found = context.get_files_found()
 
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/shistorylog.py
+++ b/scripts/artifacts/shistorylog.py
@@ -21,7 +21,8 @@ from datetime import datetime, timezone
 from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
 
 @artifact_processor
-def history_log(files_found, _report_folder, _seeker, _wrap_text):
+def history_log(context):
+    files_found = context.get_files_found()
     files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
      
     query = ('''

--- a/scripts/artifacts/siminfo.py
+++ b/scripts/artifacts/siminfo.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_siminfo": {
         "name": "siminfo",
@@ -43,7 +42,8 @@ FALLBACK_SQL = '''
 
 
 @artifact_processor
-def get_siminfo(files_found, report_folder, seeker, wrap_text):
+def get_siminfo(context):
+    files_found = context.get_files_found()
     data_list = []
     source_paths = []
     for file_found in files_found:

--- a/scripts/artifacts/skout.py
+++ b/scripts/artifacts/skout.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_skout_messages": {
         "name": "Skout Messages",
@@ -32,7 +31,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, conve
 
 
 @artifact_processor
-def get_skout_messages(files_found, report_folder, seeker, wrap_text):
+def get_skout_messages(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:
@@ -79,7 +79,8 @@ def get_skout_messages(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_skout_users(files_found, report_folder, seeker, wrap_text):
+def get_skout_users(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/skype.py
+++ b/scripts/artifacts/skype.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0702
+# pylint: disable=W0702
 __artifacts_v2__ = {
     "get_skype_call_logs": {
         "name": "Skype - Call Logs",
@@ -65,7 +65,8 @@ def _skype_db(files_found):
 
 
 @artifact_processor
-def get_skype_call_logs(files_found, report_folder, seeker, wrap_text):
+def get_skype_call_logs(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = _skype_db(files_found) or ''
     if source_path:
@@ -114,7 +115,8 @@ def get_skype_call_logs(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_skype_messages(files_found, report_folder, seeker, wrap_text):
+def get_skype_messages(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = _skype_db(files_found) or ''
     if source_path:
@@ -168,7 +170,8 @@ def get_skype_messages(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_skype_contacts(files_found, report_folder, seeker, wrap_text):
+def get_skype_contacts(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = _skype_db(files_found) or ''
     if source_path:

--- a/scripts/artifacts/slopes.py
+++ b/scripts/artifacts/slopes.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_slopes": {
         "name": "Slopes - Resort Details",
@@ -62,7 +61,8 @@ def _slopes_db(files_found):
 
 
 @artifact_processor
-def get_slopes(files_found, report_folder, seeker, wrap_text):
+def get_slopes(context):
+    files_found = context.get_files_found()
     source_path = _slopes_db(files_found)
     data_list = []
     if source_path:
@@ -83,7 +83,8 @@ def get_slopes(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_slopes_actions(files_found, report_folder, seeker, wrap_text):
+def get_slopes_actions(context):
+    files_found = context.get_files_found()
     source_path = _slopes_db(files_found)
     data_list = []
     if source_path:
@@ -106,7 +107,8 @@ def get_slopes_actions(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_slopes_lift(files_found, report_folder, seeker, wrap_text):
+def get_slopes_lift(context):
+    files_found = context.get_files_found()
     source_path = _slopes_db(files_found)
     data_list = []
     if source_path:

--- a/scripts/artifacts/smanagerCrash.py
+++ b/scripts/artifacts/smanagerCrash.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_smanagerCrash": {
         "name": "smanagerCrash",
@@ -21,7 +20,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_smanagerCrash(files_found, report_folder, seeker, wrap_text):
+def get_smanagerCrash(context):
+    files_found = context.get_files_found()
 
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)

--- a/scripts/artifacts/smanagerLow.py
+++ b/scripts/artifacts/smanagerLow.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_smanagerLow": {
         "name": "smanagerLow",
@@ -27,7 +26,8 @@ def _ms_to_utc(value):
 
 
 @artifact_processor
-def get_smanagerLow(files_found, report_folder, seeker, wrap_text):
+def get_smanagerLow(context):
+    files_found = context.get_files_found()
 
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)

--- a/scripts/artifacts/smembersAppInv.py
+++ b/scripts/artifacts/smembersAppInv.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_smembersAppInv": {
         "name": "smembersAppInv",
@@ -21,7 +20,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_smembersAppInv(files_found, report_folder, seeker, wrap_text):
+def get_smembersAppInv(context):
+    files_found = context.get_files_found()
 
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)

--- a/scripts/artifacts/smembersEvents.py
+++ b/scripts/artifacts/smembersEvents.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_smembersEvents": {
         "name": "smembersEvents",
@@ -21,7 +20,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_smembersEvents(files_found, report_folder, seeker, wrap_text):
+def get_smembersEvents(context):
+    files_found = context.get_files_found()
 
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)

--- a/scripts/artifacts/smsmms.py
+++ b/scripts/artifacts/smsmms.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_sms_mms": {
         "name": "SMS Messages",
@@ -154,7 +153,8 @@ def _mmssms_dbs(files_found):
 
 
 @artifact_processor
-def get_sms_mms(files_found, report_folder, seeker, wrap_text):
+def get_sms_mms(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for source_path in _mmssms_dbs(files_found):
@@ -175,7 +175,8 @@ def get_sms_mms(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_sms_mms_mms(files_found, report_folder, seeker, wrap_text):
+def get_sms_mms_mms(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for source_path in _mmssms_dbs(files_found):

--- a/scripts/artifacts/smyFiles.py
+++ b/scripts/artifacts/smyFiles.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_smyFiles": {
         "name": "My Files - Download History",
@@ -76,7 +76,8 @@ def _query(source_path, sql):
 
 
 @artifact_processor
-def get_smyFiles(files_found, report_folder, seeker, wrap_text):
+def get_smyFiles(context):
+    files_found = context.get_files_found()
     source_path = _myfiles_db(files_found)
     rows = _query(source_path, '''
         select mDate, mName, mFullPath, mIsHidden, mTrashed, _source, _description, _from_s_browser
@@ -88,7 +89,8 @@ def get_smyFiles(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_smyFiles_legacy(files_found, report_folder, seeker, wrap_text):
+def get_smyFiles_legacy(context):
+    files_found = context.get_files_found()
     source_path = _myfiles_db(files_found)
     rows = _query(source_path, '''
         select date, name, size, _data, _source, _description, _from_s_browser
@@ -100,7 +102,8 @@ def get_smyFiles_legacy(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_smyFiles_recent(files_found, report_folder, seeker, wrap_text):
+def get_smyFiles_recent(context):
+    files_found = context.get_files_found()
     source_path = _myfiles_db(files_found)
     rows = _query(source_path, '''
         select mDate, mName, mFullPath, mIsHidden, mTrashed, _source, _description, _from_s_browser

--- a/scripts/artifacts/smyFiles2.py
+++ b/scripts/artifacts/smyFiles2.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_smyFiles2": {
         "name": "My Files - Download History (FileInfo)",
@@ -82,7 +81,8 @@ def _rows(db_path, sql):
 
 
 @artifact_processor
-def get_smyFiles2(files_found, report_folder, seeker, wrap_text):
+def get_smyFiles2(context):
+    files_found = context.get_files_found()
     db_path = _db_path(files_found)
     rows = _rows(db_path, '''
         SELECT date_modified, name, path, is_hidden, is_trashed, _source, _description
@@ -95,7 +95,8 @@ def get_smyFiles2(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_smyFiles2_gdrive(files_found, report_folder, seeker, wrap_text):
+def get_smyFiles2_gdrive(context):
+    files_found = context.get_files_found()
     cache = [str(f) for f in files_found if '/cache/' in str(f).replace('\\', '/')]
     cache_by_name = {os.path.basename(f): f for f in cache}
     cache_by_stem = {os.path.splitext(os.path.basename(f))[0]: f for f in cache}

--- a/scripts/artifacts/smyfilesOpHistory.py
+++ b/scripts/artifacts/smyfilesOpHistory.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0702
+# pylint: disable=W0702
 __artifacts_v2__ = {
     "get_smyfiles_OpHistory": {
         "name": "My Files Operation History",
@@ -66,7 +66,8 @@ def get_user(file_found):
 
 
 @artifact_processor
-def get_smyfiles_OpHistory(files_found, report_folder, seeker, wrap_text):
+def get_smyfiles_OpHistory(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     Androidversion = aG.versionf

--- a/scripts/artifacts/smyfilesRecents.py
+++ b/scripts/artifacts/smyfilesRecents.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_smyfilesRecents": {
         "name": "My Files - Recent Files",
@@ -62,7 +62,8 @@ def _myfiles_db(files_found):
 
 
 @artifact_processor
-def get_smyfilesRecents(files_found, report_folder, seeker, wrap_text):
+def get_smyfilesRecents(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = _myfiles_db(files_found)
     if source_path:
@@ -86,7 +87,8 @@ def get_smyfilesRecents(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_smyfilesRecents_fileinfo(files_found, report_folder, seeker, wrap_text):
+def get_smyfilesRecents_fileinfo(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = _myfiles_db(files_found)
     if source_path:

--- a/scripts/artifacts/smyfilesStored.py
+++ b/scripts/artifacts/smyfilesStored.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0702
+# pylint: disable=W0702
 __artifacts_v2__ = {
     "get_smyfilesStored": {
         "name": "smyfilesStored",
@@ -25,7 +25,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, conve
 
 
 @artifact_processor
-def get_smyfilesStored(files_found, report_folder, seeker, wrap_text):
+def get_smyfilesStored(context):
+    files_found = context.get_files_found()
 
     source_path = str(files_found[0])
     all_rows = []

--- a/scripts/artifacts/smyfilesTrash.py
+++ b/scripts/artifacts/smyfilesTrash.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_smyfiles_trash": {
         "name": "My Files Trash",
@@ -38,7 +37,8 @@ def _ms_to_utc(value):
 
 
 @artifact_processor
-def get_smyfiles_trash(files_found, report_folder, seeker, wrap_text):
+def get_smyfiles_trash(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/smyfilescache.py
+++ b/scripts/artifacts/smyfilescache.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_smyfilescache": {
         "name": "My Files Cache",
@@ -46,7 +45,8 @@ def _ms_to_utc(value):
 
 
 @artifact_processor
-def get_smyfilescache(files_found, report_folder, seeker, wrap_text):
+def get_smyfilescache(context):
+    files_found = context.get_files_found()
     jpg_by_name = {os.path.basename(str(f)): str(f) for f in files_found if str(f).endswith('.jpg')}
 
     db_path = ''

--- a/scripts/artifacts/snapchat.py
+++ b/scripts/artifacts/snapchat.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_snapchat_feeds": {
         "name": "Snapchat - Feeds",
@@ -198,7 +198,8 @@ def _decrypt_meo_code(hashed):
 
 
 @artifact_processor
-def get_snapchat_feeds(files_found, report_folder, seeker, wrap_text):
+def get_snapchat_feeds(context):
+    files_found = context.get_files_found()
     source_path = _find(files_found, 'main.db', 'tcspahn.db')
     rows = _rows(source_path, '''
         SELECT lastInteractionTimestamp, key, displayInteractionType, lastReadTimestamp, lastReader,
@@ -213,7 +214,8 @@ def get_snapchat_feeds(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_snapchat_friends(files_found, report_folder, seeker, wrap_text):
+def get_snapchat_friends(context):
+    files_found = context.get_files_found()
     source_path = _find(files_found, 'main.db', 'tcspahn.db')
     rows = _rows(source_path, '''
         SELECT addedTimestamp, username, userId, displayName, phone, birthday
@@ -226,7 +228,8 @@ def get_snapchat_friends(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_snapchat_messages(files_found, report_folder, seeker, wrap_text):
+def get_snapchat_messages(context):
+    files_found = context.get_files_found()
     source_path = _find(files_found, 'main.db', 'tcspahn.db')
     rows = _rows(source_path, '''
         SELECT timestamp, seenTimestamp, senderId, username, displayName, type, content
@@ -240,7 +243,8 @@ def get_snapchat_messages(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_snapchat_memories(files_found, report_folder, seeker, wrap_text):
+def get_snapchat_memories(context):
+    files_found = context.get_files_found()
     source_path = _find(files_found, 'memories.db')
     rows = _rows(source_path, '''
         SELECT create_time, _id, snap_ids, CASE is_private WHEN 1 THEN 'YES' ELSE 'NO' END,
@@ -253,7 +257,8 @@ def get_snapchat_memories(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_snapchat_meo(files_found, report_folder, seeker, wrap_text):
+def get_snapchat_meo(context):
+    files_found = context.get_files_found()
     source_path = _find(files_found, 'memories.db')
     rows = _rows(source_path,
                  'SELECT user_id, hashed_passcode, master_key, master_key_iv FROM memories_meo_confidential')
@@ -263,7 +268,8 @@ def get_snapchat_meo(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_snapchat_snap_media(files_found, report_folder, seeker, wrap_text):
+def get_snapchat_snap_media(context):
+    files_found = context.get_files_found()
     source_path = _find(files_found, 'memories.db')
     rows = _rows(source_path, '''
         SELECT create_time, memories_snap._id, media_id, memories_entry_id, time_zone_id, format,
@@ -305,12 +311,14 @@ def _parse_xml_rows(xml_file):
 
 
 @artifact_processor
-def get_snapchat_identity(files_found, report_folder, seeker, wrap_text):
+def get_snapchat_identity(context):
+    files_found = context.get_files_found()
     source_path = _find(files_found, 'identity_persistent_store.xml')
     return ('Key', 'Value'), _parse_xml_rows(source_path), source_path
 
 
 @artifact_processor
-def get_snapchat_login_signup(files_found, report_folder, seeker, wrap_text):
+def get_snapchat_login_signup(context):
+    files_found = context.get_files_found()
     source_path = _find(files_found, 'LoginSignupStore.xml')
     return ('Key', 'Value'), _parse_xml_rows(source_path), source_path

--- a/scripts/artifacts/speedtest.py
+++ b/scripts/artifacts/speedtest.py
@@ -1,4 +1,4 @@
-# pylint: disable=E1121,W0613,W0718
+# pylint: disable=E1121,W0718
 __artifacts_v2__ = {
     "speedtest_tests": {
         "name": "Speedtest Test Results",
@@ -48,7 +48,8 @@ from scripts.ilapfuncs import open_sqlite_db_readonly, logfunc, artifact_process
 import json
 
 @artifact_processor
-def speedtest_tests(files_found, report_folder, seeker, wrap_text):
+def speedtest_tests(context):
+    files_found = context.get_files_found()
     file_path = files_found[0]
     headers = [('Timestamp', 'datetime'), 'Connection type', 'SSID', 'Latitude', 'Longitude', 'External IP', 'Internal IP', 'Download speed (Kbps)', 'Upload speed (Kbps)']
 
@@ -73,7 +74,8 @@ def speedtest_tests(files_found, report_folder, seeker, wrap_text):
     return headers, timestamped_result, file_path
 
 @artifact_processor
-def speedtest_reports_location(files_found, report_folder, seeker, wrap_text):
+def speedtest_reports_location(context):
+    files_found = context.get_files_found()
     file_path = files_found[0]
     headers = [('Timestamp', 'datetime'), 'Latitude', 'Longitude', 'Altitude', 'Accuracy (meters)']
 
@@ -107,7 +109,8 @@ def speedtest_reports_location(files_found, report_folder, seeker, wrap_text):
     return headers, reports, file_path
 
 @artifact_processor
-def speedtest_reports_wifi(files_found, report_folder, seeker, wrap_text):
+def speedtest_reports_wifi(context):
+    files_found = context.get_files_found()
     file_path = files_found[0]
     headers = [('Timestamp', 'datetime'), 'BSSID', 'SSID', 'Signal Strength']
     results = []

--- a/scripts/artifacts/suggestions.py
+++ b/scripts/artifacts/suggestions.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_suggestions": {
         "name": "suggestions",
@@ -53,7 +52,8 @@ def _parse_xml(file_found):
 
 
 @artifact_processor
-def get_suggestions(files_found, report_folder, seeker, wrap_text):
+def get_suggestions(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/swellbeing.py
+++ b/scripts/artifacts/swellbeing.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_swellbeing": {
         "name": "swellbeing",
@@ -28,7 +27,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_swellbeing(files_found, report_folder, seeker, wrap_text):
+def get_swellbeing(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/swissmeteo.py
+++ b/scripts/artifacts/swissmeteo.py
@@ -34,7 +34,8 @@ from scripts.ilapfuncs import artifact_processor, get_file_path, \
 from scripts.html_safe import esc
 
 @artifact_processor
-def plz_interaction(files_found, _report_folder, _seeker, _wrap_text):
+def plz_interaction(context):
+    files_found = context.get_files_found()
     source_path = get_file_path(files_found, "favorites_prediction_db.sqlite")
     data_list = []
     cursor = None
@@ -78,7 +79,8 @@ def plz_interaction(files_found, _report_folder, _seeker, _wrap_text):
         logfunc('No Swissmeteo')
 
 @artifact_processor
-def swissmeteo_plz(files_found, _report_folder, _seeker, _wrap_text):
+def swissmeteo_plz(context):
+    files_found = context.get_files_found()
     source_path = get_file_path(files_found, "favorites_prediction_db.sqlite")
     data_list = []
 

--- a/scripts/artifacts/tangomessage.py
+++ b/scripts/artifacts/tangomessage.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0631,W0702,W0718
+# pylint: disable=W0631,W0702,W0718
 __artifacts_v2__ = {
     "get_tangomessage": {
         "name": "tangomessage",
@@ -33,7 +33,8 @@ def _decodeMessage(wrapper, message):
 
 
 @artifact_processor
-def get_tangomessage(files_found, report_folder, seeker, wrap_text):
+def get_tangomessage(context):
+    files_found = context.get_files_found()
 
     for file_found in files_found:
         file_found = str(file_found)

--- a/scripts/artifacts/teams.py
+++ b/scripts/artifacts/teams.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_teams": {
         "name": "Teams - Messages",
@@ -117,7 +117,8 @@ def _run(source_path, sql):
 
 
 @artifact_processor
-def get_teams(files_found, report_folder, seeker, wrap_text):
+def get_teams(context):
+    files_found = context.get_files_found()
     source_path = _teams_db(files_found)
     rows = _run(source_path, '''
         SELECT arrivalTime, userDisplayName, content, displayName, deleteTime,
@@ -132,7 +133,8 @@ def get_teams(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_teams_users(files_found, report_folder, seeker, wrap_text):
+def get_teams_users(context):
+    files_found = context.get_files_found()
     source_path = _teams_db(files_found)
     rows = _run(source_path, '''
         SELECT lastSyncTime, givenName, surname, displayName, email, secondaryEmail, alternativeEmail,
@@ -145,7 +147,8 @@ def get_teams_users(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_teams_calllog(files_found, report_folder, seeker, wrap_text):
+def get_teams_calllog(context):
+    files_found = context.get_files_found()
     source_path = _teams_db(files_found)
     rows = _run(source_path, '''
         SELECT
@@ -166,7 +169,8 @@ def get_teams_calllog(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_teams_activity(files_found, report_folder, seeker, wrap_text):
+def get_teams_activity(context):
+    files_found = context.get_files_found()
     source_path = _teams_db(files_found)
     rows = _run(source_path, '''
         SELECT activityTimestamp, sourceUserImDisplayName, messagePreview, activityType, activitySubtype, isRead
@@ -178,7 +182,8 @@ def get_teams_activity(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_teams_fileinfo(files_found, report_folder, seeker, wrap_text):
+def get_teams_fileinfo(context):
+    files_found = context.get_files_found()
     source_path = _teams_db(files_found)
     rows = _run(source_path, '''
         SELECT lastModifiedTime, fileName, type, objectUrl, isFolder, lastModifiedBy

--- a/scripts/artifacts/teleguard.py
+++ b/scripts/artifacts/teleguard.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_teleguard": {
         "name": "Teleguard - Messages",
@@ -122,7 +121,8 @@ def _run(source_path, sql):
 
 
 @artifact_processor
-def get_teleguard(files_found, report_folder, seeker, wrap_text):
+def get_teleguard(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found)
     rows = _run(source_path, '''
         SELECT datetime(createDate/1000,'unixepoch'), datetime(userTime/1000,'unixepoch'),
@@ -177,7 +177,8 @@ def get_teleguard(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_teleguard_posts(files_found, report_folder, seeker, wrap_text):
+def get_teleguard_posts(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found)
     rows = _run(source_path, '''
         SELECT datetime(createDate/1000,'unixepoch'), channelId, header, content, type, localStatus,
@@ -191,7 +192,8 @@ def get_teleguard_posts(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_teleguard_contacts(files_found, report_folder, seeker, wrap_text):
+def get_teleguard_contacts(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found)
     rows = _run(source_path, '''
         SELECT datetime(lastActivityTime/1000,'unixepoch'), serverId, alias, type, color, avatar, options,
@@ -212,7 +214,8 @@ def get_teleguard_contacts(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_teleguard_channels(files_found, report_folder, seeker, wrap_text):
+def get_teleguard_channels(context):
+    files_found = context.get_files_found()
     source_path = _db(files_found)
     rows = _run(source_path, 'SELECT * FROM channels')
     data_headers = ('ID', 'Alias', 'Description', 'Category', 'Color', 'Avatar ID', 'Subscribers Count',

--- a/scripts/artifacts/textnow.py
+++ b/scripts/artifacts/textnow.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0702
+# pylint: disable=W0702
 __artifacts_v2__ = {
     "get_textnow_call_logs": {
         "name": "Text Now - Call Logs",
@@ -47,7 +47,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_textnow_call_logs(files_found, report_folder, seeker, wrap_text):
+def get_textnow_call_logs(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:
@@ -93,7 +94,8 @@ def get_textnow_call_logs(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_textnow_messages(files_found, report_folder, seeker, wrap_text):
+def get_textnow_messages(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:
@@ -165,7 +167,8 @@ def get_textnow_messages(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_textnow_contacts(files_found, report_folder, seeker, wrap_text):
+def get_textnow_contacts(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/thunderbird.py
+++ b/scripts/artifacts/thunderbird.py
@@ -71,7 +71,8 @@ def _map_uuid_to_account(file):
     return uuid_mapping
 
 @artifact_processor
-def thunderbird_accounts(files_found, _report_folder, _seeker, _wrap_text):
+def thunderbird_accounts(context):
+    files_found = context.get_files_found()
     files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
      
     query = ('''
@@ -128,7 +129,8 @@ def thunderbird_accounts(files_found, _report_folder, _seeker, _wrap_text):
 
 
 @artifact_processor
-def thunderbird_messages(files_found, _report_folder, _seeker, _wrap_text):
+def thunderbird_messages(context):
+    files_found = context.get_files_found()
 
     preferences_file = [x for x in files_found if "preferences_storage" in x and not x.endswith('journal')]
     uuid_mapping = _map_uuid_to_account(str(preferences_file[0]))

--- a/scripts/artifacts/tikTok.py
+++ b/scripts/artifacts/tikTok.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_tikTok": {
         "name": "TikTok - Messages",
@@ -79,7 +78,8 @@ def _tiktok_dbs(files_found):
 
 
 @artifact_processor
-def get_tikTok(files_found, report_folder, seeker, wrap_text):
+def get_tikTok(context):
+    files_found = context.get_files_found()
     data_list = []
     maindb, attachdb = _tiktok_dbs(files_found)
     source_path = maindb
@@ -126,7 +126,8 @@ def get_tikTok(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_tikTok_contacts(files_found, report_folder, seeker, wrap_text):
+def get_tikTok_contacts(context):
+    files_found = context.get_files_found()
     data_list = []
     maindb, attachdb = _tiktok_dbs(files_found)
     source_path = maindb

--- a/scripts/artifacts/torrentData.py
+++ b/scripts/artifacts/torrentData.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0702
+# pylint: disable=W0702
 __artifacts_v2__ = {
     "get_TorrentData": {
         "name": "TorrentData",
@@ -24,7 +24,8 @@ from scripts.html_safe import esc
 
 
 @artifact_processor
-def get_TorrentData(files_found, report_folder, seeker, wrap_text):
+def get_TorrentData(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/torrentResumeinfo.py
+++ b/scripts/artifacts/torrentResumeinfo.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0702
+# pylint: disable=W0702
 __artifacts_v2__ = {
     "get_torrentResumeinfo": {
         "name": "torrentResumeinfo",
@@ -31,7 +31,8 @@ def timestampcalc(timevalue):
 
 
 @artifact_processor
-def get_torrentResumeinfo(files_found, report_folder, seeker, wrap_text):
+def get_torrentResumeinfo(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/torrentinfo.py
+++ b/scripts/artifacts/torrentinfo.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0702,W0718
+# pylint: disable=W0702,W0718
 __artifacts_v2__ = {
     "get_torrentinfo": {
         "name": "torrentinfo",
@@ -31,7 +31,8 @@ def timestampcalc(timevalue):
 
 
 @artifact_processor
-def get_torrentinfo(files_found, report_folder, seeker, wrap_text):
+def get_torrentinfo(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/tusky.py
+++ b/scripts/artifacts/tusky.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0718
+# pylint: disable=W0718
 __artifacts_v2__ = {
     "get_tusky": {
         "name": "Tusky - Timeline",
@@ -70,7 +70,8 @@ def _attachment_urls(value):
 
 
 @artifact_processor
-def get_tusky(files_found, report_folder, seeker, wrap_text):
+def get_tusky(context):
+    files_found = context.get_files_found()
     source_path = _tusky_db(files_found)
     data_list = []
     if source_path:
@@ -113,7 +114,8 @@ def get_tusky(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_tusky_accounts(files_found, report_folder, seeker, wrap_text):
+def get_tusky_accounts(context):
+    files_found = context.get_files_found()
     source_path = _tusky_db(files_found)
     data_list = []
     if source_path:

--- a/scripts/artifacts/ulrUserprefs.py
+++ b/scripts/artifacts/ulrUserprefs.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_urluser": {
         "name": "ULR User Prefs",
@@ -52,7 +51,8 @@ def _parse_xml(file_found):
 
 
 @artifact_processor
-def get_urluser(files_found, report_folder, seeker, wrap_text):
+def get_urluser(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/usageHistory.py
+++ b/scripts/artifacts/usageHistory.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_usageHistory": {
         "name": "Usagehistory",
@@ -41,7 +40,8 @@ def _parse_xml(file_found):
 
 
 @artifact_processor
-def get_usageHistory(files_found, report_folder, seeker, wrap_text):
+def get_usageHistory(context):
+    files_found = context.get_files_found()
 
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/usageapps.py
+++ b/scripts/artifacts/usageapps.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_usageapps": {
         "name": "usageapps",
@@ -58,7 +57,8 @@ def _scalar(obj):
 
 
 @artifact_processor
-def get_usageapps(files_found, report_folder, seeker, wrap_text):
+def get_usageapps(context):
+    files_found = context.get_files_found()
     source_path = ''
     data_list = []
     for file_found in files_found:

--- a/scripts/artifacts/usagestatsVersion.py
+++ b/scripts/artifacts/usagestatsVersion.py
@@ -34,7 +34,8 @@ from scripts.ilapfuncs import artifact_processor, \
 
 
 @artifact_processor
-def usagestatsVersion(files_found, _report_folder, _seeker, _wrap_text):
+def usagestatsVersion(context):
+    files_found = context.get_files_found()
     source_path = get_file_path(files_found, "version")
     data_list = []
 

--- a/scripts/artifacts/userDict.py
+++ b/scripts/artifacts/userDict.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_userDict": {
         "name": "userDict",
@@ -30,7 +29,8 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
 
 @artifact_processor
-def get_userDict(files_found, report_folder, seeker, wrap_text):
+def get_userDict(context):
+    files_found = context.get_files_found()
 
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)

--- a/scripts/artifacts/vaulty_files.py
+++ b/scripts/artifacts/vaulty_files.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_vaulty_files": {
         "name": "vaulty_files",
@@ -21,7 +20,8 @@ from scripts.ilapfuncs import artifact_processor, convert_human_ts_to_utc
 
 
 @artifact_processor
-def get_vaulty_files(files_found, report_folder, seeker, wrap_text):
+def get_vaulty_files(context):
+    files_found = context.get_files_found()
 
     # Media database
     db_filepath = str(files_found[0])

--- a/scripts/artifacts/vaulty_info.py
+++ b/scripts/artifacts/vaulty_info.py
@@ -1,4 +1,4 @@
-# pylint: disable=E1101,W0613
+# pylint: disable=E1101
 __artifacts_v2__ = {
     "get_vaulty_info": {
         "name": "vaulty_info",
@@ -34,7 +34,8 @@ def _brute_force(target):
 
 
 @artifact_processor
-def get_vaulty_info(files_found, report_folder, seeker, wrap_text):
+def get_vaulty_info(context):
+    files_found = context.get_files_found()
 
     source_path = str(files_found[0])
     with open(source_path, "r", encoding='utf-8', errors='replace') as file:

--- a/scripts/artifacts/vlcMedia.py
+++ b/scripts/artifacts/vlcMedia.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_vlcMedia": {
         "name": "VLC",
@@ -27,7 +26,8 @@ def _ts_to_utc(value):
 
 
 @artifact_processor
-def get_vlcMedia(files_found, report_folder, seeker, wrap_text):
+def get_vlcMedia(context):
+    files_found = context.get_files_found()
 
     source_path = ''
     for file_found in files_found:

--- a/scripts/artifacts/vlcThumbs.py
+++ b/scripts/artifacts/vlcThumbs.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_vlcThumbs": {
         "name": "VLC Thumbnails",
@@ -44,7 +43,8 @@ def _sec_to_utc(value):
 
 
 @artifact_processor
-def get_vlcThumbs(files_found, report_folder, seeker, wrap_text):
+def get_vlcThumbs(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in files_found:
@@ -60,7 +60,8 @@ def get_vlcThumbs(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_vlcThumbs_data(files_found, report_folder, seeker, wrap_text):
+def get_vlcThumbs_data(context):
+    files_found = context.get_files_found()
     jpg_by_name = {os.path.basename(str(f)): str(f) for f in files_found if str(f).endswith('.jpg')}
     data_list = []
     source_path = ''

--- a/scripts/artifacts/wellbeing.py
+++ b/scripts/artifacts/wellbeing.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_wellbeing": {
         "name": "Digital Wellbeing - Events",
@@ -62,7 +61,8 @@ def _app_usage_db(files_found):
 
 
 @artifact_processor
-def get_wellbeing(files_found, report_folder, seeker, wrap_text):
+def get_wellbeing(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = _app_usage_db(files_found)
     if source_path:
@@ -96,7 +96,8 @@ def get_wellbeing(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_wellbeing_url(files_found, report_folder, seeker, wrap_text):
+def get_wellbeing_url(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = _app_usage_db(files_found)
     if source_path:

--- a/scripts/artifacts/wellbeingaccount.py
+++ b/scripts/artifacts/wellbeingaccount.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_wellbeingaccount": {
         "name": "wellbeingaccount",
@@ -31,7 +30,8 @@ from scripts.html_safe import esc
 
 
 @artifact_processor
-def get_wellbeingaccount(files_found, report_folder, seeker, wrap_text):
+def get_wellbeingaccount(context):
+    files_found = context.get_files_found()
     source_path = str(files_found[0])
     content = ParseProto(source_path)
 

--- a/scripts/artifacts/wifiConfigstore2.py
+++ b/scripts/artifacts/wifiConfigstore2.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_wifiConfigstore": {
         "name": "WiFi Config Store",
@@ -74,7 +73,8 @@ def _xml_root(file_found):
 
 
 @artifact_processor
-def get_wifiConfigstore(files_found, report_folder, seeker, wrap_text):
+def get_wifiConfigstore(context):
+    files_found = context.get_files_found()
     data_list = []
     source_paths = []
     for file_found in files_found:

--- a/scripts/artifacts/wifiHotspot.py
+++ b/scripts/artifacts/wifiHotspot.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_wifiHotspot": {
         "name": "wifiHotspot",
@@ -33,7 +32,8 @@ from scripts.ilapfuncs import artifact_processor
 
 
 @artifact_processor
-def get_wifiHotspot(files_found, report_folder, seeker, wrap_text):
+def get_wifiHotspot(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/wifiProfiles.py
+++ b/scripts/artifacts/wifiProfiles.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_wifiProfiles": {
         "name": "wifiProfiles",
@@ -66,7 +65,8 @@ def _parse_xml(file_found):
 
 
 @artifact_processor
-def get_wifiProfiles(files_found, report_folder, seeker, wrap_text):
+def get_wifiProfiles(context):
+    files_found = context.get_files_found()
     data_list = []
     source_paths = []
     for file_found in files_found:

--- a/scripts/artifacts/wireMessenger.py
+++ b/scripts/artifacts/wireMessenger.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_wire_profile": {
         "name": "Wire User Profile",
@@ -142,7 +141,8 @@ def _run(source_path, sql):
 
 
 @artifact_processor
-def get_wire_profile(files_found, report_folder, seeker, wrap_text):
+def get_wire_profile(context):
+    files_found = context.get_files_found()
     source_path = _user_db(files_found)
     rows = _run(source_path, '''
         SELECT Users._id, Users.name, Users.email, Users.phone,
@@ -172,7 +172,8 @@ def get_wire_profile(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_wire_contacts(files_found, report_folder, seeker, wrap_text):
+def get_wire_contacts(context):
+    files_found = context.get_files_found()
     source_path = _user_db(files_found)
     rows = _run(source_path, '''
         SELECT Users._id, Users.name, Users.handle, Users.connection,
@@ -186,7 +187,8 @@ def get_wire_contacts(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_wire_messages(files_found, report_folder, seeker, wrap_text):
+def get_wire_messages(context):
+    files_found = context.get_files_found()
     source_path = _user_db(files_found)
     data_list = []
     for r in _run(source_path, MESSAGES_SQL):

--- a/scripts/artifacts/zepplife.py
+++ b/scripts/artifacts/zepplife.py
@@ -1,4 +1,4 @@
-# pylint: disable=E1121,W0613,W0718
+# pylint: disable=E1121,W0718
 __artifacts_v2__ = {
     "extract_zepplife_heartrate": {
         "name": "Zepp Life - Heart Rate",
@@ -19,7 +19,8 @@ from datetime import datetime, timezone
 from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
 @artifact_processor
-def extract_zepplife_heartrate(files_found, report_folder, seeker, wrap_text):
+def extract_zepplife_heartrate(context):
+    files_found = context.get_files_found()
     data_list = []
 
     origin = None


### PR DESCRIPTION
Batch 5 of the ALEAPP **4-arg → context** migration (batches 1–4 = #963/#964/#965/#966). **Completes the pure-swap bulk.**

**What:** remaining pure-signature-swap artifacts N–Z — **183 functions across 104 files** — to `def f(context):`. Docstring-safe; redundant `# pylint: disable=W0613` removed.

**Deferred to the specials batch:** `OneDrive_Metadata` (`seeker`), `smsmmsBackup` (`wrap_text`), `usagestats` (`report_folder`) — bodies use those params, so they need a `get_seeker()`/`get_report_folder()` hoist or `wrap_text` removal.

**Validation:** pylint `--disable=C,R` = **10.00** on all 104 files; `py_compile` clean; `PluginLoader` **585**; attribution/dates preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)