### PR TITLE
ALEAPP context-form migration — batch 6 (final): specials + tail (15 files)

### DIFF
--- a/scripts/artifacts/BashHistory.py
+++ b/scripts/artifacts/BashHistory.py
@@ -14,15 +14,15 @@ __artifacts_v2__ = {
     }
 }
 
-import codecs
-from scripts.ilapfuncs import logfunc, artifact_processor
+from scripts.ilapfuncs import artifact_processor
 
 @artifact_processor
-def bashHistory(files_found, report_folder, seeker, wrap_text):
+def bashHistory(context):
+    files_found = context.get_files_found()
     data_list = []
     file_found = str(files_found[0])
     counter = 1
-    with codecs.open(file_found, 'r', 'utf-8-sig') as csvfile:
+    with open(file_found, 'r', encoding='utf-8-sig') as csvfile:
         for row in csvfile:
             data_list.append((counter, row))
             counter += 1

--- a/scripts/artifacts/Deepseek_ChatInfo.py
+++ b/scripts/artifacts/Deepseek_ChatInfo.py
@@ -23,7 +23,8 @@ __artifacts_v2__ = {
 
 
 @artifact_processor
-def deepseek_chat_info(files_found, report_folder, seeker, wrap_text):
+def deepseek_chat_info(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ""
@@ -78,7 +79,7 @@ def deepseek_chat_info(files_found, report_folder, seeker, wrap_text):
                             tz=timezone.utc
                         ).strftime('%Y-%m-%d %H:%M:%S')
 
-                    except Exception:
+                    except Exception:  # pylint: disable=broad-exception-caught
 
                         updated_at_utc = str(updated_at)
 
@@ -89,7 +90,7 @@ def deepseek_chat_info(files_found, report_folder, seeker, wrap_text):
                     updated_at_utc
                 ))
 
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-exception-caught
             print(f"Error processing {source_path}: {e}")
 
         finally:

--- a/scripts/artifacts/Deepseek_UserInfo.py
+++ b/scripts/artifacts/Deepseek_UserInfo.py
@@ -21,7 +21,8 @@ __artifacts_v2__ = {
 
 
 @artifact_processor
-def deepseek_user_info(files_found, report_folder, seeker, wrap_text):
+def deepseek_user_info(context):
+    files_found = context.get_files_found()
 
     data_list = []
     source_path = ""
@@ -65,7 +66,7 @@ def deepseek_user_info(files_found, report_folder, seeker, wrap_text):
                     mobile_number
                 ))
 
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-exception-caught
             print(f"Error processing {source_path}: {e}")
 
         finally:

--- a/scripts/artifacts/FacebookMessenger.py
+++ b/scripts/artifacts/FacebookMessenger.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_fb_user_id": {
         "name": "Facebook Messenger - User ID",
@@ -186,7 +185,9 @@ def _q(cursor, sql):
 
 
 @artifact_processor
-def get_fb_user_id(files_found, report_folder, seeker, wrap_text):
+def get_fb_user_id(context):
+    files_found = context.get_files_found()
+    seeker = context.get_seeker()
     data_list = []
     source = ''
     for file_found in files_found:
@@ -209,7 +210,9 @@ def get_fb_user_id(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fb_msys_chats(files_found, report_folder, seeker, wrap_text):
+def get_fb_msys_chats(context):
+    files_found = context.get_files_found()
+    seeker = context.get_seeker()
     data_list = []
     source = ''
     for file_found in files_found:
@@ -279,7 +282,9 @@ def get_fb_msys_chats(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fb_msys_calls(files_found, report_folder, seeker, wrap_text):
+def get_fb_msys_calls(context):
+    files_found = context.get_files_found()
+    seeker = context.get_seeker()
     data_list = []
     source = ''
     for file_found in files_found:
@@ -315,7 +320,9 @@ def get_fb_msys_calls(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fb_msys_contacts(files_found, report_folder, seeker, wrap_text):
+def get_fb_msys_contacts(context):
+    files_found = context.get_files_found()
+    seeker = context.get_seeker()
     data_list = []
     source = ''
     for file_found in files_found:
@@ -353,7 +360,9 @@ def get_fb_msys_contacts(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fb_threads_chats(files_found, report_folder, seeker, wrap_text):
+def get_fb_threads_chats(context):
+    files_found = context.get_files_found()
+    seeker = context.get_seeker()
     data_list = []
     source = ''
     primary = '''
@@ -429,7 +438,9 @@ def get_fb_threads_chats(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fb_threads_calls(files_found, report_folder, seeker, wrap_text):
+def get_fb_threads_calls(context):
+    files_found = context.get_files_found()
+    seeker = context.get_seeker()
     data_list = []
     source = ''
     for file_found in files_found:
@@ -465,7 +476,9 @@ def get_fb_threads_calls(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_fb_threads_contacts(files_found, report_folder, seeker, wrap_text):
+def get_fb_threads_contacts(context):
+    files_found = context.get_files_found()
+    seeker = context.get_seeker()
     data_list = []
     source = ''
     for file_found in files_found:

--- a/scripts/artifacts/OneDrive_Metadata.py
+++ b/scripts/artifacts/OneDrive_Metadata.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_onedrive": {
         "name": "OneDrive Metadata",
@@ -74,7 +73,9 @@ def _build_preview(found_file, extension):
 
 
 @artifact_processor
-def get_onedrive(files_found, report_folder, seeker, wrap_text):
+def get_onedrive(context):
+    files_found = context.get_files_found()
+    seeker = context.get_seeker()
     data_list = []
     source = ''
 

--- a/scripts/artifacts/adb_hosts.py
+++ b/scripts/artifacts/adb_hosts.py
@@ -31,7 +31,8 @@ from scripts.ilapfuncs import artifact_processor, \
 
 
 @artifact_processor
-def adb_hosts(files_found, report_folder, seeker, wrap_text):
+def adb_hosts(context):
+    files_found = context.get_files_found()
     source_path = get_file_path(files_found, "adb_keys")
     data_list = []
     

--- a/scripts/artifacts/alexDeviceInfo.py
+++ b/scripts/artifacts/alexDeviceInfo.py
@@ -21,12 +21,13 @@ from scripts.ilapfuncs import artifact_processor, \
 
 
 @artifact_processor
-def alex_device_info(files_found, _report_folder, _seeker, _wrap_text):
+def alex_device_info(context):
+    files_found = context.get_files_found()
     source_path = get_file_path(files_found, "device_info_alex.json")
     data_list = []
     
     try:
-        with open(source_path) as info_file:
+        with open(source_path, encoding='utf-8') as info_file:
             info_data = json.load(info_file)
             info_data.pop(0)
             for pair in info_data:

--- a/scripts/artifacts/appicons.py
+++ b/scripts/artifacts/appicons.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0612,W0613,W0631
+# pylint: disable=W0612,W0631
 __artifacts_v2__ = {
     "appIcons": {
         "name": "App Icon",
@@ -36,7 +36,8 @@ class App:
         self.icons = {} # { Component: ('Label', icon, last_update), .. }
 
 @artifact_processor
-def appIcons(files_found, report_folder, seeker, wrap_text):
+def appIcons(context):
+    files_found = context.get_files_found()
     artifact_info = inspect.stack()[0]
     source_path = get_file_path(files_found, "app_icons.db", "mirror")
     data_list = []

--- a/scripts/artifacts/chromeCookies.py
+++ b/scripts/artifacts/chromeCookies.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_chromeCookies": {
         "name": "Cookies",
@@ -28,14 +27,14 @@ __artifacts_v2__ = {
 }
 
 import os
-import textwrap
 
 from scripts.ilapfuncs import logfunc, open_sqlite_db_readonly, artifact_processor, convert_human_ts_to_utc
 from scripts.artifacts.chrome import get_browser_name
 
 
 @artifact_processor
-def get_chromeCookies(files_found, report_folder, seeker, wrap_text):
+def get_chromeCookies(context):
+    files_found = context.get_files_found()
     all_data = []
 
     data_headers = ['Last Access Date', 'Host', 'Name', 'Value', 'Created Date', 'Expiration Date', 'Path']
@@ -102,10 +101,7 @@ def get_chromeCookies(files_found, report_folder, seeker, wrap_text):
 
             data_list = []
             for row in all_rows:
-                if wrap_text:
-                    data_list.append((convert_human_ts_to_utc(row[0]),row[1],(textwrap.fill(row[2], width=50)),row[3],convert_human_ts_to_utc(row[4]),convert_human_ts_to_utc(row[5]),row[6]))
-                else:
-                    data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],row[3],convert_human_ts_to_utc(row[4]),convert_human_ts_to_utc(row[5]),row[6]))
+                data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],row[3],convert_human_ts_to_utc(row[4]),convert_human_ts_to_utc(row[5]),row[6]))
 
             data_list = [row + (browser_name,) for row in data_list]
             all_data.extend(data_list)

--- a/scripts/artifacts/chromeOfflinePages.py
+++ b/scripts/artifacts/chromeOfflinePages.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_chromeOfflinePages": {
         "name": "Offline Pages",
@@ -28,14 +27,14 @@ __artifacts_v2__ = {
 }
 
 import os
-import textwrap
 
 from scripts.ilapfuncs import logfunc, open_sqlite_db_readonly, artifact_processor, convert_human_ts_to_utc
 from scripts.artifacts.chrome import get_browser_name
 
 
 @artifact_processor
-def get_chromeOfflinePages(files_found, report_folder, seeker, wrap_text):
+def get_chromeOfflinePages(context):
+    files_found = context.get_files_found()
     all_data = []
 
     data_headers = ['Creation Time', 'Last Access Time', 'Online URL', 'File Path', 'Title', 'Access Count', 'File Size']
@@ -76,10 +75,7 @@ def get_chromeOfflinePages(files_found, report_folder, seeker, wrap_text):
         if len(all_rows) > 0:
             data_list = []
             for row in all_rows:
-                if wrap_text:
-                    data_list.append((convert_human_ts_to_utc(row[0]),convert_human_ts_to_utc(row[1]),(textwrap.fill(row[2], width=75)),row[3],row[4],row[5],row[6]))
-                else:
-                    data_list.append((convert_human_ts_to_utc(row[0]),convert_human_ts_to_utc(row[1]),row[2],row[3],row[4],row[5],row[6]))
+                data_list.append((convert_human_ts_to_utc(row[0]),convert_human_ts_to_utc(row[1]),row[2],row[3],row[4],row[5],row[6]))
 
             data_list = [row + (browser_name,) for row in data_list]
             all_data.extend(data_list)

--- a/scripts/artifacts/contacts.py
+++ b/scripts/artifacts/contacts.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0611,W0612,W0613,W0718
+# pylint: disable=W0611,W0612,W0718
 __artifacts_v2__ = {
     "contacts": {
         "name": "Contacts",
@@ -33,7 +33,9 @@ import datetime
 from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, does_column_exist_in_db
 
 @artifact_processor
-def contacts(files_found, report_folder, seeker, wrap_text):
+def contacts(context):
+    files_found = context.get_files_found()
+    seeker = context.get_seeker()
 
     source_file = ''
     data_list = []

--- a/scripts/artifacts/etc_hosts.py
+++ b/scripts/artifacts/etc_hosts.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_etc_hosts": {
         "name": "Etc_hosts",
@@ -23,17 +22,17 @@ __artifacts_v2__ = {
     }
 }
 
-import codecs
 
 from scripts.ilapfuncs import artifact_processor
 
 
 @artifact_processor
-def get_etc_hosts(files_found, report_folder, seeker, wrap_text):
+def get_etc_hosts(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = str(files_found[0])
 
-    with codecs.open(source_path, 'r', 'utf-8-sig') as csvfile:
+    with open(source_path, 'r', encoding='utf-8-sig') as csvfile:
         for row in csvfile:
             sline = '\t'.join(row.split())
             sline = sline.split('\t')

--- a/scripts/artifacts/gmailEmails.py
+++ b/scripts/artifacts/gmailEmails.py
@@ -1,4 +1,4 @@
-# pylint: disable=W0613,W0631,W0612,W0622
+# pylint: disable=W0631,W0612,W0622
 __artifacts_v2__ = {
     "gmailEmails": {
         "name": "Gmail - App Emails",
@@ -82,7 +82,9 @@ from scripts.ilapfuncs import open_sqlite_db_readonly, check_in_media, get_sqlit
 from scripts.html_safe import safe_source
 
 @artifact_processor
-def gmailEmails(files_found, report_folder, seeker, wrap_text):
+def gmailEmails(context):
+    files_found = context.get_files_found()
+    seeker = context.get_seeker()
     bigTopDataDB = ''
     source_bigTop = ''
     
@@ -214,7 +216,9 @@ def gmailEmails(files_found, report_folder, seeker, wrap_text):
     return data_headers, data_list, 'See source file(s) below:'
 
 @artifact_processor      
-def gmailLabels(files_found, report_folder, seeker, wrap_text):
+def gmailLabels(context):
+    files_found = context.get_files_found()
+    seeker = context.get_seeker()
     bigTopDataDB = ''
     source_bigTop = ''
     
@@ -258,7 +262,9 @@ def gmailLabels(files_found, report_folder, seeker, wrap_text):
     return data_headers, data_list, 'See source file(s) below:'
       
 @artifact_processor        
-def gmailDownloadRequests(files_found, report_folder, seeker, wrap_text):
+def gmailDownloadRequests(context):
+    files_found = context.get_files_found()
+    seeker = context.get_seeker()
     downloaderDB = ''
     source_downloader = ''
     data_list = []

--- a/scripts/artifacts/smsmmsBackup.py
+++ b/scripts/artifacts/smsmmsBackup.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0613
 __artifacts_v2__ = {
     "get_mms_from_backup": {
         "name": "SMS and MMS Backup - MMS",
@@ -119,15 +118,14 @@ def _backup_files(files_found, suffix):
 
 
 @artifact_processor
-def get_mms_from_backup(files_found, report_folder, seeker, wrap_text):
+def get_mms_from_backup(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in _backup_files(files_found, 'mms_backup'):
         source_path = file_found
         for mms in read_messages_from_backup(file_found):
             body = mms.get('mms_body', '')
-            if wrap_text:
-                body = body.replace("\n", "")
             data_list.append((
                 ReadUnixTime(mms.get('date', 0)), ReadUnixTime(mms.get('date_sent', 0)),
                 mms.get('ct_l', ''), ', '.join(mms.get('recipients', [])), mms.get('sub', ''),
@@ -140,15 +138,14 @@ def get_mms_from_backup(files_found, report_folder, seeker, wrap_text):
 
 
 @artifact_processor
-def get_sms_from_backup(files_found, report_folder, seeker, wrap_text):
+def get_sms_from_backup(context):
+    files_found = context.get_files_found()
     data_list = []
     source_path = ''
     for file_found in _backup_files(files_found, 'sms_backup'):
         source_path = file_found
         for sms in read_messages_from_backup(file_found):
             body = sms.get('body', '')
-            if wrap_text:
-                body = body.replace("\n", "")
             data_list.append((
                 ReadUnixTimeMs(sms.get('date', 0)), ReadUnixTimeMs(sms.get('date_sent', 0)),
                 sms.get('read', ''), sms.get('type', ''), body,

--- a/scripts/artifacts/usagestats.py
+++ b/scripts/artifacts/usagestats.py
@@ -1,4 +1,4 @@
-# pylint: disable=E0606,E1101,W0311,W0613,W0702,W1309
+# pylint: disable=E0606,E1101,W0311,W0702,W1309
 __artifacts_v2__ = {
     "get_usagestats": {
         "name": "usagestats",
@@ -253,7 +253,8 @@ def AddEntriesToDb(sourced, file_name_int, stats, db):
     db.commit()
 
 @artifact_processor
-def get_usagestats(files_found, report_folder, seeker, wrap_text):
+def get_usagestats(context):
+    files_found = context.get_files_found()
 
     logfunc('Android Usagestats XML & Protobuf Parser')
 
@@ -279,7 +280,7 @@ def get_usagestats(files_found, report_folder, seeker, wrap_text):
                 if file_found.find('{0}mirror{0}'.format(slash)) >= 0:
                     continue
                 source = source or file_found
-                data_list.extend(process_usagestats(file_found, uid, report_folder, 1))
+                data_list.extend(process_usagestats(file_found, uid, 1))
             elif len(parts) > 3 and parts[-1] == 'usagestats' and parts[-3] == 'system_ce':
                 uid = parts[-2]
                 try:
@@ -293,7 +294,7 @@ def get_usagestats(files_found, report_folder, seeker, wrap_text):
                 if file_found.find('{0}mirror{0}'.format(slash)) >= 0:
                     continue
                 source = source or file_found
-                data_list.extend(process_usagestats(file_found, uid, report_folder, 2))
+                data_list.extend(process_usagestats(file_found, uid, 2))
 
     data_headers = ('User (UID)', ('Last Time Active', 'datetime'), 'Usage Type',
                     'Time Active in Msecs', 'Time Active in Secs',
@@ -464,7 +465,7 @@ def add_v2_usagestats_to_db(folder, db):
             except:
                 logfunc(f'Parse error - Error parsing Protobuf file: {filepath}')
 
-def process_usagestats(folder, uid, report_folder, version):
+def process_usagestats(folder, uid, version):
 
     # In-memory working database; the parsed rows are returned to the framework
     # for rendering as one consolidated table across all users.


### PR DESCRIPTION
**Final batch — completes the ALEAPP 4-arg → context migration.** After this, every `@artifact_processor` function in ALEAPP is on `def f(context)`, bringing ALEAPP to parity with iLEAPP/RLEAPP/VLEAPP (all now 100% context-form). Batches 1–5 = #963–#967.

**The 15-file tail (each needed per-file handling):**
- **seeker hoist** (`context.get_seeker()`): `contacts`, `gmailEmails`, `OneDrive_Metadata`, `FacebookMessenger` (7 funcs)
- **report_folder**: `usagestats` — the plumbing was **dead** (the helper never used it), so removed the param from the helper + both call sites
- **wrap_text branch removal** (LAVA handles display): `chromeCookies`, `chromeOfflinePages` (+ dropped unused `textwrap` import), `smsmmsBackup`
- **appicons**: pure swap (the `seeker`/`report_folder` refs were only in comments)
- **CRLF files** the bulk regex skipped: `BashHistory`, `adb_hosts`
- **Pre-existing lint debt** fixed in touched files (ALEAPP CI re-lints the whole file): broad-except → inline `disable=broad-exception-caught` (Deepseek ×2); deprecated `codecs.open` → `open(encoding=)` (`etc_hosts`, `BashHistory`); missing `encoding=` (`alexDeviceInfo`); unused import (`BashHistory`)

**Validation:** pylint `--disable=C,R` = **10.00** on all 15; `py_compile` clean; `PluginLoader` **585**; **repo-wide audit = 0 non-context functions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)