### PR TITLE
Add Mister Skinnylegs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ polyline==2.0.0
 protobuf==3.10.0
 PyCryptodome
 pytz
-mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.16
+mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.17
 simplekml
 wheel
 xlsxwriter==3.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ polyline==2.0.0
 protobuf==3.10.0
 PyCryptodome
 pytz
-mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.17
+mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18
 simplekml
 wheel
 xlsxwriter==3.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ polyline==2.0.0
 protobuf==3.10.0
 PyCryptodome
 pytz
+mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.16
 simplekml
 wheel
 xlsxwriter==3.1.1

--- a/scripts/artifacts/browserArtifactsViaMisterSkinnylegs.py
+++ b/scripts/artifacts/browserArtifactsViaMisterSkinnylegs.py
@@ -66,7 +66,7 @@ class LeappArtifactStorageBinaryStream(ArtifactStorageBinaryStream):
         return self._stream.write(data)
 
     def close(self) -> None:
-        self._reference = check_in_embedded_media(self.source_file, self._stream.raw)
+        self._reference = check_in_embedded_media(self.source_file, self._stream.getvalue())
         self._stream.close()
 
     def get_file_location_reference(self) -> str:
@@ -91,7 +91,7 @@ class LeappArtifactStorageTextStream(ArtifactStorageTextStream):
         return self._stream.write(data)
 
     def close(self) -> None:
-        self._reference = check_in_embedded_media(self.source_file, self._stream.buffer)
+        self._reference = check_in_embedded_media(self.source_file, self._stream.getvalue().encode("utf-8"))
         self._stream.close()
 
     def get_file_location_reference(self) -> str:

--- a/scripts/artifacts/browserArtifactsViaMisterSkinnylegs.py
+++ b/scripts/artifacts/browserArtifactsViaMisterSkinnylegs.py
@@ -1,3 +1,223 @@
+__artifacts_v2__ = {'binance_user_details_msl_plugin': {'name': 'Browser Data - Binance User Details (Mister Skinnylegs)',
+                                                        'description': 'Recovers Binance User Details records from the Cache',
+                                                        'author': 'Mister Skinnylegs Contributors',
+                                                        'creation_date': '2026-07-16', 'last_update_date': '2026-07-16',
+                                                        'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                                                        'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                                                        'output_types': ['html', 'lava', 'tsv'],
+                                                        'artifact_icon': 'globe'},
+                    'binance_balances_msl_plugin': {'name': 'Browser Data - Binance Balances (Mister Skinnylegs)',
+                                                    'description': 'Recovers Binance Balance records from the Cache',
+                                                    'author': 'Mister Skinnylegs Contributors',
+                                                    'creation_date': '2026-07-16', 'last_update_date': '2026-07-16',
+                                                    'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                                                    'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                                                    'output_types': ['html', 'lava', 'tsv'], 'artifact_icon': 'globe'},
+                    'bing_searches_msl_plugin': {'name': 'Browser Data - Bing searches (Mister Skinnylegs)',
+                                                 'description': 'Recovers Bing searches from URLs in history, cache',
+                                                 'author': 'Mister Skinnylegs Contributors',
+                                                 'creation_date': '2026-07-16', 'last_update_date': '2026-07-16',
+                                                 'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                                                 'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                                                 'output_types': ['html', 'lava', 'tsv'], 'artifact_icon': 'globe'},
+                    'chatgpt_chat_information_msl_plugin': {
+                        'name': 'Browser Data - ChatGPT Chat Information (Mister Skinnylegs)',
+                        'description': 'Recovers ChatGPT chat information from History and Cache',
+                        'author': 'Mister Skinnylegs Contributors', 'creation_date': '2026-07-16',
+                        'last_update_date': '2026-07-16',
+                        'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                        'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                        'output_types': ['html', 'lava', 'tsv'], 'artifact_icon': 'globe'},
+                    'chatgpt_user_information_msl_plugin': {
+                        'name': 'Browser Data - ChatGPT User Information (Mister Skinnylegs)',
+                        'description': 'Recovers ChatGPT user information from Cache',
+                        'author': 'Mister Skinnylegs Contributors', 'creation_date': '2026-07-16',
+                        'last_update_date': '2026-07-16',
+                        'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                        'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                        'output_types': ['html', 'lava', 'tsv'], 'artifact_icon': 'globe'},
+                    'coinbase_payment_methods_msl_plugin': {
+                        'name': 'Browser Data - Coinbase Payment Methods (Mister Skinnylegs)',
+                        'description': 'Recovers Coinbase Payement Methods records from the Cache',
+                        'author': 'Mister Skinnylegs Contributors', 'creation_date': '2026-07-16',
+                        'last_update_date': '2026-07-16',
+                        'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                        'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                        'output_types': ['html', 'lava', 'tsv'], 'artifact_icon': 'globe'},
+                    'coinbase_user_details_msl_plugin': {'name': 'Browser Data - Coinbase User Details (Mister Skinnylegs)',
+                                                         'description': 'Recovers Coinbase User Details records from the Cache',
+                                                         'author': 'Mister Skinnylegs Contributors',
+                                                         'creation_date': '2026-07-16',
+                                                         'last_update_date': '2026-07-16',
+                                                         'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                                                         'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                                                         'output_types': ['html', 'lava', 'tsv'],
+                                                         'artifact_icon': 'globe'},
+                    'coinbase_balances_msl_plugin': {'name': 'Browser Data - Coinbase Balances (Mister Skinnylegs)',
+                                                     'description': 'Recovers Coinbase Balances records from the Cache',
+                                                     'author': 'Mister Skinnylegs Contributors',
+                                                     'creation_date': '2026-07-16', 'last_update_date': '2026-07-16',
+                                                     'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                                                     'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                                                     'output_types': ['html', 'lava', 'tsv'], 'artifact_icon': 'globe'},
+                    'coinbase_transactions_msl_plugin': {'name': 'Browser Data - Coinbase Transactions (Mister Skinnylegs)',
+                                                         'description': 'Recovers Coinbase Transactions from the Cache',
+                                                         'author': 'Mister Skinnylegs Contributors',
+                                                         'creation_date': '2026-07-16',
+                                                         'last_update_date': '2026-07-16',
+                                                         'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                                                         'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                                                         'output_types': ['html', 'lava', 'tsv'],
+                                                         'artifact_icon': 'globe'},
+                    'deepseek_user_information_msl_plugin': {
+                        'name': 'Browser Data - DeepSeek User Information (Mister Skinnylegs)',
+                        'description': 'Recovers DeepSeek user information from Cache',
+                        'author': 'Mister Skinnylegs Contributors', 'creation_date': '2026-07-16',
+                        'last_update_date': '2026-07-16',
+                        'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                        'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                        'output_types': ['html', 'lava', 'tsv'], 'artifact_icon': 'globe'},
+                    'deepseek_chat_session_information_msl_plugin': {
+                        'name': 'Browser Data - DeepSeek Chat Session Information (Mister Skinnylegs)',
+                        'description': 'Recovers DeepSeek Chat Session Information from Cache and History',
+                        'author': 'Mister Skinnylegs Contributors', 'creation_date': '2026-07-16',
+                        'last_update_date': '2026-07-16',
+                        'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                        'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                        'output_types': ['html', 'lava', 'tsv'], 'artifact_icon': 'globe'},
+                    'deepseek_chat_messages_msl_plugin': {
+                        'name': 'Browser Data - DeepSeek Chat Messages (Mister Skinnylegs)',
+                        'description': 'Recovers DeepSeek Chat Messages from Cache',
+                        'author': 'Mister Skinnylegs Contributors', 'creation_date': '2026-07-16',
+                        'last_update_date': '2026-07-16',
+                        'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                        'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                        'output_types': ['html', 'lava', 'tsv'], 'artifact_icon': 'globe'},
+                    'discord_chat_messages_msl_plugin': {'name': 'Browser Data - Discord Chat Messages (Mister Skinnylegs)',
+                                                         'description': 'Recovers Discord chat messages from the Cache',
+                                                         'author': 'Mister Skinnylegs Contributors',
+                                                         'creation_date': '2026-07-16',
+                                                         'last_update_date': '2026-07-16',
+                                                         'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                                                         'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                                                         'output_types': ['html', 'lava', 'tsv'],
+                                                         'artifact_icon': 'globe'},
+                    'dropbox_session_storage_user_activity_msl_plugin': {
+                        'name': 'Browser Data - Dropbox Session Storage User Activity (Mister Skinnylegs)',
+                        'description': "Recovers user activity from 'uxa' records in Session Storage",
+                        'author': 'Mister Skinnylegs Contributors', 'creation_date': '2026-07-16',
+                        'last_update_date': '2026-07-16',
+                        'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                        'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                        'output_types': ['html', 'lava', 'tsv'], 'artifact_icon': 'globe'},
+                    'dropbox_file_system_msl_plugin': {'name': 'Browser Data - Dropbox File System (Mister Skinnylegs)',
+                                                       'description': 'Recovers a partial file system from URLs in the history',
+                                                       'author': 'Mister Skinnylegs Contributors',
+                                                       'creation_date': '2026-07-16', 'last_update_date': '2026-07-16',
+                                                       'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                                                       'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                                                       'output_types': ['html', 'lava', 'tsv'],
+                                                       'artifact_icon': 'globe'},
+                    'dropbox_thumbnails_msl_plugin': {'name': 'Browser Data - Dropbox Thumbnails (Mister Skinnylegs)',
+                                                      'description': 'Recovers thumbnails for files stored in Dropbox',
+                                                      'author': 'Mister Skinnylegs Contributors',
+                                                      'creation_date': '2026-07-16', 'last_update_date': '2026-07-16',
+                                                      'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                                                      'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                                                      'output_types': ['html', 'lava', 'tsv'],
+                                                      'artifact_icon': 'globe'},
+                    'duckduckgo_searches_msl_plugin': {'name': 'Browser Data - Duckduckgo searches (Mister Skinnylegs)',
+                                                       'description': 'Recovers Duckduckgo searches from URLs in history, cache',
+                                                       'author': 'Mister Skinnylegs Contributors',
+                                                       'creation_date': '2026-07-16', 'last_update_date': '2026-07-16',
+                                                       'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                                                       'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                                                       'output_types': ['html', 'lava', 'tsv'],
+                                                       'artifact_icon': 'globe'},
+                    'google_drive_files_and_folders_msl_plugin': {
+                        'name': 'Browser Data - Google Drive Files and Folders (Mister Skinnylegs)',
+                        'description': 'Recovers Google Drive and Docs folder and file names (and urls) from history records',
+                        'author': 'Mister Skinnylegs Contributors', 'creation_date': '2026-07-16',
+                        'last_update_date': '2026-07-16',
+                        'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                        'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                        'output_types': ['html', 'lava', 'tsv'], 'artifact_icon': 'globe'},
+                    'google_drive_thumbnails_msl_plugin': {
+                        'name': 'Browser Data - Google Drive Thumbnails (Mister Skinnylegs)',
+                        'description': 'Recovers Google Drive thumbnails from the cache',
+                        'author': 'Mister Skinnylegs Contributors', 'creation_date': '2026-07-16',
+                        'last_update_date': '2026-07-16',
+                        'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                        'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                        'output_types': ['html', 'lava', 'tsv'], 'artifact_icon': 'globe'},
+                    'google_drive_usage_msl_plugin': {'name': 'Browser Data - Google Drive Usage (Mister Skinnylegs)',
+                                                      'description': 'Recovers indications of Google Drive usage',
+                                                      'author': 'Mister Skinnylegs Contributors',
+                                                      'creation_date': '2026-07-16', 'last_update_date': '2026-07-16',
+                                                      'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                                                      'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                                                      'output_types': ['html', 'lava', 'tsv'],
+                                                      'artifact_icon': 'globe'},
+                    'google_searches_msl_plugin': {'name': 'Browser Data - Google searches (Mister Skinnylegs)',
+                                                   'description': 'Recovers google searches from URLs in history, session storage, cache',
+                                                   'author': 'Mister Skinnylegs Contributors',
+                                                   'creation_date': '2026-07-16', 'last_update_date': '2026-07-16',
+                                                   'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                                                   'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                                                   'output_types': ['html', 'lava', 'tsv'], 'artifact_icon': 'globe'},
+                    'o365_sharepoint_recent_files_msl_plugin': {
+                        'name': 'Browser Data - O365-Sharepoint recent files (Mister Skinnylegs)',
+                        'description': 'Recovers recent files list and any thumbnails from API responses in the cache for Sharepoint and O365',
+                        'author': 'Mister Skinnylegs Contributors', 'creation_date': '2026-07-16',
+                        'last_update_date': '2026-07-16',
+                        'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                        'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                        'output_types': ['html', 'lava', 'tsv'], 'artifact_icon': 'globe'},
+                    'o365_sharepoint_user_activity_msl_plugin': {
+                        'name': 'Browser Data - O365-Sharepoint user activity (Mister Skinnylegs)',
+                        'description': 'Recovers artifacts related to user activity (viewing, editing, downloading, etc.) for Sharepoint and O365',
+                        'author': 'Mister Skinnylegs Contributors', 'creation_date': '2026-07-16',
+                        'last_update_date': '2026-07-16',
+                        'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                        'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                        'output_types': ['html', 'lava', 'tsv'], 'artifact_icon': 'globe'},
+                    'reddit_chat_messages_msl_plugin': {'name': 'Browser Data - Reddit Chat Messages (Mister Skinnylegs)',
+                                                        'description': 'Recovers Reddit chat messages from the Cache and IndexedDB',
+                                                        'author': 'Mister Skinnylegs Contributors',
+                                                        'creation_date': '2026-07-16', 'last_update_date': '2026-07-16',
+                                                        'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                                                        'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                                                        'output_types': ['html', 'lava', 'tsv'],
+                                                        'artifact_icon': 'globe'},
+                    'history_msl_plugin': {'name': 'Browser Data - History (Mister Skinnylegs)',
+                                           'description': 'Dumps History Records',
+                                           'author': 'Mister Skinnylegs Contributors', 'creation_date': '2026-07-16',
+                                           'last_update_date': '2026-07-16',
+                                           'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                                           'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                                           'output_types': ['html', 'lava', 'tsv'], 'artifact_icon': 'globe'},
+                    'downloads_msl_plugin': {'name': 'Browser Data - Downloads (Mister Skinnylegs)',
+                                             'description': 'Dumps Download Records',
+                                             'author': 'Mister Skinnylegs Contributors', 'creation_date': '2026-07-16',
+                                             'last_update_date': '2026-07-16',
+                                             'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                                             'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                                             'output_types': ['html', 'lava', 'tsv'], 'artifact_icon': 'globe'},
+                    'localstorage_msl_plugin': {'name': 'Browser Data - Localstorage (Mister Skinnylegs)',
+                                                'description': 'Dumps Localstorage Records',
+                                                'author': 'Mister Skinnylegs Contributors',
+                                                'creation_date': '2026-07-16', 'last_update_date': '2026-07-16',
+                                                'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                                                'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                                                'output_types': ['html', 'lava', 'tsv'], 'artifact_icon': 'globe'},
+                    'sessionstorage_msl_plugin': {'name': 'Browser Data - Sessionstorage (Mister Skinnylegs)',
+                                                  'description': 'Dumps Sessionstorage Records',
+                                                  'author': 'Mister Skinnylegs Contributors',
+                                                  'creation_date': '2026-07-16', 'last_update_date': '2026-07-16',
+                                                  'requirements': 'mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.18',
+                                                  'category': 'Browser Artifacts', 'paths': '*/Default/Web Data',
+                                                  'output_types': ['html', 'lava', 'tsv'], 'artifact_icon': 'globe'}}
+
 import io
 import pathlib
 import re
@@ -18,42 +238,35 @@ class ProfileFolderType:
 
 PROFILE_PATH_ROW_HEADER = "Profile Path"
 
-# Dynamically generate artifacts from Skinnylegs' plugins at runtime
-__artifacts_v2__ = {
-    skinny_plugin.name: {
-        "name": f"Mister Skinnylegs - {skinny_plugin.name}",  # adding the prefix as some artifacts are shadowed currently
-        "description": skinny_plugin.description,
-        "author": "Mister Skinnylegs Contributors",   # TODO, this should also be available in skinnylegs plugins
-        "creation_date": "2026-07-16",  # TODO, this should also be available in skinnylegs plugins
-        "last_update_date": "2026-07-16",  # TODO, this should also be available in skinnylegs plugins
-        "requirements": "mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.15",
-        "category": "Browser Artifacts",
-        "notes": "Plugin automatically generated from Mister Skinnylegs plugins",
-        # the path feels a bit general... but should get all the non-browser browser stuff - can make more specific if
-        #  required
-        "paths": "*/Default/Web Data",  # this is a good marker for any Chromium profile folder, but there may be others
-        "output_types": ["html", "lava", "tsv"],
-        "artifact_icon": "globe"
-    } for skinny_plugin, plugin_path in iter_plugins()
-}
+func_to_msl = {'binance_user_details_msl_plugin': 'Binance User Details',
+               'binance_balances_msl_plugin': 'Binance Balances', 'bing_searches_msl_plugin': 'Bing searches',
+               'chatgpt_chat_information_msl_plugin': 'ChatGPT Chat Information',
+               'chatgpt_user_information_msl_plugin': 'ChatGPT User Information',
+               'coinbase_payment_methods_msl_plugin': 'Coinbase Payment Methods',
+               'coinbase_user_details_msl_plugin': 'Coinbase User Details',
+               'coinbase_balances_msl_plugin': 'Coinbase Balances',
+               'coinbase_transactions_msl_plugin': 'Coinbase Transactions',
+               'deepseek_user_information_msl_plugin': 'DeepSeek User Information',
+               'deepseek_chat_session_information_msl_plugin': 'DeepSeek Chat Session Information',
+               'deepseek_chat_messages_msl_plugin': 'DeepSeek Chat Messages',
+               'discord_chat_messages_msl_plugin': 'Discord Chat Messages',
+               'dropbox_session_storage_user_activity_msl_plugin': 'Dropbox Session Storage User Activity',
+               'dropbox_file_system_msl_plugin': 'Dropbox File System',
+               'dropbox_thumbnails_msl_plugin': 'Dropbox Thumbnails',
+               'duckduckgo_searches_msl_plugin': 'Duckduckgo searches',
+               'google_drive_files_and_folders_msl_plugin': 'Google Drive Files and Folders',
+               'google_drive_thumbnails_msl_plugin': 'Google Drive Thumbnails',
+               'google_drive_usage_msl_plugin': 'Google Drive Usage', 'google_searches_msl_plugin': 'Google searches',
+               'o365_sharepoint_recent_files_msl_plugin': 'O365-Sharepoint recent files',
+               'o365_sharepoint_user_activity_msl_plugin': 'O365-Sharepoint user activity',
+               'reddit_chat_messages_msl_plugin': 'Reddit Chat Messages', 'history_msl_plugin': 'History',
+               'downloads_msl_plugin': 'Downloads', 'localstorage_msl_plugin': 'Localstorage',
+               'sessionstorage_msl_plugin': 'Sessionstorage'}
+
 
 _SPEC_LOOKUP = {
     skinny_plugin.name: skinny_plugin for skinny_plugin, _ in iter_plugins()
 }
-
-
-def __dir__():
-    return ["__artifacts_v2__"] + list(__artifacts_v2__.keys())
-
-
-def __getattr__(name):
-    if name in __artifacts_v2__:
-        return artifact_processor(
-            lambda context: process(name, context),
-            injected_globals=globals(),
-            injected_module_name=process.__module__,
-            injected_custom_func_name=name
-        )
 
 
 class LeappArtifactStorageBinaryStream(ArtifactStorageBinaryStream):
@@ -114,6 +327,146 @@ class LeappArtifactStorage(ArtifactStorage):
         return LeappArtifactStorageTextStream(source_file)
 
 
+@artifact_processor
+def binance_user_details_msl_plugin(context):
+    return process(func_to_msl["binance_user_details_msl_plugin"], context)
+
+
+@artifact_processor
+def binance_balances_msl_plugin(context):
+    return process(func_to_msl["binance_balances_msl_plugin"], context)
+
+
+@artifact_processor
+def bing_searches_msl_plugin(context):
+    return process(func_to_msl["bing_searches_msl_plugin"], context)
+
+
+@artifact_processor
+def chatgpt_chat_information_msl_plugin(context):
+    return process(func_to_msl["chatgpt_chat_information_msl_plugin"], context)
+
+
+@artifact_processor
+def chatgpt_user_information_msl_plugin(context):
+    return process(func_to_msl["chatgpt_user_information_msl_plugin"], context)
+
+
+@artifact_processor
+def coinbase_payment_methods_msl_plugin(context):
+    return process(func_to_msl["coinbase_payment_methods_msl_plugin"], context)
+
+
+@artifact_processor
+def coinbase_user_details_msl_plugin(context):
+    return process(func_to_msl["coinbase_user_details_msl_plugin"], context)
+
+
+@artifact_processor
+def coinbase_balances_msl_plugin(context):
+    return process(func_to_msl["coinbase_balances_msl_plugin"], context)
+
+
+@artifact_processor
+def coinbase_transactions_msl_plugin(context):
+    return process(func_to_msl["coinbase_transactions_msl_plugin"], context)
+
+
+@artifact_processor
+def deepseek_user_information_msl_plugin(context):
+    return process(func_to_msl["deepseek_user_information_msl_plugin"], context)
+
+
+@artifact_processor
+def deepseek_chat_session_information_msl_plugin(context):
+    return process(func_to_msl["deepseek_chat_session_information_msl_plugin"], context)
+
+
+@artifact_processor
+def deepseek_chat_messages_msl_plugin(context):
+    return process(func_to_msl["deepseek_chat_messages_msl_plugin"], context)
+
+
+@artifact_processor
+def discord_chat_messages_msl_plugin(context):
+    return process(func_to_msl["discord_chat_messages_msl_plugin"], context)
+
+
+@artifact_processor
+def dropbox_session_storage_user_activity_msl_plugin(context):
+    return process(func_to_msl["dropbox_session_storage_user_activity_msl_plugin"], context)
+
+
+@artifact_processor
+def dropbox_file_system_msl_plugin(context):
+    return process(func_to_msl["dropbox_file_system_msl_plugin"], context)
+
+
+@artifact_processor
+def dropbox_thumbnails_msl_plugin(context):
+    return process(func_to_msl["dropbox_thumbnails_msl_plugin"], context)
+
+
+@artifact_processor
+def duckduckgo_searches_msl_plugin(context):
+    return process(func_to_msl["duckduckgo_searches_msl_plugin"], context)
+
+
+@artifact_processor
+def google_drive_files_and_folders_msl_plugin(context):
+    return process(func_to_msl["google_drive_files_and_folders_msl_plugin"], context)
+
+
+@artifact_processor
+def google_drive_thumbnails_msl_plugin(context):
+    return process(func_to_msl["google_drive_thumbnails_msl_plugin"], context)
+
+
+@artifact_processor
+def google_drive_usage_msl_plugin(context):
+    return process(func_to_msl["google_drive_usage_msl_plugin"], context)
+
+
+@artifact_processor
+def google_searches_msl_plugin(context):
+    return process(func_to_msl["google_searches_msl_plugin"], context)
+
+
+@artifact_processor
+def o365_sharepoint_recent_files_msl_plugin(context):
+    return process(func_to_msl["o365_sharepoint_recent_files_msl_plugin"], context)
+
+
+@artifact_processor
+def o365_sharepoint_user_activity_msl_plugin(context):
+    return process(func_to_msl["o365_sharepoint_user_activity_msl_plugin"], context)
+
+
+@artifact_processor
+def reddit_chat_messages_msl_plugin(context):
+    return process(func_to_msl["reddit_chat_messages_msl_plugin"], context)
+
+
+@artifact_processor
+def history_msl_plugin(context):
+    return process(func_to_msl["history_msl_plugin"], context)
+
+
+@artifact_processor
+def downloads_msl_plugin(context):
+    return process(func_to_msl["downloads_msl_plugin"], context)
+
+
+@artifact_processor
+def localstorage_msl_plugin(context):
+    return process(func_to_msl["localstorage_msl_plugin"], context)
+
+
+@artifact_processor
+def sessionstorage_msl_plugin(context):
+    return process(func_to_msl["sessionstorage_msl_plugin"], context)
+
+
 def process(plugin_name: str, context: Context):
     data_headers = [PROFILE_PATH_ROW_HEADER]
     data_rows = []
@@ -124,7 +477,12 @@ def process(plugin_name: str, context: Context):
 
         # force the seeker to get what we need for processing
         rel_profile_path = context.get_relative_path(str(profile_folder))
-        seeker.search(str(pathlib.Path("*", rel_profile_path, "**")))
+        #seeker.search(str(pathlib.Path("*", rel_profile_path, "**")))
+        seeker.search(str(pathlib.Path("*", rel_profile_path, "Session Storage", "**")))
+        seeker.search(str(pathlib.Path("*", rel_profile_path, "Local Storage", "**")))
+        seeker.search(str(pathlib.Path("*", rel_profile_path, "IndexedDB", "**")))
+        seeker.search(str(pathlib.Path("*", rel_profile_path, "History")))
+        seeker.search(str(pathlib.Path("*", rel_profile_path, "IndexedDB", "shared_proto_db")))
 
         # We have to attempt to locate the cache folder as we don't know what app we're looking at
         # On modern devices they should be at:

--- a/scripts/artifacts/browserArtifactsViaMisterSkinnylegs.py
+++ b/scripts/artifacts/browserArtifactsViaMisterSkinnylegs.py
@@ -1,0 +1,224 @@
+import io
+import pathlib
+import enum
+import re
+import sqlite3
+
+import mister_skinnylegs.util.profile_folder_protocols
+from mister_skinnylegs import MisterSkinnylegs, iter_plugins, BrowserType
+from mister_skinnylegs.util import ArtifactStorage, ArtifactStorageBinaryStream, ArtifactStorageTextStream
+
+from scripts.ilapfuncs import artifact_processor, logfunc, check_in_media, check_in_embedded_media
+from scripts.context import Context
+
+
+class ProfileFolderType:
+    app_chrome = 1
+    webview = 2
+
+
+PROFILE_PATH_ROW_HEADER = "Profile Path"
+
+# Dynamically generate artifacts from Skinnylegs' plugins at runtime
+__artifacts_v2__ = {
+    skinny_plugin.name: {
+        "name": f"Mister Skinnylegs - {skinny_plugin.name}",  # adding the prefix as some artifacts are shadowed currently
+        "description": skinny_plugin.description,
+        "author": "Mister Skinnylegs Contributors",   # TODO, this should also be available in skinnylegs plugins
+        "creation_date": "2026-07-16",  # TODO, this should also be available in skinnylegs plugins
+        "last_update_date": "2026-07-16",  # TODO, this should also be available in skinnylegs plugins
+        "requirements": "mister_skinnylegs @ git+https://github.com/cclgroupltd/mister-skinnylegs.git@v0.0.15",
+        "category": "Browser Artifacts",
+        "notes": "Plugin automatically generated from Mister Skinnylegs plugins",
+        # the path feels a bit general... but should get all the non-browser browser stuff - can make more specific if
+        #  required
+        "paths": "*/Default/Web Data",  # this is a good marker for any Chromium profile folder, but there may be others
+        "output_types": ["html", "lava", "tsv"],
+        "artifact_icon": "globe"
+    } for skinny_plugin, plugin_path in iter_plugins()
+}
+
+_SPEC_LOOKUP = {
+    skinny_plugin.name: skinny_plugin for skinny_plugin, _ in iter_plugins()
+}
+
+
+def __dir__():
+    return ["__artifacts_v2__"] + list(__artifacts_v2__.keys())
+
+
+def __getattr__(name):
+    if name in __artifacts_v2__:
+        return artifact_processor(
+            lambda context: process(name, context),
+            injected_globals=globals(),
+            injected_module_name=process.__module__,
+            injected_custom_func_name=name
+        )
+
+
+class LeappArtifactStorageBinaryStream(ArtifactStorageBinaryStream):
+    def __init__(self, source_file: str):
+        super().__init__(source_file)
+        self._stream = io.BytesIO()
+        self._reference = None
+
+    def write(self, data: bytes) -> int:
+        return self._stream.write(data)
+
+    def close(self) -> None:
+        self._reference = check_in_embedded_media(self.source_file, self._stream.raw)
+        self._stream.close()
+
+    def get_file_location_reference(self) -> str:
+        if not self._reference:
+            raise ValueError("stream is not closed and completed")
+        return self._reference
+
+    def __enter__(self) -> "ArtifactStorageBinaryStream":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+
+class LeappArtifactStorageTextStream(ArtifactStorageTextStream):
+    def __init__(self, source_file: str):
+        super().__init__(source_file)
+        self._stream = io.StringIO()
+        self._reference = None
+
+    def write(self, data: str) -> int:
+        return self._stream.write(data)
+
+    def close(self) -> None:
+        self._reference = check_in_embedded_media(self.source_file, self._stream.buffer)
+        self._stream.close()
+
+    def get_file_location_reference(self) -> str:
+        if not self._reference:
+            raise ValueError("stream is not closed and completed")
+        return self._reference
+
+    def __enter__(self) -> "ArtifactStorageTextStream":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+
+class LeappArtifactStorage(ArtifactStorage):
+    def get_binary_stream(self, file_name: str, source_file: str) -> ArtifactStorageBinaryStream:
+        return LeappArtifactStorageBinaryStream(source_file)
+
+    def get_text_stream(self, file_name: str, source_file: str) -> ArtifactStorageTextStream:
+        return LeappArtifactStorageTextStream(source_file)
+
+
+def process(plugin_name: str, context: Context):
+    data_headers = [PROFILE_PATH_ROW_HEADER]
+    data_rows = []
+    source_files = []
+    seeker = context.get_seeker()
+    for hit_path in context.get_files_found():
+        profile_folder = pathlib.Path(hit_path).parent
+
+        # force the seeker to get what we need for processing
+        rel_profile_path = context.get_relative_path(str(profile_folder))
+        seeker.search(str(pathlib.Path("*", rel_profile_path, "**")))
+
+        # We have to attempt to locate the cache folder as we don't know what app we're looking at
+        # On modern devices they should be at:
+        #   <package folder>/cache/Cache/Cache_Data
+        #   <package folder>/cache/WebView/Default/HTTP Cache/Cache_Data
+        # On older devices they will be at:
+        #  <package folder>/cache/Cache
+        #  <package folder>/cache/WebView/Default/HTTP Cache
+
+        path_parts = list(pathlib.Path(rel_profile_path).parts)
+        profile_folder_type = None
+        while path_parts:
+            part = path_parts.pop()
+            if part == "app_chrome":
+                profile_folder_type = ProfileFolderType.app_chrome
+                break
+            elif re.match(r"^app_\w*webview", part):
+                profile_folder_type = ProfileFolderType.webview
+                break
+
+        package_path_hopefully = pathlib.Path(*path_parts)
+        cache_path = None
+        cache_rel_path = None
+        if profile_folder_type is None:
+            logfunc(f"Couldn't determine a browser profile folder type for {rel_profile_path}")
+        else:
+            # Try Modern location first
+            if profile_folder_type == ProfileFolderType.app_chrome:
+                cache_rel_path = package_path_hopefully / "cache" / "Cache" / "Cache_Data"
+            elif profile_folder_type == ProfileFolderType.webview:
+                cache_rel_path = package_path_hopefully / "cache" / "WebView" / "Default" / "HTTP Cache" / "Cache_Data"
+
+            dir_set = {pathlib.Path(x).parent for x in seeker.search(str("*" / cache_rel_path / "*")) if pathlib.Path(x).is_file()}
+            for d in dir_set:
+                if d.name == "Cache_Data":
+                    cache_path = d
+                    break
+
+            if not cache_path:
+                # Try legacy location
+                if profile_folder_type == ProfileFolderType.app_chrome:
+                    cache_rel_path = package_path_hopefully / "cache" / "Cache"
+                elif profile_folder_type == ProfileFolderType.webview:
+                    cache_rel_path = package_path_hopefully / "cache" / "WebView" / "Default" / "HTTP Cache"
+
+                dir_set = {pathlib.Path(x).parent for x in seeker.search(str("*" / cache_rel_path / "*")) if
+                           pathlib.Path(x).is_file()}
+                for d in dir_set:
+                    if ((profile_folder_type == ProfileFolderType.app_chrome and  d.name == "Cache")
+                            or (profile_folder_type == ProfileFolderType.webview and d.name == "HTTP Cache")):
+                        cache_path = d
+                        break
+
+        spec = _SPEC_LOOKUP[plugin_name]
+        context.get_output_params()
+        try:
+            result = MisterSkinnylegs.run_plugin_on_path(
+                spec=spec,
+                profile_path=profile_folder,
+                cache_path=cache_path,
+                browser_type=BrowserType.chromium,
+                storage=LeappArtifactStorage(),
+                log_callback=logfunc)
+        except (sqlite3.Error, ValueError) as ex:
+            logfunc(f"Error from {spec.name} running against {rel_profile_path}: {ex}, skipping")
+            continue
+
+        if not result.result:
+            continue
+
+        if not isinstance(result.result, list):
+            raise ValueError("Can't deal with non-list results currently - contact mister_skinnylegs devs")
+
+        for o in result.result:
+            if not isinstance(o, dict):
+                raise ValueError(
+                    "Can't deal with anything but dictionaries results currently - contact mister_skinnylegs devs")
+
+            for k in o.keys():
+                if k not in data_headers:
+                    if k in (spec.media_field_names or []):
+                        data_headers.append(("Media", k))
+                    else:
+                        data_headers.append(k)
+
+            o[PROFILE_PATH_ROW_HEADER] = rel_profile_path  # add the profile path in for reporting
+            row = tuple(
+                o[k].friendly_string
+                if isinstance(o[k], mister_skinnylegs.util.profile_folder_protocols.ArtifactLocationProtocol)
+                else o[k]
+                for k in data_headers)
+            data_rows.append(row)
+            source_files.append(profile_folder)
+
+    return data_headers, data_rows, ", ".join(str(x) for x in source_files)
+

--- a/scripts/artifacts/browserArtifactsViaMisterSkinnylegs.py
+++ b/scripts/artifacts/browserArtifactsViaMisterSkinnylegs.py
@@ -1,6 +1,5 @@
 import io
 import pathlib
-import enum
 import re
 import sqlite3
 
@@ -8,7 +7,7 @@ import mister_skinnylegs.util.profile_folder_protocols
 from mister_skinnylegs import MisterSkinnylegs, iter_plugins, BrowserType
 from mister_skinnylegs.util import ArtifactStorage, ArtifactStorageBinaryStream, ArtifactStorageTextStream
 
-from scripts.ilapfuncs import artifact_processor, logfunc, check_in_media, check_in_embedded_media
+from scripts.ilapfuncs import artifact_processor, logfunc, check_in_embedded_media
 from scripts.context import Context
 
 

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -433,15 +433,14 @@ def get_data_list_with_media(media_header_info, data_list):
     return html_data_list, txt_data_list
 
 
-def artifact_processor(func, *, injected_globals=None, injected_module_name=None, injected_custom_func_name=None):
+def artifact_processor(func):
     @wraps(func)
     def wrapper(files_found, report_folder, seeker, wrap_text):
-        module_name = injected_module_name or func.__module__.split('.')[-1]
-        func_name = injected_custom_func_name or func.__name__
+        module_name = func.__module__.split('.')[-1]
+        func_name = func.__name__
         module_file_path = inspect.getfile(func)
 
-        all_artifacts_info = (injected_globals.get('__artifacts_v2__', {}) if injected_globals
-                              else func.__globals__.get('__artifacts_v2__', {}))
+        all_artifacts_info = func.__globals__.get('__artifacts_v2__', {})
         artifact_info = all_artifacts_info.get(func_name, {})
 
         artifact_name = artifact_info.get('name', func_name)
@@ -479,7 +478,7 @@ def artifact_processor(func, *, injected_globals=None, injected_module_name=None
                 data_list, html_data_list = data_list
             else:
                 html_data_list = data_list
-            logfunc(f"Found {len(data_list):,} {'records' if len(data_list)>1 else 'record'} for {artifact_name}")
+            logfunc(f"Found {len(data_list):,} {'records' if len(data_list) > 1 else 'record'} for {artifact_name}")
             icons.setdefault(category, {artifact_name: icon}).update({artifact_name: icon})
 
             # Strip tuples from headers for HTML, TSV, and timeline
@@ -495,14 +494,16 @@ def artifact_processor(func, *, injected_globals=None, injected_module_name=None
                 report = artifact_report.ArtifactHtmlReport(artifact_name)
                 report.start_artifact_report(report_folder, artifact_name, description)
                 report.add_script()
-                report.write_artifact_data_table(stripped_headers, html_data_list, source_path, html_no_escape=html_columns)
+                report.write_artifact_data_table(stripped_headers, html_data_list, source_path,
+                                                 html_no_escape=html_columns)
                 report.end_artifact_report()
 
             if check_output_types('tsv', output_types):
                 tsv(report_folder, stripped_headers, txt_data_list if media_header_info else data_list, artifact_name)
 
             if check_output_types('timeline', output_types):
-                timeline(report_folder, artifact_name, txt_data_list if media_header_info else data_list, stripped_headers)
+                timeline(report_folder, artifact_name, txt_data_list if media_header_info else data_list,
+                         stripped_headers)
 
             if check_output_types('lava', output_types):
                 table_name, object_columns, column_map = lava_process_artifact(category,
@@ -511,19 +512,22 @@ def artifact_processor(func, *, injected_globals=None, injected_module_name=None
                                                                                data_headers,
                                                                                len(data_list),
                                                                                func_name=func_name,
-                                                                               data_views=artifact_info.get("data_views"),
+                                                                               data_views=artifact_info.get(
+                                                                                   "data_views"),
                                                                                artifact_icon=icon,
                                                                                source_path=source_path)
                 lava_insert_sqlite_data(table_name, data_list, object_columns, data_headers, column_map)
 
             if check_output_types('kml', output_types):
-                kmlgen(report_folder, artifact_name, txt_data_list if media_header_info else data_list, stripped_headers)
+                kmlgen(report_folder, artifact_name, txt_data_list if media_header_info else data_list,
+                       stripped_headers)
 
         else:
             if output_types != 'none':
                 logfunc(f"No data found for {artifact_name}")
-        
+
         return data_headers, data_list, source_path
+
     return wrapper
 
 

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -432,14 +432,16 @@ def get_data_list_with_media(media_header_info, data_list):
 
     return html_data_list, txt_data_list
 
-def artifact_processor(func):
+
+def artifact_processor(func, *, injected_globals=None, injected_module_name=None, injected_custom_func_name=None):
     @wraps(func)
     def wrapper(files_found, report_folder, seeker, wrap_text):
-        module_name = func.__module__.split('.')[-1]
-        func_name = func.__name__
+        module_name = injected_module_name or func.__module__.split('.')[-1]
+        func_name = injected_custom_func_name or func.__name__
         module_file_path = inspect.getfile(func)
 
-        all_artifacts_info = func.__globals__.get('__artifacts_v2__', {})
+        all_artifacts_info = (injected_globals.get('__artifacts_v2__', {}) if injected_globals
+                              else func.__globals__.get('__artifacts_v2__', {}))
         artifact_info = all_artifacts_info.get(func_name, {})
 
         artifact_name = artifact_info.get('name', func_name)


### PR DESCRIPTION
This PR integrates our tool Mister Skinnylegs into ALEAPP to provide parsing of website artifacts from Chromium based browsers and browser components in extractions (Mozilla support can also be added).

Skinnylegs, like the LEAPPS  is a plugin-based architecture so I have built a sub-plugin loader which dynamically builds LEAPP artifacts at runtime, so ALEAPP should only need to update the version of Skinnylegs it is targeting to automatically get those plugins. There have been quite a lot of changes in Skinnylegs and our upstream browser modules in order to make things LEAPPable, but they forced my hand to make positive changes anyway!

In order to achieve dynamic loading, I did have to make a small, non-breaking change to artifact_processor to allow LEAPP plugins working in this way to inject globals, module and function name, as it was only seeing the lambda and none of the module attributes. (It would, theortically I think, be possible to achieve this by AST but I think that's likely to be a little arcane for a lot of contributors' tastes...).

I have added a new dependency for mister_skinnylegs, which I've pinned to a specific release. This implicitly also introduces upstream dependencies for some of our libraries, which does duplicate some of the modules in the "scripts/ccl" (everything but FCM, I think). I don't believe this will cause any collisions because of how they are currently being imported, but in future, assuming that there aren't massive changes to the LEAPP version of those modules, it might make sense to consolidate those.