### PR TITLE
chore: bump Pillow 12.1.1 -> 12.3.0 for July 2026 security fixes

### DIFF
--- a/admin/test/scripts/test_runtime_requirements.py
+++ b/admin/test/scripts/test_runtime_requirements.py
@@ -13,7 +13,7 @@ class TestRuntimeRequirements(unittest.TestCase):
     def test_requirements_pin_latest_pillow(self):
         requirement_lines = (REPO_ROOT / "requirements.txt").read_text(encoding="utf-8").splitlines()
         pillow_lines = [line.strip() for line in requirement_lines if line.strip().lower().startswith("pillow")]
-        self.assertEqual(pillow_lines, ["pillow==12.1.1"])
+        self.assertEqual(pillow_lines, ["pillow==12.3.0"])
 
     def test_runtime_contract_workflow_covers_python_3_10_and_3_11(self):
         workflow_path = REPO_ROOT / ".github" / "workflows" / "python_runtime_contract.yml"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ fitdecode==0.10.0
 folium==0.14.0
 geopy==2.3.0
 packaging==20.1
-pillow==12.1.1
+pillow==12.3.0
 polyline==2.0.0
 protobuf==3.10.0
 PyCryptodome


### PR DESCRIPTION
## What

Bump Pillow `12.1.1` → `12.3.0` (the current latest) to close the coordinated **July 2026 Pillow security advisory batch** flagged by Dependabot.

## Why it matters for ALEAPP

ALEAPP calls `Image.open()` on image files taken straight from the extraction — untrusted, potentially attacker-influenced evidence — to build thumbnails and read EXIF (`samsung_honeyboard_clipboard`, `torThumbs`, `chatgpt`, `vlcthumbsADB`, `OrnetBrowser`, `hikvision`, etc.). Several of the fixed CVEs are heap out-of-bounds **writes** triggered *during image parsing*, so they sit directly on ALEAPP's attack surface (an examiner opening a case containing a crafted image).

Fixed in 12.3.0 (highlights): `Image.paste()` OOB write (CVE-2026-59199), `ImageCmsTransform` OOB write (CVE-2026-59205), `RankFilter` OOB write (CVE-2026-59197), McIdas OOB read (CVE-2026-54058), plus JPEG2000/EPS/PDF DoS and FontFile/GdImageFile decompression-bomb fixes.

## Compatibility

Low risk. The only backwards-incompatible change in 12.3.0 is removal of TGA 1-mode run-length encoding **on save**, which ALEAPP never does. None of the APIs ALEAPP uses changed (`Image.open`, `resize`, `convert`, `ImageDraw`, `ImageFont.load_default`, `ImageTk`, `UnidentifiedImageError`). Python 3.10–3.14 support unchanged.

## Verification

- `admin/test/scripts/test_dependency_compatibility.py` — **6/6 pass** (Pillow smoke test, `ImageTk` import, full plugin-loader import of all artifact modules, CLI `--help`).
- Targeted smoke test of ALEAPP's real Pillow paths — `ImageDraw`+`ImageFont.load_default(size=)`, `Image.open().resize()`, `UnidentifiedImageError` on junk — all OK.
- **Real corpus run** (Samsung S20 FFS, full extraction, all 585 artifacts): genuine parse (SMS/calls/contacts/accounts/installed-apps populated), every Pillow-dependent artifact ran, and **400 real extracted media files round-tripped through the ALEAPP thumbnail path (`open`→`verify`→`load`→`convert`→`thumbnail`) with 0 failures** (dims 4×5 up to 3375×2400). Zero tracebacks, zero PIL errors across the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
