### PR TITLE
fix: support renamed directory_path column in Firefox downloads

### DIFF
--- a/scripts/artifacts/firefoxDownloads.py
+++ b/scripts/artifacts/firefoxDownloads.py
@@ -1,14 +1,15 @@
 __artifacts_v2__ = {
     "get_firefoxDownloads": {
         "name": "Firefox - Downloads",
-        "description": "Parses Firefox downloads (created time, file name, URL, MIME type, size, status and destination) from the mozac downloads database.",
+        "description": "Parses Firefox downloads (created time, file name, URL, MIME type, size, status and destination) from the mozac downloads database. Also matches Tor Browser, which is Firefox-based and uses the same database.",
         "author": "",
         "creation_date": "2022-01-12",
-        "last_update_date": "2022-01-12",
+        "last_update_date": "2026-07-25",
+        "notes": "Newer Firefox versions renamed the destination_directory column to directory_path; both schemas are supported.",
         "requirements": "none",
         "category": "Firefox",
-        "notes": "",
-        "paths": ('*/org.mozilla.firefox/databases/mozac_downloads_database*',),
+        "paths": ('*/org.mozilla.firefox/databases/mozac_downloads_database*',
+                  '*/org.torproject.torbrowser/databases/mozac_downloads_database*'),
         "output_types": "standard",
         "artifact_icon": "globe",
         "sample_data": {
@@ -35,7 +36,12 @@ def get_firefoxDownloads(context):
         source_path = file_found
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
-        cursor.execute('''
+
+        # Newer Firefox versions renamed destination_directory to directory_path
+        table_columns = [row[1] for row in cursor.execute('PRAGMA table_info(downloads)')]
+        directory_column = 'directory_path' if 'directory_path' in table_columns else 'destination_directory'
+
+        cursor.execute(f'''
         SELECT
         datetime(created_at/1000,'unixepoch') AS CreatedDate,
         file_name AS FileName,
@@ -48,7 +54,7 @@ def get_firefoxDownloads(context):
             WHEN 5 THEN 'Failed'
             WHEN 6 THEN 'Finished'
         END AS Status,
-        destination_directory AS DestDir
+        {directory_column} AS DestDir
         FROM downloads
         ''')
 


### PR DESCRIPTION
Fixes #981.

Newer Firefox versions (confirmed on 153 by the reporter) renamed the `downloads` table's `destination_directory` column to `directory_path`, which crashed `firefoxDownloads.py` with `no such column`. The artifact now detects the actual column via `PRAGMA table_info` and queries whichever schema is present. Output headers are unchanged.

Also adds `org.torproject.torbrowser` to the path glob: Tor Browser is Firefox-based and carries the identical mozac downloads database, but was previously invisible to this artifact (two of the three corpus images with this database are Tor Browser).

Tested:
- Synthetic new-schema database: 2 rows parsed (crashed before this fix)
- Synthetic old-schema database via the Tor Browser glob: 1 row parsed
- Real old-schema database from an Android 14 corpus image: clean no-data result, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)