### PR TITLE
fix: Rema 1000 fails to import on Python 3.10 and 3.11

### DIFF
--- a/scripts/artifacts/rema_1000.py
+++ b/scripts/artifacts/rema_1000.py
@@ -89,8 +89,11 @@ def rema1000_receipt_prettified(context):
         for index, item in enumerate(list_receipt):
             if item is None:
                 list_receipt[index] = "None"
-        prettified_list[0] = f"{datetime.fromtimestamp(list_receipt[0]/1000,
-                                                       tz=ZoneInfo('Europe/Copenhagen')).strftime('%Y-%m-%d %H:%M:%S')}"
+        # Built outside the f-string: a newline inside the replacement field is PEP 701
+        # syntax, which only parses on Python 3.12+, and ALEAPP still supports 3.10.
+        payment_date = datetime.fromtimestamp(
+            list_receipt[0] / 1000, tz=ZoneInfo('Europe/Copenhagen'))
+        prettified_list[0] = payment_date.strftime('%Y-%m-%d %H:%M:%S')
         prettified_list[1] = f"{list_receipt[3].split(';')[1].capitalize()}, {list_receipt[4]}, "\
             f"{list_receipt[3].split(';')[2].capitalize()}"
         split_items = [item.translate(translation_table) for item in list_receipt[3].split(";")[3:]]


### PR DESCRIPTION
## Problem

`scripts/artifacts/rema_1000.py` formats the receipt timestamp with an f-string whose replacement field spans two lines:

```python
prettified_list[0] = f"{datetime.fromtimestamp(list_receipt[0]/1000,
                                               tz=ZoneInfo('Europe/Copenhagen')).strftime('%Y-%m-%d %H:%M:%S')}"
```

A newline inside a replacement field is PEP 701 syntax, accepted only from **Python 3.12**. On 3.10 and 3.11 it raises `SyntaxError: unterminated string literal (detected at line 92)`, so the module cannot be imported at all — the Rema 1000 artifact silently disappears from the run on those versions.

This currently fails `runtime-contract (3.10)`, `runtime-contract (3.11)` and `windows-smoke`. It landed in 85affb3 (2026-07-24); `python_runtime_contract.yml` only runs on pull requests and had not run since April, so it was not caught at merge time.

## Fix

Build the datetime before formatting it. No f-string spans lines any more, so the module parses on every supported version.

## Verification

- The formatted output is byte-identical: `'2023-07-22 06:26:40'` from both the old and new expression for the same input.
- The module imports cleanly, and pylint reports zero warnings on the file.
- A token-level scan of every `.py` in `scripts/` confirms this was the **only** genuine occurrence in the repo. Backslash-continued f-strings in `scripts/report.py` also span lines but are ordinary line continuations, legal in all versions, and are correctly left alone.

## Note

Only the syntax is changed here. The hardcoded `Europe/Copenhagen` timezone is pre-existing behaviour and left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Why this was not caught at merge time

`python_runtime_contract.yml` is path-filtered to `admin/test/scripts/**`, `requirements.txt`, `README.md` and its own workflow file. A change to `scripts/artifacts/**` therefore **cannot** trigger the very job that imports artifact modules on 3.10/3.11. That is why 85affb3 merged green.

It only surfaced because an unrelated PR (#983) added a file under `admin/test/scripts/`, which did trigger it.

Worth considering adding `scripts/**` to that workflow's path filter as a follow-up, so an artifact module change is checked by the job designed to check artifact modules.

## Check coverage on this PR

`runtime-contract` does not run here for the same path-filter reason. **`windows-smoke` is the proof**: it runs the same "import every artifact module" test on **Python 3.11**, it failed on #983 with exactly this `SyntaxError`, and it passes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)