### PR TITLE
feat: Signal for Android parser with SQLCipher decryption

### DIFF
--- a/scripts/artifacts/signalAndroid.py
+++ b/scripts/artifacts/signalAndroid.py
@@ -1,0 +1,413 @@
+__artifacts_v2__ = {
+    "get_signalMessages": {
+        "name": "Signal - Messages",
+        "description": "Parses messages from the encrypted Signal database, including sender, recipient, direction and body.",
+        "author": "Alexis Brignoni",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Signal",
+        "notes": "Requires the SQLCipher key from extra/Secrets/secrets.json, produced by the extraction tool. Without it the database cannot be read.",
+        "paths": ('*/org.thoughtcrime.securesms/databases/signal.db*',),
+        "output_types": "standard",
+        "artifact_icon": "message-circle",
+    },
+    "get_signalCalls": {
+        "name": "Signal - Calls",
+        "description": "Parses the Signal call log, including call type, direction and outcome.",
+        "author": "Alexis Brignoni",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Signal",
+        "notes": "Requires the SQLCipher key from extra/Secrets/secrets.json.",
+        "paths": ('*/org.thoughtcrime.securesms/databases/signal.db*',),
+        "output_types": "standard",
+        "artifact_icon": "phone",
+    },
+    "get_signalContacts": {
+        "name": "Signal - Contacts",
+        "description": "Parses Signal recipients, including phone numbers, ACI/PNI identifiers, usernames and profile names.",
+        "author": "Alexis Brignoni",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Signal",
+        "notes": "Requires the SQLCipher key from extra/Secrets/secrets.json.",
+        "paths": ('*/org.thoughtcrime.securesms/databases/signal.db*',),
+        "output_types": "standard",
+        "artifact_icon": "users",
+    },
+    "get_signalAttachments": {
+        "name": "Signal - Attachments",
+        "description": "Parses metadata for attachments referenced by Signal messages.",
+        "author": "Alexis Brignoni",
+        "creation_date": "2026-07-25",
+        "last_update_date": "2026-07-25",
+        "requirements": "none",
+        "category": "Signal",
+        "notes": "Attachment files on disk are separately encrypted with the modernKey from secrets.json; this artifact reports metadata only.",
+        "paths": ('*/org.thoughtcrime.securesms/databases/signal.db*',),
+        "output_types": "standard",
+        "artifact_icon": "paperclip",
+    },
+}
+
+import hashlib
+import json
+import os
+import sqlite3
+import tempfile
+
+from scripts.sqlcipher_decrypt import decrypt_sqlcipher_db
+from scripts.ilapfuncs import artifact_processor, logfunc, convert_unix_ts_to_utc
+
+SECRETS_GLOB = '*/Secrets/secrets.json'
+SIGNAL_PACKAGE = 'org.thoughtcrime.securesms'
+
+# Signal keys the database with the hex string as a passphrase and skips key
+# stretching (kdf_iter = 1) because the stored key is already random.
+SIGNAL_KDF_ITERATIONS = 1
+SIGNAL_PAGE_SIZE = 4096
+SIGNAL_HMAC = 'sha1'
+
+# MessageTypes.java base types (type & 0x1F)
+MESSAGE_BASE_TYPE_MASK = 0x1F
+MESSAGE_DIRECTIONS = {
+    20: 'Incoming',
+    21: 'Outgoing',
+    22: 'Outgoing',
+    23: 'Outgoing',
+    24: 'Outgoing',
+    27: 'Draft',
+}
+MESSAGE_STATUS = {21: 'Outbox', 22: 'Sending', 23: 'Sent', 24: 'Failed', 27: 'Draft'}
+
+RECIPIENT_TYPES = {0: 'Individual', 1: 'MMS', 2: 'Group', 3: 'Distribution list', 4: 'Call link'}
+CALL_TYPES = {0: 'Audio', 1: 'Video', 3: 'Group', 4: 'Ad hoc'}
+CALL_DIRECTIONS = {0: 'Incoming', 1: 'Outgoing'}
+CALL_EVENTS = {
+    0: 'Ongoing', 1: 'Accepted', 2: 'Not accepted', 3: 'Missed', 4: 'Deleted',
+    5: 'Generic group call', 6: 'Joined', 7: 'Ringing', 8: 'Declined',
+    9: 'Outgoing ring', 10: 'Missed (notification profile)',
+}
+
+# One decryption per database per run, shared by the artifacts in this module
+_decrypted_cache = {}
+
+
+def _read_signal_keys(secrets_path):
+    """Return (database_key, attachment_key) from an extraction secrets.json."""
+    database_key = attachment_key = None
+    try:
+        with open(secrets_path, 'r', encoding='utf-8') as secrets_file:
+            secrets = json.load(secrets_file)
+    except (OSError, ValueError) as error:
+        logfunc(f'Signal: could not read {secrets_path}: {error}')
+        return None, None
+
+    if not isinstance(secrets, list):
+        return None, None
+    for entry in secrets:
+        if not isinstance(entry, dict) or entry.get('app') != SIGNAL_PACKAGE:
+            continue
+        for item in entry.get('script_output', []):
+            payload = item.get('payload') if isinstance(item, dict) else None
+            if not isinstance(payload, dict):
+                continue
+            if payload.get('sqlite db key'):
+                database_key = payload['sqlite db key']
+            attachment = payload.get('signal attachment key')
+            if isinstance(attachment, dict) and attachment.get('modernKey'):
+                attachment_key = attachment['modernKey']
+    return database_key, attachment_key
+
+
+def _decrypted_database(context, database_path):
+    """Decrypt the Signal database once per run; return a path or None."""
+    if database_path in _decrypted_cache:
+        return _decrypted_cache[database_path]
+
+    _decrypted_cache[database_path] = None  # avoid retrying on later artifacts
+
+    seeker = context.get_seeker()
+    secrets_files = [str(path) for path in seeker.search(SECRETS_GLOB)
+                     if os.path.basename(str(path)) == 'secrets.json']
+    if not secrets_files:
+        logfunc('Signal: no Secrets/secrets.json found, the database stays encrypted')
+        return None
+
+    database_key = None
+    for secrets_path in secrets_files:
+        database_key, _ = _read_signal_keys(secrets_path)
+        if database_key:
+            break
+    if not database_key:
+        logfunc('Signal: secrets.json has no "sqlite db key" entry for Signal')
+        return None
+
+    digest = hashlib.sha1(database_path.encode('utf-8', 'replace')).hexdigest()[:12]
+    output_path = os.path.join(tempfile.gettempdir(), 'aleapp_signal', f'signal_{digest}.db')
+    try:
+        pages, verified = decrypt_sqlcipher_db(
+            database_path, database_key, output_path,
+            page_size=SIGNAL_PAGE_SIZE, kdf_iterations=SIGNAL_KDF_ITERATIONS,
+            hmac_algorithm=SIGNAL_HMAC, kdf_algorithm=SIGNAL_HMAC)
+    except Exception as error:  # pylint: disable=broad-except
+        logfunc(f'Signal: decryption failed for {database_path}: {error}')
+        return None
+
+    if not pages or not verified:
+        logfunc('Signal: the key did not authenticate the database, it may belong to another '
+                'extraction or the app data was updated after the key was captured')
+        return None
+    if verified != pages:
+        logfunc(f'Signal: {pages - verified} of {pages} decrypted pages failed HMAC '
+                'verification, the recovered data may be incomplete')
+
+    _decrypted_cache[database_path] = output_path
+    return output_path
+
+
+def _open_signal_database(context):
+    """Yield (connection, source_path) for each decryptable Signal database."""
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.basename(file_found) != 'signal.db':
+            continue
+        decrypted = _decrypted_database(context, file_found)
+        if not decrypted:
+            continue
+        yield sqlite3.connect(decrypted), file_found
+
+
+def _display_name(profile_name, system_name, phone_number, username):
+    return profile_name or system_name or phone_number or username or ''
+
+
+def _table_columns(connection, table):
+    return {row[1] for row in connection.execute(f'PRAGMA table_info({table})')}
+
+
+def _select_list(available, table_alias, columns):
+    """Build SELECT expressions, substituting NULL for columns this Signal version lacks.
+
+    Signal's schema changes between releases, so a query pinned to one version's
+    columns fails outright on another.
+    """
+    expressions = []
+    for column in columns:
+        if column in available:
+            expressions.append(f'{table_alias}.{column}')
+        else:
+            expressions.append('NULL')
+    return ', '.join(expressions)
+
+
+@artifact_processor
+def get_signalMessages(context):
+    data_list = []
+    source_path = ''
+    for connection, source_path in _open_signal_database(context):
+        cursor = connection.cursor()
+        message_columns = _table_columns(connection, 'message')
+        cursor.execute(f'''
+        SELECT
+            {_select_list(message_columns, 'message',
+                          ['date_sent', 'date_received', 'thread_id', 'type', 'body'])},
+            sender.e164, sender.profile_joined_name, sender.system_joined_name, sender.username,
+            receiver.e164, receiver.profile_joined_name, receiver.system_joined_name, receiver.username,
+            {_select_list(message_columns, 'message',
+                          ['read', 'remote_deleted', 'view_once', 'quote_body', 'expires_in'])}
+        FROM message
+        LEFT JOIN recipient AS sender ON message.from_recipient_id = sender._id
+        LEFT JOIN recipient AS receiver ON message.to_recipient_id = receiver._id
+        ORDER BY message.date_sent
+        ''')
+        for row in cursor:
+            base_type = row[3] & MESSAGE_BASE_TYPE_MASK if row[3] is not None else None
+            data_list.append((
+                convert_unix_ts_to_utc(row[0]),
+                convert_unix_ts_to_utc(row[1]),
+                row[2],
+                MESSAGE_DIRECTIONS.get(base_type, 'Unknown'),
+                MESSAGE_STATUS.get(base_type, ''),
+                _display_name(row[6], row[7], row[5], row[8]),
+                row[5] or '',
+                _display_name(row[10], row[11], row[9], row[12]),
+                row[9] or '',
+                row[4] or '',
+                'Yes' if row[13] else 'No',
+                'Yes' if row[14] else 'No',
+                'Yes' if row[15] else 'No',
+                row[16] or '',
+                row[17] or '',
+            ))
+        connection.close()
+
+    data_headers = (
+        ('Date Sent', 'datetime'),
+        ('Date Received', 'datetime'),
+        'Thread ID',
+        'Direction',
+        'Status',
+        'Sender',
+        'Sender Phone Number',
+        'Recipient',
+        'Recipient Phone Number',
+        'Message',
+        'Read',
+        'Remote Deleted',
+        'View Once',
+        'Quoted Message',
+        'Disappearing Timer (Seconds)',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_signalCalls(context):
+    data_list = []
+    source_path = ''
+    for connection, source_path in _open_signal_database(context):
+        cursor = connection.cursor()
+        call_columns = _table_columns(connection, 'call')
+        cursor.execute(f'''
+        SELECT
+            {_select_list(call_columns, 'call',
+                          ['timestamp', 'call_id', 'type', 'direction', 'event'])},
+            peer.e164, peer.profile_joined_name, peer.system_joined_name, peer.username,
+            {_select_list(call_columns, 'call', ['read', 'deletion_timestamp'])}
+        FROM call
+        LEFT JOIN recipient AS peer ON call.peer = peer._id
+        ORDER BY call.timestamp
+        ''')
+        for row in cursor:
+            data_list.append((
+                convert_unix_ts_to_utc(row[0]),
+                _display_name(row[6], row[7], row[5], row[8]),
+                row[5] or '',
+                CALL_TYPES.get(row[2], f'Unknown ({row[2]})'),
+                CALL_DIRECTIONS.get(row[3], f'Unknown ({row[3]})'),
+                CALL_EVENTS.get(row[4], f'Unknown ({row[4]})'),
+                'Yes' if row[9] else 'No',
+                convert_unix_ts_to_utc(row[10]) if row[10] else '',
+                row[1],
+            ))
+        connection.close()
+
+    data_headers = (
+        ('Timestamp', 'datetime'),
+        'Contact',
+        'Phone Number',
+        'Call Type',
+        'Direction',
+        'Outcome',
+        'Read',
+        ('Deleted Timestamp', 'datetime'),
+        'Call ID',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_signalContacts(context):
+    data_list = []
+    source_path = ''
+    for connection, source_path in _open_signal_database(context):
+        cursor = connection.cursor()
+        recipient_columns = _table_columns(connection, 'recipient')
+        cursor.execute(f'''
+        SELECT
+            {_select_list(recipient_columns, 'recipient',
+                          ['_id', 'type', 'e164', 'username', 'aci', 'pni',
+                           'profile_joined_name', 'system_joined_name', 'profile_given_name',
+                           'profile_family_name', 'registered', 'blocked', 'hidden', 'about',
+                           'note', 'last_profile_fetch'])}
+        FROM recipient
+        ORDER BY recipient._id
+        ''')
+        for row in cursor:
+            data_list.append((
+                _display_name(row[6], row[7], row[2], row[3]),
+                row[2] or '',
+                row[3] or '',
+                RECIPIENT_TYPES.get(row[1], f'Unknown ({row[1]})'),
+                row[4] or '',
+                row[5] or '',
+                'Yes' if row[11] else 'No',
+                'Yes' if row[12] else 'No',
+                row[13] or '',
+                row[14] or '',
+                convert_unix_ts_to_utc(row[15]) if row[15] else '',
+                row[0],
+            ))
+        connection.close()
+
+    data_headers = (
+        'Name',
+        'Phone Number',
+        'Username',
+        'Recipient Type',
+        'ACI',
+        'PNI',
+        'Blocked',
+        'Hidden',
+        'About',
+        'Note',
+        ('Last Profile Fetch', 'datetime'),
+        'Recipient ID',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_signalAttachments(context):
+    data_list = []
+    source_path = ''
+    for connection, source_path in _open_signal_database(context):
+        cursor = connection.cursor()
+        attachment_columns = _table_columns(connection, 'attachment')
+        cursor.execute(f'''
+        SELECT
+            message.date_sent,
+            {_select_list(attachment_columns, 'attachment',
+                          ['file_name', 'content_type', 'data_size', 'data_file',
+                           'transfer_state', 'voice_note', 'video_gif', 'width', 'height',
+                           'caption', 'upload_timestamp', 'message_id'])}
+        FROM attachment
+        LEFT JOIN message ON attachment.message_id = message._id
+        ORDER BY message.date_sent
+        ''')
+        for row in cursor:
+            data_list.append((
+                convert_unix_ts_to_utc(row[0]) if row[0] else '',
+                row[1] or '',
+                row[2] or '',
+                row[3] or '',
+                row[4] or '',
+                row[5],
+                'Yes' if row[6] else 'No',
+                'Yes' if row[7] else 'No',
+                f'{row[8]}x{row[9]}' if row[8] and row[9] else '',
+                row[10] or '',
+                convert_unix_ts_to_utc(row[11]) if row[11] else '',
+                row[12],
+            ))
+        connection.close()
+
+    data_headers = (
+        ('Message Date Sent', 'datetime'),
+        'File Name',
+        'Content Type',
+        'Size (Bytes)',
+        'Stored File',
+        'Transfer State',
+        'Voice Note',
+        'Video GIF',
+        'Dimensions',
+        'Caption',
+        ('Upload Timestamp', 'datetime'),
+        'Message ID',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/sqlcipher_decrypt.py
+++ b/scripts/sqlcipher_decrypt.py
@@ -1,0 +1,161 @@
+"""Minimal pure-python SQLCipher reader.
+
+Implemented with PyCryptodome (already an ALEAPP requirement) rather than a
+native SQLCipher build, so packaged/frozen ALEAPP builds keep working without
+an extra binary dependency.
+
+Only the subset needed to read an encrypted database is implemented: the file
+is decrypted to a plaintext copy which callers open with the stdlib sqlite3.
+"""
+import hashlib
+import hmac
+import os
+import struct
+
+from Crypto.Cipher import AES
+
+DEFAULT_PAGE_SIZE = 4096
+IV_LENGTH = 16
+FAST_KDF_ITER = 2  # SQLCipher's iteration count for the HMAC subkey
+
+HMAC_LENGTHS = {'sha1': 20, 'sha256': 32, 'sha512': 64}
+
+WAL_HEADER_SIZE = 32
+WAL_FRAME_HEADER_SIZE = 24
+WAL_MAGIC = (0x377F0682, 0x377F0683)
+
+
+def _reserve_size(hmac_length):
+    """Bytes reserved at the end of each page: IV + HMAC, padded to an AES block."""
+    return ((IV_LENGTH + hmac_length + 15) // 16) * 16
+
+
+def _decrypt_page(page, page_number, encryption_key, hmac_key, digest, hmac_length, reserve,
+                  page_size):
+    """Decrypt one SQLCipher page. Returns (plaintext_body, hmac_verified)."""
+    # Page 1 keeps the salt in the clear, so its encrypted body starts after it
+    body_start = 16 if page_number == 1 else 0
+    body_end = page_size - reserve
+    iv = page[body_end:body_end + IV_LENGTH]
+    stored_hmac = page[body_end + IV_LENGTH:body_end + IV_LENGTH + hmac_length]
+    calculated = hmac.new(hmac_key,
+                          page[body_start:body_end + IV_LENGTH]
+                          + page_number.to_bytes(4, 'little'),
+                          digest).digest()
+    body = AES.new(encryption_key, AES.MODE_CBC, iv).decrypt(page[body_start:body_end])
+    if page_number == 1:
+        body = b'SQLite format 3\x00' + body
+    return body + b'\x00' * reserve, hmac.compare_digest(calculated, stored_hmac)
+
+
+def _wal_pages(wal_path, page_size):
+    """Yield (page_number, raw_encrypted_page) for the committed frames of a SQLCipher WAL.
+
+    SQLCipher leaves the WAL and frame headers readable and encrypts only the page
+    payloads, so frames can be located without the key. Later frames supersede
+    earlier ones for the same page; anything after the final commit frame is an
+    incomplete transaction and is ignored.
+    """
+    with open(wal_path, 'rb') as wal_file:
+        wal = wal_file.read()
+    if len(wal) < WAL_HEADER_SIZE:
+        return {}, 0
+    if struct.unpack('>I', wal[0:4])[0] not in WAL_MAGIC:
+        return {}, 0
+
+    header_salts = wal[16:24]
+    frame_size = WAL_FRAME_HEADER_SIZE + page_size
+    frame_count = (len(wal) - WAL_HEADER_SIZE) // frame_size
+
+    latest = {}
+    committed = {}
+    database_pages = 0
+    for index in range(frame_count):
+        offset = WAL_HEADER_SIZE + index * frame_size
+        frame_header = wal[offset:offset + WAL_FRAME_HEADER_SIZE]
+        if frame_header[8:16] != header_salts:
+            continue  # frame belongs to an earlier WAL generation
+        page_number = struct.unpack('>I', frame_header[0:4])[0]
+        commit_size = struct.unpack('>I', frame_header[4:8])[0]
+        latest[page_number] = wal[offset + WAL_FRAME_HEADER_SIZE:offset + frame_size]
+        if commit_size:
+            # Transaction boundary: everything seen so far is durable
+            committed = dict(latest)
+            database_pages = commit_size
+    return committed, database_pages
+
+
+def decrypt_sqlcipher_db(encrypted_path, passphrase, output_path, page_size=DEFAULT_PAGE_SIZE,
+                         kdf_iterations=1, hmac_algorithm='sha1', kdf_algorithm='sha1',
+                         raw_key=False, apply_wal=True):
+    """Decrypt a SQLCipher database to a plaintext SQLite file.
+
+    Args:
+        encrypted_path: path to the encrypted database.
+        passphrase: passphrase string, or hex string when raw_key is True.
+        output_path: where the decrypted database is written.
+        page_size: SQLCipher page size.
+        kdf_iterations: PBKDF2 iterations for the encryption key. Signal uses 1
+            because its key is already random.
+        hmac_algorithm: 'sha1', 'sha256' or 'sha512'.
+        kdf_algorithm: PBKDF2 hash, usually matching hmac_algorithm.
+        raw_key: treat passphrase as a hex-encoded key used directly (PRAGMA
+            key = "x'..'") instead of deriving it.
+        apply_wal: replay a sibling '-wal' file over the database image. Without
+            this, recent records that have not been checkpointed are missed.
+
+    Returns:
+        (pages_decrypted, pages_whose_hmac_verified), counting replayed WAL frames
+        as well as main-image pages. Equal values mean everything authenticated;
+        0 verified means the passphrase or settings are wrong.
+    """
+    hmac_length = HMAC_LENGTHS[hmac_algorithm]
+    reserve = _reserve_size(hmac_length)
+
+    with open(encrypted_path, 'rb') as encrypted_file:
+        raw = encrypted_file.read()
+    if len(raw) < page_size:
+        return 0, 0
+
+    salt = raw[:16]
+    if raw_key:
+        encryption_key = bytes.fromhex(passphrase)
+    else:
+        encryption_key = hashlib.pbkdf2_hmac(kdf_algorithm, passphrase.encode(), salt,
+                                             kdf_iterations, 32)
+    hmac_key = hashlib.pbkdf2_hmac(kdf_algorithm, encryption_key,
+                                   bytes(byte ^ 0x3A for byte in salt), FAST_KDF_ITER, 32)
+
+    digest = getattr(hashlib, hmac_algorithm)
+    decrypted_pages = verified = 0
+
+    pages = []
+    for page_index in range(len(raw) // page_size):
+        body, page_ok = _decrypt_page(raw[page_index * page_size:(page_index + 1) * page_size],
+                                      page_index + 1, encryption_key, hmac_key, digest,
+                                      hmac_length, reserve, page_size)
+        pages.append(body)
+        decrypted_pages += 1
+        verified += page_ok
+
+    # Recent activity often lives only in the write-ahead log, so replay it over
+    # the main database image before handing the file to sqlite3
+    if apply_wal:
+        wal_path = encrypted_path + '-wal'
+        if os.path.exists(wal_path):
+            wal_pages, database_pages = _wal_pages(wal_path, page_size)
+            for page_number, encrypted_page in sorted(wal_pages.items()):
+                body, page_ok = _decrypt_page(encrypted_page, page_number, encryption_key,
+                                              hmac_key, digest, hmac_length, reserve, page_size)
+                while len(pages) < page_number:
+                    pages.append(b'\x00' * page_size)
+                pages[page_number - 1] = body
+                decrypted_pages += 1
+                verified += page_ok
+            if database_pages:
+                pages = pages[:database_pages]
+
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, 'wb') as output_file:
+        output_file.write(b''.join(pages))
+    return decrypted_pages, verified


### PR DESCRIPTION
Adds Signal for Android support. ALEAPP had no Signal artifacts because the app stores everything in a SQLCipher-encrypted database.

## What is included

- `scripts/sqlcipher_decrypt.py` — a small pure-python SQLCipher reader built on PyCryptodome (already a requirement), so frozen/packaged builds do not need a native SQLCipher binary
- `scripts/artifacts/signalAndroid.py` — four artifacts: **Messages**, **Calls**, **Contacts**, **Attachments** (metadata)

## Key handling

The extraction tool writes `extra/Secrets/secrets.json` containing Signal's `sqlite db key`. Signal uses that hex string as a **passphrase** with **kdf_iter = 1** (no key stretching, since the stored key is already random), HMAC_SHA1, PBKDF2_HMAC_SHA1 and a 4096 byte page size. Thanks to Matthew Plascencia for the key location and cipher settings.

## Write-ahead log

The decryptor replays the SQLCipher WAL, which is not optional in practice. On one test image the WAL held 2 messages, 1 contact, 2 attachments **and a schema migration** that the main image alone did not contain. SQLCipher leaves WAL and frame headers readable and encrypts only the page payloads, so committed frames can be located and replayed.

## Schema resilience

Signal's schema changes between releases (the same image showed 47 vs 51 tables before and after WAL replay). Queries build their column lists from `PRAGMA table_info`, substituting NULL for columns a given version lacks, so the artifacts do not break on other Signal versions.

## Testing

Two Android corpus images, different devices and Signal versions:

| Image | Messages | Calls | Contacts | Attachments |
|---|---|---|---|---|
| Pixel 7a, Android 14 | 34 | 4 | 15 | 9 |
| Samsung, Android 14 | 45 | 3 | 25 | 10 |

Zero errors, every decrypted page HMAC-verified, HTML/TSV/LAVA outputs all generated. When `secrets.json` is missing the artifacts log a clear message and skip rather than failing the run. pylint clean at 10.00/10 with the CI flags.

## Follow-up

Attachment files on disk are separately encrypted with the `modernKey` from the same secrets file; this PR reports attachment metadata only. Decrypting the files themselves is a good next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)