### PR TITLE
fix: restore Python 3.11 compatibility in rema_1000

### DIFF
--- a/scripts/artifacts/rema_1000.py
+++ b/scripts/artifacts/rema_1000.py
@@ -89,8 +89,9 @@ def rema1000_receipt_prettified(context):
         for index, item in enumerate(list_receipt):
             if item is None:
                 list_receipt[index] = "None"
-        prettified_list[0] = f"{datetime.fromtimestamp(list_receipt[0]/1000,
-                                                       tz=ZoneInfo('Europe/Copenhagen')).strftime('%Y-%m-%d %H:%M:%S')}"
+        payment_date = datetime.fromtimestamp(list_receipt[0] / 1000,
+                                              tz=ZoneInfo('Europe/Copenhagen'))
+        prettified_list[0] = payment_date.strftime('%Y-%m-%d %H:%M:%S')
         prettified_list[1] = f"{list_receipt[3].split(';')[1].capitalize()}, {list_receipt[4]}, "\
             f"{list_receipt[3].split(';')[2].capitalize()}"
         split_items = [item.translate(translation_table) for item in list_receipt[3].split(";")[3:]]


### PR DESCRIPTION
The `windows-smoke` CI job is currently failing on **every** pull request, including unrelated ones. This fixes the cause.

## Problem

`rema_1000.py` formats the payment date with a multi-line expression inside an f-string:

```python
prettified_list[0] = f"{datetime.fromtimestamp(list_receipt[0]/1000,
                                               tz=ZoneInfo('Europe/Copenhagen')).strftime('%Y-%m-%d %H:%M:%S')}"
```

Newlines inside f-string braces are only legal on Python 3.12+ (PEP 701). The `windows-smoke` workflow runs **Python 3.11**, where this is a `SyntaxError: unterminated string literal`, so `test_artifact_imports` fails to import the module and the job goes red.

It passes locally for most of us because our interpreters are 3.12 or newer, which is why it went unnoticed.

## Fix

Compute the datetime first, then format it. Output is byte-identical (verified).

## Verification

- Reproduced the failure locally on Python 3.10, which shares the pre-PEP-701 tokenizer with 3.11
- After the fix, every file under `scripts/` compiles cleanly on 3.10/3.11 — this was the only affected file
- Confirmed the formatted string is unchanged
- pylint clean with the CI flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)