### PR TITLE
ci: run the runtime contract on changes under scripts/

### DIFF
--- a/.github/workflows/python_runtime_contract.yml
+++ b/.github/workflows/python_runtime_contract.yml
@@ -8,6 +8,11 @@ on:
       - 'requirements.txt'
       # The job runs the whole admin/test/scripts suite, so trigger on all of it
       - 'admin/test/scripts/**'
+      # The suite imports every artifact module, which is the only check that a
+      # change parses on the oldest supported Python. Without this the job could
+      # not see changes under scripts/, and a 3.12-only f-string shipped broken
+      # on 3.10/3.11 until it blocked unrelated pull requests (see #986).
+      - 'scripts/**'
 
 jobs:
   runtime-contract:


### PR DESCRIPTION
Closes the CI gap that let a broken artifact reach main.

## Problem

`python_runtime_contract.yml` runs the `admin/test/scripts` suite on **Python 3.10 and 3.11**, and that suite imports every artifact module. It is the only check that a change still parses on the oldest supported Python.

Its path filter, however, listed only:

```yaml
- 'admin/test/scripts/**'
```

so a change under `scripts/artifacts/**` could never trigger it. That is exactly how the Python 3.12-only f-string in `rema_1000.py` reached main and sat there until it began failing `windows-smoke` on unrelated pull requests (fixed in #986).

## Fix

Add `scripts/**` to the filter.

## Verification

Reintroduced the offending f-string locally and ran the suite under Python 3.10:

```
Ran 2 tests in 0.353s
FAILED (failures=1, errors=1)
```

So with this filter in place the job would have caught the original bug at pull request time. YAML validated; the Python matrix ('3.10', '3.11') is unchanged.

## Note

iLEAPP has no equivalent runtime-contract workflow at all, so the same class of break could land there unnoticed. Worth considering as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)