### PR TITLE
fix(mewe): read the app_v3.db chat store, not just app_database

### DIFF
--- a/scripts/artifacts/mewe.py
+++ b/scripts/artifacts/mewe.py
@@ -2,16 +2,22 @@
 __artifacts_v2__ = {
     "get_mewe_chat": {
         "name": "MeWe - Chat",
-        "description": "Parses MeWe chat messages (timestamp, thread, user, message text, direction, type and attachments) from the MeWe app_database.",
+        "description": "Parses MeWe chat messages (timestamp, thread, user, message text, direction, type and attachments) from the MeWe chat database (app_database on older builds, app_v3.db on newer ones).",
         "author": "",
         "creation_date": "2021-11-10",
-        "last_update_date": "2026-07-03",
+        "last_update_date": "2026-07-26",
         "requirements": "none",
         "category": "MeWe",
-        "notes": "",
-        "paths": ('*/com.mewe/databases/app_database',),
+        "notes": ("MeWe moved its chat store from 'app_database' to 'app_v3.db'; both are read. "
+                  "Newer builds leave an empty 'mewe_old' database behind, which is skipped."),
+        "paths": ('*/com.mewe/databases/app_database',
+                  '*/com.mewe/databases/app_v3.db'),
         "output_types": "standard",
         "artifact_icon": "message",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.mewe vc 90017000 | app_v3.db | 13 rows",
+            "pixel7a_a14": "Android 14 | com.mewe vc 80116099 | app_v3.db | 18 rows",
+        },
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Thread Id",
@@ -45,29 +51,78 @@ __artifacts_v2__ = {
 
 import datetime
 import re
+import sqlite3
 import xml.etree.ElementTree as ET
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, logfunc
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, logfunc, \
+    does_column_exist_in_db, does_table_exist_in_db
 
 # Module-level constants (kept for backwards-compatibility; snapchat.py imports APP_NAME)
 APP_NAME = 'MeWe'
 DB_NAME = 'app_database'
+# MeWe renamed the chat store to app_v3.db. Both carry the same CHAT_MESSAGE /
+# CHAT_THREAD shape, so one query serves both; only the filename changed. Newer
+# builds also leave a 'mewe_old' database in place, but it holds no chat tables.
+DB_NAME_V3 = 'app_v3.db'
+DB_NAMES = (DB_NAME, DB_NAME_V3)
 SGSESSION_FILE = 'SGSession.xml'
 
-CHAT_MESSAGES_QUERY = '''
+# Column availability is probed rather than assumed: the two database
+# generations were seen in the wild years apart, and only app_v3.db is covered
+# by a test image, so a missing column must degrade to a blank cell instead of
+# failing the whole artifact.
+OPTIONAL_COLUMNS = {
+    'threadName': ('CHAT_THREAD', 'name'),
+    'groupId': ('CHAT_THREAD', 'groupId'),
+    'chatType': ('CHAT_THREAD', 'chatType'),
+    'ownerId': ('CHAT_MESSAGE', 'ownerId'),
+    'ownerName': ('CHAT_MESSAGE', 'ownerName'),
+    'textPlain': ('CHAT_MESSAGE', 'textPlain'),
+    'attachmentType': ('CHAT_MESSAGE', 'attachmentType'),
+    'attachmentName': ('CHAT_MESSAGE', 'attachmentName'),
+    'deleted': ('CHAT_MESSAGE', 'deleted'),
+    'currentUserMessage': ('CHAT_MESSAGE', 'currentUserMessage'),
+}
+
+
+def _column_or_null(db_path, key):
+    """Qualified column reference if the schema has it, else a NULL placeholder."""
+    table, column = OPTIONAL_COLUMNS[key]
+    if does_column_exist_in_db(db_path, table, column):
+        return f'{table}.{column}'
+    return 'NULL'
+
+
+def _build_chat_query(db_path):
+    """Assemble the chat query for whichever schema generation this database is."""
+    threadName = _column_or_null(db_path, 'threadName')
+    groupId = _column_or_null(db_path, 'groupId')
+    chatType = _column_or_null(db_path, 'chatType')
+    ownerId = _column_or_null(db_path, 'ownerId')
+    ownerName = _column_or_null(db_path, 'ownerName')
+    textPlain = _column_or_null(db_path, 'textPlain')
+    attachmentType = _column_or_null(db_path, 'attachmentType')
+    attachmentName = _column_or_null(db_path, 'attachmentName')
+    deleted = _column_or_null(db_path, 'deleted')
+    currentUserMessage = _column_or_null(db_path, 'currentUserMessage')
+
+    return f'''
     SELECT
-        createdAt,
-        threadId,
-        groupId,
-        ownerId,
-        ownerName,
-        textPlain,
-        CASE currentUserMessage WHEN 1 THEN "Sent" ELSE "Received" END currentUserMessage,
-        CASE attachmentType WHEN "UNSUPPORTED" THEN '' ELSE attachmentType END attachmentType,
-        attachmentName,
-        CASE deleted WHEN 1 THEN "YES" ELSE "NO" END deleted
+        CHAT_MESSAGE.createdAt,
+        CHAT_MESSAGE.threadId,
+        {threadName},
+        {groupId},
+        {chatType},
+        {ownerId},
+        {ownerName},
+        {textPlain},
+        CASE {currentUserMessage} WHEN 1 THEN 'Sent' ELSE 'Received' END,
+        CASE {attachmentType} WHEN 'UNSUPPORTED' THEN '' ELSE {attachmentType} END,
+        {attachmentName},
+        CASE {deleted} WHEN 1 THEN 'YES' ELSE 'NO' END
     FROM CHAT_MESSAGE
-    JOIN CHAT_THREAD ON threadId = CHAT_THREAD.id
+    JOIN CHAT_THREAD ON CHAT_MESSAGE.threadId = CHAT_THREAD.id
+    ORDER BY CHAT_MESSAGE.createdAt
 '''
 
 
@@ -93,29 +148,39 @@ def _parse_xml(file_found):
 def get_mewe_chat(context):
     files_found = context.get_files_found()
     data_list = []
-    source_path = ''
+    sources = []
     for file_found in files_found:
         file_found = str(file_found)
-        if not file_found.endswith(DB_NAME):
+        if not file_found.endswith(DB_NAMES):
+            continue
+        # Newer installs keep an empty 'mewe_old' alongside app_v3.db, and a
+        # database can be present without ever having held a chat.
+        if not does_table_exist_in_db(file_found, 'CHAT_MESSAGE'):
             continue
 
-        source_path = file_found
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         try:
-            cursor.execute(CHAT_MESSAGES_QUERY)
+            cursor.execute(_build_chat_query(file_found))
             rows = cursor.fetchall()
-        except:
+        except sqlite3.Error as ex:
+            logfunc(f'Could not read MeWe chats from {file_found}: {ex}')
             rows = []
         db.close()
 
+        if rows:
+            sources.append(file_found)
         for row in rows:
             timestamp = datetime.datetime.fromtimestamp(int(row[0]), datetime.timezone.utc) if row[0] else ''
-            data_list.append((timestamp, row[1], row[2], row[3], row[4], row[5], row[6], row[7],
-                              row[8] if row[8] else '', row[9]))
+            # Columns absent from this schema generation come back as NULL; report
+            # them as empty cells rather than the string "None".
+            values = tuple('' if value is None else value for value in row[1:])
+            data_list.append((timestamp,) + values)
 
-    data_headers = (('Timestamp', 'datetime'), 'Thread Id', 'Thread Name', 'User Id', 'User Name',
-                    'Message Text', 'Message Direction', 'Message Type', 'Attachment Name', 'Deleted')
+    source_path = ', '.join(sources)
+    data_headers = (('Timestamp', 'datetime'), 'Thread Id', 'Thread Name', 'Group Id', 'Chat Type',
+                    'User Id', 'User Name', 'Message Text', 'Message Direction', 'Message Type',
+                    'Attachment Name', 'Deleted')
     return data_headers, data_list, source_path
 
 


### PR DESCRIPTION
MeWe moved its chat database from `app_database` to `app_v3.db`. The module only globbed the old name.

## This wasn't a partial gap

I surveyed all 10 Android images in the corpus. Two have MeWe, and **neither has `app_database`**:

```
com.mewe/databases/
  app_v3.db     <- the live chat store
  mewe_old      <- empty, only android_metadata
  database.db   <- a single CONTACT row
```

So `get_mewe_chat` has been returning **zero rows on every MeWe image we hold**, not merely missing newer data.

## The query was never the problem

`app_v3.db` keeps the same `CHAT_MESSAGE` / `CHAT_THREAD` table and column names. Running the existing SQL against it unchanged returns 18 and 13 rows. Only the filename moved, so the changes are mostly about reaching it safely:

- match both filenames
- **skip any database with no `CHAT_MESSAGE` table**, so the empty `mewe_old` sitting beside `app_v3.db` isn't mistaken for a chat store
- **probe columns rather than assume them.** Only `app_v3.db` is covered by a test image, so a column the older schema lacks must degrade to a blank cell instead of failing the artifact. Missing columns resolve to `NULL`
- report which database was actually read in `source_path`, and order by timestamp

## Also fixes a mislabel

"Thread Name" was populated from `CHAT_THREAD.groupId`, whose value is the literal string `contacts`. Since that column feeds `conversationLabelColumn`, the conversation view labelled **every** thread "contacts". It now shows `CHAT_THREAD.name` — the correspondent — with `Group Id` and `Chat Type` as their own columns.

| | Before | After |
|---|---|---|
| Thread Name | `contacts` | `Jesse Pinkman` |

## Verified

| Case | Result |
|---|---|
| `pixel7a_a14` / app_v3.db | 18 rows |
| `hc_pixel8pro_a16` / app_v3.db | 13 rows |
| old filename `app_database`, full schema | 18 rows |
| reduced old schema (no `name`/`chatType`/`attachmentName`) | 1 row, blanks not a crash |
| `mewe_old` + `database.db` only | 0 rows, correctly skipped |

The last two are synthetic fixtures — no image in the corpus carries the old database, so backwards compatibility is demonstrated rather than asserted.

Full `aleapp.py -t fs` run: **0 errors**, 13 chat rows and 27 SGSession rows, LAVA table correct with the new columns. `test_artifact_imports` OK, diff-aware lint PASS.

## Not in this PR

`app_v3.db` also holds substantial unparsed content — in `pixel7a_a14`, 74 POSTs, 69 POST_MEDIA, 16 COMMENTs, 30 POLL_OPTIONs and 227 EMOJI_POSTs. None of it is covered by any ALEAPP artifact today. Worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
