### PR TITLE
feat(mewe): parse posts, comments, media, polls, reactions and groups

### DIFF
--- a/scripts/artifacts/mewe.py
+++ b/scripts/artifacts/mewe.py
@@ -8,8 +8,20 @@ __artifacts_v2__ = {
         "last_update_date": "2026-07-26",
         "requirements": "none",
         "category": "MeWe",
-        "notes": ("MeWe moved its chat store from 'app_database' to 'app_v3.db'; both are read. "
-                  "Newer builds leave an empty 'mewe_old' database behind, which is skipped."),
+        "notes": ("Source: MeWe moved its chat store from 'app_database' to 'app_v3.db'; both are read. "
+                  "Newer builds leave an empty 'mewe_old' beside it, which is skipped.\n"
+                  "Direction: 'Sent' means the account signed in on this device sent the message. "
+                  "Its user ID is the suffix of the 'user_info<id>' key in SGSession.xml (see MeWe - "
+                  "SGSession), which can be matched against User Id to confirm who the owner is.\n"
+                  "Thread Name is the other party on a one-to-one chat, not a group name; a Group Id "
+                  "of 'contacts' likewise indicates a direct chat rather than a group.\n"
+                  "Deleted: 'YES' is the app's own deletion flag. The row and its text are still "
+                  "present here, so a deleted message can remain readable.\n"
+                  "Shared locations arrive as an openstreetmap.org URL in Message Text, with the "
+                  "coordinates in the mlat/mlon parameters.\n"
+                  "Attachment Name is often empty even when Message Type is set (for example PHOTO); "
+                  "the absence of a name does not mean the absence of an attachment.\n"
+                  "Timestamps are UTC, converted from whole Unix seconds."),
         "paths": ('*/com.mewe/databases/app_database',
                   '*/com.mewe/databases/app_v3.db'),
         "output_types": "standard",
@@ -38,9 +50,19 @@ __artifacts_v2__ = {
         "last_update_date": "2026-07-26",
         "requirements": "none",
         "category": "MeWe",
-        "notes": ("A post is stored once per feed it was loaded into, so the same post can appear "
-                  "more than once with a different Feed Context. The context is reported rather "
-                  "than de-duplicated, because which feed surfaced a post is itself informative."),
+        "notes": ("This is cached feed content, not an authorship record. Rows are posts the app "
+                  "downloaded to render a feed the user scrolled, so their presence shows what was "
+                  "delivered to the device, NOT that the device owner wrote, opened or read any of "
+                  "it. In both test images every cached post belongs to someone else "
+                  "(currentUserPost = 0 for all 74). Use 'Posted By Device Owner' = Yes to isolate "
+                  "the owner's own posts.\n"
+                  "A post is stored once per feed it was loaded into, so the same post can appear "
+                  "more than once with a different Feed Context. That is reported rather than "
+                  "de-duplicated, because which feed surfaced a post is itself informative. Treat "
+                  "the Post Id, not the row, as the unit when counting distinct posts.\n"
+                  "Poll Votes is the total across all voters, not the owner's vote.\n"
+                  "Timestamps are UTC, converted from whole Unix seconds. An Edited value of 0 "
+                  "renders blank and means never edited."),
         "paths": ('*/com.mewe/databases/app_database',
                   '*/com.mewe/databases/app_v3.db'),
         "output_types": "standard",
@@ -58,7 +80,14 @@ __artifacts_v2__ = {
         "last_update_date": "2026-07-26",
         "requirements": "none",
         "category": "MeWe",
-        "notes": "",
+        "notes": ("Like MeWe - Posts, this is cached feed content: comments written by other people "
+                  "on posts the app downloaded. Presence does not imply the device owner wrote or "
+                  "read them. 'By Device Owner' = Yes marks the owner's own comments; in both test "
+                  "images none of the 16 cached comments were the owner's.\n"
+                  "'On Post By' and 'On Post Text' come from a LEFT JOIN to the cached post. If the "
+                  "parent post is no longer cached these are blank, and the comment is still "
+                  "reported rather than dropped; use Post Id to correlate.\n"
+                  "Timestamps are UTC, from whole Unix seconds."),
         "paths": ('*/com.mewe/databases/app_database',
                   '*/com.mewe/databases/app_v3.db'),
         "output_types": "standard",
@@ -76,7 +105,17 @@ __artifacts_v2__ = {
         "last_update_date": "2026-07-26",
         "requirements": "none",
         "category": "MeWe",
-        "notes": "",
+        "notes": ("Image URL and Video URL Template are server-side paths on MeWe's CDN "
+                  "(for example /api/v2/photo/...), NOT files on the device. Do not expect to find "
+                  "a file at that path. Any locally cached copy lives under the app's Glide cache "
+                  "(cache/image_manager_disk_cache) under a hashed filename that cannot be "
+                  "correlated back to these URLs by name.\n"
+                  "Rows describe media attached to cached feed posts, so the same caveat as "
+                  "MeWe - Posts applies: this is what was delivered to the device, not what the "
+                  "owner posted or viewed.\n"
+                  "Post context is a LEFT JOIN; where the parent post is no longer cached the "
+                  "Post Created, Post Author and Group Name columns are blank and the media row is "
+                  "still reported (3 of 69 rows in the Android 14 test image)."),
         "paths": ('*/com.mewe/databases/app_database',
                   '*/com.mewe/databases/app_v3.db'),
         "output_types": "standard",
@@ -93,7 +132,13 @@ __artifacts_v2__ = {
         "last_update_date": "2026-07-26",
         "requirements": "none",
         "category": "MeWe",
-        "notes": "",
+        "notes": ("One row per poll option, so a poll spans several rows sharing a Post Id and "
+                  "Question.\n"
+                  "Option Votes and Total Votes are server-reported tallies across all voters. "
+                  "Nothing here records how the device owner voted, or whether they voted at all; "
+                  "the POST table's pollVoted flag carries that and was 0 for every cached poll in "
+                  "the test image.\n"
+                  "Counts are a snapshot from when the post was cached, not live values."),
         "paths": ('*/com.mewe/databases/app_database',
                   '*/com.mewe/databases/app_v3.db'),
         "output_types": "standard",
@@ -110,7 +155,16 @@ __artifacts_v2__ = {
         "last_update_date": "2026-07-26",
         "requirements": "none",
         "category": "MeWe",
-        "notes": "MeWe keeps a reaction tally per emoji rather than naming each reactor; only the device owner's own reaction is attributable.",
+        "notes": ("Reactions are stored as a per-emoji tally, not a list of reactors. A Reaction "
+                  "Count of 106 means 106 reactions were reported by the server; it does NOT "
+                  "identify, or make identifiable, who reacted. The single exception is "
+                  "'Device Owner Reacted' = Yes, which is the only attributable reaction in this "
+                  "artifact.\n"
+                  "'Reacted To' says which object was reacted to (Post, Comment or Chat Message), "
+                  "since the three come from separate tables merged here. Target Author, Target "
+                  "Text and Target Created are LEFT JOINed from that object and are blank if it is "
+                  "no longer cached.\n"
+                  "Counts are a snapshot from when the object was cached, not live values."),
         "paths": ('*/com.mewe/databases/app_database',
                   '*/com.mewe/databases/app_v3.db'),
         "output_types": "standard",
@@ -128,7 +182,16 @@ __artifacts_v2__ = {
         "last_update_date": "2026-07-26",
         "requirements": "none",
         "category": "MeWe",
-        "notes": "",
+        "notes": ("Three tables are merged and the Type column says which one a row came from: "
+                  "Group (GROUP_), Page (PAGE) or Community (COMMUNITY). The same entity can appear "
+                  "twice, once as a Group or Page and again as a Community, because MeWe caches "
+                  "both views; match on Id.\n"
+                  "Membership is not the same as interest. A row can be present because the entity "
+                  "was merely rendered in a feed. Role and Confirmed indicate an actual "
+                  "relationship: Confirmed = Yes means the account joined the group, and Role names "
+                  "the page relationship (Owner, Admin, Follower).\n"
+                  "Last Opened is converted from milliseconds and reflects the last time the app "
+                  "surfaced the entity, which is not necessarily a deliberate visit by the user."),
         "paths": ('*/com.mewe/databases/app_database',
                   '*/com.mewe/databases/app_v3.db'),
         "output_types": "standard",
@@ -146,7 +209,15 @@ __artifacts_v2__ = {
         "last_update_date": "2026-07-26",
         "requirements": "none",
         "category": "MeWe",
-        "notes": "",
+        "notes": ("The device owner is listed as a participant alongside the other members, so a "
+                  "one-to-one thread yields the owner and the correspondent. Cross-reference "
+                  "Participant Id against the 'user_info<id>' key in SGSession.xml to tell them "
+                  "apart.\n"
+                  "Status is the presence value last cached by the app (typically OFFLINE) and "
+                  "carries no timestamp, so it should not be read as a state at any particular "
+                  "moment.\n"
+                  "Only participants of threads still cached in the database appear; a thread the "
+                  "app has aged out leaves no participants behind."),
         "paths": ('*/com.mewe/databases/app_database',
                   '*/com.mewe/databases/app_v3.db'),
         "output_types": "standard",
@@ -164,7 +235,13 @@ __artifacts_v2__ = {
         "last_update_date": "2021-11-10",
         "requirements": "none",
         "category": "MeWe",
-        "notes": "",
+        "notes": ("Identifies the account signed in on the device: the key 'user_info<id>' carries "
+                  "the owner's MeWe user ID as its suffix, which is the value to match against "
+                  "User Id / Sender fields in the other MeWe artifacts to establish who the device "
+                  "owner is.\n"
+                  "Contains authentication material (user_token, refresh_token) and a token "
+                  "expiration time. Handle accordingly.\n"
+                  "Keys containing a dot are skipped as framework noise."),
         "paths": ('*/com.mewe/shared_prefs/SGSession.xml',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "key",

--- a/scripts/artifacts/mewe.py
+++ b/scripts/artifacts/mewe.py
@@ -30,6 +30,132 @@ __artifacts_v2__ = {
             }
         },
     },
+    "get_mewe_posts": {
+        "name": "MeWe - Posts",
+        "description": "Feed posts cached by MeWe, including group, author, text, link, media and poll details.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "MeWe",
+        "notes": ("A post is stored once per feed it was loaded into, so the same post can appear "
+                  "more than once with a different Feed Context. The context is reported rather "
+                  "than de-duplicated, because which feed surfaced a post is itself informative."),
+        "paths": ('*/com.mewe/databases/app_database',
+                  '*/com.mewe/databases/app_v3.db'),
+        "output_types": "standard",
+        "artifact_icon": "news",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | app_v3.db | 74 rows",
+            "hc_pixel8pro_a16": "Android 16 | app_v3.db | 0 rows (POST empty)",
+        },
+    },
+    "get_mewe_comments": {
+        "name": "MeWe - Comments",
+        "description": "Comments on MeWe posts, with the text of the post each one replies to.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "MeWe",
+        "notes": "",
+        "paths": ('*/com.mewe/databases/app_database',
+                  '*/com.mewe/databases/app_v3.db'),
+        "output_types": "standard",
+        "artifact_icon": "message-circle",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | app_v3.db | 16 rows",
+            "hc_pixel8pro_a16": "Android 16 | app_v3.db | 0 rows (COMMENT empty)",
+        },
+    },
+    "get_mewe_post_media": {
+        "name": "MeWe - Post Media",
+        "description": "Photos and videos attached to MeWe posts.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "MeWe",
+        "notes": "",
+        "paths": ('*/com.mewe/databases/app_database',
+                  '*/com.mewe/databases/app_v3.db'),
+        "output_types": "standard",
+        "artifact_icon": "photo",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | app_v3.db | 69 rows",
+        },
+    },
+    "get_mewe_polls": {
+        "name": "MeWe - Polls",
+        "description": "Poll questions and their options with vote counts, from MeWe posts.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "MeWe",
+        "notes": "",
+        "paths": ('*/com.mewe/databases/app_database',
+                  '*/com.mewe/databases/app_v3.db'),
+        "output_types": "standard",
+        "artifact_icon": "chart-bar",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | app_v3.db | 30 rows across 3 polls",
+        },
+    },
+    "get_mewe_reactions": {
+        "name": "MeWe - Reactions",
+        "description": "Emoji reactions on posts, comments and chat messages, including whether the device owner reacted.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "MeWe",
+        "notes": "MeWe keeps a reaction tally per emoji rather than naming each reactor; only the device owner's own reaction is attributable.",
+        "paths": ('*/com.mewe/databases/app_database',
+                  '*/com.mewe/databases/app_v3.db'),
+        "output_types": "standard",
+        "artifact_icon": "mood-smile",
+        "sample_data": {
+            "pixel7a_a14": "Android 14 | app_v3.db | 240 rows (227 post, 12 comment, 1 chat)",
+            "hc_pixel8pro_a16": "Android 16 | app_v3.db | 2 rows (chat)",
+        },
+    },
+    "get_mewe_groups": {
+        "name": "MeWe - Groups and Pages",
+        "description": "Groups, pages and communities the MeWe account follows or belongs to.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "MeWe",
+        "notes": "",
+        "paths": ('*/com.mewe/databases/app_database',
+                  '*/com.mewe/databases/app_v3.db'),
+        "output_types": "standard",
+        "artifact_icon": "users-group",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | app_v3.db | 4 rows (1 group, 1 page, 2 community)",
+            "pixel7a_a14": "Android 14 | app_v3.db | 2 rows",
+        },
+    },
+    "get_mewe_chat_participants": {
+        "name": "MeWe - Chat Participants",
+        "description": "Members of each MeWe chat thread.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "MeWe",
+        "notes": "",
+        "paths": ('*/com.mewe/databases/app_database',
+                  '*/com.mewe/databases/app_v3.db'),
+        "output_types": "standard",
+        "artifact_icon": "users",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | app_v3.db | 1 row",
+            "pixel7a_a14": "Android 14 | app_v3.db | 1 row",
+        },
+    },
     "get_mewe_session": {
         "name": "MeWe - SGSession",
         "description": "Parses MeWe session preferences (key and value) from the SGSession.xml file.",
@@ -207,3 +333,267 @@ def get_mewe_session(context):
 
     data_headers = ('Key', 'Value')
     return data_headers, data_list, source_path
+
+
+# Tables that only exist in the newer app_v3.db generation. Each processor
+# checks for its own table so an older database simply yields no rows.
+def _chat_databases(files_found):
+    """Yield MeWe chat databases, skipping the empty 'mewe_old' left by upgrades."""
+    for file_found in files_found:
+        file_found = str(file_found)
+        if file_found.endswith(DB_NAMES):
+            yield file_found
+
+
+def _rows(db_path, query):
+    """Run a read-only query, logging and swallowing schema mismatches."""
+    db = open_sqlite_db_readonly(db_path)
+    try:
+        return db.cursor().execute(query).fetchall()
+    except sqlite3.Error as ex:
+        logfunc(f'MeWe: query failed on {db_path}: {ex}')
+        return []
+    finally:
+        db.close()
+
+
+def _epoch(value):
+    """MeWe stores whole seconds; 0 means unset."""
+    if not value:
+        return ''
+    return datetime.datetime.fromtimestamp(int(value), datetime.timezone.utc)
+
+
+def _millis(value):
+    """A few columns (lastVisit, lastOpenTime) are milliseconds instead."""
+    if not value:
+        return ''
+    return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc)
+
+
+def _feed_context(is_all, is_discovery, is_favorite, in_profile, is_refpost):
+    """Name the feed a post row was cached for; the same post can be in several."""
+    parts = []
+    if is_all:
+        parts.append('All Feed')
+    if is_discovery:
+        parts.append('Discovery')
+    if is_favorite:
+        parts.append('Favorites')
+    if in_profile:
+        parts.append('Profile')
+    if is_refpost:
+        parts.append('Reshared')
+    return ', '.join(parts)
+
+
+def _collect(context, table, query, build, headers):
+    """Shared shape: run query against every MeWe database holding `table`."""
+    data_list = []
+    sources = []
+    for db_path in _chat_databases(context.get_files_found()):
+        if not does_table_exist_in_db(db_path, table):
+            continue
+        rows = _rows(db_path, query)
+        if rows:
+            sources.append(db_path)
+        for row in rows:
+            data_list.append(build(row))
+    return headers, data_list, ', '.join(sources)
+
+
+POSTS_QUERY = '''
+    SELECT createdAt, editedAt, ownerName, ownerHandle, groupName, groupId, textPlain,
+           currentUserPost, commentsCount, mediasCount, sharesCount, hasLink, linkUrl,
+           linkTitle, albumName, pollQuestion, pollVotes, eventName, eventLocation,
+           isAllfeed, isDiscoveryFeed, isFavoriteFeed, inProfile, isRefpost, id
+    FROM POST ORDER BY createdAt DESC
+'''
+
+
+@artifact_processor
+def get_mewe_posts(context):
+    headers = (('Created', 'datetime'), ('Edited', 'datetime'), 'Author', 'Author Handle',
+               'Group Name', 'Group Id', 'Text', 'Posted By Device Owner', 'Comments',
+               'Media Count', 'Shares', 'Link URL', 'Link Title', 'Album Name',
+               'Poll Question', 'Poll Votes', 'Event Name', 'Event Location',
+               'Feed Context', 'Post Id')
+
+    def build(r):
+        return (_epoch(r[0]), _epoch(r[1]), r[2], r[3], r[4], r[5], r[6],
+                'Yes' if r[7] else '', r[8], r[9], r[10],
+                r[12] if r[11] else '', r[13] if r[11] else '', r[14],
+                r[15], r[16] if r[15] else '', r[17], r[18],
+                _feed_context(r[19], r[20], r[21], r[22], r[23]), r[24])
+
+    return _collect(context, 'POST', POSTS_QUERY, build, headers)
+
+
+COMMENTS_QUERY = '''
+    SELECT c.createdAt, c.editedAt, c.ownerName, c.ownerHandle, c.textPlain,
+           c.currentUserPost, c.repliesCount, c.hasPhoto, c.photoName, c.hasAudio,
+           c.audioDuration, c.hasLink, c.linkUrl, c.documentName, c.postId,
+           p.textPlain, p.ownerName, c.id
+    FROM COMMENT c
+    LEFT JOIN POST p ON p.id = c.postId
+    ORDER BY c.createdAt DESC
+'''
+
+
+@artifact_processor
+def get_mewe_comments(context):
+    headers = (('Created', 'datetime'), ('Edited', 'datetime'), 'Author', 'Author Handle',
+               'Comment Text', 'By Device Owner', 'Replies', 'Has Photo', 'Photo Name',
+               'Has Audio', 'Audio Duration', 'Link URL', 'Document Name',
+               'On Post By', 'On Post Text', 'Post Id', 'Comment Id')
+
+    def build(r):
+        return (_epoch(r[0]), _epoch(r[1]), r[2], r[3], r[4],
+                'Yes' if r[5] else '', r[6], 'Yes' if r[7] else '', r[8],
+                'Yes' if r[9] else '', r[10], r[12] if r[11] else '', r[13],
+                r[16], r[15], r[14], r[17])
+
+    return _collect(context, 'COMMENT', COMMENTS_QUERY, build, headers)
+
+
+POST_MEDIA_QUERY = '''
+    SELECT m.postId, m.type, m.mime, m.name, m.imageUrl, m.imageWidth, m.imageHeight,
+           m.videoUrlTemplate, m.availableVideoResolutions, p.createdAt, p.ownerName,
+           p.groupName, m.itemId
+    FROM POST_MEDIA m
+    LEFT JOIN POST p ON p.id = m.postId
+'''
+
+
+@artifact_processor
+def get_mewe_post_media(context):
+    headers = (('Post Created', 'datetime'), 'Post Author', 'Group Name', 'Media Type',
+               'MIME Type', 'File Name', 'Image URL', 'Width', 'Height',
+               'Video URL Template', 'Video Resolutions', 'Post Id', 'Item Id')
+
+    def build(r):
+        return (_epoch(r[9]), r[10], r[11], r[1], r[2], r[3], r[4], r[5], r[6],
+                r[7], r[8], r[0], r[12])
+
+    return _collect(context, 'POST_MEDIA', POST_MEDIA_QUERY, build, headers)
+
+
+POLLS_QUERY = '''
+    SELECT p.createdAt, p.ownerName, p.groupName, p.pollQuestion, p.pollClosed,
+           p.pollEndDate, p.pollVotes, o.text, o.votes, o.position, o.imageUrl, p.id
+    FROM POLL_OPTION o
+    LEFT JOIN POST p ON p.id = o.postId
+    ORDER BY p.createdAt DESC, o.position
+'''
+
+
+@artifact_processor
+def get_mewe_polls(context):
+    headers = (('Post Created', 'datetime'), 'Author', 'Group Name', 'Question',
+               'Option', 'Option Votes', 'Option Position', 'Total Votes', 'Closed',
+               ('Ends', 'datetime'), 'Option Image URL', 'Post Id')
+
+    def build(r):
+        return (_epoch(r[0]), r[1], r[2], r[3], r[7], r[8], r[9], r[6],
+                'Yes' if r[4] else '', _epoch(r[5]), r[10], r[11])
+
+    return _collect(context, 'POLL_OPTION', POLLS_QUERY, build, headers)
+
+
+# Reactions live in three parallel tables, one per reactable object.
+REACTION_SOURCES = (
+    ('EMOJI_POST', 'Post', '''
+        SELECT e.key, e.count, e.userReacted, e.postId, p.ownerName, p.textPlain, p.createdAt
+        FROM EMOJI_POST e LEFT JOIN POST p ON p.id = e.postId'''),
+    ('EMOJI_COMMENT', 'Comment', '''
+        SELECT e.key, e.count, e.userReacted, e.commentId, c.ownerName, c.textPlain, c.createdAt
+        FROM EMOJI_COMMENT e LEFT JOIN COMMENT c ON c.id = e.commentId'''),
+    ('EMOJI_CHAT_MESSAGE', 'Chat Message', '''
+        SELECT e.key, e.count, e.userReacted, e.chatMessageId, m.ownerName, m.textPlain, m.createdAt
+        FROM EMOJI_CHAT_MESSAGE e LEFT JOIN CHAT_MESSAGE m ON m.id = e.chatMessageId'''),
+)
+
+
+@artifact_processor
+def get_mewe_reactions(context):
+    headers = (('Target Created', 'datetime'), 'Reacted To', 'Emoji', 'Reaction Count',
+               'Device Owner Reacted', 'Target Author', 'Target Text', 'Target Id')
+    data_list = []
+    sources = []
+
+    for db_path in _chat_databases(context.get_files_found()):
+        found_any = False
+        for table, label, query in REACTION_SOURCES:
+            if not does_table_exist_in_db(db_path, table):
+                continue
+            for row in _rows(db_path, query):
+                found_any = True
+                data_list.append((_epoch(row[6]), label, row[0], row[1],
+                                  'Yes' if row[2] else '', row[4], row[5], row[3]))
+        if found_any:
+            sources.append(db_path)
+
+    return headers, data_list, ', '.join(sources)
+
+
+@artifact_processor
+def get_mewe_groups(context):
+    headers = (('Last Opened', 'datetime'), 'Type', 'Name', 'Description', 'Access',
+               'Role', 'Public', 'Confirmed', 'Verified', 'Followers', 'Public URL Id',
+               'Owner Id', 'Id')
+    data_list = []
+    sources = []
+
+    for db_path in _chat_databases(context.get_files_found()):
+        found_any = False
+
+        if does_table_exist_in_db(db_path, 'GROUP_'):
+            for r in _rows(db_path, '''SELECT lastOpenTime, name, descriptionPlain,
+                    groupAccessType, roleEnum, isPublic, isConfirmed, publicUrlId,
+                    ownerId, _id FROM GROUP_'''):
+                found_any = True
+                data_list.append((_millis(r[0]), 'Group', r[1], r[2], r[3], r[4],
+                                  'Yes' if r[5] else '', 'Yes' if r[6] else '', '',
+                                  '', r[7], r[8], r[9]))
+
+        if does_table_exist_in_db(db_path, 'PAGE'):
+            for r in _rows(db_path, '''SELECT name, description, categoryName, followers,
+                    isVerified, isFollower, isOwner, isAdmin, urlId, id FROM PAGE'''):
+                found_any = True
+                role = ', '.join(n for n, f in
+                                 (('Owner', r[6]), ('Admin', r[7]), ('Follower', r[5])) if f)
+                data_list.append(('', 'Page', r[0], r[1], r[2], role, '', '',
+                                  'Yes' if r[4] else '', r[3], r[8], '', r[9]))
+
+        if does_table_exist_in_db(db_path, 'COMMUNITY'):
+            for r in _rows(db_path, '''SELECT lastVisit, name, type, isConfirmed,
+                    isVerified, id FROM COMMUNITY'''):
+                found_any = True
+                data_list.append((_millis(r[0]), f'Community ({r[2]})', r[1], '', '', '',
+                                  '', 'Yes' if r[3] else '', 'Yes' if r[4] else '',
+                                  '', '', '', r[5]))
+
+        if found_any:
+            sources.append(db_path)
+
+    return headers, data_list, ', '.join(sources)
+
+
+PARTICIPANTS_QUERY = '''
+    SELECT p.name, p.handle, p.status, p.isOwner, p.isAdmin, p.fingerprint,
+           t.name, t.chatType, p.chatThreadId, p.id
+    FROM CHAT_THREAD_PARTICIPANT p
+    LEFT JOIN CHAT_THREAD t ON t.id = p.chatThreadId
+'''
+
+
+@artifact_processor
+def get_mewe_chat_participants(context):
+    headers = ('Thread Name', 'Chat Type', 'Participant', 'Handle', 'Status',
+               'Is Owner', 'Is Admin', 'Fingerprint', 'Thread Id', 'Participant Id')
+
+    def build(r):
+        return (r[6], r[7], r[0], r[1], r[2], 'Yes' if r[3] else '',
+                'Yes' if r[4] else '', r[5], r[8], r[9])
+
+    return _collect(context, 'CHAT_THREAD_PARTICIPANT', PARTICIPANTS_QUERY, build, headers)


### PR DESCRIPTION
Follow-up to #991. `app_v3.db` holds far more than chat, and none of it was covered by any artifact. In `pixel7a_a14` that's **74 posts, 69 media items, 16 comments, 30 poll options and 227 post reactions** sitting unparsed.

## Six new artifacts

| Artifact | Contents |
|---|---|
| MeWe - Posts | feed posts with group, author, text, link, media/comment/share counts, poll summary |
| MeWe - Comments | comments joined to the post they answer, so a comment reads in context |
| MeWe - Post Media | photos and videos with dimensions and MIME type |
| MeWe - Polls | one row per option, with votes and the question |
| MeWe - Reactions | `EMOJI_POST`, `EMOJI_COMMENT` and `EMOJI_CHAT_MESSAGE` in one table, labelled by target |
| MeWe - Groups and Pages | `GROUP_`, `PAGE` and `COMMUNITY` combined |
| MeWe - Chat Participants | thread membership |

## Two schema details drove the design

**A post is stored once per feed it was loaded into.** The primary key carries `inProfile / hashTag / isRefpost / isAllfeed / isDiscoveryFeed / isFavoriteFeed`, so the same post can legitimately appear more than once. Rather than de-duplicate and hide that, each row reports a **Feed Context** — `Discovery`, `All Feed, Reshared` — because which feed surfaced a post is itself informative. In the test image all 74 rows are distinct ids, so the duplication is latent rather than observed; the column documents the possibility instead of pretending it away.

**Reactions are a per-emoji tally, not a list of reactors.** MeWe stores `key`/`count`/`userReacted`, so only the device owner's own reaction is attributable. That's surfaced as its own column and stated in the artifact note — nothing in the database identifies who else reacted.

## Robustness

Every processor checks for its table before querying, so an older `app_database` lacking these tables yields no rows rather than an error. Joins to `POST` are LEFT, so an orphaned comment or media row is kept with blank context rather than dropped — 3 of the 69 media rows have no cached parent post.

## Verified on both images, 0 errors

| | Posts | Comments | Media | Polls | Reactions | Groups | Participants |
|---|---|---|---|---|---|---|---|
| `pixel7a_a14` | 74 | 16 | 69 | 30 | 240 | 2 | 1 |
| `hc_pixel8pro_a16` | 0 | 0 | 0 | 0 | 2 | 4 | 1 |

`hc_pixel8pro_a16` has empty POST tables, and correctly reports no rows for those artifacts rather than erroring. Reaction total splits 227 post + 12 comment + 1 chat. Join coverage checked: 0 orphaned comments, 3 orphaned media (retained).

`test_artifact_imports` OK, diff-aware lint PASS, parses on Python 3.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
