### PR TITLE
Parse settings_global/settings_system; read system build.prop

### DIFF
--- a/scripts/artifacts/build.py
+++ b/scripts/artifacts/build.py
@@ -1,24 +1,26 @@
 __artifacts_v2__ = {
     "get_build": {
         "name": "Build",
-        "description": "Parses device build properties (key and value) from the vendor build.prop file.",
+        "description": "Parses device build properties (key and value) from the vendor "
+                       "and system build.prop files. When both files are present the "
+                       "vendor values are reported.",
         "author": "",
         "creation_date": "2020-03-30",
-        "last_update_date": "2020-03-30",
+        "last_update_date": "2026-07-30",
         "requirements": "none",
         "category": "Device Information",
         "notes": "",
-        "paths": ('*/vendor/build.prop',),
+        "paths": ('*/vendor/build.prop', '*/system/build.prop'),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "info-circle",
         "sample_data": {
             "anne_a15": "Android 15 | 0 rows",
-            "galaxys10_a10": "Android 10 | 6 rows",
-            "hc_pixel8pro_a16": "Android 16 | 6 rows",
-            "pixel7a_a14": "Android 14 | 6 rows",
-            "samsunga53_a14": "Android 14 | 6 rows",
-            "sharon_a14": "Android 14 | 6 rows",
-            "russell_pixel6a_a13": "Android 13 | 6 rows",
+            "galaxys10_a10": "Android 10 | 7 rows",
+            "hc_pixel8pro_a16": "Android 16 | 7 rows",
+            "pixel7a_a14": "Android 14 | 7 rows",
+            "samsunga53_a14": "Android 14 | 7 rows",
+            "sharon_a14": "Android 14 | 7 rows",
+            "russell_pixel6a_a13": "Android 13 | 7 rows",
         },
     }
 }
@@ -27,55 +29,61 @@ import scripts.artifacts.artGlobals
 
 from scripts.ilapfuncs import artifact_processor, logfunc, logdevinfo
 
+# prop key -> report label. The vendor build.prop uses the ro.*vendor* keys; the
+# system build.prop carries ro.product.system.* plus the unqualified legacy
+# ro.build.version.* keys.
+BUILD_PROPS = {
+    'ro.product.vendor.manufacturer': 'Manufacturer',
+    'ro.product.system.manufacturer': 'Manufacturer',
+    'ro.product.vendor.brand': 'Brand',
+    'ro.product.system.brand': 'Brand',
+    'ro.product.vendor.model': 'Model',
+    'ro.product.system.model': 'Model',
+    'ro.product.vendor.device': 'Device',
+    'ro.product.system.device': 'Device',
+    'ro.vendor.build.version.release': 'Android Version',
+    'ro.build.version.release': 'Android Version',
+    'ro.vendor.build.version.sdk': 'SDK',
+    'ro.build.version.sdk': 'SDK',
+    'ro.system.build.version.release': 'Version Release',
+}
+
+# labels whose device info entry keeps its historical wording
+DEVINFO_TEXT = {
+    'Android Version': 'Android version per build.props',
+    'Version Release': 'Version release',
+}
+
 
 @artifact_processor
 def get_build(context):
-    files_found = context.get_files_found()
-    data_list = []
-    Androidversion = scripts.artifacts.artGlobals.versionf
+    files_found = [str(x) for x in context.get_files_found()]
+    # vendor/build.prop first so its values win over system/build.prop duplicates
+    files_found.sort(key=lambda p: 0 if p.replace('\\', '/').endswith('/vendor/build.prop') else 1)
 
-    source_path = str(files_found[0])
-    with open(source_path, "r", encoding='utf-8', errors='replace') as f:
-        for line in f:
-            splits = line.split('=')
-            if splits[0] == 'ro.product.vendor.manufacturer':
-                key = 'Manufacturer'
-                value = splits[1]
-                logdevinfo(f"<b>Manufacturer: </b>{value}")
-                data_list.append((key, value))
-            elif splits[0] == 'ro.product.vendor.brand':
-                key = 'Brand'
-                value = splits[1]
-                logdevinfo(f"<b>Brand: </b>{value}")
-                data_list.append((key, value))
-            elif splits[0] == 'ro.product.vendor.model':
-                key = 'Model'
-                value = splits[1]
-                logdevinfo(f"<b>Model: </b>{value}")
-                data_list.append((key, value))
-            elif splits[0] == 'ro.product.vendor.device':
-                key = 'Device'
-                value = splits[1]
-                logdevinfo(f"<b>Device: </b>{value}")
-                data_list.append((key, value))
-            elif splits[0] == 'ro.vendor.build.version.release':
-                key = 'Android Version'
-                value = splits[1]
-                if Androidversion == 0:
-                    scripts.artifacts.artGlobals.versionf = value
-                logfunc(f"Android version per build.props: {value}")
-                logdevinfo(f"<b>Android version per build.props: </b>{value}")
-                data_list.append((key, value))
-            elif splits[0] == 'ro.vendor.build.version.sdk':
-                key = 'SDK'
-                value = splits[1]
-                logdevinfo(f"<b>SDK: </b>{value}")
-                data_list.append((key, value))
-            elif splits[0] == 'ro.system.build.version.release':
-                key = 'Version Release'
-                value = splits[1]
-                logdevinfo(f"<b>Version release: </b>{value}")
-                data_list.append((key, value))
+    data_list = []
+    seen_labels = set()
+    source_path = ''
+
+    for file_found in files_found:
+        with open(file_found, "r", encoding='utf-8', errors='replace') as f:
+            for line in f:
+                key, sep, value = line.strip().partition('=')
+                label = BUILD_PROPS.get(key)
+                if not sep or label is None or label in seen_labels:
+                    continue
+                seen_labels.add(label)
+                data_list.append((label, value))
+                if not source_path:
+                    source_path = file_found
+                if label == 'Android Version':
+                    if scripts.artifacts.artGlobals.versionf == 0:
+                        scripts.artifacts.artGlobals.versionf = value
+                    logfunc(f"Android version per build.props: {value}")
+                logdevinfo(f"<b>{DEVINFO_TEXT.get(label, label)}: </b>{value}")
+
+    if not source_path:
+        source_path = files_found[0]
 
     data_headers = ('Key', 'Value')
     return data_headers, data_list, source_path

--- a/scripts/artifacts/settingsGlobalSystem.py
+++ b/scripts/artifacts/settingsGlobalSystem.py
@@ -1,0 +1,105 @@
+__artifacts_v2__ = {
+    "get_settingsGlobal": {
+        "name": "Settings Global",
+        "description": "Device-wide settings (name, value and owning package) parsed "
+                       "from the settings_global.xml file of each Android user.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Device Information",
+        "notes": "More info: https://blog.digital-forensics.it/2024/01/analysis-of-android-settings-during.html",
+        "paths": ('*/system/users/*/settings_global.xml',),
+        "output_types": ['html', 'tsv', 'lava'],
+        "artifact_icon": "settings",
+        "sample_data": {
+            "anne_a15": "Android 15 | 397 rows",
+            "galaxys10_a10": "Android 10 | 254 rows",
+            "hc_pixel8pro_a16": "Android 16 | 280 rows",
+            "kevin_pocox7_a15": "Android 15 | 511 rows",
+            "pixel7a_a14": "Android 14 | 247 rows",
+            "samsunga53_a14": "Android 14 | 336 rows",
+            "samsungs20_a13": "Android 13 | 311 rows",
+            "sharon_a14": "Android 14 | 379 rows",
+            "russell_pixel6a_a13": "Android 13 | 260 rows",
+            "userb2_a13": "Android 13 | 244 rows",
+        },
+    },
+    "get_settingsSystem": {
+        "name": "Settings System",
+        "description": "Per-user settings (name, value and owning package) parsed "
+                       "from the settings_system.xml file of each Android user.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Device Information",
+        "notes": "More info: https://blog.digital-forensics.it/2024/01/analysis-of-android-settings-during.html",
+        "paths": ('*/system/users/*/settings_system.xml',),
+        "output_types": ['html', 'tsv', 'lava'],
+        "artifact_icon": "settings",
+        "sample_data": {
+            "anne_a15": "Android 15 | 366 rows",
+            "galaxys10_a10": "Android 10 | 345 rows",
+            "hc_pixel8pro_a16": "Android 16 | 53 rows",
+            "kevin_pocox7_a15": "Android 15 | 323 rows",
+            "pixel7a_a14": "Android 14 | 52 rows",
+            "samsunga53_a14": "Android 14 | 317 rows",
+            "samsungs20_a13": "Android 13 | 472 rows",
+            "sharon_a14": "Android 14 | 671 rows",
+            "russell_pixel6a_a13": "Android 13 | 99 rows",
+            "userb2_a13": "Android 13 | 43 rows",
+        },
+    },
+}
+
+from scripts.artifacts.settingsSecure import parse_settings_root
+from scripts.ilapfuncs import artifact_processor, logdevinfo, is_platform_windows
+
+
+def _parse_settings_files(context, artifact_label):
+    files_found = context.get_files_found()
+
+    slash = '\\' if is_platform_windows() else '/'
+    data_list = []
+    source_path = ''
+
+    for file_found in files_found:
+        file_found = str(file_found)
+        uid = file_found.split(slash)[-2]
+        try:
+            int(uid)
+        except ValueError:
+            continue  # uid was not a number
+        if file_found.find('{0}mirror{0}'.format(slash)) >= 0:
+            continue  # Skip mirror, it should be duplicate data
+
+        root = parse_settings_root(file_found, artifact_label)
+        if root is None:
+            continue
+
+        source_path = file_found
+        for setting in root.iter('setting'):
+            data_list.append((uid, setting.get('name'), setting.get('value'), setting.get('package')))
+
+    return data_list, source_path
+
+
+@artifact_processor
+def get_settingsGlobal(context):
+    data_list, source_path = _parse_settings_files(context, 'settingsGlobal')
+
+    for uid, name, value, _package in data_list:
+        if name == 'device_name':
+            logdevinfo(f"<b>Device name (user {uid}): </b>{value}")
+
+    data_headers = ('User', 'Name', 'Value', 'Package')
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_settingsSystem(context):
+    data_list, source_path = _parse_settings_files(context, 'settingsSystem')
+
+    data_headers = ('User', 'Name', 'Value', 'Package')
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/settingsSecure.py
+++ b/scripts/artifacts/settingsSecure.py
@@ -37,10 +37,10 @@ INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
 BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
 
 
-def _parse_root(file_found):
+def parse_settings_root(file_found, artifact_label='settingsSecure'):
     '''Return the XML root, tolerating ABX, Android-11 rootless files, and invalid XML tokens.
 
-    settings_secure.xml occasionally contains raw control characters or unescaped
+    The settings_*.xml files occasionally contain raw control characters or unescaped
     ampersands inside setting values, which make a plain ET.parse() raise
     "not well-formed (invalid token)". We recover by sanitizing the text; if it is
     still unparseable the file is skipped (None) rather than erroring the artifact.
@@ -60,7 +60,7 @@ def _parse_root(file_found):
         try:
             return ET.fromstring(xml)
         except ET.ParseError as ex:
-            logfunc(f'settingsSecure: skipping unparseable {file_found}: {ex}')
+            logfunc(f'{artifact_label}: skipping unparseable {file_found}: {ex}')
             return None
 
 
@@ -83,7 +83,7 @@ def get_settingsSecure(context):
         if file_found.find('{0}mirror{0}'.format(slash)) >= 0:
             continue  # Skip mirror, it should be duplicate data
 
-        root = _parse_root(file_found)
+        root = parse_settings_root(file_found)
         if root is None:
             continue
 


### PR DESCRIPTION
First batch from Mattia Epifani's aLEAPP gap report (July 2026).

## build.py: also read /system/build.prop

Mattia flagged that the Build artifact only searched `*/vendor/build.prop`, and some extractions don't include the vendor partition — so device build info silently came up empty even when `/system/build.prop` was acquired.

- Paths are now `*/vendor/build.prop` **and** `*/system/build.prop`.
- Vendor values win when both files are present (labels are deduped, vendor file read first), so existing images keep their current values.
- The system file contributes via `ro.product.system.*` and the legacy unqualified `ro.build.version.*` keys; `ro.system.build.version.release` still maps to the historical "Version Release" label, which is why images with both partitions go from 6 to 7 rows.
- Device-info log strings keep their historical wording.

## New: Settings Global / Settings System artifacts

Requested in the report ("parse global, system and secure settings"), complementing the existing settingsSecure artifact. Both dump every setting — user, name, value, owning package — from `*/system/users/*/settings_global.xml` and `settings_system.xml`. Reference: https://blog.digital-forensics.it/2024/01/analysis-of-android-settings-during.html

The hardened XML reader from settingsSecure (ABX detection, Android-11 rootless files, invalid-token recovery) is now shared as `parse_settings_root()` and reused by both new artifacts. `device_name` from settings_global is surfaced to device info.

## Testing

Ran all three artifacts plus settingsSecure against all 10 registered corpus images (profile-limited runs):

- settingsSecure row counts match its existing `sample_data` on every image — the refactor is behavior-neutral.
- Build: 6 → 7 rows on the six images with system+vendor partitions; Anne stays 0 rows (its only match is a 60-byte carrier stub under `prism/`); images without any build.prop still match nothing.
- Settings Global/System parsed on all 10 images (plain XML on Android 10, ABX on 12+), 43–671 rows; `sample_data` blocks were filled from these runs.
- `admin/test/scripts` + `tests/core` suites pass; `lint_changed.py --base-ref origin/main` reports no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)