### PR TITLE
Google Dialer and Samsung battery history artifacts

### DIFF
--- a/scripts/artifacts/googleDialer.py
+++ b/scripts/artifacts/googleDialer.py
@@ -1,0 +1,312 @@
+__artifacts_v2__ = {
+    "googleDialerAnnotatedCallLog": {
+        "name": "Google Dialer Annotated Call Log",
+        "description": "Call log kept by the Google Phone app (annotated_call_log.db). "
+                       "Call types follow the Android CallLog.Calls constants.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Google Dialer",
+        "notes": "",
+        "paths": ('*/com.google.android.dialer/databases/annotated_call_log.db*',
+                  '*/com.google.android.apps.messaging/databases/annotated_call_log.db*'),
+        "output_types": "standard",
+        "artifact_icon": "phone",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.dialer vc 19806568 | 705 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.dialer vc 19106378 | 12 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.dialer vc 15435008 | 501 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.dialer vc 11945968 | 42 rows",
+        },
+    },
+    "googleDialerPhoneLookupHistory": {
+        "name": "Google Dialer Phone Lookup History",
+        "description": "Caller-id information cached per phone number by the Google Phone "
+                       "app (phone_lookup_history.db). The contact name, label and lookup "
+                       "URI come from the device contacts (Cp2Info) and the CNAP name from "
+                       "the carrier, per the app's phone_lookup_info protobuf.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Google Dialer",
+        "notes": "",
+        "paths": ('*/com.google.android.dialer/databases/phone_lookup_history.db*',
+                  '*/com.google.android.apps.messaging/databases/phone_lookup_history.db*'),
+        "output_types": "standard",
+        "artifact_icon": "user",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.dialer vc 19806568 | 3 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.dialer vc 19106378 | 5 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.dialer vc 15435008 | 446 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.dialer vc 11945968 | 22 rows",
+        },
+    },
+    "googleDialerSmartdial": {
+        "name": "Google Dialer Smartdial",
+        "description": "Contacts indexed for smart dialing by the Google Phone app "
+                       "(dialer.db, smartdial_table).",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Google Dialer",
+        "notes": "",
+        "paths": ('*/com.google.android.dialer/databases/dialer.db*',),
+        "output_types": "standard",
+        "artifact_icon": "users",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.dialer vc 19806568 | 1 row",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.dialer vc 19106378 | 14 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.dialer vc 15435008 | 11 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.dialer vc 11945968 | 2 rows",
+        },
+    },
+    "googleDialerCachedNumberContacts": {
+        "name": "Google Dialer Cached Number Contacts",
+        "description": "Caller-id lookups cached per phone number by the Google Phone app "
+                       "(dialer.db, cached_number_contacts).",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Google Dialer",
+        "notes": "",
+        "paths": ('*/com.google.android.dialer/databases/dialer.db*',),
+        "output_types": "standard",
+        "artifact_icon": "user-check",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.dialer vc 19806568 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.dialer vc 19106378 | 0 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.dialer vc 15435008 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.dialer vc 11945968 | 0 rows",
+        },
+    },
+}
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
+    convert_unix_ts_to_utc, decode_protobuf
+
+# Android CallLog.Calls type constants
+CALL_TYPES = {
+    1: 'Incoming',
+    2: 'Outgoing',
+    3: 'Missed',
+    4: 'Voicemail',
+    5: 'Rejected',
+    6: 'Blocked',
+    7: 'Answered Externally',
+}
+
+# Android CallLog.Calls presentation constants
+PRESENTATIONS = {
+    1: 'Allowed',
+    2: 'Restricted',
+    3: 'Unknown',
+    4: 'Payphone',
+    5: 'Unavailable',
+}
+
+
+def _db_files(context):
+    '''The db globs also match -journal/-wal/-shm sidecars; keep only the databases.'''
+    return [str(x) for x in context.get_files_found() if str(x).endswith('.db')]
+
+
+def _ms_to_utc(value):
+    if not value:
+        return ''
+    return convert_unix_ts_to_utc(int(value) / 1000)
+
+
+def _pb_str(node, *path):
+    '''Defensively walk a blackboxprotobuf dict and return the value at path as text.'''
+    cur = node
+    for key in path:
+        if isinstance(cur, list):
+            cur = cur[0] if cur else None
+        if not isinstance(cur, dict):
+            return ''
+        cur = cur.get(key)
+    if isinstance(cur, list):
+        cur = cur[0] if cur else None
+    if isinstance(cur, bytes):
+        return cur.decode('utf-8', 'replace')
+    if isinstance(cur, str):
+        return cur
+    return ''
+
+
+@artifact_processor
+def googleDialerAnnotatedCallLog(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in _db_files(context):
+        db_records = get_sqlite_db_records(file_found, '''
+            SELECT timestamp, formatted_number, raw_number, call_type, presentation,
+                   duration, geocoded_location, phone_account_id, is_read, new,
+                   is_voicemail_call, voicemail_transcription
+            FROM AnnotatedCallLog
+            ORDER BY timestamp DESC
+        ''')
+
+        for row in db_records:
+            source_path = file_found
+            data_list.append((
+                _ms_to_utc(row[0]),
+                row[1],
+                row[2],
+                CALL_TYPES.get(row[3], row[3]),
+                PRESENTATIONS.get(row[4], row[4]),
+                row[5],
+                row[6],
+                row[7],
+                row[8],
+                row[9],
+                row[10],
+                row[11],
+            ))
+
+    data_headers = (
+        ('Timestamp', 'datetime'),
+        ('Formatted Number', 'phonenumber'),
+        ('Raw Number', 'phonenumber'),
+        'Call Type',
+        'Presentation',
+        'Duration (Seconds)',
+        'Geocoded Location',
+        'Phone Account ID',
+        'Is Read',
+        'New',
+        'Is Voicemail Call',
+        'Voicemail Transcription',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def googleDialerPhoneLookupHistory(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in _db_files(context):
+        db_records = get_sqlite_db_records(file_found, '''
+            SELECT normalized_number, phone_lookup_info, last_modified
+            FROM PhoneLookupHistory
+            ORDER BY last_modified DESC
+        ''')
+
+        for row in db_records:
+            source_path = file_found
+            name = label = lookup_uri = cnap_name = location = ''
+            try:
+                info, _ = decode_protobuf(row[1])
+                # PhoneLookupInfo: 1 = default_cp2_info (Cp2ContactInfo: 1 name,
+                # 5 label, 7 lookup_uri), 7 = cnap_info (1 name)
+                name = _pb_str(info, '1', '1', '1')
+                label = _pb_str(info, '1', '1', '5')
+                lookup_uri = _pb_str(info, '1', '1', '7')
+                cnap_name = _pb_str(info, '7', '1')
+                location = _pb_str(info, '13', '1')
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass  # unparseable protobuf blob; keep the row with empty lookup fields
+            data_list.append((
+                _ms_to_utc(row[2]),
+                row[0],
+                name,
+                label,
+                cnap_name,
+                location,
+                lookup_uri,
+            ))
+
+    data_headers = (
+        ('Last Modified', 'datetime'),
+        ('Number', 'phonenumber'),
+        'Contact Name',
+        'Number Label',
+        'CNAP Name',
+        'Location Info',
+        'Contact Lookup URI',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def googleDialerSmartdial(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in _db_files(context):
+        db_records = get_sqlite_db_records(file_found, '''
+            SELECT display_name, phone_number, normalized_number, contact_id,
+                   last_smartdial_update_time, last_time_used, times_used, starred
+            FROM smartdial_table
+            ORDER BY display_name
+        ''')
+
+        for row in db_records:
+            source_path = file_found
+            data_list.append((
+                row[0],
+                row[1],
+                row[2],
+                row[3],
+                _ms_to_utc(row[4]),
+                _ms_to_utc(row[5]),
+                row[6],
+                row[7],
+            ))
+
+    data_headers = (
+        'Display Name',
+        ('Phone Number', 'phonenumber'),
+        ('Normalized Number', 'phonenumber'),
+        'Contact ID',
+        ('Last Update Time', 'datetime'),
+        ('Last Time Used', 'datetime'),
+        'Times Used',
+        'Starred',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def googleDialerCachedNumberContacts(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in _db_files(context):
+        db_records = get_sqlite_db_records(file_found, '''
+            SELECT time_last_updated, number, normalized_number, display_name,
+                   phone_label, source_name, photo_uri, lookup_key
+            FROM cached_number_contacts
+            ORDER BY time_last_updated DESC
+        ''')
+
+        for row in db_records:
+            source_path = file_found
+            data_list.append((
+                _ms_to_utc(row[0]),
+                row[1],
+                row[2],
+                row[3],
+                row[4],
+                row[5],
+                row[6],
+                row[7],
+            ))
+
+    data_headers = (
+        ('Time Last Updated', 'datetime'),
+        ('Number', 'phonenumber'),
+        ('Normalized Number', 'phonenumber'),
+        'Display Name',
+        'Phone Label',
+        'Source Name',
+        'Photo URI',
+        'Lookup Key',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/samsungBatteryStats.py
+++ b/scripts/artifacts/samsungBatteryStats.py
@@ -1,0 +1,250 @@
+__artifacts_v2__ = {
+    "sdhmsBatteryAppHistory": {
+        "name": "SDHMS Battery App History",
+        "description": "Per-app usage recorded in time windows by the Samsung Device Health "
+                       "Manager Service (sec_batterystats_history, APP_HISTORY table): power "
+                       "drain, foreground/background time, CPU, wakelocks, network packets, "
+                       "GPS and audio use per uid.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Samsung Device Health Management Service",
+        "notes": "Times are in milliseconds. The bluetooth_scan column does not exist on "
+                 "older One UI versions and is reported empty there.",
+        "paths": ('*/com.sec.android.sdhms/databases/sec_batterystats_history*',),
+        "output_types": "standard",
+        "artifact_icon": "battery-charging",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.sec.android.sdhms | 1533 rows",
+            "galaxys10_a10": "Android 10 | com.sec.android.sdhms | 3341 rows",
+            "samsunga53_a14": "Android 14 | com.sec.android.sdhms | 397 rows",
+            "samsungs20_a13": "Android 13 | com.sec.android.sdhms | 246 rows",
+            "sharon_a14": "Android 14 | com.sec.android.sdhms | 961 rows",
+        },
+    },
+    "sdhmsBatteryDeviceHistory": {
+        "name": "SDHMS Battery Device History",
+        "description": "Device-wide screen and discharge figures recorded in time windows by "
+                       "the Samsung Device Health Manager Service (sec_batterystats_history, "
+                       "DEVICE_HISTORY table).",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Samsung Device Health Management Service",
+        "notes": "Times are in milliseconds. The screen-on count, high-brightness and "
+                 "high-refresh columns do not exist on older One UI versions and are "
+                 "reported empty there.",
+        "paths": ('*/com.sec.android.sdhms/databases/sec_batterystats_history*',),
+        "output_types": "standard",
+        "artifact_icon": "smartphone",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.sec.android.sdhms | 322 rows",
+            "galaxys10_a10": "Android 10 | com.sec.android.sdhms | 567 rows",
+            "samsunga53_a14": "Android 14 | com.sec.android.sdhms | 37 rows",
+            "samsungs20_a13": "Android 13 | com.sec.android.sdhms | 42 rows",
+            "sharon_a14": "Android 14 | com.sec.android.sdhms | 69 rows",
+        },
+    },
+    "sdhmsBatteryEventHistory": {
+        "name": "SDHMS Battery Event History",
+        "description": "Battery events recorded by the Samsung Device Health Manager Service "
+                       "(sec_batterystats_history, BATTERY_EVENT_HISTORY table). Event type "
+                       "and value are stored as raw integers and their encoding differs "
+                       "between One UI versions, so they are reported as-is.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Samsung Device Health Management Service",
+        "notes": "The id column does not exist on older One UI versions and is reported "
+                 "empty there.",
+        "paths": ('*/com.sec.android.sdhms/databases/sec_batterystats_history*',),
+        "output_types": "standard",
+        "artifact_icon": "battery",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.sec.android.sdhms | 232 rows",
+            "galaxys10_a10": "Android 10 | com.sec.android.sdhms | 362 rows",
+            "samsunga53_a14": "Android 14 | com.sec.android.sdhms | 23 rows",
+            "samsungs20_a13": "Android 13 | com.sec.android.sdhms | 225 rows",
+            "sharon_a14": "Android 14 | com.sec.android.sdhms | 67 rows",
+        },
+    },
+    "sdhmsBatterySystemHistory": {
+        "name": "SDHMS Battery System History",
+        "description": "System power drain recorded in time windows by the Samsung Device "
+                       "Health Manager Service (sec_batterystats_history, SYSTEM_HISTORY "
+                       "table). The drain type is stored as a raw integer and is reported "
+                       "as-is.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Samsung Device Health Management Service",
+        "notes": "",
+        "paths": ('*/com.sec.android.sdhms/databases/sec_batterystats_history*',),
+        "output_types": "standard",
+        "artifact_icon": "cpu",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.sec.android.sdhms | 490 rows",
+            "galaxys10_a10": "Android 10 | com.sec.android.sdhms | 577 rows",
+            "samsunga53_a14": "Android 14 | com.sec.android.sdhms | 36 rows",
+            "samsungs20_a13": "Android 13 | com.sec.android.sdhms | 48 rows",
+            "sharon_a14": "Android 14 | com.sec.android.sdhms | 83 rows",
+        },
+    },
+}
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
+    convert_unix_ts_to_utc, does_column_exist_in_db
+
+
+def _history_db(context):
+    '''First sec_batterystats_history database, skipping -wal/-shm sidecars and mirrors.'''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if file_found.endswith(('-wal', '-shm')):
+            continue
+        if 'data_mirror' in file_found:
+            continue
+        return file_found
+    return None
+
+
+def _ms_to_utc(value):
+    if not value:
+        return ''
+    return convert_unix_ts_to_utc(int(value) / 1000)
+
+
+@artifact_processor
+def sdhmsBatteryAppHistory(context):
+    data_list = []
+    source_path = _history_db(context)
+
+    if source_path:
+        # older One UI versions do not have the bluetooth_scan column
+        has_bt_scan = does_column_exist_in_db(source_path, 'APP_HISTORY', 'bluetooth_scan')
+        bt_scan_column = 'bluetooth_scan' if has_bt_scan else "''"
+        db_records = get_sqlite_db_records(source_path, f'''
+            SELECT start_time, end_time, uid, power, screen_power, fg_time, bg_time,
+                   cpu_time, wakelock_time, mobile_packet, wifi_packet, wakeup_alarm,
+                   gps_time, audio_time, mobile_active, {bt_scan_column}
+            FROM APP_HISTORY
+            ORDER BY start_time DESC
+        ''')
+
+        for row in db_records:
+            data_list.append((_ms_to_utc(row[0]), _ms_to_utc(row[1])) + tuple(row[2:]))
+
+    data_headers = (
+        ('Window Start', 'datetime'),
+        ('Window End', 'datetime'),
+        'UID',
+        'Power',
+        'Screen Power',
+        'Foreground Time (ms)',
+        'Background Time (ms)',
+        'CPU Time (ms)',
+        'Wakelock Time (ms)',
+        'Mobile Packets',
+        'Wi-Fi Packets',
+        'Wakeup Alarms',
+        'GPS Time (ms)',
+        'Audio Time (ms)',
+        'Mobile Active',
+        'Bluetooth Scan',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def sdhmsBatteryDeviceHistory(context):
+    data_list = []
+    source_path = _history_db(context)
+
+    if source_path:
+        # older One UI versions lack the screen_on_count/high_brightness_time/
+        # high_refresh_time columns
+        if does_column_exist_in_db(source_path, 'DEVICE_HISTORY', 'screen_on_count'):
+            newer_columns = 'screen_on_count, high_brightness_time, high_refresh_time'
+        else:
+            newer_columns = "'', '', ''"
+        db_records = get_sqlite_db_records(source_path, f'''
+            SELECT start_time, end_time, all_power, screen_power, screen_on_time,
+                   screen_off_time, screen_on_discharge, screen_off_discharge,
+                   {newer_columns}
+            FROM DEVICE_HISTORY
+            ORDER BY start_time DESC
+        ''')
+
+        for row in db_records:
+            data_list.append((_ms_to_utc(row[0]), _ms_to_utc(row[1])) + tuple(row[2:]))
+
+    data_headers = (
+        ('Window Start', 'datetime'),
+        ('Window End', 'datetime'),
+        'All Power',
+        'Screen Power',
+        'Screen On Time (ms)',
+        'Screen Off Time (ms)',
+        'Screen On Discharge',
+        'Screen Off Discharge',
+        'Screen On Count',
+        'High Brightness Time (ms)',
+        'High Refresh Time (ms)',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def sdhmsBatteryEventHistory(context):
+    data_list = []
+    source_path = _history_db(context)
+
+    if source_path:
+        # older One UI versions lack the id column
+        id_column = 'id' if does_column_exist_in_db(
+            source_path, 'BATTERY_EVENT_HISTORY', 'id') else "''"
+        db_records = get_sqlite_db_records(source_path, f'''
+            SELECT update_time, event_type, event_value, {id_column}
+            FROM BATTERY_EVENT_HISTORY
+            ORDER BY update_time DESC
+        ''')
+
+        for row in db_records:
+            data_list.append((_ms_to_utc(row[0]), row[1], row[2], row[3]))
+
+    data_headers = (
+        ('Update Time', 'datetime'),
+        'Event Type',
+        'Event Value',
+        'ID',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def sdhmsBatterySystemHistory(context):
+    data_list = []
+    source_path = _history_db(context)
+
+    if source_path:
+        db_records = get_sqlite_db_records(source_path, '''
+            SELECT start_time, end_time, drain_type, power, used_time
+            FROM SYSTEM_HISTORY
+            ORDER BY start_time DESC
+        ''')
+
+        for row in db_records:
+            data_list.append((_ms_to_utc(row[0]), _ms_to_utc(row[1]), row[2], row[3], row[4]))
+
+    data_headers = (
+        ('Window Start', 'datetime'),
+        ('Window End', 'datetime'),
+        'Drain Type',
+        'Power',
+        'Used Time (ms)',
+    )
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Second batch from Mattia Epifani's aLEAPP gap report (July 2026).

## New: Google Dialer module (4 artifacts)

- **Annotated Call Log** — the Google Phone app's own call log (`annotated_call_log.db`), with call types and presentation mapped per the documented Android `CallLog.Calls` constants and everything else reported as stored.
- **Phone Lookup History** — per-number cached caller-id (`phone_lookup_history.db`). The `phone_lookup_info` protobuf is decoded with the vendored blackboxprotobuf; the contact name/label/lookup-URI fields (Cp2Info, field 1) and CNAP name (field 7) follow the field numbers in the AOSP Dialer `phone_lookup_info.proto`. A geographic string observed at field 13 (not present in the public proto) is reported neutrally as "Location Info".
- **Smartdial** and **Cached Number Contacts** — both tables of `dialer.db`.

Note: the gap report listed `annotated_call_log.db`/`phone_lookup_history.db` under `com.google.android.apps.messaging`; on every corpus image that has them they live under `com.google.android.dialer`. Both packages are in the search globs.

## New: Samsung battery history module (4 artifacts)

`sec_batterystats_history` from the Samsung Device Health Manager Service (`com.sec.android.sdhms`), in the existing SDHMS category:

- **APP_HISTORY** — per-uid usage windows (power, foreground/background/CPU/wakelock time, packets, GPS/audio).
- **DEVICE_HISTORY** — screen on/off time, discharge, screen-on counts.
- **BATTERY_EVENT_HISTORY** and **SYSTEM_HISTORY** — event and drain records. Their type codes are stored as raw integers whose encoding demonstrably differs between One UI versions (Android 10/13 images use small enumerations, Android 14/15 images pack values differently), so they are reported as-is rather than interpreted.

Schema drift handled via column checks: `bluetooth_scan` (APP_HISTORY), `screen_on_count`/`high_brightness_time`/`high_refresh_time` (DEVICE_HISTORY) and `id` (BATTERY_EVENT_HISTORY) don't exist on Android 10 and are reported empty there.

The remaining sec_batterystats items from the report (per-uid tables in the main DB, `sec_batterystats_ext`) need semantic research and are left for a later batch; `high_cpu_processes` was checked and is empty on every corpus image.

## Testing

- Profile-limited runs against all 10 registered corpus images (Android 10–16). Row counts from the artifacts match direct sqlite queries of the source databases, including the WAL-heavy Samsung files.
- Protobuf decode spot-checked against known data (contact "Annie L"/Mobile/lookup URI, CNAP "Scam Likely").
- `admin/test/scripts` + `tests/core` pass; `lint_changed.py --base-ref origin/main` reports no new warnings.
- `sample_data` blocks were filled from these runs (dialer versionCodes taken from the coverage entries already recorded on googleCallScreen for the same images).

🤖 Generated with [Claude Code](https://claude.com/claude-code)