### PR TITLE
Google Play services database artifacts (constellation, account history, icing, ODLH)

### DIFF
--- a/scripts/artifacts/googleAccountHistory.py
+++ b/scripts/artifacts/googleAccountHistory.py
@@ -1,0 +1,76 @@
+__artifacts_v2__ = {
+    "gmsAccountHistory": {
+        "name": "Google Account History",
+        "description": "History of Google accounts on the device recorded by Google Play "
+                       "services (google_account_history.db, AccountHistory table). The "
+                       "change type is stored as a raw integer and is reported as-is.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Accounts",
+        "notes": "More info: https://blog.digital-forensics.it/2024/01/a-first-look-at-android-14-forensics.html",
+        "paths": ('*/com.google.android.gms/databases/google_account_history.db*',),
+        "output_types": "standard",
+        "artifact_icon": "user",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 1 row",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 1 row",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 1 row",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 1 row",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 1 row",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 2 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 4 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 2 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 1 row",
+            "userb2_a13": "Android 13 | com.google.android.gms | 2 rows",
+        },
+    },
+}
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
+
+
+def _unique_db_files(context, name_suffix):
+    '''Database files matching the suffix, without -journal/-wal/-shm sidecars and
+    without the duplicates extractions carry for the same file (data_mirror, and
+    /data/data next to /data/user/0).'''
+    seen = set()
+    result = []
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith(name_suffix):
+            continue
+        if 'data_mirror' in file_found:
+            continue
+        normalized = file_found.replace('\\', '/').replace('/data/data/', '/data/user/0/')
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(file_found)
+    return result
+
+
+@artifact_processor
+def gmsAccountHistory(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in _unique_db_files(context, 'google_account_history.db'):
+        db_records = get_sqlite_db_records(file_found, '''
+            SELECT account_name, change_type, event_index, change_data
+            FROM AccountHistory
+            ORDER BY id
+        ''')
+
+        for row in db_records:
+            source_path = file_found
+            data_list.append((row[0], row[1], row[2], row[3]))
+
+    data_headers = (
+        'Account Name',
+        'Change Type',
+        'Event Index',
+        'Change Data',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/googleConstellation.py
+++ b/scripts/artifacts/googleConstellation.py
@@ -1,0 +1,94 @@
+__artifacts_v2__ = {
+    "constellationSimVerifications": {
+        "name": "Constellation SIM Verifications",
+        "description": "Phone numbers of SIM cards verified on the device by Google Play "
+                       "services (constellation.db, sim_verifications table), with the IMSI "
+                       "and verification time and method.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Device Information",
+        "notes": "The sim_slot column does not exist on older Play services versions and "
+                 "is reported empty there. The state column is stored as a raw integer "
+                 "and is reported as-is.",
+        "paths": ('*/com.google.android.gms/databases/constellation.db*',),
+        "output_types": "standard",
+        "artifact_icon": "smartphone",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 1 row",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 1 row",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 2 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 2 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 2 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 1 row",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 2 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
+        },
+    },
+}
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
+    convert_unix_ts_to_utc, does_column_exist_in_db
+
+
+def _unique_db_files(context, name_suffix):
+    '''Database files matching the suffix, without -journal/-wal/-shm sidecars and
+    without the duplicates extractions carry for the same file (data_mirror, and
+    /data/data next to /data/user/0).'''
+    seen = set()
+    result = []
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith(name_suffix):
+            continue
+        if 'data_mirror' in file_found:
+            continue
+        normalized = file_found.replace('\\', '/').replace('/data/data/', '/data/user/0/')
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(file_found)
+    return result
+
+
+@artifact_processor
+def constellationSimVerifications(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in _unique_db_files(context, 'constellation.db'):
+        # older Play services versions do not have the sim_slot column
+        slot_column = 'sim_slot' if does_column_exist_in_db(
+            file_found, 'sim_verifications', 'sim_slot') else "''"
+        db_records = get_sqlite_db_records(file_found, f'''
+            SELECT verification_time, phone_number, imsi, sim_readable_number, state,
+                   verification_method, {slot_column}
+            FROM sim_verifications
+            ORDER BY verification_time DESC
+        ''')
+
+        for row in db_records:
+            source_path = file_found
+            data_list.append((
+                convert_unix_ts_to_utc(row[0]),
+                row[1],
+                row[2],
+                row[3],
+                row[4],
+                row[5],
+                row[6],
+            ))
+
+    data_headers = (
+        ('Verification Time', 'datetime'),
+        ('Phone Number', 'phonenumber'),
+        'IMSI',
+        ('SIM Readable Number', 'phonenumber'),
+        'State',
+        'Verification Method',
+        'SIM Slot',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/googleIcingContacts.py
+++ b/scripts/artifacts/googleIcingContacts.py
@@ -1,0 +1,169 @@
+__artifacts_v2__ = {
+    "gmsIcingContacts": {
+        "name": "Icing Contacts",
+        "description": "Snapshot of device contacts indexed for search by Google Play "
+                       "services (icing_contacts.db, contacts table). Kept independently "
+                       "of the Contacts database, so the two may diverge.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Contacts",
+        "notes": "",
+        "paths": ('*/com.google.android.gms/databases/icing_contacts.db*',),
+        "output_types": "standard",
+        "artifact_icon": "users",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 7 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 3 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 1 row",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 9 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 4 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 3 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 8 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 5 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 19 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
+        },
+    },
+    "gmsIcingContactMethods": {
+        "name": "Icing Contact Methods",
+        "description": "Individual phone numbers, e-mail addresses and postal addresses "
+                       "from the Google Play services contacts index (icing_contacts.db, "
+                       "phones/emails/postals tables). The type is stored as a raw integer "
+                       "and is reported as-is.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Contacts",
+        "notes": "",
+        "paths": ('*/com.google.android.gms/databases/icing_contacts.db*',),
+        "output_types": "standard",
+        "artifact_icon": "book",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 8 rows",
+            "galaxys10_a10": "Android 10 | com.google.android.gms vc 210915037 | 3 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 2 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 19 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 16 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 4 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 8 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 6 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 26 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
+        },
+    },
+}
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
+    convert_unix_ts_to_utc, does_column_exist_in_db
+
+
+def _unique_db_files(context, name_suffix):
+    '''Database files matching the suffix, without -journal/-wal/-shm sidecars and
+    without the duplicates extractions carry for the same file (data_mirror, and
+    /data/data next to /data/user/0).'''
+    seen = set()
+    result = []
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith(name_suffix):
+            continue
+        if 'data_mirror' in file_found:
+            continue
+        normalized = file_found.replace('\\', '/').replace('/data/data/', '/data/user/0/')
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(file_found)
+    return result
+
+
+@artifact_processor
+def gmsIcingContacts(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in _unique_db_files(context, 'icing_contacts.db'):
+        # older Play services versions lack the last_updated_timestamp and starred columns
+        updated_column = 'last_updated_timestamp' if does_column_exist_in_db(
+            file_found, 'contacts', 'last_updated_timestamp') else "''"
+        starred_column = 'starred' if does_column_exist_in_db(
+            file_found, 'contacts', 'starred') else "''"
+        db_records = get_sqlite_db_records(file_found, f'''
+            SELECT {updated_column}, contact_id, display_name, given_names, nickname,
+                   organization, note, emails, phone_numbers, postal_address,
+                   times_contacted, {starred_column}, lookup_key
+            FROM contacts
+            ORDER BY display_name
+        ''')
+
+        for row in db_records:
+            source_path = file_found
+            data_list.append((
+                convert_unix_ts_to_utc(row[0]) if row[0] else '',
+                row[1],
+                row[2],
+                row[3],
+                row[4],
+                row[5],
+                row[6],
+                row[7],
+                row[8],
+                row[9],
+                row[10],
+                row[11],
+                row[12],
+            ))
+
+    data_headers = (
+        ('Last Updated', 'datetime'),
+        'Contact ID',
+        'Display Name',
+        'Given Names',
+        'Nickname',
+        'Organization',
+        'Note',
+        'Emails',
+        'Phone Numbers',
+        'Postal Address',
+        'Times Contacted',
+        'Starred',
+        'Lookup Key',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def gmsIcingContactMethods(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in _unique_db_files(context, 'icing_contacts.db'):
+        db_records = get_sqlite_db_records(file_found, '''
+            SELECT m.kind, m.value, m.label, m.type, m.contact_id, c.display_name
+            FROM (
+                SELECT 'Phone' AS kind, phone AS value, label, type, contact_id FROM phones
+                UNION ALL
+                SELECT 'Email' AS kind, email AS value, label, type, contact_id FROM emails
+                UNION ALL
+                SELECT 'Postal' AS kind, postal AS value, label, type, contact_id FROM postals
+            ) AS m
+            LEFT JOIN contacts AS c ON c.contact_id = m.contact_id
+            ORDER BY c.display_name, m.kind
+        ''')
+
+        for row in db_records:
+            source_path = file_found
+            data_list.append((row[5], row[0], row[1], row[2], row[3], row[4]))
+
+    data_headers = (
+        'Display Name',
+        'Kind',
+        'Value',
+        'Label',
+        'Type',
+        'Contact ID',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/googleOdlh.py
+++ b/scripts/artifacts/googleOdlh.py
@@ -1,0 +1,206 @@
+__artifacts_v2__ = {
+    "gmsOdlhSemanticSegments": {
+        "name": "ODLH Semantic Segments",
+        "description": "Time-bounded segments stored by Google's On Device Location "
+                       "History (odlh-storage.db, semantic_segment_table). For segments "
+                       "whose semantic_segment protobuf embeds a coordinate pair the "
+                       "latitude and longitude are decoded; the segment type is stored "
+                       "as a raw integer and is reported as-is.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "GEO Location",
+        "notes": "Coordinates are stored as E7 fixed-point integers inside the protobuf "
+                 "and were validated against multiple test images. Reference: Cellebrite "
+                 "Location Booklet 2025.",
+        "paths": ('*/com.google.android.gms/databases/odlh-storage.db*',),
+        "output_types": "all",
+        "artifact_icon": "map-pin",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 545 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 605 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 3251 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 2102 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 393 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 254 rows",
+        },
+    },
+    "gmsOdlhEditedSegments": {
+        "name": "ODLH Edited Segments",
+        "description": "Entries in the edited_segment_table of Google's On Device Location "
+                       "History (odlh-storage.db): segment time ranges with the block range "
+                       "they belong to and whether the edit was uploaded.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "GEO Location",
+        "notes": "",
+        "paths": ('*/com.google.android.gms/databases/odlh-storage.db*',),
+        "output_types": "standard",
+        "artifact_icon": "edit",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.google.android.gms | 112 rows",
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.gms vc 253830035 | 61 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 184 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 0 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
+            "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
+            "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
+        },
+    },
+}
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
+    convert_unix_ts_to_utc, decode_protobuf
+
+
+def _unique_db_files(context, name_suffix):
+    '''Database files matching the suffix, without -journal/-wal/-shm sidecars and
+    without the duplicates extractions carry for the same file (data_mirror, and
+    /data/data next to /data/user/0).'''
+    seen = set()
+    result = []
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith(name_suffix):
+            continue
+        if 'data_mirror' in file_found:
+            continue
+        normalized = file_found.replace('\\', '/').replace('/data/data/', '/data/user/0/')
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(file_found)
+    return result
+
+
+def _pb_get(node, *path):
+    '''Defensively walk a blackboxprotobuf dict.'''
+    cur = node
+    for key in path:
+        if isinstance(cur, list):
+            cur = cur[0] if cur else None
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(key)
+    return cur
+
+
+def _e7_to_deg(value, limit):
+    '''E7 fixed-point coordinate stored as an unsigned varint; negative values wrap.'''
+    if not isinstance(value, int):
+        return ''
+    if value > 2**31:
+        value -= 2**32
+    degrees = value / 1e7
+    if abs(degrees) > limit:
+        return ''
+    return degrees
+
+
+def _segment_coordinates(blob):
+    '''Lat/long of the place coordinate a semantic_segment protobuf embeds, if any.'''
+    try:
+        info, _ = decode_protobuf(blob)
+    except Exception:  # pylint: disable=broad-exception-caught
+        return '', ''
+    point = _pb_get(info, '3', '1', '4', '5')
+    if not isinstance(point, dict):
+        return '', ''
+    latitude = _e7_to_deg(point.get('1'), 90)
+    longitude = _e7_to_deg(point.get('2'), 180)
+    if latitude == '' or longitude == '':
+        return '', ''
+    return latitude, longitude
+
+
+@artifact_processor
+def gmsOdlhSemanticSegments(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in _unique_db_files(context, 'odlh-storage.db'):
+        db_records = get_sqlite_db_records(file_found, '''
+            SELECT start_timestamp_seconds, end_timestamp_seconds, segment_type,
+                   semantic_segment, shown_in_timeline, is_finalized, hierarchy_level,
+                   segment_id, obfuscated_gaia_id
+            FROM semantic_segment_table
+            ORDER BY start_timestamp_seconds DESC
+        ''')
+
+        for row in db_records:
+            source_path = file_found
+            latitude, longitude = _segment_coordinates(row[3])
+            data_list.append((
+                convert_unix_ts_to_utc(row[0]),
+                convert_unix_ts_to_utc(row[1]),
+                row[2],
+                latitude,
+                longitude,
+                row[4],
+                row[5],
+                row[6],
+                row[7],
+                row[8],
+            ))
+
+    data_headers = (
+        ('Start Time', 'datetime'),
+        ('End Time', 'datetime'),
+        'Segment Type',
+        'Latitude',
+        'Longitude',
+        'Shown In Timeline',
+        'Is Finalized',
+        'Hierarchy Level',
+        'Segment ID',
+        'Obfuscated GAIA ID',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def gmsOdlhEditedSegments(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in _unique_db_files(context, 'odlh-storage.db'):
+        db_records = get_sqlite_db_records(file_found, '''
+            SELECT start_timestamp_seconds, end_timestamp_seconds,
+                   block_start_timestamp_seconds, block_end_timestamp_seconds,
+                   segment_type, is_edit_uploaded, segment_id, obfuscated_gaia_id
+            FROM edited_segment_table
+            ORDER BY start_timestamp_seconds DESC
+        ''')
+
+        for row in db_records:
+            source_path = file_found
+            data_list.append((
+                convert_unix_ts_to_utc(row[0]),
+                convert_unix_ts_to_utc(row[1]),
+                convert_unix_ts_to_utc(row[2]),
+                convert_unix_ts_to_utc(row[3]),
+                row[4],
+                row[5],
+                row[6],
+                row[7],
+            ))
+
+    data_headers = (
+        ('Start Time', 'datetime'),
+        ('End Time', 'datetime'),
+        ('Block Start Time', 'datetime'),
+        ('Block End Time', 'datetime'),
+        'Segment Type',
+        'Is Edit Uploaded',
+        'Segment ID',
+        'Obfuscated GAIA ID',
+    )
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Third batch from Mattia Epifani's aLEAPP gap report (July 2026) — four previously unparsed databases under `com.google.android.gms/databases/`.

## Constellation SIM Verifications (`constellation.db`)

The device's own phone numbers: number, IMSI, verification time, verification method (MO_SMS/MT_SMS/TS43 observed) and SIM slot. On the dual-SIM test image this cleanly showed both the US and UK numbers with their carriers' IMSIs. The `sim_slot` column doesn't exist on older Play services (Android 10 image) and is reported empty there; `gaia_verifications` was checked and is empty on every corpus image, so it is not parsed.

## Google Account History (`google_account_history.db`)

Accounts recorded in `AccountHistory` with their change type (kept as the raw integer — the table has no timestamps and the type encoding is not documented in the data). Reference: Mattia's Android 14 write-up, linked in the artifact notes.

## Icing Contacts (`icing_contacts.db`)

The Play services contacts search index, which is kept independently of the Contacts provider and so can diverge from it — Mattia's original point in requesting it. Two artifacts: the contacts snapshot, and per-kind rows (phones/emails/postals UNION, joined to display names). Older versions lack `last_updated_timestamp`/`starred` (caught on the Android 10 image during testing, handled via column checks).

## On Device Location History (`odlh-storage.db`)

- **Semantic Segments** with KML output: time-bounded segments; where the `semantic_segment` protobuf embeds a coordinate pair it is decoded from E7 fixed-point (signed-int32 wrap). The field path was validated by decoding two independent images and confirming both produce consistent, in-range coordinates clustering in the same real-world area (604 of 3,251 rows carried coordinates on the richest image). Segment types are version-dependent raw codes and are reported as-is.
- **Edited Segments** from `edited_segment_table` (populated on two corpus images): segment and block time ranges plus the is_edit_uploaded flag.

## Common handling

All four modules skip `-journal`/`-wal`/`-shm` sidecars and `data_mirror` paths, and dedupe the `/data/data` vs `/data/user/0` copies some extractions carry for the same file (the UserB2 tar has both).

## Testing

- Profile-limited runs against all 10 registered corpus images (Android 10–16); row counts match direct sqlite queries; `sample_data` filled from these runs.
- KML export verified for the ODLH artifact.
- `admin/test/scripts` + `tests/core` pass; `lint_changed.py --base-ref origin/main` reports no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)