### PR TITLE
Samsung system database artifacts (Privacy Dashboard, WiFi DBs, Sleep Detection, Badge)

### DIFF
--- a/scripts/artifacts/samsungBadgeProvider.py
+++ b/scripts/artifacts/samsungBadgeProvider.py
@@ -1,0 +1,72 @@
+__artifacts_v2__ = {
+    "samsungBadgeApps": {
+        "name": "Samsung Badge Provider",
+        "description": "App icon badge counts recorded by the Samsung badge provider "
+                       "(badge.db, apps table): the package and activity each badge belongs "
+                       "to, its count and whether it is hidden.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Samsung Badge Provider",
+        "notes": "More info: https://blog.digital-forensics.it/2025/11/beyond-known-call-to-forensic-research.html",
+        "paths": ('*/com.sec.android.provider.badge/databases/badge.db*',),
+        "output_types": "standard",
+        "artifact_icon": "bell",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.sec.android.provider.badge | 18 rows",
+            "galaxys10_a10": "Android 10 | com.sec.android.provider.badge | 11 rows",
+            "samsunga53_a14": "Android 14 | com.sec.android.provider.badge | 20 rows",
+            "samsungs20_a13": "Android 13 | com.sec.android.provider.badge | 19 rows",
+            "sharon_a14": "Android 14 | com.sec.android.provider.badge | 24 rows",
+        },
+    },
+}
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
+
+
+def _unique_db_files(context, name_suffix):
+    '''Database files matching the suffix, without -journal/-wal/-shm sidecars and
+    without the duplicates extractions carry for the same file (data_mirror, and
+    /data/data next to /data/user/0).'''
+    seen = set()
+    result = []
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith(name_suffix):
+            continue
+        if 'data_mirror' in file_found:
+            continue
+        normalized = file_found.replace('\\', '/').replace('/data/data/', '/data/user/0/')
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(file_found)
+    return result
+
+
+@artifact_processor
+def samsungBadgeApps(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in _unique_db_files(context, 'badge.db'):
+        db_records = get_sqlite_db_records(file_found, '''
+            SELECT package, class, badgecount, hidden, extraData
+            FROM apps
+            ORDER BY package
+        ''')
+
+        for row in db_records:
+            source_path = file_found
+            data_list.append((row[0], row[1], row[2], row[3], row[4]))
+
+    data_headers = (
+        'Package',
+        'Class',
+        'Badge Count',
+        'Hidden',
+        'Extra Data',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/samsungPrivacyDashboard.py
+++ b/scripts/artifacts/samsungPrivacyDashboard.py
@@ -1,0 +1,92 @@
+__artifacts_v2__ = {
+    "samsungPrivacyDashboardAccess": {
+        "name": "Samsung Privacy Dashboard Permission Access",
+        "description": "Permission accesses logged by the Samsung Privacy Dashboard "
+                       "(permission_db, permissionAccessInformations table): the accessing "
+                       "package, permission group, access time and whether the access "
+                       "happened in the background. The operation code is stored as a raw "
+                       "integer and is reported as-is.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Permissions",
+        "notes": "More info: https://blog.digital-forensics.it/2025/11/beyond-known-call-to-forensic-research.html. "
+                 "The UID column does not exist on older One UI versions and is reported "
+                 "empty there.",
+        "paths": ('*/com.samsung.android.privacydashboard/databases/permission_db*',),
+        "output_types": "standard",
+        "artifact_icon": "eye",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.samsung.android.privacydashboard | 3758 rows",
+            "samsunga53_a14": "Android 14 | com.samsung.android.privacydashboard | 652 rows",
+            "samsungs20_a13": "Android 13 | com.samsung.android.privacydashboard | 239 rows",
+            "sharon_a14": "Android 14 | com.samsung.android.privacydashboard | 2232 rows",
+        },
+    },
+}
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
+    convert_unix_ts_to_utc, does_column_exist_in_db
+
+
+def _unique_db_files(context, name_suffix):
+    '''Database files matching the suffix, without -journal/-wal/-shm sidecars and
+    without the duplicates extractions carry for the same file (data_mirror, and
+    /data/data next to /data/user/0).'''
+    seen = set()
+    result = []
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith(name_suffix):
+            continue
+        if 'data_mirror' in file_found:
+            continue
+        normalized = file_found.replace('\\', '/').replace('/data/data/', '/data/user/0/')
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(file_found)
+    return result
+
+
+@artifact_processor
+def samsungPrivacyDashboardAccess(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in _unique_db_files(context, 'permission_db'):
+        # older One UI versions do not have the UID column
+        uid_column = 'UID' if does_column_exist_in_db(
+            file_found, 'permissionAccessInformations', 'UID') else "''"
+        db_records = get_sqlite_db_records(file_found, f'''
+            SELECT ACCESS_TIME, PACKAGE_NAME, PERMISSION_GROUP_ID, OPERATION_CODE,
+                   BACKGROUND, PROXY_NAME, PROXY_ATTRIBUTION_TAG, {uid_column}
+            FROM permissionAccessInformations
+            ORDER BY ACCESS_TIME DESC
+        ''')
+
+        for row in db_records:
+            source_path = file_found
+            data_list.append((
+                convert_unix_ts_to_utc(row[0]),
+                row[1],
+                row[2],
+                row[3],
+                row[4],
+                row[5],
+                row[6],
+                row[7],
+            ))
+
+    data_headers = (
+        ('Access Time', 'datetime'),
+        'Package Name',
+        'Permission Group',
+        'Operation Code',
+        'Background',
+        'Proxy Name',
+        'Proxy Attribution Tag',
+        'UID',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/samsungSleepDetection.py
+++ b/scripts/artifacts/samsungSleepDetection.py
@@ -1,0 +1,131 @@
+__artifacts_v2__ = {
+    "samsungSleepScreenData": {
+        "name": "Samsung Sleep Detection Screen Data",
+        "description": "Screen state changes logged by the Samsung Continuity Service sleep "
+                       "detection (SleepDetection.db, screen_data table), with the user "
+                       "present and keyguard flags. State values are stored as raw integers "
+                       "and are reported as-is.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Samsung Continuity Service",
+        "notes": "The Time Text column is the device-local time string as stored.",
+        "paths": ('*/com.samsung.android.mcfds/databases/SleepDetection.db*',),
+        "output_types": "standard",
+        "artifact_icon": "smartphone",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.samsung.android.mcfds | 86 rows",
+        },
+    },
+    "samsungSleepTime": {
+        "name": "Samsung Sleep Detection Sleep Times",
+        "description": "Sleep windows computed by the Samsung Continuity Service sleep "
+                       "detection (SleepDetection.db, sleep_time table): the recorded start "
+                       "and end of each window and when the record was written.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Samsung Continuity Service",
+        "notes": "The *Text columns are the device-local time strings as stored.",
+        "paths": ('*/com.samsung.android.mcfds/databases/SleepDetection.db*',),
+        "output_types": "standard",
+        "artifact_icon": "moon",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.samsung.android.mcfds | 5 rows",
+        },
+    },
+}
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
+    convert_unix_ts_to_utc
+
+
+def _unique_db_files(context, name_suffix):
+    '''Database files matching the suffix, without -journal/-wal/-shm sidecars and
+    without the duplicates extractions carry for the same file (data_mirror, and
+    /data/data next to /data/user/0).'''
+    seen = set()
+    result = []
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith(name_suffix):
+            continue
+        if 'data_mirror' in file_found:
+            continue
+        normalized = file_found.replace('\\', '/').replace('/data/data/', '/data/user/0/')
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(file_found)
+    return result
+
+
+@artifact_processor
+def samsungSleepScreenData(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in _unique_db_files(context, 'SleepDetection.db'):
+        db_records = get_sqlite_db_records(file_found, '''
+            SELECT time, timeText, screenState, userPresent, useKeyGuard
+            FROM screen_data
+            ORDER BY time DESC
+        ''')
+
+        for row in db_records:
+            source_path = file_found
+            data_list.append((
+                convert_unix_ts_to_utc(row[0]),
+                row[1],
+                row[2],
+                row[3],
+                row[4],
+            ))
+
+    data_headers = (
+        ('Time', 'datetime'),
+        'Time Text (Device Local)',
+        'Screen State',
+        'User Present',
+        'Use Keyguard',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def samsungSleepTime(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in _unique_db_files(context, 'SleepDetection.db'):
+        db_records = get_sqlite_db_records(file_found, '''
+            SELECT startTime, startTimeText, endTime, endTimeText, time, timeText,
+                   ignoreSleep
+            FROM sleep_time
+            ORDER BY startTime DESC
+        ''')
+
+        for row in db_records:
+            source_path = file_found
+            data_list.append((
+                convert_unix_ts_to_utc(row[0]),
+                row[1],
+                convert_unix_ts_to_utc(row[2]),
+                row[3],
+                convert_unix_ts_to_utc(row[4]),
+                row[5],
+                row[6],
+            ))
+
+    data_headers = (
+        ('Sleep Start', 'datetime'),
+        'Sleep Start Text (Device Local)',
+        ('Sleep End', 'datetime'),
+        'Sleep End Text (Device Local)',
+        ('Recorded', 'datetime'),
+        'Recorded Text (Device Local)',
+        'Ignore Sleep',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/samsungWifiDatabases.py
+++ b/scripts/artifacts/samsungWifiDatabases.py
@@ -1,0 +1,168 @@
+__artifacts_v2__ = {
+    "samsungWifiConfigStoreDb": {
+        "name": "Samsung WiFi Config Store DB",
+        "description": "Saved Wi-Fi networks recorded in the Samsung WifiConfigStore.db "
+                       "(configs table): SSID with security type and, where present, the "
+                       "creation time - a timestamp WifiConfigStore.xml does not carry.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "WiFi Profiles",
+        "notes": "The CREATION_TIME column does not exist on older One UI versions and is "
+                 "reported empty there; where it exists, entries created before the column "
+                 "was introduced hold 0 and are also reported empty.",
+        "paths": ('*/system/WifiConfigStore.db*',),
+        "output_types": "standard",
+        "artifact_icon": "wifi",
+        "sample_data": {
+            "anne_a15": "Android 15 | 24 rows",
+            "samsunga53_a14": "Android 14 | 4 rows",
+            "samsungs20_a13": "Android 13 | 0 rows",
+            "sharon_a14": "Android 14 | 29 rows",
+        },
+    },
+    "samsungWifiGeofence": {
+        "name": "Samsung WiFi Geofence",
+        "description": "Wi-Fi networks with the geographic coordinates recorded for them in "
+                       "the Samsung wifigeofence.db (geofence_wifi table). The latitude and "
+                       "longitude come from the base columns when set and from the "
+                       "*_major columns otherwise; the Coordinate Source column names which "
+                       "pair supplied them.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "GEO Location",
+        "notes": "Unset coordinates are stored as -1.0 or the schema default 1000.0 and are "
+                 "reported empty.",
+        "paths": ('*/system/wifigeofence.db*',),
+        "output_types": "all",
+        "artifact_icon": "map-pin",
+        "sample_data": {
+            "anne_a15": "Android 15 | 11 rows",
+            "galaxys10_a10": "Android 10 | 4 rows",
+            "samsunga53_a14": "Android 14 | 0 rows",
+            "samsungs20_a13": "Android 13 | 0 rows",
+            "sharon_a14": "Android 14 | 14 rows",
+        },
+    },
+}
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
+    convert_unix_ts_to_utc, does_column_exist_in_db
+
+# unset coordinates observed in the data / declared as the column default
+COORD_SENTINELS = (-1.0, 1000.0)
+
+
+def _db_files(context, name_suffix):
+    '''Database files matching the suffix, without -wal/-shm sidecars.'''
+    return [str(x) for x in context.get_files_found() if str(x).endswith(name_suffix)]
+
+
+def _ts(value):
+    '''CREATION_TIME is a TEXT column; unset values are '', '0' or 0.'''
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        return ''
+    if value <= 0:
+        return ''
+    return convert_unix_ts_to_utc(value)
+
+
+def _coord(value):
+    if value is None or value in COORD_SENTINELS:
+        return ''
+    return value
+
+
+@artifact_processor
+def samsungWifiConfigStoreDb(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in _db_files(context, 'WifiConfigStore.db'):
+        # older One UI versions do not have the CREATION_TIME column
+        creation_column = 'CREATION_TIME' if does_column_exist_in_db(
+            file_found, 'configs', 'CREATION_TIME') else "''"
+        db_records = get_sqlite_db_records(file_found, f'''
+            SELECT {creation_column}, CONFIG_KEY, NETWORK_SCORE, CAPTIVE_PORTAL, LOCK_DOWN,
+                   NO_INTERNET_ACCESS_EXPECTED, NETWORK_DISABLE_REASON
+            FROM configs
+            ORDER BY _ID
+        ''')
+
+        for row in db_records:
+            source_path = file_found
+            data_list.append((
+                _ts(row[0]),
+                row[1],
+                row[2],
+                row[3],
+                row[4],
+                row[5],
+                row[6],
+            ))
+
+    data_headers = (
+        ('Creation Time', 'datetime'),
+        'Config Key',
+        'Network Score',
+        'Captive Portal',
+        'Lock Down',
+        'No Internet Access Expected',
+        'Network Disable Reason',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def samsungWifiGeofence(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in _db_files(context, 'wifigeofence.db'):
+        db_records = get_sqlite_db_records(file_found, '''
+            SELECT time, time_major, config_key, bssid, latitude, longitude,
+                   latitude_major, longitude_major, location_id, network_id
+            FROM geofence_wifi
+            ORDER BY _id
+        ''')
+
+        for row in db_records:
+            source_path = file_found
+            latitude, longitude = _coord(row[4]), _coord(row[5])
+            coord_source = 'latitude/longitude'
+            if latitude == '' or longitude == '':
+                latitude, longitude = _coord(row[6]), _coord(row[7])
+                coord_source = 'latitude_major/longitude_major' if latitude != '' else ''
+            data_list.append((
+                _ts(row[0]),
+                _ts(row[1]),
+                row[2],
+                row[3],
+                latitude,
+                longitude,
+                coord_source,
+                _coord(row[6]),
+                _coord(row[7]),
+                row[8],
+                row[9],
+            ))
+
+    data_headers = (
+        ('Time', 'datetime'),
+        ('Time Major', 'datetime'),
+        'Config Key',
+        'BSSID',
+        'Latitude',
+        'Longitude',
+        'Coordinate Source',
+        'Latitude Major',
+        'Longitude Major',
+        'Location ID',
+        'Network ID',
+    )
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Fourth batch from Mattia Epifani's aLEAPP gap report (July 2026) — six new artifacts across four Samsung system databases.

## Samsung Privacy Dashboard (`permission_db`)

Per-access permission log from `permissionAccessInformations`: package, permission group, access time, background flag, proxy attribution and uid — up to 3,758 rows on the corpus images. The uid column doesn't exist on the Android 13 image and is feature-detected. Operation codes stay raw. Reference: Mattia's "beyond the known call" post, linked in the notes.

## Samsung WiFi databases (`/data/system/`)

- **WifiConfigStore.db** (`configs`): saved networks (SSID + security type in the config key) with the **creation timestamp** that `WifiConfigStore.xml` lacks — Mattia's specific point in requesting this file. The CREATION_TIME column is TEXT, absent on older One UI, and 0 for entries predating its introduction; all handled. Note the file lives under `/data/system/`, not `/system/` as the gap report stated — the glob matches either.
- **wifigeofence.db** (`geofence_wifi`) with KML output: saved networks with recorded coordinates and timestamps (hotel networks resolving to their real cities on the test images). The schema has base and `*_major` coordinate pairs — the Android 10 image populates base, newer images only major — so both are reported, a Coordinate Source column names which pair filled the Latitude/Longitude columns, and the -1.0/1000.0 unset sentinels are blanked.

## Samsung Continuity Service (`SleepDetection.db`)

Two artifacts: the `screen_data` screen-state log (with user-present and keyguard flags) and the computed `sleep_time` windows. Device-local time-text columns are kept as stored alongside the converted UTC timestamps. The `motion_data`/`user_info` tables are empty on the corpus and not parsed.

## Samsung Badge Provider (`badge.db`)

Per-app/activity badge counts with the hidden flag. Testing caught that the Android 10 image keeps every row in the 960 KB `-wal` sidecar (main file is a single page) — the glob collects the sidecars so the WAL contents are read.

## Testing

- Runs against the 5 Samsung corpus images (Android 10–15); counts match direct sqlite queries; `sample_data` filled from the runs.
- KML export verified for wifigeofence.
- `admin/test/scripts` + `tests/core` pass; `lint_changed.py` reports no new warnings.

Remaining Samsung items from the report (launcher OneUI.db/Icon.db, scpmv2.db, providers.media media.db, storyservice dme.db, sec_batterystats main/_ext) are left for a later batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)