### PR TITLE
Sync authorities, Google Calendar app events, Samsung launcher and SCPM

### DIFF
--- a/scripts/artifacts/googleCalendar.py
+++ b/scripts/artifacts/googleCalendar.py
@@ -48,13 +48,39 @@ __artifacts_v2__ = {
             "russell_pixel6a_a13": "Android 13 | com.android.providers.calendar | 3 rows",
             "userb2_a13": "Android 13 | com.android.providers.calendar | 1 row",
         },
-    }
+    },
+    "googleCalendarAppEvents": {
+        "name": "Google Calendar App Events",
+        "description": "Events from the Google Calendar app's own store (cal_v2a, Events "
+                       "table), which can hold events that are not in the calendar provider "
+                       "database: start and end, title, description, the calendar and "
+                       "account they belong to and the event web link, decoded from each "
+                       "event's protobuf record.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Calendar",
+        "notes": "Created and Updated are protobuf fields 4 and 5 of the event record. The "
+                 "event type is stored as a raw integer and is reported as-is.",
+        "paths": ('*/com.google.android.calendar/databases/cal_v2a*',),
+        "output_types": "standard",
+        "artifact_icon": "calendar",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.google.android.calendar | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.calendar | 190 rows",
+            "pixel7a_a14": "Android 14 | com.google.android.calendar | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.calendar | 96 rows",
+            "userb2_a13": "Android 13 | com.google.android.calendar | 0 rows",
+        },
+    },
 }
 
 import datetime
 import sqlite3
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, \
+    get_sqlite_db_records, convert_unix_ts_to_utc, decode_protobuf, does_column_exist_in_db
 
 
 def _ms_to_utc(value):
@@ -126,4 +152,126 @@ def get_calendar_calendars(context):
         ('Created Timestamp', 'datetime'), 'Calendar Name', 'Calendar Display Name', 'Account Name',
         'Account Type', 'Visible', 'Calendar Location', 'Timezone', 'Owner Account', 'Is Primary',
         'Color', 'Color Index')
+    return data_headers, data_list, source_path
+
+
+def _unique_db_files(context, name_suffix):
+    '''Database files matching the suffix, without -wal/-shm sidecars and without the
+    duplicates extractions carry for the same file (data_mirror, and /data/data next
+    to /data/user/0).'''
+    seen = set()
+    result = []
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith(name_suffix):
+            continue
+        if 'data_mirror' in file_found:
+            continue
+        normalized = file_found.replace('\\', '/').replace('/data/data/', '/data/user/0/')
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(file_found)
+    return result
+
+
+def _pb_get(node, *path):
+    '''Defensively walk a blackboxprotobuf dict.'''
+    cur = node
+    for key in path:
+        if isinstance(cur, list):
+            cur = cur[0] if cur else None
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(key)
+    return cur
+
+
+def _pb_str(node, *path):
+    value = _pb_get(node, *path)
+    if isinstance(value, list):
+        value = value[0] if value else None
+    if isinstance(value, bytes):
+        return value.decode('utf-8', 'replace')
+    if isinstance(value, str):
+        return value
+    return ''
+
+
+def _pb_ts(node, *path):
+    value = _pb_get(node, *path)
+    if isinstance(value, int) and value > 0:
+        return convert_unix_ts_to_utc(value)
+    return ''
+
+
+@artifact_processor
+def googleCalendarAppEvents(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in _unique_db_files(context, 'cal_v2a'):
+        # older Google Calendar versions do not have the EventType column
+        event_type_column = 'e.EventType' if does_column_exist_in_db(
+            file_found, 'Events', 'EventType') else "''"
+        db_records = get_sqlite_db_records(file_found, f'''
+            SELECT e.Proto, e.EventId, {event_type_column}, e.ToBeRemoved,
+                   a.PlatformAccountName
+            FROM Events AS e
+            LEFT JOIN Accounts AS a ON a.AccountId = e.AccountId
+            ORDER BY e.StartDayUtc DESC
+        ''')
+
+        for row in db_records:
+            source_path = file_found
+            title = description = link = ical_uid = ''
+            calendar_id = calendar_name = ''
+            start = end = created = updated = ''
+            try:
+                event, _ = decode_protobuf(row[0])
+                title = _pb_str(event, '6')
+                description = _pb_str(event, '7')
+                link = _pb_str(event, '3')
+                ical_uid = _pb_str(event, '19')
+                calendar_id = _pb_str(event, '10', '1') or _pb_str(event, '35', '1')
+                calendar_name = _pb_str(event, '10', '2') or _pb_str(event, '35', '2')
+                start = _pb_ts(event, '36', '1')
+                end = _pb_ts(event, '37', '1')
+                created = _pb_ts(event, '4')
+                updated = _pb_ts(event, '5')
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass  # unparseable protobuf; keep the row with the table columns only
+            data_list.append((
+                start,
+                end,
+                title,
+                description,
+                row[4],
+                calendar_name,
+                calendar_id,
+                created,
+                updated,
+                row[2],
+                row[3],
+                link,
+                ical_uid,
+                row[1],
+            ))
+
+    data_headers = (
+        ('Start', 'datetime'),
+        ('End', 'datetime'),
+        'Title',
+        'Description',
+        'Account',
+        'Calendar Name',
+        'Calendar ID',
+        ('Created', 'datetime'),
+        ('Updated', 'datetime'),
+        'Event Type',
+        'To Be Removed',
+        'Event Web Link',
+        'iCal UID',
+        'Event ID',
+    )
     return data_headers, data_list, source_path

--- a/scripts/artifacts/samsungLauncher.py
+++ b/scripts/artifacts/samsungLauncher.py
@@ -1,0 +1,134 @@
+__artifacts_v2__ = {
+    "samsungLauncherItems": {
+        "name": "Samsung Launcher Items",
+        "description": "Home screen and app screen layout of the Samsung One UI launcher "
+                       "(OneUI.db, item table): each item's title, component, position, "
+                       "container and hidden flag. Type and container codes are stored as "
+                       "raw values and are reported as-is.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Installed Apps",
+        "notes": "",
+        "paths": ('*/com.sec.android.app.launcher/databases/OneUI.db*',),
+        "output_types": "standard",
+        "artifact_icon": "grid",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.sec.android.app.launcher | 90 rows",
+            "samsunga53_a14": "Android 14 | com.sec.android.app.launcher | 236 rows",
+            "sharon_a14": "Android 14 | com.sec.android.app.launcher | 111 rows",
+        },
+    },
+    "samsungLauncherIcons": {
+        "name": "Samsung Launcher Icons",
+        "description": "App icon cache of the Samsung One UI launcher (Icon.db, icon "
+                       "table): the component name, displayed label, Android user profile "
+                       "and when the entry was last updated.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Installed Apps",
+        "notes": "",
+        "paths": ('*/com.sec.android.app.launcher/databases/Icon.db*',),
+        "output_types": "standard",
+        "artifact_icon": "package",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.sec.android.app.launcher | 62 rows",
+            "samsunga53_a14": "Android 14 | com.sec.android.app.launcher | 184 rows",
+            "sharon_a14": "Android 14 | com.sec.android.app.launcher | 90 rows",
+        },
+    },
+}
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
+    convert_unix_ts_to_utc
+
+
+def _unique_db_files(context, name_suffix):
+    '''Database files matching the suffix, without -wal/-shm sidecars and without the
+    duplicates extractions carry for the same file (data_mirror, and /data/data next
+    to /data/user/0).'''
+    seen = set()
+    result = []
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith(name_suffix):
+            continue
+        if 'data_mirror' in file_found:
+            continue
+        normalized = file_found.replace('\\', '/').replace('/data/data/', '/data/user/0/')
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(file_found)
+    return result
+
+
+@artifact_processor
+def samsungLauncherItems(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in _unique_db_files(context, 'OneUI.db'):
+        db_records = get_sqlite_db_records(file_found, '''
+            SELECT title, component, type, item_position, position_x, position_y, rank,
+                   container_type, container_id, hidden, profile_id, restored,
+                   reference_package_name
+            FROM item
+            ORDER BY container_type, container_id, rank
+        ''')
+
+        for row in db_records:
+            source_path = file_found
+            data_list.append(tuple(row))
+
+    data_headers = (
+        'Title',
+        'Component',
+        'Type',
+        'Item Position',
+        'Position X',
+        'Position Y',
+        'Rank',
+        'Container Type',
+        'Container ID',
+        'Hidden',
+        'Profile ID',
+        'Restored',
+        'Reference Package',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def samsungLauncherIcons(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in _unique_db_files(context, 'Icon.db'):
+        db_records = get_sqlite_db_records(file_found, '''
+            SELECT last_updated, label, component_name, profile_id, version
+            FROM icon
+            ORDER BY last_updated DESC
+        ''')
+
+        for row in db_records:
+            source_path = file_found
+            data_list.append((
+                convert_unix_ts_to_utc(row[0]),
+                row[1],
+                row[2],
+                row[3],
+                row[4],
+            ))
+
+    data_headers = (
+        ('Last Updated', 'datetime'),
+        'Label',
+        'Component Name',
+        'Profile ID',
+        'Version',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/samsungScpm.py
+++ b/scripts/artifacts/samsungScpm.py
@@ -1,0 +1,98 @@
+__artifacts_v2__ = {
+    "samsungScpmDevices": {
+        "name": "Samsung Cloud Platform Devices",
+        "description": "Devices recorded by the Samsung Cloud Platform Manager (scpmv2.db, "
+                       "devices table): device alias, model, OS version, country and SIM "
+                       "codes, with the registration and last access times.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Device Information",
+        "notes": "",
+        "paths": ('*/com.samsung.android.scpm/databases/scpmv2.db*',),
+        "output_types": "standard",
+        "artifact_icon": "cloud",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.samsung.android.scpm | 1 row",
+            "samsunga53_a14": "Android 14 | com.samsung.android.scpm | 2 rows",
+            "samsungs20_a13": "Android 13 | com.samsung.android.scpm | 1 row",
+            "sharon_a14": "Android 14 | com.samsung.android.scpm | 1 row",
+        },
+    },
+}
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
+    convert_unix_ts_to_utc
+
+
+def _unique_db_files(context, name_suffix):
+    '''Database files matching the suffix, without -wal/-shm sidecars and without the
+    duplicates extractions carry for the same file (data_mirror, and /data/data next
+    to /data/user/0).'''
+    seen = set()
+    result = []
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith(name_suffix):
+            continue
+        if 'data_mirror' in file_found:
+            continue
+        normalized = file_found.replace('\\', '/').replace('/data/data/', '/data/user/0/')
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(file_found)
+    return result
+
+
+@artifact_processor
+def samsungScpmDevices(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in _unique_db_files(context, 'scpmv2.db'):
+        db_records = get_sqlite_db_records(file_found, '''
+            SELECT registration_time, last_access_time, alias, type, model_name,
+                   model_code, os_type, os_version, platform_version, country_code,
+                   sim_mcc, sim_mnc, csc, id
+            FROM devices
+            ORDER BY registration_time DESC
+        ''')
+
+        for row in db_records:
+            source_path = file_found
+            data_list.append((
+                convert_unix_ts_to_utc(row[0]),
+                convert_unix_ts_to_utc(row[1]),
+                row[2],
+                row[3],
+                row[4],
+                row[5],
+                row[6],
+                row[7],
+                row[8],
+                row[9],
+                row[10],
+                row[11],
+                row[12],
+                row[13],
+            ))
+
+    data_headers = (
+        ('Registration Time', 'datetime'),
+        ('Last Access Time', 'datetime'),
+        'Alias',
+        'Type',
+        'Model Name',
+        'Model Code',
+        'OS Type',
+        'OS Version',
+        'Platform Version',
+        'Country Code',
+        'SIM MCC',
+        'SIM MNC',
+        'CSC',
+        'Device ID',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/syncAccounts.py
+++ b/scripts/artifacts/syncAccounts.py
@@ -1,0 +1,70 @@
+__artifacts_v2__ = {
+    "syncAccountsXml": {
+        "name": "Account Sync Authorities",
+        "description": "Per-account sync authorities from /data/system/sync/accounts.xml: "
+                       "which data types each account on the device syncs, whether syncing "
+                       "is enabled and the syncable state.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Accounts",
+        "notes": "",
+        "paths": ('*/system/sync/accounts.xml',),
+        "output_types": ['html', 'tsv', 'lava'],
+        "artifact_icon": "refresh-cw",
+        "sample_data": {
+            "anne_a15": "Android 15 | 33 rows",
+            "galaxys10_a10": "Android 10 | 31 rows",
+            "hc_pixel8pro_a16": "Android 16 | 24 rows",
+            "kevin_pocox7_a15": "Android 15 | 36 rows",
+            "pixel7a_a14": "Android 14 | 41 rows",
+            "russell_pixel6a_a13": "Android 13 | 53 rows",
+            "samsunga53_a14": "Android 14 | 44 rows",
+            "samsungs20_a13": "Android 13 | 44 rows",
+            "sharon_a14": "Android 14 | 39 rows",
+            "userb2_a13": "Android 13 | 21 rows",
+        },
+    },
+}
+
+from scripts.artifacts.settingsSecure import parse_settings_root
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
+def syncAccountsXml(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if 'data_mirror' in file_found:
+            continue
+
+        root = parse_settings_root(file_found, 'syncAccounts')
+        if root is None:
+            continue
+
+        source_path = file_found
+        for authority in root.iter('authority'):
+            data_list.append((
+                authority.get('user'),
+                authority.get('account'),
+                authority.get('type'),
+                authority.get('authority'),
+                authority.get('enabled'),
+                authority.get('syncable'),
+                authority.get('id'),
+            ))
+
+    data_headers = (
+        'User',
+        'Account',
+        'Account Type',
+        'Authority',
+        'Enabled',
+        'Syncable',
+        'ID',
+    )
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Fifth batch from Mattia Epifani's aLEAPP gap report (July 2026) — five new artifacts.

## Account Sync Authorities (`/data/system/sync/accounts.xml`)

Which data types each account on the device syncs (authority, enabled, syncable, per Android user). Present on 9 of the 10 corpus images; plain XML on Android 10, ABX on newer — handled by reusing the hardened settings XML reader from batch 1.

## Google Calendar App Events (`cal_v2a`)

A correction to the earlier triage: ALEAPP already parses the calendar *provider* database (Kevin Pagano's artifacts). What the gap report asked for — and what was missing — is the Google Calendar app's **own** store, which can hold events the provider DB doesn't (190 vs 62 on one image). Added to the existing googleCalendar module.

- Start/end, title, description, calendar name/id, account, web link and iCal UID are decoded from each event's protobuf. The start/end field path was validated against the table's own `StartDayUtc`/`EndDayUtc` day-number columns (exact ms equality) and against a known user-created event on the CTF image.
- Created/Updated map to protobuf fields 4 and 5 (stated in the notes).
- The `EventType` column doesn't exist on older app versions (two corpus images) and is feature-detected — this was caught during corpus testing.

## Samsung One UI launcher (`OneUI.db`, `Icon.db`)

- **Launcher Items**: full home/app screen layout — titles, components, grid positions, container, and notably the `hidden` flag (apps hidden from the launcher).
- **Launcher Icons**: the icon cache as an app inventory — component, displayed label, Android user profile (work-profile apps show as a distinct profile id), last-updated time.

## Samsung Cloud Platform Manager (`scpmv2.db`)

The `devices` table: device alias as the user named it, model name/code, OS version, country code, SIM MCC/MNC, CSC, registration and last-access times. On one corpus image this holds two devices registered to the account.

## Testing

- Runs against all 10 corpus images; counts match direct sqlite queries; `sample_data` filled from the runs.
- `admin/test/scripts` + `tests/core` pass; `lint_changed.py` reports no new warnings.

Remaining from the report after this batch: Samsung `providers.media` media.db and storyservice dme.db, plus the research-flagged items (sec_batterystats main/_ext, mcfds context_engine_database).

🤖 Generated with [Claude Code](https://claude.com/claude-code)