### PR TITLE
Samsung media provider and story service artifacts

### DIFF
--- a/scripts/artifacts/samsungMediaProvider.py
+++ b/scripts/artifacts/samsungMediaProvider.py
@@ -1,0 +1,184 @@
+__artifacts_v2__ = {
+    "samsungMediaFiles": {
+        "name": "Samsung Media Provider - Files",
+        "description": "Media files indexed by the Samsung media provider (media.db, files "
+                       "table): file path and name, taken/added/modified times, "
+                       "coordinates and packed address, the URL and app a captured file "
+                       "came from, and the favorite/hidden/trashed/deleted flags.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Samsung Media Provider",
+        "notes": "The Address column is the packed multi-part string as stored (parts "
+                 "separated by '|'). Reference: Cellebrite Location Booklet 2025.",
+        "paths": ('*/com.samsung.android.providers.media/databases/media.db*',),
+        "output_types": "all",
+        "artifact_icon": "image",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.samsung.android.providers.media | 223 rows",
+            "galaxys10_a10": "Android 10 | com.samsung.android.providers.media | 32 rows",
+            "samsunga53_a14": "Android 14 | com.samsung.android.providers.media | 4 rows",
+            "samsungs20_a13": "Android 13 | com.samsung.android.providers.media | 16 rows",
+            "sharon_a14": "Android 14 | com.samsung.android.providers.media | 1439 rows",
+        },
+    },
+    "samsungMediaLocations": {
+        "name": "Samsung Media Provider - Locations",
+        "description": "Reverse-geocoded places recorded by the Samsung media provider "
+                       "(media.db, location table): coordinates with the resolved country, "
+                       "locality, street and full address text.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Samsung Media Provider",
+        "notes": "Reference: Cellebrite Location Booklet 2025.",
+        "paths": ('*/com.samsung.android.providers.media/databases/media.db*',),
+        "output_types": "all",
+        "artifact_icon": "map-pin",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.samsung.android.providers.media | 91 rows",
+            "galaxys10_a10": "Android 10 | com.samsung.android.providers.media | 15 rows",
+            "samsunga53_a14": "Android 14 | com.samsung.android.providers.media | 0 rows",
+            "samsungs20_a13": "Android 13 | com.samsung.android.providers.media | 0 rows",
+            "sharon_a14": "Android 14 | com.samsung.android.providers.media | 116 rows",
+        },
+    },
+}
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
+    convert_unix_ts_to_utc
+
+
+def _unique_db_files(context, name_suffix):
+    '''Database files matching the suffix, without -wal/-shm sidecars and without the
+    duplicates extractions carry for the same file (data_mirror, and /data/data next
+    to /data/user/0).'''
+    seen = set()
+    result = []
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith(name_suffix):
+            continue
+        if 'data_mirror' in file_found:
+            continue
+        normalized = file_found.replace('\\', '/').replace('/data/data/', '/data/user/0/')
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(file_found)
+    return result
+
+
+def _ts(value):
+    if not value:
+        return ''
+    return convert_unix_ts_to_utc(value)
+
+
+def _coord_pair(latitude, longitude):
+    '''Blank the unset coordinate pair (NULL, or 0/0).'''
+    if latitude is None or longitude is None:
+        return '', ''
+    if latitude == 0 and longitude == 0:
+        return '', ''
+    return latitude, longitude
+
+
+@artifact_processor
+def samsungMediaFiles(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in _unique_db_files(context, 'media.db'):
+        db_records = get_sqlite_db_records(file_found, '''
+            SELECT datetaken, date_added, date_modified, _display_name, _data, mime_type,
+                   _size, latitude, longitude, addr, bucket_display_name,
+                   owner_package_name, captured_url, captured_app, is_favorite, is_hide,
+                   is_trashed, deleted
+            FROM files
+            ORDER BY datetaken DESC
+        ''')
+
+        for row in db_records:
+            source_path = file_found
+            latitude, longitude = _coord_pair(row[7], row[8])
+            data_list.append((
+                _ts(row[0]),
+                _ts(row[1]),
+                _ts(row[2]),
+                row[3],
+                row[4],
+                row[5],
+                row[6],
+                latitude,
+                longitude,
+                row[9],
+                row[10],
+                row[11],
+                row[12],
+                row[13],
+                row[14],
+                row[15],
+                row[16],
+                row[17],
+            ))
+
+    data_headers = (
+        ('Date Taken', 'datetime'),
+        ('Date Added', 'datetime'),
+        ('Date Modified', 'datetime'),
+        'Display Name',
+        'Path',
+        'MIME Type',
+        'Size',
+        'Latitude',
+        'Longitude',
+        'Address',
+        'Bucket',
+        'Owner Package',
+        'Captured URL',
+        'Captured App',
+        'Is Favorite',
+        'Is Hide',
+        'Is Trashed',
+        'Deleted',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def samsungMediaLocations(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in _unique_db_files(context, 'media.db'):
+        db_records = get_sqlite_db_records(file_found, '''
+            SELECT latitude, longitude, address_text, country_name, country_code,
+                   admin_area, sub_admin_area, locality, sub_locality, street_name,
+                   street_number, postal_code
+            FROM location
+            ORDER BY _id
+        ''')
+
+        for row in db_records:
+            source_path = file_found
+            latitude, longitude = _coord_pair(row[0], row[1])
+            data_list.append((latitude, longitude) + tuple(row[2:]))
+
+    data_headers = (
+        'Latitude',
+        'Longitude',
+        'Address Text',
+        'Country',
+        'Country Code',
+        'Admin Area',
+        'Sub Admin Area',
+        'Locality',
+        'Sub Locality',
+        'Street Name',
+        'Street Number',
+        'Postal Code',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/samsungStoryService.py
+++ b/scripts/artifacts/samsungStoryService.py
@@ -1,0 +1,189 @@
+__artifacts_v2__ = {
+    "samsungStoryServiceInfo": {
+        "name": "Samsung Story Service - Media Info",
+        "description": "Media entries indexed by the Samsung story service (dme.db, info "
+                       "table): taken/added times, file path, coordinates with the "
+                       "resolved place names, detected scene names, face count and the "
+                       "moment each entry belongs to.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Samsung Story Service",
+        "notes": "Reference: Cellebrite Location Booklet 2025.",
+        "paths": ('*/com.samsung.storyservice/databases/dme.db*',),
+        "output_types": "all",
+        "artifact_icon": "image",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.samsung.storyservice | 0 rows",
+            "galaxys10_a10": "Android 10 | com.samsung.storyservice | 0 rows",
+            "samsunga53_a14": "Android 14 | com.samsung.storyservice | 4 rows",
+            "samsungs20_a13": "Android 13 | com.samsung.storyservice | 16 rows",
+            "sharon_a14": "Android 14 | com.samsung.storyservice | 1435 rows",
+        },
+    },
+    "samsungStoryServiceMoments": {
+        "name": "Samsung Story Service - Moments",
+        "description": "Moments grouped by the Samsung story service (dme.db, moment "
+                       "table): the time range each moment covers, its creation time, "
+                       "title, media count and recorded place information.",
+        "author": "",
+        "creation_date": "2026-07-30",
+        "last_update_date": "2026-07-30",
+        "requirements": "none",
+        "category": "Samsung Story Service",
+        "notes": "",
+        "paths": ('*/com.samsung.storyservice/databases/dme.db*',),
+        "output_types": "standard",
+        "artifact_icon": "book-open",
+        "sample_data": {
+            "anne_a15": "Android 15 | com.samsung.storyservice | 0 rows",
+            "galaxys10_a10": "Android 10 | com.samsung.storyservice | 0 rows",
+            "samsunga53_a14": "Android 14 | com.samsung.storyservice | 2 rows",
+            "samsungs20_a13": "Android 13 | com.samsung.storyservice | 4 rows",
+            "sharon_a14": "Android 14 | com.samsung.storyservice | 62 rows",
+        },
+    },
+}
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
+    convert_unix_ts_to_utc
+
+
+def _unique_db_files(context, name_suffix):
+    '''Database files matching the suffix, without -wal/-shm sidecars and without the
+    duplicates extractions carry for the same file (data_mirror, and /data/data next
+    to /data/user/0).'''
+    seen = set()
+    result = []
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith(name_suffix):
+            continue
+        if 'data_mirror' in file_found:
+            continue
+        normalized = file_found.replace('\\', '/').replace('/data/data/', '/data/user/0/')
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(file_found)
+    return result
+
+
+def _ts(value):
+    if not value:
+        return ''
+    return convert_unix_ts_to_utc(value)
+
+
+def _coord_pair(latitude, longitude):
+    '''Blank the unset coordinate pair (NULL, or 0/0).'''
+    if latitude is None or longitude is None:
+        return '', ''
+    if latitude == 0 and longitude == 0:
+        return '', ''
+    return latitude, longitude
+
+
+@artifact_processor
+def samsungStoryServiceInfo(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in _unique_db_files(context, 'dme.db'):
+        db_records = get_sqlite_db_records(file_found, '''
+            SELECT datetaken, date_added, title, _data, media_type, latitude, longitude,
+                   country_name, locality, poi_name, poi_city, street_name, scene_names,
+                   face_count, is_delete, moment_id
+            FROM info
+            ORDER BY datetaken DESC
+        ''')
+
+        for row in db_records:
+            source_path = file_found
+            latitude, longitude = _coord_pair(row[5], row[6])
+            data_list.append((
+                _ts(row[0]),
+                _ts(row[1]),
+                row[2],
+                row[3],
+                row[4],
+                latitude,
+                longitude,
+                row[7],
+                row[8],
+                row[9],
+                row[10],
+                row[11],
+                row[12],
+                row[13],
+                row[14],
+                row[15],
+            ))
+
+    data_headers = (
+        ('Date Taken', 'datetime'),
+        ('Date Added', 'datetime'),
+        'Title',
+        'Path',
+        'Media Type',
+        'Latitude',
+        'Longitude',
+        'Country',
+        'Locality',
+        'POI Name',
+        'POI City',
+        'Street Name',
+        'Scene Names',
+        'Face Count',
+        'Is Delete',
+        'Moment ID',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def samsungStoryServiceMoments(context):
+    data_list = []
+    source_path = ''
+
+    for file_found in _unique_db_files(context, 'dme.db'):
+        db_records = get_sqlite_db_records(file_found, '''
+            SELECT start_time, end_time, creation_time, title, media_count, country_name,
+                   location, poi_info, street_name_info, type, story_id, moment_id
+            FROM moment
+            ORDER BY start_time DESC
+        ''')
+
+        for row in db_records:
+            source_path = file_found
+            data_list.append((
+                _ts(row[0]),
+                _ts(row[1]),
+                _ts(row[2]),
+                row[3],
+                row[4],
+                row[5],
+                row[6],
+                row[7],
+                row[8],
+                row[9],
+                row[10],
+                row[11],
+            ))
+
+    data_headers = (
+        ('Start Time', 'datetime'),
+        ('End Time', 'datetime'),
+        ('Creation Time', 'datetime'),
+        'Title',
+        'Media Count',
+        'Country',
+        'Location',
+        'POI Info',
+        'Street Name Info',
+        'Type',
+        'Story ID',
+        'Moment ID',
+    )
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Sixth and final batch from Mattia Epifani's aLEAPP gap report (July 2026) — the two Samsung media databases, both cited in the report against the Cellebrite Location Booklet 2025.

## Samsung Media Provider (`media.db`, 4 KML-producing artifacts total with story service)

- **Files**: every media file the Samsung provider indexes — taken/added/modified times, path, size, MIME type, coordinates, the packed reverse-geocoded address string, owner package, capture provenance columns (`captured_url`/`captured_app`), and the favorite/hidden/trashed/deleted flags. 1,439 rows on the richest image, with camera photos resolving to full street addresses.
- **Locations**: the provider's own reverse-geocoding cache — coordinates with country/locality/street/postal and the full address text ("8955 International Dr, Orlando, FL 32819, USA" style).

The `files` schema is unusually stable: identical column sets from the Android 10 image through Android 15, so no feature detection was needed. Unset coordinate pairs (NULL or 0/0) are blanked so KML only gets real points.

## Samsung Story Service (`dme.db`)

- **Media Info**: the story service's per-media index — times, path, coordinates with resolved country/locality/POI/street names, detected scene names ("scenery,skies,streets"), face count, `is_delete`, and the moment each entry belongs to. 1,435 rows / 149 located on the richest image.
- **Moments**: the grouped moments with their covered time range, creation time, title and media count.

The WAL sidecars matter here: two corpus images keep essentially all rows in the `-wal`, which the db globs collect.

## Testing

- Runs against the 5 Samsung corpus images (Android 10–15); counts match direct sqlite queries; `sample_data` filled from the runs; KML exports verified.
- `admin/test/scripts` + `tests/core` pass; `lint_changed.py` reports no new warnings.

With this batch every parseable item from the gap report is covered (28 new artifacts + the build.py fix across PRs #1001–#1006). The only remaining items are the ones the report itself flagged as needing research: the per-uid tables and `_ext` database of sec_batterystats, and the mcfds `context_engine_database`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)