### PR TITLE
docs: remove unsourced claims from artifact descriptions and notes

### DIFF
--- a/scripts/artifacts/googleCalendar.py
+++ b/scripts/artifacts/googleCalendar.py
@@ -52,7 +52,7 @@ __artifacts_v2__ = {
     "googleCalendarAppEvents": {
         "name": "Google Calendar App Events",
         "description": "Events from the Google Calendar app's own store (cal_v2a, Events "
-                       "table), which can hold events that are not in the calendar provider "
+                       "table), kept separately from the calendar provider "
                        "database: start and end, title, description, the calendar and "
                        "account they belong to and the event web link, decoded from each "
                        "event's protobuf record.",

--- a/scripts/artifacts/googleIcingContacts.py
+++ b/scripts/artifacts/googleIcingContacts.py
@@ -1,8 +1,8 @@
 __artifacts_v2__ = {
     "gmsIcingContacts": {
         "name": "Icing Contacts",
-        "description": "Snapshot of device contacts indexed for search by Google Play "
-                       "services (icing_contacts.db, contacts table). Kept independently "
+        "description": "Snapshot of device contacts kept by Google Play services "
+                       "(icing_contacts.db, contacts table). Kept independently "
                        "of the Contacts database, so the two may diverge.",
         "author": "",
         "creation_date": "2026-07-30",

--- a/scripts/artifacts/samsungWifiDatabases.py
+++ b/scripts/artifacts/samsungWifiDatabases.py
@@ -3,15 +3,15 @@ __artifacts_v2__ = {
         "name": "Samsung WiFi Config Store DB",
         "description": "Saved Wi-Fi networks recorded in the Samsung WifiConfigStore.db "
                        "(configs table): SSID with security type and, where present, the "
-                       "creation time - a timestamp WifiConfigStore.xml does not carry.",
+                       "creation time.",
         "author": "",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",
         "category": "WiFi Profiles",
-        "notes": "The CREATION_TIME column does not exist on older One UI versions and is "
-                 "reported empty there; where it exists, entries created before the column "
-                 "was introduced hold 0 and are also reported empty.",
+        "notes": "The CREATION_TIME column does not exist in every schema observed and is "
+                 "reported empty there; where it exists, entries holding 0 are also "
+                 "reported empty.",
         "paths": ('*/system/WifiConfigStore.db*',),
         "output_types": "standard",
         "artifact_icon": "wifi",
@@ -34,8 +34,8 @@ __artifacts_v2__ = {
         "last_update_date": "2026-07-30",
         "requirements": "none",
         "category": "GEO Location",
-        "notes": "Unset coordinates are stored as -1.0 or the schema default 1000.0 and are "
-                 "reported empty.",
+        "notes": "Coordinates of 1000.0 (the declared column default) or -1.0 (observed for "
+                 "unset entries in test data) are reported empty.",
         "paths": ('*/system/wifigeofence.db*',),
         "output_types": "all",
         "artifact_icon": "map-pin",

--- a/scripts/artifacts/settingsSecure.py
+++ b/scripts/artifacts/settingsSecure.py
@@ -1,10 +1,11 @@
 __artifacts_v2__ = {
     "get_settingsSecure": {
         "name": "settingsSecure",
-        "description": "Filter for path xxx/yyy/system_ce/0",
+        "description": "Selected values (android_id, bluetooth name and address, "
+                       "mock_location) from settings_secure.xml of each Android user",
         "author": "",
         "creation_date": "2020-04-02",
-        "last_update_date": "2020-04-02",
+        "last_update_date": "2026-07-30",
         "requirements": "none",
         "category": "Device Information",
         "notes": "",


### PR DESCRIPTION
Fixes from a documentation audit of artifacts touched 2026-07-29/30, applying the project standard that notes and descriptions must not state what data means in the real world unless the data (or a cited source) proves it. No parsing behavior changes.

- **samsungWifiDatabases**: the description claimed the DB carries "a timestamp WifiConfigStore.xml does not carry" — an unsourced negative claim about a different artifact's contents. The notes asserted rows holding 0 "were created before the column was introduced" (unverified schema-history provenance) and stated the -1.0 coordinate sentinel as stored fact when it is a test-data observation (1000.0 is the declared column default; -1.0 is a physically valid coordinate).
- **googleIcingContacts**: "indexed for search by Google Play services" attributed a purpose not observable from the data; now "kept by Google Play services".
- **googleCalendar**: "can hold events that are not in the calendar provider database" was a cross-store capability claim; the observable fact is that cal_v2a is a separate store.
- **settingsSecure**: description was still the 2020 placeholder "Filter for path xxx/yyy/system_ce/0"; now describes the reported values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)