### PR TITLE
fix: stop resolving ProtonVPN hostnames over the network at parse time

### DIFF
--- a/scripts/artifacts/protonVPN.py
+++ b/scripts/artifacts/protonVPN.py
@@ -1,4 +1,3 @@
-# pylint: disable=W0702
 __artifacts_v2__ = {
     "get_protonvpn_device_info": {
         "name": "ProtonVPN - Device Info",
@@ -18,10 +17,13 @@ __artifacts_v2__ = {
         "description": "Parses ProtonVPN connection history (server address and timestamp) from the ProtonVPN Data.log.",
         "author": "",
         "creation_date": "2022-09-04",
-        "last_update_date": "2022-09-04",
+        "last_update_date": "2026-07-31",
         "requirements": "none",
         "category": "ProtonVPN",
-        "notes": "",
+        "notes": "The server address is reported exactly as recorded in Data.log. Earlier versions "
+                 "resolved the hostname to an IP address at parse time; that lookup was removed "
+                 "because it generated network traffic from the examiner's workstation and the "
+                 "resolved address reflected DNS at the time of analysis, not the logged connection.",
         "paths": ('*/ch.protonvpn.android/log/Data.log',),
         "output_types": "standard",
         "artifact_icon": "user",
@@ -42,7 +44,6 @@ __artifacts_v2__ = {
 }
 
 import re
-import socket
 import datetime
 import xml.etree.ElementTree as ET
 
@@ -126,15 +127,9 @@ def get_protonvpn_connection_history(context):
                 initial_connect = entry.find('to:')
                 if initial_connect != -1:
                     timestamp = convert_human_ts_to_utc(entry[:entry.find('|')-1].split('.')[0].replace('T', ' '))
-                    try:
-                        server_hostname = regex.search(entry)[0]
-                        server_ip = socket.gethostbyname(server_hostname)
-                        data_list.append((server_hostname + f"  -  [ {server_ip} ]", timestamp))
-                    except socket.error:
-                        server_hostname = regex.search(entry)[0]
-                        data_list.append((server_hostname, timestamp))
-                    except:
-                        pass
+                    server_hostname = regex.search(entry)
+                    if server_hostname:
+                        data_list.append((server_hostname[0], timestamp))
 
     data_headers = ('Server Address', ('Timestamp', 'datetime'))
     return data_headers, data_list, source_path


### PR DESCRIPTION
## Problem

`get_protonvpn_connection_history` called `socket.gethostbyname()` on every parsed row and rendered the result into the **Server Address** column as `hostname  -  [ resolved_ip ]`.

**1. A forensic tool should not generate network traffic while parsing evidence.**
Each parsed connection record produced a live DNS query from the examiner's workstation. That discloses analysis activity to third parties (the resolver operator, and Proton's authoritative nameservers), and may be prohibited outright by the examiner's environment or the terms of the engagement. An analyst running ALEAPP on an air-gapped or monitored host had no way to know this was happening.

**2. The resolved IP was contemporaneous with the analysis, not the connection.**
The value was placed directly beside a historical VPN connection record, which implies the device connected to that address. VPN server IPs change frequently, so the column could assert a connection to an address the device never contacted. That is a defect that survives into a report and into testimony.

The behavior was also silently inconsistent: when resolution failed, the row emitted a bare hostname, so the same column carried two different value shapes depending on the workstation's connectivity at parse time.

## Fix

Emit the hostname exactly as recorded in `Data.log`. If an IP column is considered valuable, it has to come from the evidence itself, not from a live lookup.

Rows with no hostname are now skipped via an explicit match check instead of a bare `except:`, which also retires the file-level `# pylint: disable=W0702`.

```
Server Address                  Timestamp
node-us-free-01.protonvpn.net   2022-08-30 14:23:11+00:00
node-ch-12.protonvpn.net        2022-08-31 09:02:47+00:00
```

## Repo-wide audit

Grepped `scripts/` for `socket.gethostbyname`, `socket.getaddrinfo`, `socket.*`, `requests.`, `urllib`, `urlopen`, `http.client`, `httpx`, `urllib3`, plus `ftplib`/`smtplib`/`paramiko`/`boto3`/`aiohttp`/`websocket`/`dns.resolver` and `subprocess`/`os.system`.

**`protonVPN.py` was the only live network call in the repository.** The remaining `urllib` hits are all `urllib.parse` (`urlparse`, `unquote`, `parse_qs`) doing string decoding on stored values, which touches no network. No other artifact performs I/O beyond reading the evidence.

This should be treated as a repo-wide invariant: artifact parsers read evidence and nothing else.

## Verification

- `py_compile` clean.
- `admin/scripts/lint_changed.py --base-ref origin/main` — 0 pre-existing, 0 new warnings, PASS.
- `admin/test/scripts` suite — 30 tests, OK (this is the runtime-contract job that imports every artifact module).
- **End-to-end:** no ProtonVPN data was present in any available Android corpus, so a synthetic `Data.log` was run through the normal ALEAPP pipeline (`-t fs`). 3 records parsed, hostnames and timestamps intact, malformed line correctly skipped.
- **Network proof:** the run was executed with an instrumented `socket` module recording `gethostbyname`/`getaddrinfo`/`create_connection`/`connect`. **Zero calls recorded.** As a control, the previous code over the same fixture recorded one `gethostbyname` per row — and one invented hostname resolved to a current, live Proton IP that would have been printed beside a 2022 connection record, which is problem 2 reproduced exactly.

Docs under `admin/docs/generated/` are intentionally not touched here; the `update_module_info` workflow regenerates them on merge to main.