### PR TITLE
fix: stop two artifacts from writing to evidence files

### DIFF
--- a/scripts/artifacts/GarminUser.py
+++ b/scripts/artifacts/GarminUser.py
@@ -28,29 +28,33 @@ import xml.etree.ElementTree as ET
 from scripts.ilapfuncs import artifact_processor, logfunc
 
 
-# remove whitespace from xml first line
-def remove_whitespace_from_xml_first_line(xml_file):
-    with open(xml_file, 'r', encoding='utf-8') as f:
+# read the xml with a clean first line, without touching the file on disk
+def read_xml_with_clean_first_line(xml_file):
+    """Return the file text with the first line replaced by a well formed XML declaration.
+
+    The stored declaration can carry leading whitespace that ElementTree rejects. The
+    replacement is made on an in-memory copy: the source is evidence, so it is only
+    ever opened for reading.
+    """
+    with open(xml_file, 'r', encoding='utf-8', errors='replace') as f:
         lines = f.readlines()
-    # replace first line with <?xml version='1.0' encoding='utf-8' standalone='yes' ?>
-    lines[0] = '<?xml version=\'1.0\' encoding=\'utf-8\' standalone=\'yes\' ?>\n'
-    with open(xml_file, 'w', encoding='utf-8') as f:
-        f.writelines(lines)
+    if lines:
+        lines[0] = '<?xml version=\'1.0\' encoding=\'utf-8\' standalone=\'yes\' ?>\n'
+    return ''.join(lines)
 
 
 INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
 BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
 
 
-def _parse_xml(file_found):
-    """Parse XML, recovering from invalid tokens / unescaped ampersands; empty element if unparseable."""
+def _parse_xml(xml, file_found):
+    """Parse XML text, recovering from invalid tokens / unescaped ampersands; empty element if unparseable."""
     try:
-        return ET.parse(file_found).getroot()
+        return ET.fromstring(xml)
     except ET.ParseError:
-        with open(file_found, encoding='utf-8', errors='replace') as f:
-            xml = BARE_AMPERSAND.sub('&amp;', INVALID_XML_CHARS.sub('', f.read()))
+        repaired = BARE_AMPERSAND.sub('&amp;', INVALID_XML_CHARS.sub('', xml))
         try:
-            return ET.fromstring(xml)
+            return ET.fromstring(repaired)
         except ET.ParseError as ex:
             logfunc(f'Skipping unparseable XML {file_found}: {ex}')
             return ET.Element('empty')
@@ -72,9 +76,8 @@ def get_garminUP(context):
     logfunc("Processing data for Garmin User Profile XML")
     source_path = str(files_found[0])
     logfunc("Processing file: " + source_path)
-    # File is not well formatted, remove first element from first line
-    remove_whitespace_from_xml_first_line(source_path)
-    root = _parse_xml(source_path)
+    # File is not well formatted, replace the first line on an in-memory copy
+    root = _parse_xml(read_xml_with_clean_first_line(source_path), source_path)
     for child in root:
         for i in attribute:
             if child.attrib["name"] == i:

--- a/scripts/artifacts/Grok.py
+++ b/scripts/artifacts/Grok.py
@@ -32,11 +32,10 @@ import os
 import datetime
 import re
 from pathlib import Path
-import sqlite3
 import xml.etree.ElementTree as ET
 import json
 
-from scripts.ilapfuncs import artifact_processor, check_in_media, logfunc
+from scripts.ilapfuncs import artifact_processor, check_in_media, logfunc, open_sqlite_db_readonly
 
 INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
 BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
@@ -71,7 +70,9 @@ def grok_generatedvideos(context):
             continue
 
         try:
-            conn = sqlite3.connect(source_path)
+            conn = open_sqlite_db_readonly(source_path)
+            if not conn:
+                continue
             cur = conn.cursor()
 
             # Metadata tables: ExoPlayerCacheFileMetadata*
@@ -104,9 +105,10 @@ def grok_generatedvideos(context):
     exo_meta = {}
     id_to_url = {}
 
-    if db_path:
+    conn = open_sqlite_db_readonly(db_path) if db_path else None
+
+    if conn:
         try:
-            conn = sqlite3.connect(db_path)
             cur = conn.cursor()
 
             for tbl in meta_tables:


### PR DESCRIPTION
Two artifacts opened their source file in a non-read-only way. A forensic parser must only ever read the file it is handed — ALEAPP passes artifacts the extracted source file it preserves in the report's `data/` folder and records timestamps for, so writing to it alters the copy the report presents as the source.

Found during the 2026-08-01 documentation audit.

## GarminUser.py

`remove_whitespace_from_xml_first_line()` read the source XML, replaced its first line, and wrote the result back over the source before parsing. The file already contains `_parse_xml()`, a repaired-parse helper, so the rewrite was never necessary: the declaration fix is now applied to an in-memory copy of the text and the source path is only ever opened for reading.

`_parse_xml()` now takes the XML text plus the path (for the log message) instead of re-reading the file. It is module-private and not used elsewhere.

## Grok.py

`grok_generatedvideos` called `sqlite3.connect(source_path)` directly, opening the evidence database read-write. It now uses `open_sqlite_db_readonly()` from `scripts.ilapfuncs`, as the rest of the project does. The now-unused `sqlite3` import is dropped, and both call sites guard against the helper returning `None` on a failed open.

## Verification

**Parse results are unchanged.**

- Garmin, end-to-end via `aleapp.py -t fs` against the Pixel 7a Android 14 image: **23 rows** before and after, matching the artifact's recorded `sample_data`. An A/B of the old and new implementations on the same file produced identical key/value lists.
- Grok, end-to-end against a constructed corpus (ExoPlayer cache index/metadata tables plus `.exo` files, including one db-only entry): **3 rows**, with Present/Not Present, Content Type and URL resolution all correct.

**The old code demonstrably altered files; the new code does not.**

Garmin, on the malformed first line the helper exists for (leading whitespace or a BOM ahead of the declaration) — both versions parse the same 23 rows:

| | rows | bytes | mtime |
|---|---|---|---|
| old | 23 | changed (18111 → 18108) | changed |
| new | 23 | unchanged | unchanged |

Grok, against a database captured with an uncheckpointed `-wal` (the state a live seizure produces) — both versions read the same 3 rows:

| | `exoplayer_internal.db` | `exoplayer_internal.db-wal` |
|---|---|---|
| old (`sqlite3.connect`) | **modified** (4096 → 8192 bytes, hash changed) | **deleted** |
| new (`open_sqlite_db_readonly`) | unchanged | unchanged |

The read-write open checkpoints the WAL into the database and removes it on close, which folds records into the main file and destroys the WAL as a separate source. The read-only handle refuses writes (`OperationalError: attempt to write a readonly database`); it creates a `-shm`, which SQLite requires for any WAL reader, but alters no evidence file.

`python3 admin/scripts/lint_changed.py --base-ref origin/main scripts/artifacts/GarminUser.py scripts/artifacts/Grok.py` passes with no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
