### PR TITLE
fix: attach the second evidence database read-only

### DIFF
--- a/admin/test/scripts/test_attach_readonly.py
+++ b/admin/test/scripts/test_attach_readonly.py
@@ -1,0 +1,95 @@
+"""Read-only ATTACH tests.
+
+Artifacts that need a second database open it with ATTACH DATABASE. When the
+statement is built by pasting the filesystem path into SQL, SQLite opens that
+database read-write even though the primary connection came from
+open_sqlite_db_readonly - the attached evidence copy can then be written to,
+and its -wal/-shm/journal siblings created, modified or checkpointed away.
+ilapfuncs.attach_sqlite_db_readonly builds the same statement with a
+"file:<path>?mode=ro" URI instead, which SQLite refuses to write to.
+
+These tests pin both halves: no artifact hand-builds an ATTACH statement, and
+the helper's statement really does produce a read-only attachment.
+"""
+import os
+import re
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from scripts.ilapfuncs import attach_sqlite_db_readonly, open_sqlite_db_readonly
+
+ARTIFACTS_DIR = Path(ROOT_DIR, 'scripts', 'artifacts')
+
+# Matches an ATTACH statement written out in artifact source, however the path
+# is interpolated (concatenation, %-format or f-string).
+ATTACH_LITERAL = re.compile(r'attach\s+database', re.IGNORECASE)
+
+
+class TestArtifactsUseReadonlyAttach(unittest.TestCase):
+    def test_no_artifact_builds_its_own_attach_statement(self):
+        offenders = []
+        for py_file in sorted(ARTIFACTS_DIR.glob('*.py')):
+            source = py_file.read_text(encoding='utf-8')
+            for lineno, line in enumerate(source.splitlines(), start=1):
+                if ATTACH_LITERAL.search(line):
+                    offenders.append(f'{py_file.name}:{lineno}: {line.strip()}')
+
+        self.assertEqual(
+            offenders, [],
+            'Artifacts must attach a second database with '
+            'ilapfuncs.attach_sqlite_db_readonly() so the evidence copy is '
+            'opened read-only. Hand-built statements found:\n' + '\n'.join(offenders))
+
+
+class TestAttachSqliteDbReadonly(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = Path(tempfile.mkdtemp(prefix='aleapp_attach_ro_'))
+        self.addCleanup(self._cleanup)
+
+        self.main_db = self.test_dir / 'main.db'
+        self.attached_db = self.test_dir / 'attached.db'
+        for db_path, table in ((self.main_db, 'main_rows'), (self.attached_db, 'attached_rows')):
+            connection = sqlite3.connect(db_path)
+            connection.execute(f'CREATE TABLE {table} (value TEXT)')
+            connection.execute(f"INSERT INTO {table} VALUES ('expected')")
+            connection.commit()
+            connection.close()
+
+    def _cleanup(self):
+        import shutil
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def test_attached_database_is_readable(self):
+        db = open_sqlite_db_readonly(str(self.main_db))
+        self.addCleanup(db.close)
+        cursor = db.cursor()
+        cursor.execute(attach_sqlite_db_readonly(str(self.attached_db), 'attached'))
+        self.assertEqual(
+            cursor.execute(
+                'SELECT main_rows.value, attached.attached_rows.value '
+                'FROM main_rows, attached.attached_rows').fetchone(),
+            ('expected', 'expected'),
+        )
+
+    def test_attached_database_rejects_writes(self):
+        db = open_sqlite_db_readonly(str(self.main_db))
+        self.addCleanup(db.close)
+        cursor = db.cursor()
+        cursor.execute(attach_sqlite_db_readonly(str(self.attached_db), 'attached'))
+        with self.assertRaises(sqlite3.OperationalError) as raised:
+            cursor.execute('CREATE TABLE attached.write_probe (value TEXT)')
+        self.assertIn('readonly', str(raised.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/artifacts/WhatsApp.py
+++ b/scripts/artifacts/WhatsApp.py
@@ -190,7 +190,7 @@ import sqlite3
 
 import xmltodict
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, check_in_media
+from scripts.ilapfuncs import artifact_processor, attach_sqlite_db_readonly, open_sqlite_db_readonly, check_in_media
 
 # Re-used location columns shared by the one-to-one and group message queries.
 _LOCATION_HEADERS = ('Shared Latitude/Starting Latitude (Live Location)',
@@ -248,7 +248,7 @@ def _open_msgstore(files_found):
     cursor = db.cursor()
     if wa:
         try:
-            cursor.execute('attach database "%s" as wadb' % wa)
+            cursor.execute(attach_sqlite_db_readonly(wa, 'wadb'))
         except sqlite3.Error:
             pass
     return db, cursor, msg, wa

--- a/scripts/artifacts/line.py
+++ b/scripts/artifacts/line.py
@@ -62,7 +62,7 @@ __artifacts_v2__ = {
 
 import datetime
 
-from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, attach_sqlite_db_readonly, logfunc, open_sqlite_db_readonly
 
 
 def _sec_to_utc(value):
@@ -154,7 +154,7 @@ def get_line_calls(context):
     if call_db and msg_db:
         db = open_sqlite_db_readonly(call_db)
         cursor = db.cursor()
-        cursor.execute('attach database "' + msg_db + '" as naver_line ')
+        cursor.execute(attach_sqlite_db_readonly(msg_db, 'naver_line'))
         try:
             cursor.execute('''
                 SELECT case Substr(calls.call_type, -1) when "O" then "Outgoing" else "Incoming" end AS direction,

--- a/scripts/artifacts/tikTok.py
+++ b/scripts/artifacts/tikTok.py
@@ -63,7 +63,7 @@ import datetime
 import os
 import re
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, attach_sqlite_db_readonly, open_sqlite_db_readonly
 
 
 def _tiktok_dbs(files_found):
@@ -86,7 +86,7 @@ def get_tikTok(context):
     if maindb and attachdb:
         db = open_sqlite_db_readonly(maindb)
         cursor = db.cursor()
-        cursor.execute(f"ATTACH DATABASE '{attachdb}' as db_im_xx;")
+        cursor.execute(attach_sqlite_db_readonly(attachdb, 'db_im_xx'))
         cursor.execute('''
             select
             created_time,
@@ -134,7 +134,7 @@ def get_tikTok_contacts(context):
     if maindb and attachdb:
         db = open_sqlite_db_readonly(maindb)
         cursor = db.cursor()
-        cursor.execute(f"ATTACH DATABASE '{attachdb}' as db_im_xx;")
+        cursor.execute(attach_sqlite_db_readonly(attachdb, 'db_im_xx'))
         cursor.execute('''
             select UID, NICK_NAME, UNIQUE_ID, INITIAL_LETTER,
             json_extract(AVATAR_THUMB, '$.url_list[0]') as avatarURL,


### PR DESCRIPTION
## Problem

Three artifacts open a second database with an `ATTACH DATABASE` statement built by pasting the filesystem path straight into SQL:

| File | Line | Statement |
|---|---|---|
| `scripts/artifacts/line.py` | 157 | `'attach database "' + msg_db + '" as naver_line '` |
| `scripts/artifacts/WhatsApp.py` | 251 | `'attach database "%s" as wadb' % wa` |
| `scripts/artifacts/tikTok.py` | 89, 137 | `f"ATTACH DATABASE '{attachdb}' as db_im_xx;"` |

SQLite opens an attached database **read-write**. The primary connection coming from `open_sqlite_db_readonly()` does not extend its read-only mode to the attachment, so in each case a forensic tool held a writable handle on an evidence database and could create, modify or checkpoint away its `-wal`/`-shm`/journal siblings.

## Fix

All four call sites now go through `ilapfuncs.attach_sqlite_db_readonly()`, which already existed and builds the same statement with a `file:<path>?mode=ro` URI. It also runs the path through `get_sqlite_db_path()`, so spaces, `#` and `%` in an extraction path are percent-encoded rather than parsed as URI syntax.

`scripts/artifacts/` was grepped for other hand-built ATTACH statements; these four were the only ones.

## Verification

**Behaviour change is real.** Same two connections, same query, only the ATTACH statement differs (against a copy of a real `msgstore.db` + `wa.db` pair):

| | rows read from attached db | write probe `CREATE TABLE wadb.probe` | evidence files changed |
|---|---|---|---|
| bare path (before) | 268 | **succeeded** | `wa.db`, `wa.db-wal`, `wa.db-shm` |
| `mode=ro` URI (after) | 268 | rejected: `attempt to write a readonly database` | none |

**Row counts unchanged.** Full ALEAPP runs on two Android extractions, against an unpatched build of the same commit for comparison — identical on every artifact:

- Pixel 7a / Android 14: WhatsApp Contacts 92, Call Logs 4, One To One 73, Group 300, User Profile 1; TikTok Messages 10, Contacts 2
- Samsung SM-S911U1 / Android 15: WhatsApp Contacts 268, Call Logs 1, One To One 29, Group 7, Group Details 1, User Profile 1; TikTok Messages 11, Contacts 24

Both source trees were hashed before and after each run; no evidence file was modified by either.

LINE holds zero rows in every extraction available here, so its cross-database join was verified against a synthetic `naver_line` + `call_history` pair instead: 2 call rows, byte-identical results before and after.

**Regression guard.** `admin/test/scripts/test_attach_readonly.py` (picked up by the Python Runtime Contract workflow) asserts that no artifact hand-builds an ATTACH statement, and that the helper's attachment rejects writes. The scan half fails on all four pre-fix call sites.

`python3 admin/scripts/lint_changed.py --base-ref origin/main <files>` — no new warnings. Full `admin/test/scripts` suite: 37 tests, OK.

## Note, not addressed here

Opening a WAL database with `mode=ro` still lets SQLite write the WAL index into the `-shm` file — that is inherent to SQLite's read-only WAL handling and affects `open_sqlite_db_readonly()` generally, not just these call sites. Out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)