### PR TITLE
fix: open the Vaulty media database read-only

### DIFF
--- a/scripts/artifacts/vaulty_files.py
+++ b/scripts/artifacts/vaulty_files.py
@@ -4,19 +4,23 @@ __artifacts_v2__ = {
         "description": "Vaulty (com.theronrogers.vaultyfree) media database. Research at https://kibaffo33.data.blog/2022/03/05/decoding-vaulty/",
         "author": "",
         "creation_date": "2022-02-23",
-        "last_update_date": "2022-02-23",
+        "last_update_date": "2026-08-01",
         "requirements": "none",
         "category": "Vaulty",
-        "notes": "",
+        "notes": "Column names in media.db do not describe their contents: date_added holds the "
+                 "creation timestamp of the file and date_modified holds the timestamp the file "
+                 "was added to the vault, per the research linked above. The headers below are "
+                 "named for the contents, not for the source column. The two values are also "
+                 "decoded with different epochs, date_added as seconds and date_modified as "
+                 "milliseconds, as set by that original research; the divergence has not been "
+                 "re-verified against a test image.",
         "paths": ('*/com.theronrogers.vaultyfree/databases/media.db',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "lock",
     }
 }
 
-import sqlite3
-
-from scripts.ilapfuncs import artifact_processor, convert_human_ts_to_utc
+from scripts.ilapfuncs import artifact_processor, convert_human_ts_to_utc, open_sqlite_db_readonly
 
 
 @artifact_processor
@@ -25,14 +29,17 @@ def get_vaulty_files(context):
 
     # Media database
     db_filepath = str(files_found[0])
-    conn = sqlite3.connect(db_filepath)
+    conn = open_sqlite_db_readonly(db_filepath)
     c = conn.cursor()
+    # date_added is stored in seconds, date_modified in milliseconds; see notes above.
     sql = """SELECT Media._id, datetime(Media.date_added, 'unixepoch'), datetime(Media.date_modified / 1000, 'unixepoch'), Media.path, Media._data FROM Media"""
     c.execute(sql)
     results = c.fetchall()
     conn.close()
 
     # Data results
+    # Headers name what each value holds, not the column it comes from: date_added
+    # holds the file's creation time and date_modified the added-to-vault time.
     data_headers = (
         'ID',
         ('Date Created', 'datetime'),


### PR DESCRIPTION
## Why

`get_vaulty_files` opened the evidence database with `sqlite3.connect(db_filepath)` — a **read-write** open of the source `media.db`. A forensic tool must never open evidence read-write: SQLite may roll back a hot rollback journal, or checkpoint and delete a `-wal`, changing the hash of the file the examiner is attesting to.

This is not theoretical. Measured on a synthetic hot `media.db` (rows committed into the `-wal`, never checkpointed, then all three files copied out from under a still-open connection — exactly what imaging a running device produces):

| | `media.db` | `media.db-wal` |
|---|---|---|
| **read-write open (before)** | MODIFIED 4096 → 8192 bytes, hash changed | **DELETED — 12,392 bytes of records destroyed** |
| **read-only open (after)** | byte-identical | byte-identical |

The read-write open silently folded the WAL into the main database and then unlinked it. Any record recoverable only from the WAL was gone, and the main file's hash no longer matched the acquisition.

## What changed

- `sqlite3.connect()` → `open_sqlite_db_readonly()` from `scripts.ilapfuncs`, which opens `file:...?mode=ro`. This matches the 186 other artifacts already using it. Rows held only in the `-wal` are still returned, so nothing is lost by reading read-only.
- Dropped the now-unused `import sqlite3`.

The `-shm` index is rebuilt in place when a WAL database is opened, read-only included. It carries no record data and is regenerated from the `-wal`, so evidence content is untouched. Avoiding even that would require `immutable=1`, which makes SQLite ignore the WAL entirely and would drop rows — the wrong trade for a forensic parser.

## Documentation

Two things in this file read as bugs but are deliberate. Both are now recorded in `notes` and in comments so they are not "corrected" into being wrong later:

1. **The headers name contents, not columns.** Per [the cited research](https://kibaffo33.data.blog/2022/03/05/decoding-vaulty/) by this artifact's original author, `date_added` holds the file's *creation* timestamp and `date_modified` holds the *added-to-vault* timestamp — the column names do not describe their contents. Commit `13298ba` renamed the headers from the literal column names to these semantic ones in the very change that added the research link. Renaming `Date Created`/`Date Added` back to match the column names would put the wrong label on a timestamp in a forensic report.

2. **The epoch split is intentional.** `date_added` is decoded as seconds and `date_modified` as milliseconds; that divergence dates to commit `2652939` by the same author, made while they had a live sample. No Vaulty database exists in any of the 11 local Android images, so `notes` records the split as **not re-verified against a test image** rather than asserting it as tested.

## Verification

- `python3 -m py_compile scripts/artifacts/vaulty_files.py` — OK
- `python3 admin/scripts/lint_changed.py --base-ref origin/main scripts/artifacts/vaulty_files.py` — PASS, 0 new warnings
- `admin/test/scripts/test_artifact_imports.py` — 2 passed
- Parse run against a synthetic hot `media.db`: 3 rows returned with correctly decoded timestamps, including rows resident only in the `-wal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
