### PR TITLE
Fix pattern-of-life parsing found in real images

### DIFF
--- a/admin/test/scripts/test_pattern_of_life_artifacts.py
+++ b/admin/test/scripts/test_pattern_of_life_artifacts.py
@@ -105,11 +105,42 @@ class UsageStatsModernizationTests(unittest.TestCase):
         self.assertEqual(event_row[18:23], ('channel', 42, 'com.root', 'RootActivity', 'locus'))
         self.assertEqual(event_row[23:25], ('button', 'tap'))
 
+    def test_v2_event_without_optional_string_tokens_is_not_rejected(self):
+        with tempfile.TemporaryDirectory() as folder:
+            daily = os.path.join(folder, 'daily')
+            os.mkdir(daily)
+            interval_begin = 1_700_000_000_000
+            mappings = usagestatsservice_v2_pb2.ObfuscatedPackagesProto()
+            app = mappings.packages_map.add()
+            app.package_token = 1
+            app.strings.extend(['com.example', 'MainActivity'])
+            with open(os.path.join(folder, 'mappings'), 'wb') as output:
+                output.write(mappings.SerializeToString())
+
+            stats = usagestatsservice_v2_pb2.IntervalStatsObfuscatedProto()
+            event = stats.event_log.add()
+            event.package_token = 1
+            event.class_token = 2
+            event.time_ms = 4000
+            event.type = 1
+            with open(os.path.join(daily, str(interval_begin)), 'wb') as output:
+                output.write(stats.SerializeToString())
+
+            rows = usagestats.process_usagestats(folder, '0', 2)
+
+        event_row = next(row for row in rows if row[2] == 'event-log')
+        self.assertEqual(event_row[11:14], ('com.example', 'ACTIVITY_RESUMED', 'MainActivity'))
+        self.assertEqual(event_row[15:25], ('', '', '', '', '', '', '', '', '', ''))
+
 
 class RecentActivityModernizationTests(unittest.TestCase):
     def test_snapshot_proto_metadata_is_exposed(self):
         with tempfile.TemporaryDirectory() as folder:
             snapshots = os.path.join(folder, 'snapshots')
+            os.mkdir(snapshots)
+            # Newer Android images may place snapshots below an additional
+            # per-snapshot-set directory instead of directly in snapshots/.
+            snapshots = os.path.join(snapshots, 'snapshot-set-id')
             os.mkdir(snapshots)
             snapshot = task_snapshot_pb2.TaskSnapshotProto(
                 id=1_700_000_000_000,

--- a/scripts/artifacts/recentactivity.py
+++ b/scripts/artifacts/recentactivity.py
@@ -77,17 +77,33 @@ def _media(folder, *parts):
     return ''
 
 
+def _snapshot_file(folder, filename):
+    """Find old flat or newer per-snapshot-directory task snapshot files."""
+    snapshot_folder = os.path.join(folder, 'snapshots')
+    direct_path = os.path.join(snapshot_folder, filename)
+    if os.path.isfile(direct_path):
+        return direct_path
+    matches = glob.glob(os.path.join(snapshot_folder, '**', filename), recursive=True)
+    return next((path for path in matches if os.path.isfile(path)), '')
+
+
+def _snapshot_media(folder, filename):
+    path = _snapshot_file(folder, filename)
+    if not path:
+        return ''
+    return check_in_media(path, os.path.basename(path)) or ''
+
+
 def _snapshot_metadata(folder, task_id):
     """Return TaskSnapshot protobuf details and linked high/low resolution images."""
     empty = ('',) * 15
     if not task_id:
         return empty
 
-    snapshot_folder = os.path.join(folder, 'snapshots')
-    high_image = _media(snapshot_folder, f'{task_id}.jpg')
-    low_image = _media(snapshot_folder, f'{task_id}_reduced.jpg')
-    proto_path = os.path.join(snapshot_folder, f'{task_id}.proto')
-    if not os.path.isfile(proto_path):
+    high_image = _snapshot_media(folder, f'{task_id}.jpg')
+    low_image = _snapshot_media(folder, f'{task_id}_reduced.jpg')
+    proto_path = _snapshot_file(folder, f'{task_id}.proto')
+    if not proto_path:
         return (high_image, low_image) + ('',) * 13
 
     snapshot = task_snapshot_pb2.TaskSnapshotProto()

--- a/scripts/artifacts/usagestats.py
+++ b/scripts/artifacts/usagestats.py
@@ -174,16 +174,22 @@ def _standby_parts(value):
 
 def get_string_by_token(packages, token1, token2=0):
     strings = packages.get(token1, None)
-    if strings:
-        if token2 == 0:
-            return strings[0]
-        if len(strings) >= token2:
-            return strings[token2 - 1]
-        else:
-            logfunc(f'index {token2 - 1} out of range')
-    else:
-        pass
-        # logfunc('No strings!') # This happens with deleted processes
+    if not strings:
+        # This happens with deleted processes.
+        return ''
+    # Optional event token fields are represented by an empty string in the
+    # shared field helper. They are not package-name token 0.
+    if token2 in (None, ''):
+        return ''
+    try:
+        token2 = int(token2)
+    except (TypeError, ValueError):
+        return ''
+    if token2 == 0:
+        return strings[0]
+    if len(strings) >= token2:
+        return strings[token2 - 1]
+    logfunc(f'index {token2 - 1} out of range')
     return ''
 
 def ReadUsageStatsV2PbFile(input_path):


### PR DESCRIPTION
## Findings from data-drive validation

The UsageStats and Recent Activity updates were run against real device data from two full-file-system images on the data drive.

### Samsung S20 data set

- Before fix: 4,003 UsageStats rows; all ten daily interval files rejected
- After fix: 11,904 UsageStats rows; all ten daily files parsed
- Recent Activity: 29 usable tasks with snapshot metadata and both image resolutions
- The one rejected task XML is a zero-byte source file
- Real Snapshot contains both Yes and No values

### Pixel 8 Pro, Android 16

- UsageStats: 6,843 rows
- Recent Activity: four tasks
- All four nested snapshot protobufs, full-resolution images, and reduced images recovered

## Fixes

- Treat absent optional UsageStats string tokens as absent instead of comparing empty strings to integers and rejecting the complete interval file
- Locate task snapshot files in both the older flat snapshots directory and newer per-snapshot-set subdirectories
- Add regression coverage for both cases

## Validation

- Five focused pattern-of-life tests pass
- Full suite: 38 tests pass
- Changed-file pylint: no new warnings
- git diff --check clean