### PR TITLE
fix: guard the Vaulty read-only db handle against None

### DIFF
--- a/scripts/artifacts/vaulty_files.py
+++ b/scripts/artifacts/vaulty_files.py
@@ -27,16 +27,6 @@ from scripts.ilapfuncs import artifact_processor, convert_human_ts_to_utc, open_
 def get_vaulty_files(context):
     files_found = context.get_files_found()
 
-    # Media database
-    db_filepath = str(files_found[0])
-    conn = open_sqlite_db_readonly(db_filepath)
-    c = conn.cursor()
-    # date_added is stored in seconds, date_modified in milliseconds; see notes above.
-    sql = """SELECT Media._id, datetime(Media.date_added, 'unixepoch'), datetime(Media.date_modified / 1000, 'unixepoch'), Media.path, Media._data FROM Media"""
-    c.execute(sql)
-    results = c.fetchall()
-    conn.close()
-
     # Data results
     # Headers name what each value holds, not the column it comes from: date_added
     # holds the file's creation time and date_modified the added-to-vault time.
@@ -47,6 +37,21 @@ def get_vaulty_files(context):
         'Original Path',
         'Vault Path',
     )
+    data_list = []
+
+    # Media database
+    db_filepath = str(files_found[0])
+    conn = open_sqlite_db_readonly(db_filepath)
+    if not conn:
+        return data_headers, data_list, db_filepath
+
+    c = conn.cursor()
+    # date_added is stored in seconds, date_modified in milliseconds; see notes above.
+    sql = """SELECT Media._id, datetime(Media.date_added, 'unixepoch'), datetime(Media.date_modified / 1000, 'unixepoch'), Media.path, Media._data FROM Media"""
+    c.execute(sql)
+    results = c.fetchall()
+    conn.close()
+
     data_list = [(r[0], convert_human_ts_to_utc(r[1]), convert_human_ts_to_utc(r[2]), r[3], r[4]) for r in results]
 
     return data_headers, data_list, db_filepath


### PR DESCRIPTION
Follow-up to #1012.

That PR moved `get_vaulty_files` off `sqlite3.connect()` and onto `open_sqlite_db_readonly()`, which is the important part and is already merged. It left one loose end: the return value is passed straight to `.cursor()` without a guard.

`open_sqlite_db_readonly()` returns `None` when `sqlite3.connect()` raises `OperationalError` — the database cannot be opened at all. In practice that is an unreadable file, or a path the seeker could not stage. The artifact then dies on `'NoneType' object has no attribute 'cursor'`, and `aleapp.py` catches it as an artifact failure with a traceback.

Measured against an extraction whose `media.db` the process cannot read (mode 000, so the seeker's copy fails and the helper returns `None`):

| | log output |
|---|---|
| before | `Reading get_vaulty_files artifact had errors!` / `Error was 'NoneType' object has no attribute 'cursor'` + full traceback, artifact aborted |
| after | `Error with <path>: - unable to open database file` / `No data found for vaulty_files` / artifact completed |

The headers move above the open so the early return can carry them, matching the shape already used in `waze.py`.

## Verification

No Vaulty data exists in the local corpora, so the parse was checked end to end against a synthetic `media.db` with a `Media` table (`_id`, `date_added`, `date_modified`, `path`, `_data`) and three rows, run through `python3 aleapp.py -t fs`:

- `Found 3 records for vaulty_files`, all five columns correct in the TSV, both timestamps decoded as before.
- Evidence database byte-identical afterward (sha256 verified), no `-wal` or `-shm` left beside it.
- `python3 admin/scripts/lint_changed.py --base-ref origin/main scripts/artifacts/vaulty_files.py` — no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)