### PR TITLE
feat: report stale allowlist entries and uncheckable modules in claim-language check

### DIFF
--- a/admin/scripts/check_claim_language.py
+++ b/admin/scripts/check_claim_language.py
@@ -33,10 +33,36 @@ Handling a match
   The allowlist is a deliberate act and every entry is reviewed; it is not a place to
   silence a finding you have not thought about.
 
+Two ways the check can quietly stop doing its job
+-------------------------------------------------
+Both are reported rather than hidden, because a check that has silently narrowed its
+own scope is worse than no check: it still prints a pass.
+
+* **A stale ALLOWLIST entry** -- one that no longer matches anything. It means the
+  description was reworded or the artifact key was renamed, so the entry now shields
+  nothing at all, except the next claim that happens to land under that same key. That
+  is how an allowlist quietly becomes a dumping ground: entries accumulate, nobody
+  rereads them, and each one is a pre-approval for text nobody has seen. Stale entries
+  fail the run and must be deleted.
+
+* **A module whose `__artifacts_v2__` is not a static literal** -- its fields cannot be
+  read without importing the module, so they are never checked. These are printed as
+  NOT CHECKED on every run, not just under `--verbose`, and counted in the summary, so
+  the coverage hole stays in front of whoever reads the output.
+
+  As of this writing that is exactly two modules, both structural rather than
+  accidental:
+    - `scripts/artifacts/artGlobals.py` -- shared globals, declares no
+      `__artifacts_v2__` dict at all.
+    - `scripts/artifacts/fitbit.py` -- builds its dict through an `_art()` helper, so
+      there is no literal for `ast.literal_eval` to read.
+  If that list ever drifts from reality, the runtime output is the authority, not this
+  docstring.
+
 Usage:
     python admin/scripts/check_claim_language.py           # fail on unallowlisted claims
     python admin/scripts/check_claim_language.py --list    # show every match, allowlisted too
-    python admin/scripts/check_claim_language.py --verbose # also report skipped modules
+    python admin/scripts/check_claim_language.py --verbose # add coverage and allowlist counts
 """
 
 import argparse
@@ -55,8 +81,10 @@ import sys
 #
 # Matching is case-insensitive and word-boundary aware -- `\ball\b` must not fire on
 # "call log", which is why the boundaries are explicit rather than relying on a trailing
-# space. Prefixes without a closing boundary (`\bcomplete`, `\breliable`, `\bhabit`) are
-# intentional so inflections such as "completed", "reliably" and "habits" are caught.
+# space. Prefixes without a closing boundary (`\bcomplete`, `\breliable`) are intentional
+# so inflections such as "completed" and "reliably" are caught. `\bhabits?\b` is closed on
+# purpose: the open stem `\bhabit` used by the sibling iLEAPP implementation also matches
+# "habitat", and the closed spelling already covers both inflections that occur in prose.
 CLAIM_PATTERN = re.compile(
     r"\ball\b|\bevery\b|\bcomplete|\bfull list\b|\bentire\b|"
     r"\bthe user (searched|typed|viewed|visited|opened|selected|deleted|read|sent|"
@@ -160,23 +188,50 @@ def main():
     parser.add_argument('--list', action='store_true', dest='list_all',
                         help='print every match including allowlisted ones, then exit 0')
     parser.add_argument('--verbose', action='store_true',
-                        help='also report modules that were skipped')
+                        help='also report coverage and allowlist counts')
     args = parser.parse_args()
 
     repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     all_matches = []
     skipped = []
+    # Every (filename, artifact_key, field) the pattern actually fired on this run,
+    # allowlisted or not. An ALLOWLIST entry missing from this set matches nothing.
+    fired = set()
+    checked = 0
     for path in artifact_paths(repo_root):
         matches, skip_reason = scan_file(path)
         if skip_reason is not None:
             skipped.append((os.path.basename(path), skip_reason))
             continue
+        checked += 1
+        for match in matches:
+            fired.add((match['filename'], match['artifact_key'], match['field']))
         all_matches.extend(matches)
 
-    if args.verbose and skipped:
-        print(f'Skipped {len(skipped)} module(s):')
+    stale = sorted(ALLOWLIST - fired)
+
+    # A module whose __artifacts_v2__ cannot be evaluated statically is a real coverage
+    # hole -- its examiner-facing fields are never read. Print it on every run.
+    if skipped:
+        print(f'NOT CHECKED -- {len(skipped)} module(s) have no statically readable '
+              f'__artifacts_v2__:')
         for name, reason in skipped:
-            print(f'  {name}: {reason}')
+            print(f'  scripts/artifacts/{name}: {reason}')
+        print()
+
+    if args.verbose:
+        print(f'Scanned {checked + len(skipped)} module(s); {checked} checked, '
+              f'{len(skipped)} not checked.')
+        allowed_count = sum(1 for match in all_matches if match['allowlisted'])
+        print(f'Allowlist holds {len(ALLOWLIST)} entr(ies); {allowed_count} fired this run.')
+        print()
+
+    # A stale entry shields nothing except the next claim that lands under that key.
+    if stale:
+        print(f'Stale ALLOWLIST entr(ies) ({len(stale)}) -- these no longer match anything '
+              f'and should be deleted:')
+        for entry in stale:
+            print(f'  {entry[0]}:{entry[1]}:{entry[2]}')
         print()
 
     if args.list_all:
@@ -192,6 +247,16 @@ def main():
 
     violations = [match for match in all_matches if not match['allowlisted']]
     if not violations:
+        if stale:
+            print('Remove the stale entr(ies) above from ALLOWLIST in '
+                  f'{os.path.relpath(__file__, repo_root)}.')
+            return 1
+        allowed_count = sum(1 for match in all_matches if match['allowlisted'])
+        summary = (f'Checked {checked} artifact module(s): no unsupported claim language '
+                   f'({allowed_count} reviewed exception(s) allowlisted).')
+        if skipped:
+            summary += f' {len(skipped)} module(s) NOT checked, listed above.'
+        print(summary)
         return 0
 
     print('Unsupported-claim language in examiner-facing artifact fields:\n')


### PR DESCRIPTION
## The parity gap

`admin/scripts/check_claim_language.py` exists in all four LEAPP cores. iLEAPP (PR #1856), VLEAPP and RLEAPP carry the current version; ALEAPP's landed earlier (PR #1016) as a slightly weaker variant. It was the only one of the four missing both self-audit features below, which meant it could narrow its own coverage and still print a pass. This closes the gap.

## 1. Stale allowlist detection

Every `(filename, artifact_key, field)` the pattern fires on is now recorded, and any `ALLOWLIST` entry not in that set is reported and fails the run.

A stale entry means the description was reworded or the artifact key renamed. The entry now shields nothing at all, except the next claim that happens to land under that same key. That is how an allowlist quietly becomes a dumping ground: entries accumulate, nobody rereads them, and each one is standing pre-approval for text nobody has seen.

## 2. Always-on NOT CHECKED reporting

Modules whose `__artifacts_v2__` cannot be `ast.literal_eval`'d are never scanned. That is a genuine coverage hole, and it was only visible under `--verbose`. It is now printed on every run and counted in the summary.

ALEAPP has exactly two, both structural rather than accidental:

- `scripts/artifacts/artGlobals.py` — shared globals, declares no `__artifacts_v2__` dict at all.
- `scripts/artifacts/fitbit.py` — builds its dict through an `_art()` helper, so there is no literal to read.

Both are named in the docstring as a known gap, with the note that the runtime output is the authority if the hand-written list ever drifts.

## The regex is unchanged

ALEAPP's `\bhabits?\b` is kept over iLEAPP's open `\bhabit` stem. The closed form covers both inflections that occur in prose without also matching "habitat", and no artifact in this tree uses "habitat" or "habitual", so the two spellings select identically here. The `\b` anchors corrected in #1016 and the existing two allowlist entries are untouched.

One documentation fix: the comment above the pattern claimed the `habit` stem was open. It is now corrected to describe the regex it actually sits above.

## Verification

| Check | Result |
|---|---|
| Clean tree | exit 0, summary reports the 2 NOT CHECKED modules |
| Break 1 — claim language inserted into an artifact description | exit 1, names file, artifact key, field, and matched terms `all, the user viewed` |
| Break 2 — bogus allowlist entry matching nothing | exit 1, reported as stale |
| `python3 -m py_compile` | OK |
| `lint_changed.py --base-ref origin/main` | 0 new warnings, PASS |
| `python3 -m unittest discover -s admin/test/scripts` | 38 tests, OK |

Both deliberate breaks were reverted; the only file changed is the check script.

Clean-tree output:

```
NOT CHECKED -- 2 module(s) have no statically readable __artifacts_v2__:
  scripts/artifacts/artGlobals.py: no __artifacts_v2__ assignment
  scripts/artifacts/fitbit.py: __artifacts_v2__ is not a static literal

Checked 337 artifact module(s): no unsupported claim language (2 reviewed exception(s) allowlisted). 2 module(s) NOT checked, listed above.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)