### PR TITLE
fix: make the unsupported-entry branch reachable in My Files Operation History

### DIFF
--- a/scripts/artifacts/smyfilesOpHistory.py
+++ b/scripts/artifacts/smyfilesOpHistory.py
@@ -96,12 +96,12 @@ def get_smyfiles_OpHistory(context):
 
         for entry in all_rows:
             cipher = entry[1]
-            if cipher != '':
-                clear_path = process_string(cipher)
+            if not cipher:
+                clear_path = '*blank entry*'
             elif cipher[:3] == '#G$':  # not supported, have seen in Android 13/14.
                 clear_path = '*unsupported entry*'
             else:
-                clear_path = '*blank entry*'
+                clear_path = process_string(cipher)
             data_list.append((user, clear_path, entry[2], entry[3], entry[4], entry[5], entry[6]))
 
     data_headers = ('Account', 'Item Path', 'Operation Date (timezone unverified)', 'Operation Type', 'Item Count', 'Folder Count', 'Page Type')


### PR DESCRIPTION
Found during the artifact documentation audit (PR #1015), deferred as out of scope at the time.

## The bug

```python
cipher = entry[1]
if cipher != '':
    clear_path = process_string(cipher)
elif cipher[:3] == '#G$':      # only reachable when cipher == ''
    clear_path = '*unsupported entry*'
else:
    clear_path = '*blank entry*'
```

The `elif` can only run when `cipher == ''`, and `''[:3]` is `''`, which never equals `'#G$'`. The branch is dead.

**Consequence:** a `#G$` value is non-empty, so it goes through `process_string()`, which maps each character via `DECODE_DIC.get(value, '?')`. The Item Path column then shows a partially substituted string that *looks* like a decoded path — an examiner has no signal the row was not parseable. The author already wrote the correct marker; it simply never ran.

Reordering also fixes a crash: a NULL `cipher` passes `!= ""` and then raises `TypeError` inside `process_string()` when it iterates `None`. `if not cipher` covers empty and NULL together.

## Verified end-to-end

Run through `aleapp.py` against a database carrying all four cipher forms:

| cipher | before | after |
|---|---|---|
| `'pwvi/lrvl'` | `homr7timt` | `homr7timt` |
| `'#G$abc123'` | `#G$bac*)+` | `*unsupported entry*` |
| `''` | `*blank entry*` | `*blank entry*` |
| `NULL` | **TypeError** | `*blank entry*` |

The normal decode path is unchanged.

## Scope, stated honestly

The `#G$` form is documented in-code as appearing on **Android 13/14**, while the artifact gates itself to **Android 10-12** (`if not 9 < int(Androidversion) < 13`). So that branch stays unreachable in practice on current data — it is corrected so the code matches its own stated intent and behaves correctly if the gate is ever widened. **The NULL fix applies on supported versions today.**

**No corpus contains `#G$` rows.** Both registered samples are Android 14/15 (gated out), and the only other Samsung image carrying this database has an empty `operation_history` table, so the four-form database above was constructed to exercise every path.

Compiles clean; lint gate passes with zero new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)