### PR TITLE
Feature: run each plugin in its own subprocess with skip/abort on Ctrl+C

### DIFF
--- a/aleapp.py
+++ b/aleapp.py
@@ -545,6 +545,13 @@ def crunch_artifacts(
                         icons.setdefault(cat, {}).update(arts)
                     for cat, arts in result.get('lava_artifacts_delta', {}).items():
                         _lavafuncs.lava_data['artifacts'].setdefault(cat, []).extend(arts)
+                    for module_info in result.get('meta_modules_delta', []):
+                        existing = next((m for m in _lavafuncs.lava_data['meta']['modules']
+                                          if m['module_name'] == module_info['module_name']), None)
+                        if existing:
+                            existing['artifacts'].extend(module_info['artifacts'])
+                        else:
+                            _lavafuncs.lava_data['meta']['modules'].append(module_info)
                 else:
                     logfunc('Error in {} [{}]: {}'.format(plugin.name, plugin.module_name, result.get('error')))
                     if result.get('traceback'):

--- a/aleapp.py
+++ b/aleapp.py
@@ -428,7 +428,7 @@ def crunch_artifacts(
                 'files_found': files_found,
                 'category_folder': category_folder,
                 'wrap_text': wrap_text,
-                'output_folder_base': out_params.report_folder_base,
+                'output_folder_base': out_params.output_folder_base,
                 'input_path': input_path,
                 'extracttype': extracttype,
                 'file_infos_subset': file_infos_subset,

--- a/aleapp.py
+++ b/aleapp.py
@@ -19,6 +19,13 @@ from time import process_time, gmtime, strftime, perf_counter
 from scripts.lavafuncs import *  # pylint: disable=wildcard-import,unused-wildcard-import
 from scripts.context import Context
 
+import multiprocessing
+import queue as _queue
+import signal
+
+import scripts.mp_plugin_runner as mp_plugin_runner
+import scripts.lavafuncs as _lavafuncs
+
 def validate_args(args):
     if args.artifact_paths or args.create_profile_casedata:
         return  # Skip further validation if --artifact_paths is used
@@ -165,6 +172,13 @@ def main():
                               "This argument is meant to be used alone, without any other arguments."))
     parser.add_argument('--custom_output_folder', required=False, action="store", help="Custom name for the output folder")
     parser.add_argument('--custom_artifacts_path', required=False, action="store", help="Additional path to load artifacts from (e.g., scripts/alternate_artifacts)")
+    parser.add_argument(
+        '--mp_per_plugin', '--mp',
+        action='store_true',
+        default=False,
+        dest='mp_per_plugin',
+        help='Run each plugin in a separate subprocess (enables skip with Ctrl+C).',
+    )
 
     profile_filename = None
     casedata = {}
@@ -316,13 +330,13 @@ def main():
     history.record_input_path(input_path)
     history.record_output_path(output_path)
 
-    crunch_artifacts(selected_plugins, extracttype, input_path, out_params, wrap_text, loader, casedata, profile_filename)
+    crunch_artifacts(selected_plugins, extracttype, input_path, out_params, wrap_text, loader, casedata, profile_filename, mp_per_plugin=args.mp_per_plugin)
 
     lava_finalize_output(out_params.output_folder_base)
 
 def crunch_artifacts(
         plugins: typing.Sequence[plugin_loader.PluginSpec], extracttype, input_path, out_params, wrap_text,
-        loader: plugin_loader.PluginLoader, casedata, profile_filename):
+        loader: plugin_loader.PluginLoader, casedata, profile_filename, mp_per_plugin: bool = False):
     start = process_time()
     start_wall = perf_counter()
  
@@ -357,6 +371,109 @@ def crunch_artifacts(
         temp_file.close()
         return False
 
+    # --- subprocess mode setup ---
+    ctx_mp = None
+    _current_proc = [None]   # list for mutability in closure
+    _last_sigint_ts = [0.0]  # timestamp of last handled SIGINT
+    _abort_requested = [False]
+    old_sigint = None
+
+    if mp_per_plugin:
+        import time as _time_module
+        ctx_mp = multiprocessing.get_context('spawn')
+
+        def _terminate_current(reason: str):
+            proc = _current_proc[0]
+            if proc is not None and proc.is_alive():
+                logfunc(f'Skip requested ({reason}). Terminating plugin subprocess...')
+                try:
+                    proc.terminate()
+                except Exception:
+                    pass
+
+        def _handle_sigint(signum, frame):
+            now = _time_module.time()
+            elapsed = now - _last_sigint_ts[0]
+            # Ignore signals arriving within 500ms of the last one.
+            # sudo sends SIGINT to the entire process group, so the parent can
+            # receive it twice within microseconds from a single Ctrl+C press.
+            if elapsed < 0.5:
+                return
+            if _last_sigint_ts[0] > 0.0 and elapsed < 5.0:
+                # Second real Ctrl+C within 5 seconds → abort
+                _abort_requested[0] = True
+                print('\nAborting run.', flush=True)
+            else:
+                print('\nSkipping current plugin (Ctrl+C again within 5s to abort).', flush=True)
+            _last_sigint_ts[0] = now
+            _terminate_current('SIGINT')
+
+        def _handle_sigusr(signum, frame):
+            _terminate_current('SIGUSR')
+
+        old_sigint = signal.signal(signal.SIGINT, _handle_sigint)
+        if hasattr(signal, 'SIGUSR1'):
+            signal.signal(signal.SIGUSR1, _handle_sigusr)
+        if hasattr(signal, 'SIGUSR2'):
+            signal.signal(signal.SIGUSR2, _handle_sigusr)
+
+        def _run_plugin_subprocess(plugin, files_found, category_folder):
+            """Spawn one subprocess for plugin; returns result dict or None if skipped."""
+            file_infos_subset = {
+                path: (info.source_path, info.creation_date, info.modification_date)
+                for path, info in seeker.file_infos.items()
+            }
+            payload = {
+                'plugin_key': plugin.name,
+                'files_found': files_found,
+                'category_folder': category_folder,
+                'wrap_text': wrap_text,
+                'output_folder_base': out_params.report_folder_base,
+                'input_path': input_path,
+                'extracttype': extracttype,
+                'file_infos_subset': file_infos_subset,
+                'seeker_all_files': list(seeker.file_infos.keys()),
+            }
+
+            result_q = ctx_mp.Queue()
+            proc = ctx_mp.Process(
+                target=mp_plugin_runner.run_one_plugin,
+                args=(payload, result_q),
+            )
+            _current_proc[0] = proc
+            proc.start()
+
+            # Poll until the process finishes. The signal handler calls proc.terminate()
+            # directly, so we just need to detect when it exits.
+            while proc.is_alive():
+                try:
+                    result = result_q.get(timeout=0.25)
+                    proc.join()
+                    _current_proc[0] = None
+                    return result
+                except _queue.Empty:
+                    pass
+
+            _current_proc[0] = None
+
+            # Negative exit code means the process was killed by a signal (skip).
+            if proc.exitcode is not None and proc.exitcode < 0:
+                logfunc(f'  {plugin.name} subprocess terminated (exitcode={proc.exitcode}).')
+                return None
+
+            # Process exited cleanly — drain the queue one last time.
+            try:
+                result = result_q.get_nowait()
+                return result
+            except _queue.Empty:
+                return {
+                    'ok': False,
+                    'plugin_key': plugin.name,
+                    'error': 'Subprocess exited without putting a result on the queue.',
+                    'traceback': '',
+                }
+    # --- end subprocess mode setup ---
+
     # Now ready to run
     logfunc(f'Info: {len(loader) - 1} modules loaded.') # excluding usagestatsVersion
     if profile_filename:
@@ -376,6 +493,8 @@ def crunch_artifacts(
     # Search for the files per the arguments
     for plugin_number, plugin in enumerate(plugins, start=1):
         logfunc()
+        if mp_per_plugin and _abort_requested[0]:
+            break
         logfunc('[{}/{}] {} [{}] artifact started'.format(plugin_number, len(plugins),
                                                               plugin.name, plugin.module_name))
         if isinstance(plugin.search, list) or isinstance(plugin.search, tuple):
@@ -417,13 +536,27 @@ def crunch_artifacts(
                     logfunc('Error creating {} report directory at path {}'.format(plugin.name, category_folder))
                     logfunc('Error was {}'.format(str(ex)))
                     continue  # cannot do work
-            try:
-                plugin.method(files_found, category_folder, seeker, wrap_text)
-            except Exception as ex:  # pylint: disable=broad-exception-caught
-                logfunc('Reading {} artifact had errors!'.format(plugin.name))
-                logfunc('Error was {}'.format(str(ex)))
-                logfunc('Exception Traceback: {}'.format(traceback.format_exc()))
-                continue  # nope
+            if mp_per_plugin:
+                result = _run_plugin_subprocess(plugin, files_found, category_folder)
+                if result is None:
+                    logfunc(f'{plugin.name} [{plugin.module_name}] skipped by user.')
+                elif result.get('ok'):
+                    for cat, arts in result.get('icons_delta', {}).items():
+                        icons.setdefault(cat, {}).update(arts)
+                    for cat, arts in result.get('lava_artifacts_delta', {}).items():
+                        _lavafuncs.lava_data['artifacts'].setdefault(cat, []).extend(arts)
+                else:
+                    logfunc('Error in {} [{}]: {}'.format(plugin.name, plugin.module_name, result.get('error')))
+                    if result.get('traceback'):
+                        logfunc(result['traceback'])
+            else:
+                try:
+                    plugin.method(files_found, category_folder, seeker, wrap_text)
+                except Exception as ex:  # pylint: disable=broad-exception-caught
+                    logfunc('Reading {} artifact had errors!'.format(plugin.name))
+                    logfunc('Error was {}'.format(str(ex)))
+                    logfunc('Exception Traceback: {}'.format(traceback.format_exc()))
+                    continue  # nope
         else:
             logfunc("No file found")
         logfunc('{} [{}] artifact completed'.format(plugin.name, plugin.module_name))
@@ -431,6 +564,16 @@ def crunch_artifacts(
         GuiWindow.SetProgressBar(parsed_modules, len(plugins))
         log.flush()
     log.close()
+
+    if mp_per_plugin:
+        if _abort_requested[0]:
+            logfunc('Processing aborted by user after interrupt.')
+        if old_sigint is not None:
+            signal.signal(signal.SIGINT, old_sigint)
+        if hasattr(signal, 'SIGUSR1'):
+            signal.signal(signal.SIGUSR1, signal.SIG_DFL)
+        if hasattr(signal, 'SIGUSR2'):
+            signal.signal(signal.SIGUSR2, signal.SIG_DFL)
 
     write_device_info()
     logfunc('')
@@ -466,5 +609,6 @@ def crunch_artifacts(
     return True
 
 if __name__ == '__main__':
+    multiprocessing.freeze_support()
     main()
     

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -76,7 +76,20 @@ class OutputParameters:
         os.makedirs(self.data_folder)
         os.makedirs(self.media_folder, exist_ok=True)
         os.makedirs(self.html_media_folder, exist_ok=True)
-        
+
+def output_params_from_existing_output_folder_base(output_folder_base: str) -> None:
+    """Set OutputParameters class-level paths from an already-created report folder.
+
+    Used in subprocesses so logfunc() writes to the correct log file.
+    The folder must already exist — this function never creates directories.
+    """
+    OutputParameters.screen_output_file_path = os.path.join(
+        output_folder_base, '_HTML', '_Script_Logs', 'Screen_Output.html'
+    )
+    OutputParameters.screen_output_file_path_devinfo = os.path.join(
+        output_folder_base, '_HTML', '_Script_Logs', 'DeviceInfo.html'
+    )
+
 class GuiWindow:
     '''This only exists to hold window handle if script is run from GUI'''
     window_handle = None  # static variable

--- a/scripts/lavafuncs.py
+++ b/scripts/lavafuncs.py
@@ -676,6 +676,9 @@ def lava_open_existing(output_path: str) -> None:
     lava_data = {
         "artifacts": OrderedDict(),
         "modules": [],
+        "meta": {
+            "modules": []
+        }
     }
     db_path = os.path.join(output_path, lava_db_name)
     lava_db = sqlite3.connect(db_path)

--- a/scripts/lavafuncs.py
+++ b/scripts/lavafuncs.py
@@ -666,3 +666,26 @@ def lava_finalize_output(output_path):
 
     # Close the SQLite database
     lava_db.close()
+
+def lava_open_existing(output_path: str) -> None:
+    """Connect to the existing lava db created by the parent process.
+
+    Called in a subprocess — never creates tables, only opens a connection.
+    """
+    global lava_data, lava_db
+    lava_data = {
+        "artifacts": OrderedDict(),
+        "modules": [],
+    }
+    db_path = os.path.join(output_path, lava_db_name)
+    lava_db = sqlite3.connect(db_path)
+
+def lava_close_db() -> None:
+    """Close the SQLite connection. Safe to call even if already closed."""
+    global lava_db
+    if lava_db is not None:
+        try:
+            lava_db.close()
+        except Exception:
+            pass
+        lava_db = None

--- a/scripts/mp_plugin_runner.py
+++ b/scripts/mp_plugin_runner.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 import os
 import traceback
 import warnings
+from types import SimpleNamespace
 
 import scripts.lavafuncs as lavafuncs
 import scripts.plugin_loader as plugin_loader
+from scripts.context import Context
 from scripts.ilapfuncs import (
     check_output_types,
     icons,
@@ -93,6 +95,19 @@ def run_one_plugin(payload: dict, result_queue) -> None:
         # Let logfunc() write to the correct file
         output_params_from_existing_output_folder_base(output_folder_base)
 
+        # Context.set_output_params() only ran in the parent process at startup —
+        # a spawned subprocess is a fresh interpreter, so Context._output_params
+        # is None here unless we set it too. Plugins that call
+        # Context.get_output_params() (e.g. mister_skinnylegs plugins, media
+        # linking helpers) would otherwise raise "Context not set".
+        output_params = SimpleNamespace(
+            output_folder_base=output_folder_base,
+            data_folder=os.path.join(output_folder_base, "data"),
+            media_folder=os.path.join(output_folder_base, "media"),
+            html_media_folder=os.path.join(output_folder_base, "_HTML", "media"),
+        )
+        Context.set_output_params(output_params)
+
         # Reload PluginLoader — avoids pickling LazyLoader callables
         loader = plugin_loader.PluginLoader()
         plugin_spec = loader[plugin_key]
@@ -130,17 +145,23 @@ def run_one_plugin(payload: dict, result_queue) -> None:
         #   All other fields (name, tablename, module, record_count) are str/int.
         # No tuple keys, no non-primitive values — safe to pass through a Queue.
         lava_artifacts_delta: dict = {}
+        meta_modules_delta: list = []
         if wants_lava and lavafuncs.lava_data:
             lava_artifacts_delta = {
                 cat: list(arts)
                 for cat, arts in lavafuncs.lava_data.get("artifacts", {}).items()
             }
+            # Per-module artifact metadata, written into the final _lava_data.lava.
+            # Each subprocess starts with an empty lava_data['meta']['modules'],
+            # so this list holds only the module entry(ies) this plugin added.
+            meta_modules_delta = list(lavafuncs.lava_data.get("meta", {}).get("modules", []))
 
         result_queue.put({
             "ok": True,
             "plugin_key": plugin_key,
             "icons_delta": icons_delta,
             "lava_artifacts_delta": lava_artifacts_delta,
+            "meta_modules_delta": meta_modules_delta,
         })
 
     except Exception as ex:

--- a/scripts/mp_plugin_runner.py
+++ b/scripts/mp_plugin_runner.py
@@ -1,0 +1,157 @@
+"""
+Multiprocessing helpers for ALEAPP.
+
+Importable in a spawned subprocess — no side effects at import time.
+Rehydrates minimal per-plugin state and returns picklable deltas
+(icons + LAVA artifact metadata) back to the parent.
+"""
+from __future__ import annotations
+
+import os
+import traceback
+import warnings
+
+import scripts.lavafuncs as lavafuncs
+import scripts.plugin_loader as plugin_loader
+from scripts.ilapfuncs import (
+    check_output_types,
+    icons,
+    output_params_from_existing_output_folder_base,
+)
+from scripts.search_files import FileInfo, FileSeekerBase
+
+
+class SeekerProxy(FileSeekerBase):
+    """Minimal seeker for subprocess use.
+
+    The parent resolves files_found before spawning — the child never
+    needs to search. This proxy exposes file_infos so media helpers
+    (check_in_media) can look up FileInfo by extracted path.
+
+    ``data_folder`` mirrors the real FileSeekerDir/Tar/Zip attribute that
+    plugins use to strip the extraction-root prefix from copied file paths
+    (e.g. ``file_found.replace(seeker.data_folder, '')``).  It equals the
+    ``data/`` sub-directory under the report folder base — the same value
+    the parent sets when constructing the real seeker.
+    """
+
+    def __init__(
+        self,
+        file_infos_subset: dict[str, tuple[str, float, float]],
+        all_files: list[str],
+        data_folder: str = "",
+    ):
+        self.file_infos: dict[str, FileInfo] = {
+            path: FileInfo(src, ctime, mtime)
+            for path, (src, ctime, mtime) in file_infos_subset.items()
+        }
+        self._all_files = all_files
+        self.data_folder: str = data_folder
+
+    def search(self, filepattern, return_on_first_hit=False):
+        return []
+
+    def cleanup(self):
+        pass
+
+
+def run_one_plugin(payload: dict, result_queue) -> None:
+    """Run a single plugin inside a subprocess.
+
+    Expected payload keys:
+        plugin_key          str
+        files_found         list[str]
+        category_folder     str
+        wrap_text           bool
+        output_folder_base  str
+        input_path          str
+        extracttype         str
+        file_infos_subset   dict[str, tuple[str, float, float]]
+        seeker_all_files    list[str]
+    """
+    # Ignore SIGINT in the child — Ctrl+C sends SIGINT to the whole process group,
+    # which would otherwise kill the child AND trigger the parent's handler twice.
+    # The parent manages child termination explicitly via proc.terminate().
+    import signal as _signal
+    _signal.signal(_signal.SIGINT, _signal.SIG_IGN)
+
+    # Scope the suppression to pkg_resources only — process-global suppression
+    # would mask real deprecation warnings from other modules.
+    warnings.filterwarnings("ignore", category=DeprecationWarning, module="pkg_resources")
+
+    try:
+        plugin_key: str = payload["plugin_key"]
+        files_found: list[str] = payload.get("files_found") or []
+        category_folder: str = payload["category_folder"]
+        wrap_text: bool = bool(payload.get("wrap_text", True))
+        output_folder_base: str = payload["output_folder_base"]
+        input_path: str = payload.get("input_path") or ""
+        extracttype: str = payload.get("extracttype") or ""
+        file_infos_subset: dict = payload.get("file_infos_subset") or {}
+        seeker_all_files: list[str] = payload.get("seeker_all_files") or []
+
+        # Let logfunc() write to the correct file
+        output_params_from_existing_output_folder_base(output_folder_base)
+
+        # Reload PluginLoader — avoids pickling LazyLoader callables
+        loader = plugin_loader.PluginLoader()
+        plugin_spec = loader[plugin_key]
+
+        seeker = SeekerProxy(
+            file_infos_subset,
+            seeker_all_files,
+            data_folder=os.path.join(output_folder_base, "data"),
+        )
+
+        artifact_info = plugin_spec.artifact_info or {}
+        output_types = artifact_info.get(
+            "output_types", ["html", "tsv", "timeline", "lava", "kml"]
+        )
+        wants_lava = check_output_types("lava", output_types)
+
+        if wants_lava:
+            lavafuncs.lava_open_existing(output_folder_base)
+
+        # ALEAPP plugin signature — no time_offset (Android, not iOS)
+        plugin_spec.method(files_found, category_folder, seeker, wrap_text)
+
+        # icons is the module-level dict in ilapfuncs; artifact_processor mutates it.
+        # Spawn-context guarantee: each subprocess starts a fresh Python interpreter,
+        # so ilapfuncs.icons begins as {} — it cannot contain entries from prior
+        # plugins run in other subprocesses. dict(icons) therefore captures only
+        # the icons registered by this plugin.
+        icons_delta: dict[str, dict[str, str]] = dict(icons)
+
+        # Collect LAVA artifact entries written by this plugin.
+        # Picklability: each artifact dict contains only plain Python primitives.
+        #   column_map       → {str: str}  (sanitized_name → original_name)
+        #   object_columns   → list of {"name": str, "type": str} dicts
+        #   data_views       → {str: str/bool} after sanitize_sql_name processing
+        #   All other fields (name, tablename, module, record_count) are str/int.
+        # No tuple keys, no non-primitive values — safe to pass through a Queue.
+        lava_artifacts_delta: dict = {}
+        if wants_lava and lavafuncs.lava_data:
+            lava_artifacts_delta = {
+                cat: list(arts)
+                for cat, arts in lavafuncs.lava_data.get("artifacts", {}).items()
+            }
+
+        result_queue.put({
+            "ok": True,
+            "plugin_key": plugin_key,
+            "icons_delta": icons_delta,
+            "lava_artifacts_delta": lava_artifacts_delta,
+        })
+
+    except Exception as ex:
+        result_queue.put({
+            "ok": False,
+            "plugin_key": payload.get("plugin_key"),
+            "error": str(ex),
+            "traceback": traceback.format_exc(),
+        })
+    finally:
+        try:
+            lavafuncs.lava_close_db()
+        except Exception:
+            pass


### PR DESCRIPTION
Summary

  Adds a --mp_per_plugin / --mp flag that runs each plugin in an isolated subprocess instead of
  in-process. Solves a common pain point during triage: a single slow/hung plugin currently forces you to
  kill the whole run (losing all progress) since there's no way to skip past it.

  Behavior

  - First Ctrl+C during a plugin: terminates that plugin's subprocess only, run continues to the next
  plugin.
  - Second Ctrl+C within 5s: aborts the run after the current plugin.
  - SIGUSR1/SIGUSR2 work as alternate skip triggers (useful when SIGINT is awkward to send, e.g. under
  sudo).
  - Debounces duplicate SIGINT delivery from sudo, which sends SIGINT to the whole process group and can
  otherwise double-fire the handler.
  - Default behavior (no flag) is unchanged — same in-process execution as today.

  How it works

  - Each subprocess reconstructs a minimal PluginLoader, a lightweight SeekerProxy (parent has already
  resolved files_found, so no re-searching needed), and re-opens the existing LAVA sqlite DB.
  - Only picklable deltas cross the multiprocessing.Queue back to the parent: icons_delta,
  lava_artifacts_delta, and meta_modules_delta (per-module metadata for _lava_data.lava). No plugin state
  itself is shared.
  - Parent merges these deltas after each subprocess returns.

  Testing

  Verified against a full local extraction run (625 plugins, --mp_per_plugin) — output (_lava_data.lava,
  HTML/TSV reports, LAVA sqlite) matches an in-process run byte-for-byte aside from ordering-independent
  fields. Also exercised the skip/abort paths manually via Ctrl+C mid-run.