### PR TITLE
Harden zip extraction and Swissmeteo against missing-file crashes

### DIFF
--- a/admin/test/scripts/test_extraction_illegal_filenames.py
+++ b/admin/test/scripts/test_extraction_illegal_filenames.py
@@ -1,0 +1,137 @@
+"""Guard extraction against archive members whose names Windows cannot write.
+
+Device extractions can carry files with ASCII control characters in their
+names; an iOS 26 full file system image held chronod icon entries like
+'╞¼\\x01\\x0e::com.apple.siri.heic', and this FileSeekerZip code is shared
+across the LEAPP family. ZipFile.extract() only replaces a fixed set of
+printable characters (:<>|"?*) and only on Windows, so the control bytes
+reach the OS untouched and open() fails with [Errno 22] Invalid argument.
+In the iLEAPP case run that surfaced this, every affected member logged
+'Could not write file to filesystem' and was silently absent from the
+extraction; worse, the failing member appended the *previous* member's path
+to the seeker's result list because `extracted_path` still held its stale
+value.
+
+These tests pin the fix: sanitize_file_path()/sanitize_file_name() treat
+control characters as illegal, and FileSeekerZip writes such members manually
+to a sanitized path inside the data folder on every platform.
+"""
+import os
+import pathlib
+import shutil
+import sys
+import tempfile
+import unittest
+import zipfile
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from leapp_functions.app.platform import (  # pylint: disable=wrong-import-position
+    sanitize_file_name, sanitize_file_path, validate_filename)
+from scripts.search_files import FileSeekerZip  # pylint: disable=wrong-import-position
+
+# The real member name observed in an iOS 26 full file system extraction.
+ICON_MEMBER = ('/private/var/mobile/Library/chronod/icons/'
+               '╖¬\x01\x0e::com.apple.siri.heic')
+ICON_CONTENT = b'not really a heic'
+
+
+def _has_control_chars(text):
+    return any(ord(c) < 0x20 or ord(c) == 0x7f for c in text)
+
+
+class TestSanitizeControlChars(unittest.TestCase):
+    """The sanitize helpers must replace what Windows rejects with EINVAL."""
+
+    def test_file_path_replaces_control_chars_but_keeps_separators(self):
+        cleaned = sanitize_file_path('icons/\x01\x0e::a.heic')
+        self.assertEqual(cleaned, 'icons/__::a.heic'.replace(':', '_'))
+        self.assertIn('/', cleaned)
+        self.assertFalse(_has_control_chars(cleaned))
+
+    def test_file_name_replaces_control_chars(self):
+        self.assertEqual(sanitize_file_name('a\x00b\x1fc\x7fd'), 'a_b_c_d')
+
+    def test_printable_illegal_chars_still_replaced(self):
+        self.assertEqual(sanitize_file_name('a:b*c?d'), 'a_b_c_d')
+
+    def test_unicode_stays_untouched(self):
+        self.assertEqual(sanitize_file_name('╖¬ café'),
+                         '╖¬ café')
+
+    def test_validate_filename_rejects_control_chars_without_crashing(self):
+        is_valid, message = validate_filename('output\x01folder')
+        self.assertFalse(is_valid)
+        self.assertTrue(message)
+
+
+class TestFileSeekerZipIllegalNames(unittest.TestCase):
+    """A zip member with control characters in its name must still extract."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.data_folder = os.path.join(self.tmpdir, 'data')
+        os.makedirs(self.data_folder)
+        self.zip_path = os.path.join(self.tmpdir, 'fs-full.zip')
+        with zipfile.ZipFile(self.zip_path, 'w') as z:
+            z.writestr(ICON_MEMBER, ICON_CONTENT)
+            z.writestr('/private/var/mobile/Library/chronod/icons/plain.heic',
+                       b'plain content')
+        self.seeker = FileSeekerZip(self.zip_path, self.data_folder)
+
+    def tearDown(self):
+        self.seeker.cleanup()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_both_members_are_extracted(self):
+        paths = self.seeker.search('*/chronod/icons/*')
+        self.assertEqual(len(paths), 2)
+        for path in paths:
+            self.assertTrue(os.path.isfile(path), path)
+
+    def test_extracted_path_carries_no_illegal_characters(self):
+        paths = self.seeker.search('*/chronod/icons/*')
+        sanitized = [p for p in paths if p.endswith('com.apple.siri.heic')]
+        self.assertEqual(len(sanitized), 1)
+        relative = os.path.relpath(sanitized[0], self.data_folder)
+        self.assertFalse(_has_control_chars(relative))
+        self.assertNotIn(':', relative)
+
+    def test_extracted_content_is_intact(self):
+        paths = self.seeker.search('*/chronod/icons/*')
+        sanitized = [p for p in paths if p.endswith('com.apple.siri.heic')][0]
+        with open(sanitized, 'rb') as f:
+            self.assertEqual(f.read(), ICON_CONTENT)
+
+    def test_extraction_stays_inside_the_data_folder(self):
+        """Member names lead with '/'; a naive join would escape data_folder."""
+        for path in self.seeker.search('*/chronod/icons/*'):
+            self.assertTrue(
+                os.path.realpath(path).startswith(
+                    os.path.realpath(self.data_folder) + os.sep), path)
+
+    def test_file_info_is_recorded_for_sanitized_members(self):
+        paths = self.seeker.search('*/chronod/icons/*')
+        sanitized = [p for p in paths if p.endswith('com.apple.siri.heic')][0]
+        self.assertIn(sanitized, self.seeker.file_infos)
+        self.assertEqual(self.seeker.file_infos[sanitized].source_path, ICON_MEMBER)
+
+    def test_dot_dot_segments_cannot_escape_the_data_folder(self):
+        traversal_zip = os.path.join(self.tmpdir, 'traversal.zip')
+        with zipfile.ZipFile(traversal_zip, 'w') as z:
+            z.writestr('icons/../../../evil\x01.txt', b'x')
+        seeker = FileSeekerZip(traversal_zip, self.data_folder)
+        try:
+            paths = seeker.search('**')
+            self.assertTrue(paths)
+            for path in paths:
+                self.assertTrue(
+                    os.path.realpath(path).startswith(
+                        os.path.realpath(self.data_folder) + os.sep), path)
+        finally:
+            seeker.cleanup()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/admin/test/scripts/test_swissmeteo_missing_files.py
+++ b/admin/test/scripts/test_swissmeteo_missing_files.py
@@ -1,0 +1,114 @@
+"""Swissmeteo artifacts must return a result tuple even when files are absent.
+
+When the app is not on the device, plz_interaction and swissmeteo_plz logged
+'No Swissmeteo'/'No plz_interaction' and then fell off the end of the
+function, returning None. The artifact_processor wrapper unpacks three
+values, so every extraction without Swissmeteo reported
+
+    TypeError: cannot unpack non-iterable NoneType object
+
+as a parsing error. Both functions also indexed files_found[0] and
+files_found[1] directly, so a single matched file raised IndexError, and
+with the favorites database present but localdata.sqlite absent the
+localdata cursor stayed None and get_location_infos(None, ...) would raise
+AttributeError.
+
+These tests run both artifacts through the missing-file and partial-file
+shapes and require a well-formed (headers, rows, source) result each time.
+"""
+import pathlib
+import shutil
+import sqlite3
+import sys
+import tempfile
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.artifacts.swissmeteo import plz_interaction, swissmeteo_plz  # pylint: disable=wrong-import-position
+from scripts.context import Context  # pylint: disable=wrong-import-position
+
+TS_MS = 1756684800000  # 2025-09-01 00:00:00 UTC in milliseconds
+
+
+class TestSwissmeteoMissingFiles(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        Context.clear()
+        Context.set_report_folder(self.tmpdir)
+
+    def tearDown(self):
+        Context.clear()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _make_prediction_db(self):
+        db_path = pathlib.Path(self.tmpdir) / 'favorites_prediction_db.sqlite'
+        db = sqlite3.connect(db_path)
+        db.execute('CREATE TABLE plz_interaction '
+                   '(timestamp INTEGER, plz INTEGER, lat REAL, lon REAL)')
+        db.execute('INSERT INTO plz_interaction VALUES (?, 1000, 46.5, 6.6)',
+                   (TS_MS,))
+        db.execute('CREATE TABLE app_open (timestamp INTEGER, lat REAL, lon REAL)')
+        db.execute('INSERT INTO app_open VALUES (?, 46.5, 6.6)', (TS_MS,))
+        db.commit()
+        db.close()
+        return str(db_path)
+
+    def _make_localdata_db(self):
+        db_path = pathlib.Path(self.tmpdir) / 'localdata.sqlite'
+        db = sqlite3.connect(db_path)
+        db.execute('CREATE TABLE plz (plz_pk INTEGER, x REAL, y REAL, '
+                   'altitude REAL, primary_name TEXT)')
+        db.execute("INSERT INTO plz VALUES (1000, 538000, 152000, 500, 'Lausanne')")
+        db.commit()
+        db.close()
+        return str(db_path)
+
+    def test_plz_interaction_returns_tuple_when_app_absent(self):
+        # The real-world trigger: the path globs matched only a stray
+        # localdata.sqlite (another app's file), never the favorites database.
+        Context.set_files_found([self._make_localdata_db()])
+        result = plz_interaction.__wrapped__(Context)
+        self.assertIsNotNone(result)
+        data_headers, data_list, _source = result
+        self.assertEqual(len(data_headers), 4)
+        self.assertEqual(data_list, [])
+
+    def test_swissmeteo_plz_returns_tuple_when_app_absent(self):
+        Context.set_files_found([self._make_localdata_db()])
+        result = swissmeteo_plz.__wrapped__(Context)
+        self.assertIsNotNone(result)
+        data_headers, data_list, _source = result
+        self.assertEqual(len(data_headers), 4)
+        self.assertEqual(data_list, [])
+
+    def test_plz_interaction_without_localdata_keeps_raw_rows(self):
+        """favorites db present, localdata.sqlite absent: no cursor, no crash."""
+        Context.set_files_found([self._make_prediction_db()])
+        _headers, data_list, source = plz_interaction.__wrapped__(Context)
+        self.assertEqual(len(data_list), 1)
+        self.assertEqual(data_list[0][1], 1000)
+        self.assertEqual(data_list[0][2], '')
+        self.assertIn('openstreetmap.org', data_list[0][3])
+        self.assertTrue(str(source).endswith('favorites_prediction_db.sqlite'))
+
+    def test_plz_interaction_with_localdata_enriches_rows(self):
+        Context.set_files_found([self._make_prediction_db(),
+                                 self._make_localdata_db()])
+        _headers, data_list, _source = plz_interaction.__wrapped__(Context)
+        self.assertEqual(len(data_list), 1)
+        self.assertEqual(data_list[0][1], 'Lausanne')
+        self.assertIn('openstreetmap.org', data_list[0][2])
+
+    def test_swissmeteo_plz_parses_app_open_rows(self):
+        Context.set_files_found([self._make_prediction_db()])
+        _headers, data_list, _source = swissmeteo_plz.__wrapped__(Context)
+        self.assertEqual(len(data_list), 1)
+        self.assertEqual(data_list[0][1], 46.5)
+        self.assertIn('openstreetmap.org', data_list[0][3])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/leapp_functions/app/platform.py
+++ b/leapp_functions/app/platform.py
@@ -17,14 +17,24 @@ ILLEGAL_FILENAME_CHARS = {
     '\n': '\\n newline',
 }
 
+# ASCII control characters (0x00-0x1F, 0x7F): Windows rejects them in paths
+# with EINVAL, so they must be sanitized alongside the printable illegal set.
+# iOS extractions really do contain them, e.g. chronod icon files named
+# '╞¼\x01\x0e::com.apple.siri.heic'.
+_CONTROL_CHARS_PATTERN = '\\x00-\\x1f\\x7f'
+
+
+def _is_control_char(char):
+    return ord(char) < 0x20 or ord(char) == 0x7f
+
 
 def _illegal_filename_char_pattern():
-    return '[' + re.escape(''.join(ILLEGAL_FILENAME_CHARS)) + ']'
+    return '[' + re.escape(''.join(ILLEGAL_FILENAME_CHARS)) + _CONTROL_CHARS_PATTERN + ']'
 
 
 def _illegal_filepath_char_pattern():
     chars = ''.join(c for c in ILLEGAL_FILENAME_CHARS if c not in '\\/')
-    return '[' + re.escape(chars) + ']'
+    return '[' + re.escape(chars) + _CONTROL_CHARS_PATTERN + ']'
 
 
 def format_illegal_filename_chars(chars):
@@ -36,8 +46,10 @@ def format_illegal_filename_chars(chars):
 
 def illegal_chars_in_filename(filename):
     '''Return sorted illegal characters present in filename.'''
-    return sorted({c for c in filename if c in ILLEGAL_FILENAME_CHARS},
-                  key=lambda c: list(ILLEGAL_FILENAME_CHARS).index(c))
+    order = {char: index for index, char in enumerate(ILLEGAL_FILENAME_CHARS)}
+    return sorted({c for c in filename
+                   if c in ILLEGAL_FILENAME_CHARS or _is_control_char(c)},
+                  key=lambda c: order.get(c, len(order)))
 
 
 def sanitize_file_path(filename, replacement_char='_'):

--- a/scripts/artifacts/swissmeteo.py
+++ b/scripts/artifacts/swissmeteo.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parse the plz_interaction table: postal code entries with timestamps and stored coordinates",
         "author": "jerome.arn@vd.ch",
         "creation_date": "2025-09-25",
-        "last_update_date": "2026-08-01",
+        "last_update_date": "2026-08-04",
         "requirements": "none",
         "category": "Meteo",
         "notes": "The 'Meteo of the city (link)' coordinates are converted from the x and y columns "
@@ -25,7 +25,7 @@ __artifacts_v2__ = {
         "description": "Parse the app opening time and location",
         "author": "jerome.arn@vd.ch",
         "creation_date": "2025-09-25",
-        "last_update_date": "2026-08-01",
+        "last_update_date": "2026-08-04",
         "requirements": "none",
         "category": "Meteo",
         "notes": "",
@@ -44,15 +44,22 @@ from scripts.html_safe import esc
 def plz_interaction(context):
     files_found = context.get_files_found()
     source_path = get_file_path(files_found, "favorites_prediction_db.sqlite")
+    data_headers = (('Interaction Timestamp', 'datetime'), "Meteo of the city", "Meteo of the city (link)", "Recorded Coordinates")
     data_list = []
     cursor = None
+    prediction_db = ""
+    localdata_db = ""
 
     for file_found in files_found:
         file_found = str(file_found)
+        if file_found.endswith('favorites_prediction_db.sqlite'):
+            prediction_db = file_found
+        if file_found.endswith('localdata.sqlite'):
+            localdata_db = file_found
 
-    if files_found[0].endswith('favorites_prediction_db.sqlite'):
+    if prediction_db != "":
         query = '''
-        SELECT 
+        SELECT
             datetime(timestamp/1000, 'unixepoch') AS created_date,
             plz,
             lat,
@@ -60,16 +67,15 @@ def plz_interaction(context):
         FROM plz_interaction
         '''
 
-        data_headers = (('Interaction Timestamp', 'datetime'), "Meteo of the city", "Meteo of the city (link)", "Recorded Coordinates")
-        db_records = get_sqlite_db_records(files_found[0], query)
+        db_records = get_sqlite_db_records(prediction_db, query)
 
         local_data = []
-        if files_found[1].endswith('localdata.sqlite'):
-            db = open_sqlite_db_readonly(files_found[1])
+        if localdata_db != "":
+            db = open_sqlite_db_readonly(localdata_db)
             cursor = db.cursor()
 
         for record in db_records:
-            local_data = get_location_infos(cursor, record[1])
+            local_data = get_location_infos(cursor, record[1]) if cursor else []
             if not (record[2] and record[3]):
                 cons_link = ''
             else:
@@ -80,37 +86,40 @@ def plz_interaction(context):
                 data_list.append((record[0], local_data[0][4], meteo_link, cons_link))
             else:
                 data_list.append((record[0], record[1], '', cons_link))
-
-        return data_headers, data_list, source_path
     else:
         logfunc('No Swissmeteo')
+
+    return data_headers, data_list, source_path
 
 @artifact_processor
 def swissmeteo_plz(context):
     files_found = context.get_files_found()
     source_path = get_file_path(files_found, "favorites_prediction_db.sqlite")
+    data_headers = (('Opened Timestamp', 'datetime'), 'Latitude', 'Longitude', "Map link")
     data_list = []
+    prediction_db = ""
 
     for file_found in files_found:
         file_found = str(file_found)
+        if file_found.endswith('favorites_prediction_db.sqlite'):
+            prediction_db = file_found
 
-    if files_found[0].endswith('favorites_prediction_db.sqlite'):
+    if prediction_db != "":
         query = '''
-        SELECT 
+        SELECT
             datetime(timestamp/1000, 'unixepoch') AS created_date,
             lat,
             lon
         FROM app_open
         '''
 
-        data_headers = (('Opened Timestamp', 'datetime'), 'Latitude', 'Longitude', "Map link")
-        db_records = get_sqlite_db_records(files_found[0], query)
+        db_records = get_sqlite_db_records(prediction_db, query)
         for record in db_records:
             data_list.append((record[0], record[1], record[2], coordinate_to_osm(record[1], record[2])))
-
-        return data_headers, data_list, source_path
     else:
         logfunc('No plz_interaction')
+
+    return data_headers, data_list, source_path
 
 def coordinate_to_osm(lat, lon):
     return f"https://www.openstreetmap.org/?mlat={esc(lat)}&mlon={esc(lon)}&zoom=15"

--- a/scripts/search_files.py
+++ b/scripts/search_files.py
@@ -291,8 +291,7 @@ class FileSeekerZip(FileSeekerBase):
             if pat(root + normcase(member)) is not None:
                 if member not in self.copied or force:
                     try:
-                        # already replaces illegal chars with _ when exporting
-                        extracted_path = self.zip_file.extract(member, path=self.data_folder)
+                        extracted_path = self._extract_member(member)
                         f = self.zip_file.getinfo(member)
                         creation_date, modification_date = self.decode_extended_timestamp(f.extra)
                         file_info = FileInfo(member, creation_date, modification_date)
@@ -303,6 +302,7 @@ class FileSeekerZip(FileSeekerBase):
                         self.copied[member] = extracted_path
                     except OSError as ex:
                         logfunc(f'Could not write file to filesystem, path was {member} ' + str(ex))
+                        continue
                 else:
                     extracted_path = self.copied[member]
                 pathlist.append(extracted_path)
@@ -311,6 +311,29 @@ class FileSeekerZip(FileSeekerBase):
                     return extracted_path
         self.searched[filepattern] = pathlist
         return pathlist
+
+    def _extract_member(self, member):
+        """Extract one member, sanitizing names ZipFile.extract() cannot write.
+
+        ZipFile.extract() only replaces a fixed set of printable characters
+        (:<>|"?*) and only on Windows; ASCII control characters in the stored
+        name (present in real iOS extractions, e.g. chronod icon files) reach
+        the OS untouched and Windows rejects them with EINVAL. Members whose
+        names need sanitizing are written out manually to a cleaned path.
+        """
+        clean_member = sanitize_file_path(member)
+        if clean_member == member:
+            return self.zip_file.extract(member, path=self.data_folder)
+        parts = [part for part in clean_member.split('/')
+                 if part not in ('', '.', '..')]
+        extracted_path = os.path.join(self.data_folder, *parts)
+        if member.endswith('/'):
+            os.makedirs(extracted_path, exist_ok=True)
+        else:
+            os.makedirs(os.path.dirname(extracted_path), exist_ok=True)
+            with self.zip_file.open(member) as fin, open(extracted_path, 'wb') as fout:
+                fout.write(fin.read())
+        return extracted_path
 
     def cleanup(self):
         self.zip_file.close()


### PR DESCRIPTION
Port of iLEAPP [commit 5ee6a09e](https://github.com/abrignoni/iLEAPP/commit/5ee6a09e967afae44211dd1e0eb1b148dd5dfc0b) (PR #1879). The failing code paths are shared across the LEAPP family.

## FileSeekerZip: members with control characters in their names
`ZipFile.extract()` only replaces a fixed set of printable characters (`:<>|"?*`) and only on Windows, so ASCII control characters in a member name (observed in a real iOS 26 extraction: chronod icon files like `╞¼\x01\x0e::com.apple.siri.heic`) reach the OS untouched and Windows rejects them with EINVAL. The member then silently went missing from the extraction, and worse, the failing member appended the *previous* member's stale `extracted_path` to the seeker's result list. Such members are now written manually to a sanitized path inside the data folder on every platform, and `sanitize_file_path`/`sanitize_file_name` treat control characters (0x00-0x1F, 0x7F) as illegal.

## Swissmeteo: crashes when files are absent
- With the app absent, `plz_interaction` and `swissmeteo_plz` logged and fell off the end of the function, so the `artifact_processor` wrapper reported `TypeError: cannot unpack non-iterable NoneType object` on every extraction without the app.
- Both functions indexed `files_found[0]`/`files_found[1]` directly, raising `IndexError` when only one of the two path patterns matched.
- With the favorites database present but `localdata.sqlite` absent, `get_location_infos` ran on a `None` cursor.

Both functions now always return `(headers, rows, source)`, resolve their inputs by filename suffix instead of list position, and skip the localdata lookup when there is no cursor.

## Tests
16 new tests in `admin/test/scripts/` (synthetic zips and databases only, no image data), including a path-traversal guard for the manual extraction path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)