### PR TITLE
Correct misleading swissmeteo_plz log message

### DIFF
--- a/scripts/artifacts/swissmeteo.py
+++ b/scripts/artifacts/swissmeteo.py
@@ -117,7 +117,7 @@ def swissmeteo_plz(context):
         for record in db_records:
             data_list.append((record[0], record[1], record[2], coordinate_to_osm(record[1], record[2])))
     else:
-        logfunc('No plz_interaction')
+        logfunc('Swissmeteo favorites_prediction_db.sqlite not found')
 
     return data_headers, data_list, source_path
 


### PR DESCRIPTION
`swissmeteo_plz` logged `No plz_interaction` when `favorites_prediction_db.sqlite` was absent — misleading twice over: the function reads the `app_open` table (not `plz_interaction`), and the condition is a missing database, not a missing table. The message now names the actual missing file: `Swissmeteo favorites_prediction_db.sqlite not found`.

Same fix applied to iLEAPP's sibling artifact, which logged `No app_open` under the same condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)