### PR TITLE
Report the file when a database will not open

### DIFF
--- a/admin/test/scripts/test_unreadable_database.py
+++ b/admin/test/scripts/test_unreadable_database.py
@@ -1,0 +1,108 @@
+"""Unreadable evidence database tests.
+
+open_sqlite_db_readonly used to return None when a database would not open,
+and almost every artifact used the handle without checking it. An evidence
+file that was locked, truncated or simply unreadable therefore surfaced as
+"AttributeError: 'NoneType' object has no attribute 'row_factory'" further
+down the module, naming neither the file nor the reason - even though the
+real cause had already been logged one line earlier.
+
+open_sqlite_db_readonly now raises SQLiteDatabaseError naming the file, and
+the runner in aleapp.py logs that and skips the artifact. Helpers that probe
+a database whose absence is a legitimate answer - does_table_exist_in_db and
+friends - keep the tolerant behaviour through
+open_sqlite_db_readonly_or_none.
+
+These tests pin both halves: the probe helpers stay tolerant, and everything
+else fails loudly enough to name the file.
+"""
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from scripts.ilapfuncs import (SQLiteDatabaseError, does_column_exist_in_db,
+                               does_table_exist_in_db, does_view_exist_in_db,
+                               get_sqlite_db_records, open_sqlite_db_readonly,
+                               open_sqlite_db_readonly_or_none)
+
+
+class TestUnreadableDatabase(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.db_path = str(Path(self.temp_dir.name, 'mmssms.db'))
+        db = sqlite3.connect(self.db_path)
+        try:
+            db.execute('CREATE TABLE sms (_id INTEGER, body TEXT)')
+            db.execute("INSERT INTO sms VALUES (1, 'hello')")
+            db.commit()
+        finally:
+            db.close()
+
+    def _make_unreadable(self):
+        '''Drop read permission, or skip where the OS does not honour that.'''
+        os.chmod(self.db_path, 0o000)
+        self.addCleanup(os.chmod, self.db_path, 0o600)
+        if os.access(self.db_path, os.R_OK):
+            # Windows ignores the mode, and root bypasses it entirely.
+            self.skipTest('filesystem does not enforce the read permission here')
+
+    # -- a database that opens is untouched by any of this --------------------
+
+    def test_readable_database_still_opens(self):
+        db = open_sqlite_db_readonly(self.db_path)
+        try:
+            self.assertEqual(db.execute('SELECT body FROM sms').fetchone(), ('hello',))
+        finally:
+            db.close()
+
+    def test_probe_helpers_still_answer_for_a_readable_database(self):
+        self.assertTrue(does_column_exist_in_db(self.db_path, 'sms', 'body'))
+        self.assertFalse(does_column_exist_in_db(self.db_path, 'sms', 'not_a_column'))
+        self.assertTrue(does_table_exist_in_db(self.db_path, 'sms'))
+        self.assertFalse(does_table_exist_in_db(self.db_path, 'not_a_table'))
+        self.assertEqual(list(get_sqlite_db_records(self.db_path, 'SELECT body FROM sms')),
+                         [('hello',)])
+
+    # -- a database that will not open ---------------------------------------
+
+    def test_open_names_the_file_it_could_not_open(self):
+        self._make_unreadable()
+        with self.assertRaises(SQLiteDatabaseError) as caught:
+            open_sqlite_db_readonly(self.db_path)
+        self.assertIn(self.db_path, str(caught.exception))
+
+    def test_open_rejects_an_empty_path(self):
+        with self.assertRaises(SQLiteDatabaseError):
+            open_sqlite_db_readonly('')
+
+    def test_probe_helpers_report_absence_instead_of_raising(self):
+        self._make_unreadable()
+        # This is the call that used to raise AttributeError on a None handle.
+        self.assertFalse(does_column_exist_in_db(self.db_path, 'sms', 'body'))
+        self.assertFalse(does_table_exist_in_db(self.db_path, 'sms'))
+        self.assertFalse(does_view_exist_in_db(self.db_path, 'sms_view'))
+        self.assertEqual(list(get_sqlite_db_records(self.db_path, 'SELECT 1')), [])
+        self.assertIsNone(open_sqlite_db_readonly_or_none(self.db_path))
+
+    def test_artifact_style_caller_fails_with_the_database_error(self):
+        '''The smsmms shape from the original report: open, then use the handle.'''
+        self._make_unreadable()
+        import scripts.artifacts.smsmms as smsmms
+        read_rows = getattr(smsmms, '_rows')
+        with self.assertRaises(SQLiteDatabaseError):
+            read_rows(self.db_path, 'SELECT * FROM sms')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/aleapp.py
+++ b/aleapp.py
@@ -419,6 +419,13 @@ def crunch_artifacts(
                     continue  # cannot do work
             try:
                 plugin.method(files_found, category_folder, seeker, wrap_text)
+            except SQLiteDatabaseError as ex:
+                # The database named itself and open_sqlite_db_readonly_or_none()
+                # already logged why it would not open, so a traceback here would
+                # only bury that. Skip the artifact the same way as any other error.
+                logfunc('Reading {} artifact had errors!'.format(plugin.name))
+                logfunc('Error was {}'.format(str(ex)))
+                continue  # nope
             except Exception as ex:  # pylint: disable=broad-exception-caught
                 logfunc('Reading {} artifact had errors!'.format(plugin.name))
                 logfunc('Error was {}'.format(str(ex)))

--- a/scripts/artifacts/Deepseek_ChatInfo.py
+++ b/scripts/artifacts/Deepseek_ChatInfo.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 
 from scripts.ilapfuncs import (
     artifact_processor,
-    open_sqlite_db_readonly
+    open_sqlite_db_readonly_or_none
 )
 
 __artifacts_v2__ = {
@@ -47,7 +47,7 @@ def deepseek_chat_info(context):
 
     for source_path in files_found:
 
-        db = open_sqlite_db_readonly(source_path)
+        db = open_sqlite_db_readonly_or_none(source_path)
 
         if db is None:
             continue

--- a/scripts/artifacts/Deepseek_ChatMessages.py
+++ b/scripts/artifacts/Deepseek_ChatMessages.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 
 from scripts.ilapfuncs import (
     artifact_processor,
-    open_sqlite_db_readonly
+    open_sqlite_db_readonly_or_none
 )
 from scripts.html_safe import safe_source
 
@@ -84,7 +84,7 @@ def deepseek_chat_messages(context):
 
     for source_path in files_found:
 
-        db = open_sqlite_db_readonly(source_path)
+        db = open_sqlite_db_readonly_or_none(source_path)
 
         if db is None:
             continue

--- a/scripts/artifacts/Deepseek_UserInfo.py
+++ b/scripts/artifacts/Deepseek_UserInfo.py
@@ -1,6 +1,6 @@
 from scripts.ilapfuncs import (
     artifact_processor,
-    open_sqlite_db_readonly
+    open_sqlite_db_readonly_or_none
 )
 
 __artifacts_v2__ = {
@@ -41,7 +41,7 @@ def deepseek_user_info(context):
 
     for source_path in files_found:
 
-        db = open_sqlite_db_readonly(source_path)
+        db = open_sqlite_db_readonly_or_none(source_path)
 
         if db is None:
             continue

--- a/scripts/artifacts/Grok.py
+++ b/scripts/artifacts/Grok.py
@@ -35,7 +35,7 @@ from pathlib import Path
 import xml.etree.ElementTree as ET
 import json
 
-from scripts.ilapfuncs import artifact_processor, check_in_media, logfunc, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, check_in_media, logfunc, open_sqlite_db_readonly_or_none
 
 INVALID_XML_CHARS = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
 BARE_AMPERSAND = re.compile(r'&(?!(?:amp|lt|gt|quot|apos|#\d+|#x[0-9A-Fa-f]+);)')
@@ -70,7 +70,7 @@ def grok_generatedvideos(context):
             continue
 
         try:
-            conn = open_sqlite_db_readonly(source_path)
+            conn = open_sqlite_db_readonly_or_none(source_path)
             if not conn:
                 continue
             cur = conn.cursor()
@@ -105,7 +105,7 @@ def grok_generatedvideos(context):
     exo_meta = {}
     id_to_url = {}
 
-    conn = open_sqlite_db_readonly(db_path) if db_path else None
+    conn = open_sqlite_db_readonly_or_none(db_path) if db_path else None
 
     if conn:
         try:

--- a/scripts/artifacts/vaulty_files.py
+++ b/scripts/artifacts/vaulty_files.py
@@ -20,7 +20,7 @@ __artifacts_v2__ = {
     }
 }
 
-from scripts.ilapfuncs import artifact_processor, convert_human_ts_to_utc, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, convert_human_ts_to_utc, open_sqlite_db_readonly_or_none
 
 
 @artifact_processor
@@ -41,7 +41,7 @@ def get_vaulty_files(context):
 
     # Media database
     db_filepath = str(files_found[0])
-    conn = open_sqlite_db_readonly(db_filepath)
+    conn = open_sqlite_db_readonly_or_none(db_filepath)
     if not conn:
         return data_headers, data_list, db_filepath
 

--- a/scripts/artifacts/waze.py
+++ b/scripts/artifacts/waze.py
@@ -196,7 +196,7 @@ from math import log10
 import gzip
 from scripts.ilapfuncs import decode_protobuf
 from scripts.ilapfuncs import (
-    open_sqlite_db_readonly, get_sqlite_db_records,
+    open_sqlite_db_readonly_or_none, get_sqlite_db_records,
     does_column_exist_in_db, get_txt_file_content, convert_unix_ts_to_utc,
     artifact_processor, logfunc
 )
@@ -1485,7 +1485,7 @@ def waze_search_history(context):
     if not source_path:
         return data_headers, data_list, source_path
 
-    db = open_sqlite_db_readonly(source_path)
+    db = open_sqlite_db_readonly_or_none(source_path)
     if not db:
         return data_headers, data_list, source_path
 
@@ -2296,7 +2296,7 @@ def waze_planned_events(context):
     if not source_path:
         return data_headers, (data_list, data_list_html), source_path
 
-    db = open_sqlite_db_readonly(source_path)
+    db = open_sqlite_db_readonly_or_none(source_path)
     if not db:
         return data_headers, (data_list, data_list_html), source_path
 
@@ -2564,7 +2564,7 @@ def waze_tts(context):
     all_tables = get_sqlite_db_records(source_path, query)
 
     # Open the database ONCE for all subsequent table scans
-    db_table = open_sqlite_db_readonly(source_path)
+    db_table = open_sqlite_db_readonly_or_none(source_path)
     if not db_table:
         return data_headers, data_list, source_path
 

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -690,17 +690,51 @@ def get_sqlite_db_path(path):
     else:
         return quote(str(path), safe='/')
 
-def open_sqlite_db_readonly(path):
-    '''Opens a sqlite db in read-only mode, so original db (and -wal/journal are intact)'''
+class SQLiteDatabaseError(Exception):
+    '''Raised when an evidence database cannot be opened read-only.
+
+    The artifact runner catches this, logs the file that could not be opened
+    and skips that artifact. Before this existed, open_sqlite_db_readonly()
+    returned None to every caller and the overwhelming majority used the handle
+    without checking it, so an unreadable file surfaced further down as
+    "AttributeError: 'NoneType' object has no attribute ..." with a traceback
+    that named neither the file nor the reason.
+    '''
+
+
+def open_sqlite_db_readonly_or_none(path):
+    '''Opens a sqlite db in read-only mode, returning None if it cannot be opened.
+
+    For callers that probe a database which may legitimately be absent or
+    unreadable and have a defined answer for that case - see
+    does_table_exist_in_db() below, which reports "no" rather than failing the
+    artifact. Callers that need the handle to do any work should use
+    open_sqlite_db_readonly() instead, so the failure names the file.
+    '''
     try:
         if path:
-            path = get_sqlite_db_path(path)
-            with sqlite3.connect(f"file:{path}?mode=ro", uri=True) as db:
+            uri_path = get_sqlite_db_path(path)
+            with sqlite3.connect(f"file:{uri_path}?mode=ro", uri=True) as db:
                 return db
     except sqlite3.OperationalError as e:
         logfunc(f"Error with {path}:")
         logfunc(f" - {str(e)}")
     return None
+
+
+def open_sqlite_db_readonly(path):
+    '''Opens a sqlite db in read-only mode, so original db (and -wal/journal are intact)
+
+    Raises SQLiteDatabaseError if the database cannot be opened, so the caller
+    does not have to check the handle. Use open_sqlite_db_readonly_or_none()
+    where an unreadable database is an expected, handled outcome.
+    '''
+    if not path:
+        raise SQLiteDatabaseError('No database path was given to open')
+    db = open_sqlite_db_readonly_or_none(path)
+    if db is None:
+        raise SQLiteDatabaseError(f'Could not open database read-only: {path}')
+    return db
 
 def attach_sqlite_db_readonly(path, db_name):
     '''Return the query to attach a sqlite db in read-only mode.
@@ -710,7 +744,7 @@ def attach_sqlite_db_readonly(path, db_name):
     return  f'''ATTACH DATABASE "file:{path}?mode=ro" AS {db_name}'''
 
 def get_sqlite_db_records(path, query, attach_query=None):
-    db = open_sqlite_db_readonly(path)
+    db = open_sqlite_db_readonly_or_none(path)
     if db:
         try:
             cursor = db.cursor()
@@ -751,25 +785,26 @@ def get_results_with_extra_sourcepath_if_needed(path_list, query, data_headers):
 
 def does_column_exist_in_db(path, table_name, col_name):
     '''Checks if a specific col exists'''
-    db = open_sqlite_db_readonly(path)
+    db = open_sqlite_db_readonly_or_none(path)
     col_name = col_name.lower()
-    try:
-        db.row_factory = sqlite3.Row # For fetching columns by name
+    if db:
         query = f"pragma table_info('{table_name}');"
-        cursor = db.cursor()
-        cursor.execute(query)
-        all_rows = cursor.fetchall()
-        for row in all_rows:
-            if row['name'].lower() == col_name:
-                return True
-    except sqlite3.Error as ex:
-        logfunc(f"Query error, query={query} Error={str(ex)}")
+        try:
+            db.row_factory = sqlite3.Row # For fetching columns by name
+            cursor = db.cursor()
+            cursor.execute(query)
+            all_rows = cursor.fetchall()
+            for row in all_rows:
+                if row['name'].lower() == col_name:
+                    return True
+        except sqlite3.Error as ex:
+            logfunc(f"Query error, query={query} Error={str(ex)}")
     return False
 
 def does_table_exist_in_db(path, table_name):
     '''Checks if a table with specified name exists in an sqlite db'''
-    db = open_sqlite_db_readonly(path)
-    if db:    
+    db = open_sqlite_db_readonly_or_none(path)
+    if db:
         try:
             query = f"SELECT name FROM sqlite_master WHERE type='table' AND name='{table_name}'"
             cursor = db.execute(query)
@@ -781,7 +816,7 @@ def does_table_exist_in_db(path, table_name):
 
 def does_view_exist_in_db(path, table_name):
     '''Checks if a table with specified name exists in an sqlite db'''
-    db = open_sqlite_db_readonly(path)
+    db = open_sqlite_db_readonly_or_none(path)
     if db:
         try:
             query = f"SELECT name FROM sqlite_master WHERE type='view' AND name='{table_name}'"


### PR DESCRIPTION
## The problem

`open_sqlite_db_readonly()` returns `None` when it cannot open a database. I audited every call site: **257 of 268 use the handle without checking it.**

Running the SMS/MMS modules against a copy of `mmssms.db` whose permissions blocked reading gave:

```
File "scripts/artifacts/smsmms.py", line 137, in _rows
  db.row_factory = sqlite3.Row
AttributeError: 'NoneType' object has no attribute 'row_factory'
```

with the same failure from `does_column_exist_in_db()`. The log line right above it already said `Error with <path>: - unable to open database file`, so the real cause was known and simply not carried forward.

## The fix

Adding a check at 257 call sites would be a huge diff, and each one needs its own "empty result" shape — often the headers are not even defined yet at that point. So the fix goes where the `None` comes from.

`open_sqlite_db_readonly()` now raises `SQLiteDatabaseError` naming the file, and callers no longer have to check the handle. `crunch_artifacts()` logs it and skips the artifact like any other error, minus the traceback that used to bury the message:

```
Reading SMS/MMS artifact had errors!
Error was Could not open database read-only: /path/to/mmssms.db
```

That covers all 257 sites at once, and a new module written in the usual style is correct without anyone remembering to add a check.

Helpers that probe a database whose absence is a real answer keep the old behaviour through the new `open_sqlite_db_readonly_or_none()`: `get_sqlite_db_records`, `does_table_exist_in_db`, `does_view_exist_in_db`, and the eight artifact call sites that already checked the handle (Deepseek x3, Grok, vaulty_files, waze). Those are unchanged in behaviour.

`does_column_exist_in_db()` was the one helper that did not check, and it is the call in the reported crash. It now reports "no" like its siblings. Its query string also moved above the `try`, so a failure on the first statement no longer trips a `NameError` in the `except`.

## Checking it

Reproduced the original failure against the fix — the `AttributeError` is gone and the error names the file. A readable database is unaffected.

New `admin/test/scripts/test_unreadable_database.py` pins both halves: the probe helpers stay tolerant, everything else fails loudly enough to name the file. It skips itself where the filesystem does not enforce the read permission (Windows, or running as root).

- 89 tests pass in `admin/test/scripts`
- `tests/core/test_sqlite_uri_paths.py` passes
- pylint `--disable=C,R` introduces no new warnings
- `check_claim_language.py` passes

## Notes for reviewers

The judgment call here is that this changes a public helper's contract rather than fixing 257 call sites, so the blast radius is wider than the 9-file diff suggests. Worth pushing back on if you disagree.

**What changed for whom:**

- `open_sqlite_db_readonly()` raises instead of returning `None`. Every artifact module calling it is affected. For the 257 sites that never checked the handle, this only changes the error they produce - they aborted the artifact before and they abort it now, so there is no behaviour regression, just a message that names the file.
- The 11 sites that did check are moved to `open_sqlite_db_readonly_or_none()` and are behaviour-identical.
- Out-of-tree artifact modules that rely on the `None` return would need the `_or_none` variant. I can only see this repo, so I cannot rule that out for anyone maintaining private modules.

**The alternative I did not take:** leave `open_sqlite_db_readonly()` alone, add a raising variant, and migrate the 257 call sites to it. Same end behaviour, no contract change, but a ~185-file diff and the original footgun stays in place for new modules. Happy to switch if the team prefers that trade.

**Known limitation:** a module that loops over several databases still aborts the whole artifact on the first unreadable file, rather than skipping that file and continuing. That is what happens today too, so it is not a regression, but it is not an improvement either. Per-file resilience needs per-module judgement and would be a separate change.

**On the red checks:** the first runs landed during the GitHub Actions major outage on 6 Aug (incident opened 15:22 UTC). Those jobs were cancelled at setup with no steps executed and no logs, so they are not real results. `runtime-contract (3.10)` did run and passed - that is the job that runs the whole `admin/test/scripts` suite and imports every artifact module. The rest will be re-run once Actions recovers.
