### PR TITLE
Remove every remote destination from the HTML report

### DIFF
--- a/scripts/artifacts/AdidasUser.py
+++ b/scripts/artifacts/AdidasUser.py
@@ -76,7 +76,10 @@ def get_adidas_user(context):
         elif key == 'lastV3SessionSyncAtLocalTime':
             last_sync = _ms_to_utc(val)
 
-    image_html = f'<img src="{esc(image)}" alt="{esc(image)}" width="50" height="50">' if image else ''
+    # The avatar URL is remote, so an <img> here would make opening the report
+    # fetch it and disclose the examination to the service. Report the URL as
+    # escaped text instead; the evidence is preserved, nothing is fetched.
+    image_html = esc(image) if image else ''
     data_list = [(user_id, name, height, weight, country, gender, email, created_at, image_html, my_fitness_pal, garmin_connect, polar, last_sync)]
 
     data_headers = ('ID', 'Name', 'Height', 'Weight', 'Country', 'Gender', 'Email', ('Created At', 'datetime'), 'Image', 'My Fitness Pal', 'Garmin Connect', 'Polar', ('LastSync', 'datetime'))

--- a/scripts/artifacts/BadooConnections.py
+++ b/scripts/artifacts/BadooConnections.py
@@ -40,7 +40,10 @@ def get_badoo_conn(context):
     data_list = []
     for row in all_rows:
         sort_timestamp = datetime.datetime.fromtimestamp(int(row[4]) / 1000, datetime.timezone.utc) if row[4] else ''
-        avatar_url = '<img src="' + esc(row[5]) + '" width="100" height="100">' if row[5] else ''
+        # The avatar URL is remote, so an <img> here would make opening the report
+        # fetch it and disclose the examination to the service. Report the URL as
+        # escaped text instead; the evidence is preserved, nothing is fetched.
+        avatar_url = esc(row[5]) if row[5] else ''
         data_list.append((row[0], row[1], row[2], row[3], sort_timestamp, avatar_url, row[6]))
 
     data_headers = ('ID', 'Name', 'Gender', 'Origin', ('Sort Timestamp', 'datetime'), 'Avatar URL', 'Display Message')

--- a/scripts/artifacts/MMWUsers.py
+++ b/scripts/artifacts/MMWUsers.py
@@ -50,7 +50,10 @@ def get_map_users(context):
         height = round(row[6], 2) if row[6] is not None else row[6]
         weight = round(row[7], 2) if row[7] is not None else row[7]
         if row[12]:
-            image = '<img src="' + esc(row[12]) + '" alt="' + esc(str(row[10])) + '" width="50" height="50">'
+            # The avatar URL is remote, so an <img> here would make opening the report
+            # fetch it and disclose the examination to the service. Report the URL as
+            # escaped text instead; the evidence is preserved, nothing is fetched.
+            image = esc(row[12])
         else:
             image = 'N/A'
         data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], height, weight, row[8],

--- a/scripts/artifacts/PumaUsers.py
+++ b/scripts/artifacts/PumaUsers.py
@@ -43,7 +43,10 @@ def get_puma_users(context):
     for row in all_rows:
         dob = datetime.datetime.fromtimestamp(int(row[4]) / 1000, datetime.timezone.utc) if row[4] else ''
         work_time = row[16] / 60 if row[16] else 'N/A'
-        image = '<img src="' + esc(row[10]) + '" alt="' + esc(row[10]) + '" width="50" height="50">' if row[10] else 'N/A'
+        # The avatar URL is remote, so an <img> here would make opening the report
+        # fetch it and disclose the examination to the service. Report the URL as
+        # escaped text instead; the evidence is preserved, nothing is fetched.
+        image = esc(row[10]) if row[10] else 'N/A'
         data_list.append((row[0], row[1], row[2], row[3], dob, row[5], row[6], row[7], row[8], row[9], image, row[11], row[12], row[13], row[14], row[15], work_time))
 
     data_headers = ('ID', 'Email', 'Name', 'Gender', ('Date of Birth', 'datetime'), 'Weight', 'Height', 'Country', 'Location', 'Interests', 'Profile Image URL', 'Total Score', 'Following Count', 'Followers Count', 'Goal', 'Workout Time of Day', 'Workout Duration')

--- a/scripts/artifacts/RunkeeperUser.py
+++ b/scripts/artifacts/RunkeeperUser.py
@@ -82,7 +82,8 @@ def get_run_user(context):
                     # Does the attribute have text?
                     if child.text:
                         if i == "profilePictureUrl":
-                            user_info[i] = '<img src="' + child.text + '" alt="' + child.text + '" width="50" height="50">'
+                            # Remote avatar URL: reported as text, never fetched.
+                            user_info[i] = child.text
                         else:
                             user_info[i] = child.text
 

--- a/scripts/artifacts/packageGplinks.py
+++ b/scripts/artifacts/packageGplinks.py
@@ -47,7 +47,9 @@ def get_packageGplinks(context):
 
         for x in values:
             bundleid = x.split(' ', 1)
-            url = f'<a href="https://play.google.com/store/apps/details?id={esc(bundleid[0])}" target="_blank"><font color="blue">https://play.google.com/store/apps/details?id={esc(bundleid[0])}</font></a>'
+            # The Play Store URL is reported as text, not an anchor: a report
+            # reaches nothing outside its own folder.
+            url = esc(f'https://play.google.com/store/apps/details?id={bundleid[0]}')
             data_list.append((bundleid[0], url))
 
     data_headers = ('Bundle ID', 'Possible Google Play Store Link')

--- a/scripts/artifacts/walStrings.py
+++ b/scripts/artifacts/walStrings.py
@@ -32,6 +32,7 @@ import re
 import string
 from pathlib import Path
 
+from scripts.html_safe import safe_local_link
 from scripts.ilapfuncs import artifact_processor
 
 control_chars = ''.join(map(chr, range(0, 32))) + ''.join(map(chr, range(127, 160)))
@@ -72,7 +73,10 @@ def get_walStrings(context):
                         unique_items.add(match.group())
 
         if unique_items:
-            out = f'<a href="{final}" style = "color:blue" target="_blank">{journalName}</a>'
+            # Report-relative link to the strings file written beside the report.
+            # safe_local_link() escapes the label and refuses any target that would
+            # leave the report folder.
+            out = safe_local_link(final, journalName)
             data_list.append((out, context.get_relative_path(file_found)))
         else:
             try:

--- a/scripts/html_safe.py
+++ b/scripts/html_safe.py
@@ -8,16 +8,26 @@ HTML/JavaScript injection sink: malicious content in a parsed return renders liv
 the examiner's report (stored XSS, CWE-79).
 
 Route every evidence-derived value in an ``html_columns`` cell through these helpers so
-the dynamic parts are escaped while the tool's own structural markup (``<a>``, ``<br>``,
+the dynamic parts are escaped while the tool's own structural markup (``<br>``,
 ``<table>``) is preserved.
+
+**A report links to nothing outside its own folder.** A remote destination in a
+report is a disclosure channel: an ``<img src="https://...">`` is fetched the moment
+the report is opened, with no click, which tells whoever controls that host that the
+account is under examination, when, and from which IP address. An ``<a href>`` needs a
+click but reaches the same place. Reports are read on analyst workstations and mailed
+to counsel, so no ``href`` or ``src`` may leave the report folder -- not ``http``,
+``https``, ``ftp``, and not ``mailto``/``tel``, which hand the subject's own address or
+number to a mail client or dialer.
+
+Evidence URLs are still *evidence*, so nothing is dropped: they are rendered as escaped
+text the examiner can read and copy. Only the anchor goes away. Report-relative
+destinations -- ``media/<file>`` thumbnails, files an artifact writes beside the report
+-- stay clickable through ``safe_local_link()``; they resolve offline and reach nothing.
 """
 
 import html
 from urllib.parse import urlparse
-
-# Schemes we are willing to turn into a live <a href>. Anything else (notably
-# javascript: and data:) is rendered as escaped text, never as a clickable link.
-ALLOWED_URL_SCHEMES = ('http', 'https', 'mailto', 'tel', 'ftp', 'ftps')
 
 
 def esc(value):
@@ -31,25 +41,42 @@ def esc(value):
     return html.escape(str(value), quote=True)
 
 
-def safe_url(url, text=None, target='_blank'):
-    """Build an ``<a href>`` anchor with an escaped, scheme-checked href.
+def safe_url(url, text=None, target=None):      # pylint: disable=unused-argument
+    """Render an evidence URL as escaped text. **Never returns a link.**
 
-    Returns the escaped visible text with **no** anchor when the URL is empty or its
-    scheme is not allowlisted, so ``javascript:``/``data:`` URLs never become live
-    links. ``text`` (the visible label) defaults to the URL itself.
+    A URL read out of an extraction names a host chosen by whoever wrote the data, so
+    it is exactly the destination a report must not reach; see the module docstring.
+    The URL itself is evidence and is preserved verbatim as escaped text, so an
+    examiner can read it, copy it, and open it deliberately elsewhere.
+
+    ``text`` overrides the visible string when the caller has a better label than the
+    raw URL. ``target`` is accepted and ignored: it exists so the call sites that
+    passed it before this became text-only keep working.
     """
     url = '' if url is None else str(url).strip()
-    label = esc(text if text is not None else url)
-    if not url:
+    return esc(text if text is not None else url)
+
+
+def safe_local_link(path, text=None):
+    """Build an ``<a href>`` to a file inside the report folder.
+
+    This is the only helper that still emits an anchor. The destination must be
+    report-relative -- no scheme, no protocol-relative ``//host``, no absolute path,
+    and no ``..`` escaping the folder -- so following it can never leave the report.
+    Anything else is returned as escaped text with no anchor.
+    """
+    path = '' if path is None else str(path).strip()
+    label = esc(text if text is not None else path)
+    if not path:
+        return label
+    if path.startswith(('/', '\\', '//')) or '..' in path.replace('\\', '/').split('/'):
         return label
     try:
-        scheme = urlparse(url).scheme.lower()
+        if urlparse(path).scheme:
+            return label
     except ValueError:
         return label
-    if scheme not in ALLOWED_URL_SCHEMES:
-        return label
-    rel = ' rel="noopener noreferrer"' if target == '_blank' else ''
-    return f'<a href="{esc(url)}" target="{esc(target)}"{rel}>{label}</a>'
+    return f'<a href="{esc(path)}" target="_blank">{label}</a>'
 
 
 def safe_join(values, sep='<br>'):


### PR DESCRIPTION
## Why

Port of iLEAPP #1887. A remote `href` or `src` in a report is a disclosure channel, and ALEAPP had the worst form of it: four artifacts embedded an `<img src="{url from the app database}">`, so **simply opening the report** made the examiner's browser fetch avatars from the app's CDN. No click involved. That tells the service operator the account is under examination, when, and from which IP address.

Those four were already `esc()`-escaped, so this is not an injection fix. Escaping never stopped the fetch.

## What changed

Helper, shared with iLEAPP and byte-identical to it:

- `safe_url()` no longer builds an anchor; it returns the URL as escaped text, so the evidence stays readable and copyable while the destination goes.
- `safe_local_link()` is added for report-relative destinations, refusing a scheme, a protocol-relative `//host`, an absolute path, or any `..` segment.

Artifacts:

| Artifact | Change |
|---|---|
| `AdidasUser`, `PumaUsers`, `MMWUsers`, `BadooConnections` | avatar `<img>` becomes the escaped URL as text |
| `RunkeeperUser` | same, and it stops being a latent sink (see below) |
| `packageGplinks` | play.google.com anchor becomes text |
| `walStrings` | stays clickable via `safe_local_link()` |

`RunkeeperUser` built the same `<img>` by raw concatenation of `child.text` and declares no `html_columns`, so the writer escaped it and the examiner saw raw markup in the cell. It was not a beacon, but it would have become one the moment an `html_columns` was added.

`walStrings` is the one iLEAPP fixed in GHSA-45q2-q93c-cfv2 and ALEAPP never received — the identical artifact, unescaped here for weeks. Routing it through `safe_local_link()` closes that interpolation on the same line.

## What examiners will notice

Avatar thumbnails in those four artifacts stop rendering and show the URL as text instead. No evidence is lost, only the fetch.

## Validation

- `py_compile` clean
- `pylint --disable=C,R` reports no warning other than the pre-existing `E0401` import-error noise (5 on an untouched file)
- `PluginLoader` loads 644 plugins, every changed module present
- Repo-wide AST scan reports 0 remaining remote destinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)