### PR TITLE
Stop waze anchoring evidence URLs in the report

### DIFF
--- a/scripts/artifacts/waze.py
+++ b/scripts/artifacts/waze.py
@@ -469,19 +469,11 @@ def format_url(str_url: str | None, html_format: bool = False, label: str | None
     # Visible text: label or raw URL
     visible = label if label else s
 
-    # HTML rendering
+    # HTML rendering: escaped text, never an anchor. The host in a Waze URL comes
+    # from the evidence, and a report must not reach a destination outside its own
+    # folder. The URL is preserved verbatim for the examiner to read and copy.
     if html_format:
-        safe_text = html.escape(visible, quote=False)
-
-        if is_clickable:
-            safe_href = html.escape(s, quote=True)
-            return (
-                f'<a href="{safe_href}" target="_blank" '
-                f'rel="noopener noreferrer">{safe_text}</a>'
-            )
-
-        # Non-clickable: return escaped plain text — evidence preserved
-        return safe_text
+        return html.escape(visible, quote=False)
 
     # Plain text rendering
     if is_clickable and label:


### PR DESCRIPTION
Follow-up to #1037. That change removed every remote destination I could find in ALEAPP; this one was missed.

## The issue

`format_url()` in `waze.py` still returns a live anchor for any `http`/`https` URL with a hostname:

```python
if is_clickable:
    safe_href = html.escape(s, quote=True)
    return f'<a href="{safe_href}" target="_blank" rel="noopener noreferrer">{safe_text}</a>'
```

It feeds the `Profile Picture URL` and `Image URL` `html_columns`, so ALEAPP reports today contain clickable anchors pointing at hosts named by the evidence. Escaped, so not an injection — but a report should reach nothing outside its own folder.

This is the identical builder removed from iLEAPP's `waze.py` in the no-external-link work. ALEAPP's copy is the third time this specific artifact has drifted between cores.

## Why #1037 didn't catch it

The scan that cleared #1037 used an earlier revision of `check_html_safety.py` whose assignment collection descended into nested functions. The resulting leak made `safe_href` resolve as an already-safe destination, so the finding never fired. Fixing that leak (in iLEAPP #1891) is what surfaced this. Re-running the corrected checker against every core turned up this one artifact and nothing else.

## The fix

The `html_format` branch returns escaped text, matching `box`, `booking`, `foursquareSwarm` and iLEAPP's `waze`. The URL is preserved verbatim for the examiner to read and copy; only the anchor goes.

## Validation

- `py_compile` clean; unit tests OK
- `check_html_safety.py` reports no remaining remote destination in this core

🤖 Generated with [Claude Code](https://claude.com/claude-code)