### PR TITLE
Empty the html-safety baseline: all five findings were false positives

### DIFF
--- a/admin/scripts/check_html_safety.py
+++ b/admin/scripts/check_html_safety.py
@@ -45,7 +45,7 @@ THREE RULES
     A literal remote URL appears in a markup-bearing string, or an `href=`/`src=`
     attribute is completed by an interpolation. A dynamic destination cannot be shown
     to be report-relative by reading the source, so it fails unless it comes from
-    `safe_local_link()`.
+    `safe_local_path()` or `safe_local_link()`.
 
 `unguarded-html-columns`
     A module declares `html_columns` but never references an escaper. This catches the
@@ -125,25 +125,9 @@ LOCAL_LINK_NAMES = frozenset({
 
 # Pre-existing violations. Delete an entry when its violation is fixed; a stale entry
 # fails the run. See the module docstring before adding one.
-BASELINE = {
-    # media_to_html() assigns `source` four times before emitting it -- the raw match,
-    # a relative path, a copied path, then safe_local_path(). A name is treated as safe
-    # only when *every* assignment to it is, because this check does not order
-    # assignments. The function is in fact correct: the last write is safe_local_path()
-    # and nothing reads `source` before it. Rewriting it to bind the escaped value to
-    # its own name would clear this honestly.
-    ('scripts/ilapfuncs.py', 'remote-destination', 'media_to_html'),
-    ('scripts/ilapfuncs.py', 'unescaped-interpolation', 'media_to_html'),
-
-    # The torrent artifacts escape most operands and miss one per function. In
-    # torrentinfo the 'creation date' branch interpolates key.decode() raw while the
-    # branch two lines below it escapes both operands, so a torrent whose key names
-    # carry markup renders live. Real, and a partial fix rather than a design choice.
-    ('scripts/artifacts/torrentinfo.py', 'unescaped-interpolation', 'get_torrentinfo'),
-    ('scripts/artifacts/torrentData.py', 'unescaped-interpolation', 'get_TorrentData'),
-    ('scripts/artifacts/torrentResumeinfo.py', 'unescaped-interpolation',
-     'get_torrentResumeinfo'),
-}
+#
+# Empty: every finding this core had is now fixed rather than carried.
+BASELINE = set()
 
 # Reviewed exceptions expected to stay. Every entry needs a comment saying why.
 ALLOWLIST = {
@@ -293,6 +277,12 @@ def _resolve(node, assignments, names, seen):
     if isinstance(node, ast.JoinedStr):
         return all(_resolve(v.value, assignments, names, seen)
                    for v in node.values if isinstance(v, ast.FormattedValue))
+    # `agg = agg + f'<td>{esc(v)}</td>'` -- the accumulator shape most of these
+    # builders use. A concatenation is safe when both sides are, and the
+    # self-reference on the left terminates through `seen`.
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        return (_resolve(node.left, assignments, names, seen)
+                and _resolve(node.right, assignments, names, seen))
     if isinstance(node, ast.Call):
         if call_name(node) in names:
             return True

--- a/scripts/artifacts/torrentResumeinfo.py
+++ b/scripts/artifacts/torrentResumeinfo.py
@@ -61,7 +61,9 @@ def get_torrentResumeinfo(context):
             elif key.decode() == 'pieces':
                 pass
             elif key.decode() == 'creation date':
-                aggregate = aggregate + f'{key.decode()}: {timestampcalc(value)} <br>'
+                # The branch above pins the key to this literal, so say it outright
+                # rather than re-decoding it, and escape the formatted timestamp.
+                aggregate = aggregate + f'creation date: {esc(timestampcalc(value))} <br>'
             else:
                 aggregate = aggregate + f'{esc(key.decode())}: {esc(value)} <br>' #add if value is binary decode
 

--- a/scripts/artifacts/torrentinfo.py
+++ b/scripts/artifacts/torrentinfo.py
@@ -69,7 +69,9 @@ def get_torrentinfo(context):
                 elif key.decode() == 'pieces':
                     pass
                 elif key.decode() == 'creation date':
-                    aggregate = aggregate + f'{key.decode()}: {timestampcalc(value)} <br>'
+                    # The branch above pins the key to this literal, so say it outright
+                    # rather than re-decoding it, and escape the formatted timestamp.
+                    aggregate = aggregate + f'creation date: {esc(timestampcalc(value))} <br>'
                 else:
                     aggregate = aggregate + f'{esc(key.decode())}: {esc(value.decode())} <br>' #add if value is binary decode
 

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -966,17 +966,21 @@ def media_to_html(media_path, files_found, report_folder):
         # allow_parent: relative_paths() above deliberately emits ../data/... to reach
         # the extraction folder beside the report. The evidence filename in the
         # fallback link text is escaped -- it used to be interpolated raw.
-        source = safe_local_path(source, allow_parent=True)
-        filename = esc(filename)
+        # Bind the escaped values to their own names rather than writing back over
+        # `source`, which is assigned several times above. Reading a name that only
+        # ever holds a checked value makes the safety local and obvious, to a reader
+        # and to admin/scripts/check_html_safety.py alike.
+        safe_source = safe_local_path(source, allow_parent=True)
+        safe_filename = esc(filename)
 
         if 'video' in mimetype:
-            thumb = f'<video width="320" height="240" controls="controls"><source src="{source}" type="video/mp4" preload="none">Your browser does not support the video tag.</video>'
+            thumb = f'<video width="320" height="240" controls="controls"><source src="{safe_source}" type="video/mp4" preload="none">Your browser does not support the video tag.</video>'
         elif 'image' in mimetype:
-            thumb = f'<a href="{source}" target="_blank"><img src="{source}" width="300"></img></a>'
+            thumb = f'<a href="{safe_source}" target="_blank"><img src="{safe_source}" width="300"></img></a>'
         elif 'audio' in mimetype:
-            thumb = f'<audio controls><source src="{source}" type="audio/ogg"><source src="{source}" type="audio/mpeg">Your browser does not support the audio element.</audio>'
+            thumb = f'<audio controls><source src="{safe_source}" type="audio/ogg"><source src="{safe_source}" type="audio/mpeg">Your browser does not support the audio element.</audio>'
         else:
-            thumb = f'<a href="{source}" target="_blank"> Link to {filename} file</a>'
+            thumb = f'<a href="{safe_source}" target="_blank"> Link to {safe_filename} file</a>'
     return thumb
 
 


### PR DESCRIPTION
Follow-up to #1041, which landed the guard with a five-entry baseline. Reading the flagged code rather than trusting the labels, **none of the five was an unescaped sink.** Three were the check failing to see safety that was already there; two were a shape it could not follow. Each is fixed at the source, so the baseline goes to zero instead of carrying explanations.

I had described the torrent findings as real partial-escaping bugs when the guard landed. That was wrong, and this PR is the correction.

## `torrentinfo` / `torrentResumeinfo` — safe already

```python
elif key.decode() == 'creation date':
    aggregate = aggregate + f'{key.decode()}: {timestampcalc(value)} <br>'
```

The branch condition pins `key.decode()` to that literal, and `timestampcalc()` runs `int()` then `strftime()` — so it returns a fixed-format string or raises. Both interpolations were already safe.

They now say `creation date` outright rather than re-decoding a key just compared to it, which reads better, and the timestamp is `esc()`'d because it costs nothing.

## `torrentData` — a checker gap, now closed

`aggf = aggf + '</table>'`: an accumulator concatenated with a tool-owned literal, where every other write to `aggf` is an escaped f-string. The check did not resolve `+` chains at all, so the accumulator read as unknown.

It now resolves a concatenation when both sides resolve, with the self-reference terminating through the existing `seen` set. That is a general improvement — accumulate-then-emit is how most of these builders work — and it will reduce noise in the other cores too.

## `media_to_html` — correct, but not locally provable

`source` was assigned four times and then emitted. The final write was `safe_local_path()` and nothing read it earlier, so the function was correct; but a name counts as safe only when *every* assignment to it is, because this check does not order assignments.

The escaped values now bind to their own names, `safe_source` and `safe_filename`. That makes the safety local and obvious to a reader as much as to the checker, which is the better shape regardless of tooling.

## Result

ALEAPP is the first core with an empty `BASELINE`. The two `ALLOWLIST` entries stay — `calllog` builds its cell from feather-icon constants, `RandoChat` declares only a media column.

## Validation

- `py_compile` clean; `lint_changed` reports no new warnings
- 83 tests OK; `PluginLoader` loads 666 plugins
- `check_html_safety` exits 0 with 0 baselined, and still exits 1 on injected probes

🤖 Generated with [Claude Code](https://claude.com/claude-code)