### PR TITLE
Remove dead geopy geocoding cluster from ilapfuncs

### DIFF
--- a/admin/test/scripts/test_dependency_compatibility.py
+++ b/admin/test/scripts/test_dependency_compatibility.py
@@ -16,7 +16,6 @@ import simplekml
 import xlsxwriter
 import xmltodict
 from bs4 import BeautifulSoup
-from geopy.geocoders import Nominatim
 from packaging import version
 from PIL import Image
 from google.protobuf import descriptor
@@ -30,7 +29,6 @@ THIRD_PARTY_IMPORTS = (
     "bencoding",
     "fitdecode",
     "folium",
-    "geopy",
     "packaging",
     "PIL",
     "polyline",
@@ -92,7 +90,6 @@ class TestDependencyCompatibility(unittest.TestCase):
             finally:
                 os.unlink(html_file.name)
 
-        self.assertEqual(Nominatim(user_agent="aleapp-test").scheme, "https")
         self.assertLess(version.parse("1.2.3"), version.parse("2.0.0"))
 
         with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as image_file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ beautifulsoup4==4.8.2
 bencoding
 fitdecode==0.10.0
 folium==0.14.0
-geopy==2.3.0
 packaging==20.1
 pillow==12.3.0
 polyline==2.0.0

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -44,9 +44,6 @@ from scripts import blackboxprotobuf
 from scripts.filetype import guess_mime, guess_extension
 from functools import wraps
 
-# LEAPP version unique imports
-from geopy.geocoders import Nominatim
-
 from scripts.html_safe import esc, safe_local_path
 from scripts.lavafuncs import lava_process_artifact, lava_insert_sqlite_data, lava_get_media_item, \
     lava_insert_sqlite_media_item, lava_insert_sqlite_media_references, lava_get_media_references, \
@@ -1482,70 +1479,3 @@ def checkabx(in_path):
         return (False)
     else:
         return (True)
-
-
-def get_raw_fields(latitude, longitude, c, conn):
-    geolocator = Nominatim(user_agent="address-retrieval")
-    location = geolocator.reverse(f"{latitude}, {longitude}")
-    if location:
-        raw_data = location.raw
-        # check if raw_data["address"]["road"] exists
-        not_present = False
-        if "road" in raw_data["address"]:
-            road = raw_data["address"]["road"]
-        elif "hamlet" in raw_data["address"]:
-            road = raw_data["address"]["hamlet"]
-        else:
-            road = 'Not Present'
-            not_present = True
-
-        if "city" in raw_data["address"]:
-            city = raw_data["address"]["city"]
-        elif "town" in raw_data["address"]:
-            city = raw_data["address"]["town"]
-        else:
-            city = 'Not present'
-            not_present = True
-        if not not_present:
-            store_raw_fields(latitude, longitude, road, city,
-                             raw_data["address"]["postcode"], raw_data["address"]["country"], c, conn)
-        # create a dict
-        obtained_data = {"road": road, "city": city, "postcode": raw_data["address"]["postcode"],
-                         "country": raw_data["address"]["country"]}
-        return obtained_data
-    else:
-        print("Location not found.")
-
-
-def store_raw_fields(latitude_value, longitude_value, road_value, city_value, postcode_value, country_value, c, conn):
-    # Check if the entry is already present
-    c.execute('''SELECT * FROM raw_fields WHERE latitude=? AND longitude=?''', (latitude_value, longitude_value))
-    if c.fetchone() is None:
-        # Insert a row of data
-        c.execute('''INSERT INTO raw_fields (latitude, longitude, road, city, postcode, country) 
-                      VALUES (?, ?, ?, ?, ?, ?)''',
-                  (latitude_value, longitude_value, road_value, city_value, postcode_value, country_value))
-
-        # Save (commit) the changes
-        conn.commit()
-
-# Function to check if the raw fields are already present in the database and return them if present or return None
-def check_raw_fields(latitude, longitude, c):
-    # Check if the entry is already present
-    c.execute('''SELECT * FROM raw_fields WHERE latitude=? AND longitude=?''', (latitude, longitude))
-    data = c.fetchone()
-    # convert to dict
-    return data
-
-#Function to check if the user as internet connection to do the geocoding features
-def check_internet_connection():
-    try:
-        geolocator = Nominatim(user_agent="check_internet_connection")
-        geolocator.reverse("39.7495, 8.8077")  # Leiria coordinates
-        logfunc("Internet connection is available.")
-        return True
-    except:  # pylint: disable=bare-except
-        logfunc("Internet connection is not available.")
-        return False
-    
-    


### PR DESCRIPTION
## What

Removes a dead geocoding cluster from `scripts/ilapfuncs.py`: `get_raw_fields`, `check_raw_fields`, `store_raw_fields` and `check_internet_connection`, plus the `from geopy.geocoders import Nominatim` import. Nothing in the repo calls any of them. Verified by grep across all .py files: the only references were the functions calling each other.

## Why

If this code ever got resurrected it would send evidence coordinates (latitude and longitude from a case) to the third-party Nominatim/OpenStreetMap service, and `check_internet_connection` performs a live reverse geocode as a connectivity probe. That contradicts the zero-remote-destinations report hardening policy. Dead code that violates the policy is safer gone.

## Also in this PR

- `geopy==2.3.0` leaves `requirements.txt`. Nothing else in the repo imports it.
- `admin/test/scripts/test_dependency_compatibility.py` drops its geopy import, the `geopy` entry in `THIRD_PARTY_IMPORTS`, and the Nominatim smoke check.

## Verification

- `admin/scripts/lint_changed.py --base-ref origin/main` on both changed .py files: no new warnings. The one remaining warning (`deprecated-method` at ilapfuncs.py:810) is pre-existing and unrelated.
- Dependency compatibility suite passes locally: 6 tests OK, including the `scripts.ilapfuncs` core module import.
- Swept iLEAPP, RLEAPP, VLEAPP and DLEAPP per the sibling sweep procedure after fetching all checkouts: none of them carry this cluster or reference geopy anywhere. No sibling PRs needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)