### PR TITLE
feat: Snapchat arroyo.db rows the WAL removes, with row provenance columns

### DIFF
--- a/scripts/artifacts/snapchat.py
+++ b/scripts/artifacts/snapchat.py
@@ -131,6 +131,78 @@ __artifacts_v2__ = {
             "hc_pixel8pro_a17": "Android 17 | com.snapchat.android vc 302522 | 4 rows",
         },
     },
+    "get_snapchat_arroyo_superseded_messages": {
+        "name": "Snapchat - Messages Not In Committed State (arroyo.db)",
+        "description": "Rows from the conversation_message table in arroyo.db that are present "
+                       "when the database file is read as of its last checkpoint and absent when "
+                       "the write-ahead log is applied. Columns match Snapchat - Messages "
+                       "(arroyo.db), with a Record State column added.",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-08-07", "last_update_date": "2026-08-07",
+        "requirements": "blackboxprotobuf", "category": "Snapchat",
+        "notes": "These rows are NOT in the live conversation view and must not be read as "
+                 "current messages. Snapchat - Messages (arroyo.db) is the committed state.\n"
+                 "Method: arroyo.db is opened twice through SQLite, once with immutable=1, which "
+                 "ignores the write-ahead log and yields the file as of its last checkpoint, and "
+                 "once with mode=ro, which applies the log and yields the committed state. Rows "
+                 "whose (client_conversation_id, client_message_id) primary key appears in the "
+                 "first result and not the second are reported here. Both sides are consistent "
+                 "SQLite reads of the same bytes, so column names, type affinity and overflow "
+                 "pages are handled by SQLite rather than by a hand-written page parser.\n"
+                 "Why a row did not survive into the committed state is NOT established by this "
+                 "artifact. Removal by the application, a server re-sync rewriting those pages, "
+                 "and deletion are all consistent with the same result. On the tested image most "
+                 "of these rows carried Team Snapchat broadcast content, which is consistent with "
+                 "a re-sync, and that is an observation about one image rather than a general "
+                 "property.\n"
+                 "This is NOT deleted-record carving. It does not read freelist pages, "
+                 "unallocated space or freeblocks, and it does not parse WAL frames, so records "
+                 "that only ever existed inside the log are not recovered. It returns nothing "
+                 "when no -wal file accompanies the database, which was verified by removing the "
+                 "sidecar and confirming both reads agreed at 11 rows.\n"
+                 "Timestamps here are the values stored on the rows and will overlap the "
+                 "committed artifact's range, so take care not to count a conversation twice "
+                 "across the two artifacts or in the timeline. No conversation data view is "
+                 "declared, deliberately, so these rows do not render as chat messages in LAVA.",
+        "paths": ('*/com.snapchat.android/databases/arroyo.db*',
+                  '*/com.snapchat.android/databases/main.db*',
+                  '*/com.snapchat.android/shared_prefs/identity_persistent_store.xml'),
+        "output_types": "standard", "artifact_icon": "alert-triangle",
+        "sample_data": {
+            "hc_pixel8pro_a17": "Android 17 | com.snapchat.android vc 302522 | 8 rows",
+        },
+    },
+    "get_snapchat_arroyo_superseded_conversations": {
+        "name": "Snapchat - Conversations Not In Committed State (arroyo.db)",
+        "description": "Rows from the conversation and feed_entry tables in arroyo.db that are "
+                       "present when the database file is read as of its last checkpoint and "
+                       "absent when the write-ahead log is applied.",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-08-07", "last_update_date": "2026-08-07",
+        "requirements": "blackboxprotobuf", "category": "Snapchat",
+        "notes": "These rows are NOT in the live conversation list. Snapchat - Conversations "
+                 "(arroyo.db) is the committed state. Method and limits are the same as Snapchat "
+                 "- Messages Not In Committed State (arroyo.db); see that artifact's notes.\n"
+                 "A conversation is reported when its client_conversation_id is present in "
+                 "conversation or feed_entry as of the last checkpoint and in neither table once "
+                 "the log is applied. Comparing row counts alone would not find these: on the "
+                 "tested image conversation, conversation_identifier and feed_entry each held 4 "
+                 "rows in both reads, and it was only comparing primary keys that showed one "
+                 "identifier had been replaced by a different one.\n"
+                 "Participants, message counts and titles for these rows are read from the same "
+                 "pre-checkpoint view, so they describe the conversation as it stood at that "
+                 "point. A participant absent from the Friend table in main.db is reported as a "
+                 "bare UUID; that is an unresolved identifier, not a finding about the account.\n"
+                 "Message Count counts conversation_message rows carrying that "
+                 "client_conversation_id in the pre-checkpoint view, which is not necessarily the "
+                 "number of messages exchanged in the conversation.",
+        "paths": ('*/com.snapchat.android/databases/arroyo.db*',
+                  '*/com.snapchat.android/databases/main.db*'),
+        "output_types": "standard", "artifact_icon": "alert-triangle",
+        "sample_data": {
+            "hc_pixel8pro_a17": "Android 17 | com.snapchat.android vc 302522 | 1 row",
+        },
+    },
     "get_snapchat_memories": {
         "name": "Snapchat - Memories",
         "description": "Snapchat memories entries",
@@ -214,7 +286,8 @@ import xml.etree.ElementTree as ET
 
 import bcrypt
 
-from scripts.ilapfuncs import artifact_processor, decode_protobuf, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, decode_protobuf, get_sqlite_db_path, \
+    open_sqlite_db_readonly
 
 _MEO_CODES = {}
 _XML_UNIX_KEYS = {'INSTALL_ON_DEVICE_TIMESTAMP', 'LONG_CLIENT_ID_DEVICE_TIMESTAMP',
@@ -397,10 +470,52 @@ def _friend_name(friends, user_id, index=0):
     return friends.get(user_id, ('', ''))[index]
 
 
-def _participants(arroyo_path, friends):
+def _rows_pre_wal(source_path, sql):
+    '''Run sql against the database file as of its last checkpoint, ignoring the WAL.
+
+    immutable=1 is strictly read-only. Unlike mode=ro it does not even create a -shm
+    sidecar, so no evidence file is altered. Path handling goes through the same
+    get_sqlite_db_path() that open_sqlite_db_readonly() uses, so Windows long paths and
+    URI-special characters behave identically.
+    '''
+    if not source_path:
+        return []
+    try:
+        db = sqlite3.connect(f'file:{get_sqlite_db_path(source_path)}?immutable=1', uri=True)
+    except sqlite3.Error:
+        return []
+    cursor = db.cursor()
+    try:
+        cursor.execute(sql)
+        rows = cursor.fetchall()
+    except sqlite3.Error:
+        rows = []
+    db.close()
+    return rows
+
+
+def _superseded(source_path, sql, key_indexes):
+    '''Rows present at the last checkpoint and absent once the write-ahead log is applied.
+
+    Both sides are consistent SQLite views of the same file, one ignoring the WAL and one
+    applying it, compared on the columns at key_indexes. Comparing row counts is not enough:
+    on the tested image counting flagged 2 of 30 tables in arroyo.db while comparing primary
+    keys flagged 6, because four tables held the same number of rows with different keys.
+
+    Empty when the file has no WAL alongside it. Why a row did not survive into the
+    committed state is not established here.
+    '''
+    def key(row):
+        return tuple(row[index] for index in key_indexes)
+
+    committed = {key(row) for row in _rows(source_path, sql)}
+    return [row for row in _rows_pre_wal(source_path, sql) if key(row) not in committed]
+
+
+def _participants(arroyo_path, friends, reader=_rows):
     '''Map client_conversation_id to (participant ids, participant usernames).'''
     participants = {}
-    for conversation_id, blob in _rows(
+    for conversation_id, blob in reader(
             arroyo_path, 'SELECT client_conversation_id, conversation_metadata FROM conversation'):
         entries = _pb_get(_decode(blob), '3')
         if isinstance(entries, dict):
@@ -440,22 +555,56 @@ def _yes_no(value):
     return 'YES' if value else 'NO'
 
 
-@artifact_processor
-def get_snapchat_arroyo_messages(context):
-    files_found = context.get_files_found()
-    source_path = _find(files_found, 'arroyo.db')
-    friends = _friends(_find(files_found, 'main.db'))
-    participants = _participants(source_path, friends)
-    local_user_id = _local_user_id(files_found, source_path, friends)
+_MESSAGE_SQL = '''
+    SELECT creation_timestamp, read_timestamp, sender_id, content_type, message_content,
+           message_state_type, is_saved, is_viewed_by_user, created_on_device,
+           remote_media_count, replies_count, quoted_server_message_id,
+           client_conversation_id, client_message_id, server_message_id
+    FROM conversation_message ORDER BY creation_timestamp
+'''
+# conversation_message primary key (client_conversation_id, client_message_id), as offsets
+# into the columns selected above.
+_MESSAGE_KEY = (12, 13)
 
+_MESSAGE_HEADERS = (('Creation Timestamp', 'datetime'), ('Read Timestamp', 'datetime'),
+                    'Sender Username', 'Sender Display Name', 'Sender ID', 'Message Direction',
+                    'Conversation Participants', 'Message Text', 'Content Type (as stored)',
+                    'Message State Type', 'Is Saved', 'Is Viewed By User', 'Created On Device',
+                    'Remote Media Count', 'Replies Count', 'Quoted Server Message ID',
+                    'Conversation ID', 'Client Message ID', 'Server Message ID')
+
+_CONVERSATION_HEADERS = (('Creation Timestamp', 'datetime'), ('Last Updated Timestamp', 'datetime'),
+                         ('Display Timestamp', 'datetime'), ('Tombstoned At Timestamp', 'datetime'),
+                         ('Streak Expiration Timestamp', 'datetime'), 'Conversation Title',
+                         'Participants', 'Participant IDs', 'Message Count', 'Streak Count',
+                         'Conversation Type (as stored)', 'Send State Type', 'Feed Item Creator',
+                         'Feed Item Creator ID', 'Last Chat Sender', 'Last Chat Sender ID',
+                         'Tombstoned', 'Conversation ID')
+
+_RECORD_STATE = 'Record State'
+_STATE_SUPERSEDED = 'Present at last checkpoint, absent after WAL'
+
+
+def _add_state(headers, rows, state):
+    '''Add a record state column, inserted after the leading timestamp columns.
+
+    Keeping every datetime column leftmost is the house ordering, so the insert point is
+    derived from the headers rather than hardcoded.
+    '''
+    index = 0
+    while (index < len(headers) and isinstance(headers[index], tuple)
+           and headers[index][1] == 'datetime'):
+        index += 1
+
+    def insert(values, value):
+        return tuple(values[:index]) + (value,) + tuple(values[index:])
+
+    return insert(headers, _RECORD_STATE), [insert(row, state) for row in rows]
+
+
+def _message_rows(rows, friends, participants, local_user_id):
     data_list = []
-    for row in _rows(source_path, '''
-            SELECT creation_timestamp, read_timestamp, sender_id, content_type, message_content,
-                   message_state_type, is_saved, is_viewed_by_user, created_on_device,
-                   remote_media_count, replies_count, quoted_server_message_id,
-                   client_conversation_id, client_message_id, server_message_id
-            FROM conversation_message ORDER BY creation_timestamp
-    '''):
+    for row in rows:
         (created, read, sender_id, content_type, blob, state, saved, viewed, on_device,
          media_count, replies, quoted_id, conversation_id, client_message_id, server_message_id) = row
         text = _pb_text(_decode(blob), '4', '4', '2', '1') if content_type == 1 else ''
@@ -469,40 +618,32 @@ def get_snapchat_arroyo_messages(context):
             direction, participants.get(conversation_id, ('', ''))[1], text, content_type, state,
             _yes_no(saved), _yes_no(viewed), _yes_no(on_device), media_count, replies, quoted_id,
             conversation_id, client_message_id, server_message_id))
-
-    data_headers = (('Creation Timestamp', 'datetime'), ('Read Timestamp', 'datetime'),
-                    'Sender Username', 'Sender Display Name', 'Sender ID', 'Message Direction',
-                    'Conversation Participants', 'Message Text', 'Content Type (as stored)',
-                    'Message State Type', 'Is Saved', 'Is Viewed By User', 'Created On Device',
-                    'Remote Media Count', 'Replies Count', 'Quoted Server Message ID',
-                    'Conversation ID', 'Client Message ID', 'Server Message ID')
-    return data_headers, data_list, source_path
+    return data_list
 
 
-@artifact_processor
-def get_snapchat_arroyo_conversations(context):
-    files_found = context.get_files_found()
-    source_path = _find(files_found, 'arroyo.db')
-    friends = _friends(_find(files_found, 'main.db'))
-    participants = _participants(source_path, friends)
-
-    conversations = {row[0]: row[1:] for row in _rows(source_path, '''
+def _conversation_rows(source_path, friends, reader, only_ids=None):
+    participants = _participants(source_path, friends, reader)
+    conversations = {row[0]: row[1:] for row in reader(source_path, '''
         SELECT client_conversation_id, creation_timestamp, tombstoned_at_timestamp, send_state_type
         FROM conversation
     ''')}
-    feeds = {row[0]: row[1:] for row in _rows(source_path, '''
+    feeds = {row[0]: row[1:] for row in reader(source_path, '''
         SELECT client_conversation_id, last_updated_timestamp, display_timestamp,
                streak_expiration_timestamp_ms, conversation_title, conversation_type, streak_count,
                feedItemCreator, last_chat_sender, tombstoned
         FROM feed_entry
     ''')}
-    counts = dict(_rows(source_path, '''
+    counts = dict(reader(source_path, '''
         SELECT client_conversation_id, COUNT(*) FROM conversation_message
         GROUP BY client_conversation_id
     '''))
 
+    wanted = set(conversations) | set(feeds)
+    if only_ids is not None:
+        wanted &= set(only_ids)
+
     data_list = []
-    for conversation_id in sorted(set(conversations) | set(feeds)):
+    for conversation_id in sorted(wanted):
         created, tombstoned_at, send_state = conversations.get(conversation_id, (None, None, ''))
         (updated, displayed, streak_expiry, title, conversation_type, streak, creator,
          last_sender, tombstoned) = feeds.get(conversation_id, (None,) * 9)
@@ -514,14 +655,58 @@ def get_snapchat_arroyo_conversations(context):
             counts.get(conversation_id, 0), streak, conversation_type, send_state,
             _friend_name(friends, creator), creator, _friend_name(friends, last_sender), last_sender,
             _yes_no(tombstoned), conversation_id))
+    return data_list
 
-    data_headers = (('Creation Timestamp', 'datetime'), ('Last Updated Timestamp', 'datetime'),
-                    ('Display Timestamp', 'datetime'), ('Tombstoned At Timestamp', 'datetime'),
-                    ('Streak Expiration Timestamp', 'datetime'), 'Conversation Title',
-                    'Participants', 'Participant IDs', 'Message Count', 'Streak Count',
-                    'Conversation Type (as stored)', 'Send State Type', 'Feed Item Creator',
-                    'Feed Item Creator ID', 'Last Chat Sender', 'Last Chat Sender ID',
-                    'Tombstoned', 'Conversation ID')
+
+def _superseded_conversation_ids(source_path):
+    '''client_conversation_id values that the WAL removes from conversation or feed_entry.'''
+    pre, committed = set(), set()
+    for sql in ('SELECT client_conversation_id FROM conversation',
+                'SELECT client_conversation_id FROM feed_entry'):
+        pre |= {row[0] for row in _rows_pre_wal(source_path, sql)}
+        committed |= {row[0] for row in _rows(source_path, sql)}
+    return pre - committed
+
+
+@artifact_processor
+def get_snapchat_arroyo_messages(context):
+    files_found = context.get_files_found()
+    source_path = _find(files_found, 'arroyo.db')
+    friends = _friends(_find(files_found, 'main.db'))
+    data_list = _message_rows(_rows(source_path, _MESSAGE_SQL), friends,
+                              _participants(source_path, friends),
+                              _local_user_id(files_found, source_path, friends))
+    return _MESSAGE_HEADERS, data_list, source_path
+
+
+@artifact_processor
+def get_snapchat_arroyo_superseded_messages(context):
+    files_found = context.get_files_found()
+    source_path = _find(files_found, 'arroyo.db')
+    friends = _friends(_find(files_found, 'main.db'))
+    rows = _message_rows(_superseded(source_path, _MESSAGE_SQL, _MESSAGE_KEY), friends,
+                         _participants(source_path, friends, _rows_pre_wal),
+                         _local_user_id(files_found, source_path, friends))
+    data_headers, data_list = _add_state(_MESSAGE_HEADERS, rows, _STATE_SUPERSEDED)
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def get_snapchat_arroyo_conversations(context):
+    files_found = context.get_files_found()
+    source_path = _find(files_found, 'arroyo.db')
+    friends = _friends(_find(files_found, 'main.db'))
+    return _CONVERSATION_HEADERS, _conversation_rows(source_path, friends, _rows), source_path
+
+
+@artifact_processor
+def get_snapchat_arroyo_superseded_conversations(context):
+    files_found = context.get_files_found()
+    source_path = _find(files_found, 'arroyo.db')
+    friends = _friends(_find(files_found, 'main.db'))
+    rows = _conversation_rows(source_path, friends, _rows_pre_wal,
+                              _superseded_conversation_ids(source_path))
+    data_headers, data_list = _add_state(_CONVERSATION_HEADERS, rows, _STATE_SUPERSEDED)
     return data_headers, data_list, source_path
 
 

--- a/scripts/artifacts/snapchat.py
+++ b/scripts/artifacts/snapchat.py
@@ -52,9 +52,11 @@ __artifacts_v2__ = {
         "name": "Snapchat - Messages (arroyo.db)",
         "description": "Chat message records from the conversation_message table in arroyo.db, "
                        "both the rows a normal read returns and rows that are present only before "
-                       "the write-ahead log is applied. Sender and participant UUIDs are resolved "
-                       "against the Friend table in main.db, and message text is decoded from the "
-                       "message_content protobuf on rows where content_type is 1.",
+                       "the write-ahead log is applied, distinguished by the Record Origin column. "
+                       "Sender and participant UUIDs are resolved against the Friend table in "
+                       "main.db, and message text is decoded from the message_content protobuf on "
+                       "rows where content_type is 1. WAL frames are not parsed, so absence of a "
+                       "message here is not evidence it did not exist.",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07", "last_update_date": "2026-08-07",
         "requirements": "blackboxprotobuf", "category": "Snapchat",
@@ -111,6 +113,20 @@ __artifacts_v2__ = {
                  "among rows where created_on_device is set (the schema comments in arroyo.db "
                  "define that column as set when the message was created on this device). Both "
                  "paths agreed on the tested image. The column is left blank when neither resolves.\n"
+                 "WHAT THIS DOES NOT RECOVER, measured rather than assumed. This artifact does not "
+                 "parse WAL frames. On the tested image a one-off frame parser written during "
+                 "development read a further 29 conversation_message rows that neither view "
+                 "reports, across 10 conversations, 9 of which appear in neither view of the "
+                 "conversation table; creation timestamps were readable for 21 of those 29 and "
+                 "span 2025-11-18 to 2026-07-24. ABSENCE OF A MESSAGE FROM THIS ARTIFACT IS NOT "
+                 "EVIDENCE THAT THE MESSAGE DID NOT EXIST. A shared SQLite recovery capability "
+                 "covering WAL frames is being built separately. The run log records how many "
+                 "frames the write-ahead log of the image being processed actually holds, which "
+                 "is the per-device measure of what is left uncovered.\n"
+                 "To re-derive a Recovered row without this tool, query the database with its log "
+                 "ignored and confirm the same row is absent from a normal read, for example: "
+                 "sqlite3 \"file:arroyo.db?immutable=1\" \"SELECT * FROM conversation_message "
+                 "WHERE client_message_id = 962\"\n"
                  "Not covered: media files on disk are not linked to message rows, and reactions, "
                  "message_state history and Kraken epoch encrypted content are not parsed.",
         "paths": ('*/com.snapchat.android/databases/arroyo.db*',
@@ -136,9 +152,11 @@ __artifacts_v2__ = {
         "name": "Snapchat - Conversations (arroyo.db)",
         "description": "Conversation records from the conversation and feed_entry tables in "
                        "arroyo.db, both the rows a normal read returns and rows that are present "
-                       "only before the write-ahead log is applied. Participant UUIDs are decoded "
-                       "from the conversation_metadata protobuf and resolved against the Friend "
-                       "table in main.db.",
+                       "only before the write-ahead log is applied, distinguished by the Record "
+                       "Origin column. Participant UUIDs are decoded from the conversation_metadata "
+                       "protobuf and resolved against the Friend table in main.db. WAL frames are "
+                       "not parsed, so absence of a conversation here is not evidence it did not "
+                       "exist.",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07", "last_update_date": "2026-08-07",
         "requirements": "blackboxprotobuf", "category": "Snapchat",
@@ -171,7 +189,14 @@ __artifacts_v2__ = {
                  "arroyo.db describe as when the conversation was locally left by the user.\n"
                  "Message Count is a count of conversation_message rows carrying that "
                  "client_conversation_id in the matching view, which is not necessarily the number "
-                 "of messages exchanged in the conversation.",
+                 "of messages exchanged in the conversation.\n"
+                 "WHAT THIS DOES NOT RECOVER, measured rather than assumed. This artifact does not "
+                 "parse WAL frames. On the tested image a one-off frame parser written during "
+                 "development read conversation_message rows belonging to 9 conversations that "
+                 "appear in neither view of the conversation table and are therefore absent from "
+                 "this artifact entirely. ABSENCE OF A CONVERSATION HERE IS NOT EVIDENCE THAT IT "
+                 "DID NOT EXIST. A shared SQLite recovery capability covering WAL frames is being "
+                 "built separately.",
         "paths": ('*/com.snapchat.android/databases/arroyo.db*',
                   '*/com.snapchat.android/databases/main.db*'),
         "output_types": "standard", "artifact_icon": "messages",
@@ -260,12 +285,13 @@ __artifacts_v2__ = {
 import datetime
 import os
 import sqlite3
+import struct
 import xml.etree.ElementTree as ET
 
 import bcrypt
 
 from scripts.ilapfuncs import artifact_processor, decode_protobuf, get_sqlite_db_path, \
-    open_sqlite_db_readonly
+    logfunc, open_sqlite_db_readonly
 
 _MEO_CODES = {}
 _XML_UNIX_KEYS = {'INSTALL_ON_DEVICE_TIMESTAMP', 'LONG_CLIENT_ID_DEVICE_TIMESTAMP',
@@ -581,6 +607,46 @@ def _provenance(source_path, origin):
     return (_ORIGIN_RECOVERED, _METHOD_WAL_DIFF, f'{name} (pre-checkpoint)')
 
 
+def _log_wal_extent(files_found):
+    '''Log how much write-ahead log this artifact leaves unparsed, per image.
+
+    Reads the WAL header and the 24-byte frame headers only; no page images are loaded.
+    A frame whose salt pair does not match the WAL header belongs to a previous log
+    generation that the current one has cycled past, so it holds older content still on
+    disk. Reporting both counts gives the examiner the size of what is not covered here.
+    '''
+    wal_path = _find(files_found, 'arroyo.db-wal')
+    if not wal_path:
+        return
+    try:
+        with open(wal_path, 'rb') as handle:
+            header = handle.read(32)
+            if len(header) < 32:
+                return
+            magic, page_size = struct.unpack('>I', header[:4])[0], struct.unpack('>I', header[8:12])[0]
+            if magic not in (0x377F0682, 0x377F0683) or page_size < 512:
+                return
+            salts = struct.unpack('>2I', header[16:24])
+            frame_size = 24 + page_size
+            total = max(0, (os.path.getsize(wal_path) - 32) // frame_size)
+            current = 0
+            for index in range(total):
+                handle.seek(32 + index * frame_size)
+                frame_header = handle.read(24)
+                if len(frame_header) < 24:
+                    total = index
+                    break
+                if struct.unpack('>2I', frame_header[8:16]) == salts:
+                    current += 1
+    except (OSError, struct.error, ValueError):
+        return
+    logfunc(f'Snapchat arroyo.db-wal holds {total} frames of {page_size} bytes '
+            f'({current} in the current log generation, {total - current} from previous '
+            f'generations). This artifact does not parse WAL frames, so records held only in '
+            f'them are not reported and absence of a message from the Snapchat arroyo.db '
+            f'artifacts is not evidence that it did not exist.')
+
+
 def _by_creation(row):
     '''Sort key on the first column, tolerating rows whose timestamp is blank.
 
@@ -668,6 +734,7 @@ def get_snapchat_arroyo_messages(context):
     source_path = _find(files_found, 'arroyo.db')
     friends = _friends(_find(files_found, 'main.db'))
     local_user_id = _local_user_id(files_found, source_path, friends)
+    _log_wal_extent(files_found)
 
     data_list = _message_rows(
         _rows(source_path, _MESSAGE_SQL), friends, _participants(source_path, friends),

--- a/scripts/artifacts/snapchat.py
+++ b/scripts/artifacts/snapchat.py
@@ -50,15 +50,45 @@ __artifacts_v2__ = {
     },
     "get_snapchat_arroyo_messages": {
         "name": "Snapchat - Messages (arroyo.db)",
-        "description": "Chat message records from the conversation_message table in arroyo.db. "
-                       "Sender and participant UUIDs are resolved against the Friend table in "
-                       "main.db, and message text is decoded from the message_content protobuf on "
-                       "rows where content_type is 1.",
+        "description": "Chat message records from the conversation_message table in arroyo.db, "
+                       "both the rows a normal read returns and rows that are present only before "
+                       "the write-ahead log is applied. Sender and participant UUIDs are resolved "
+                       "against the Friend table in main.db, and message text is decoded from the "
+                       "message_content protobuf on rows where content_type is 1.",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07", "last_update_date": "2026-08-07",
         "requirements": "blackboxprotobuf", "category": "Snapchat",
         "notes": "Newer Snapchat builds store conversations in arroyo.db. The Snapchat - Messages "
                  "artifact reads main.db and tcspahn.db and returns no rows against those builds.\n"
+                 "READ THE RECORD ORIGIN COLUMN. This table holds two kinds of row. Record Origin "
+                 "'Live' means the row is returned by a normal read of the database with its "
+                 "write-ahead log applied. Record Origin 'Recovered' means the row is NOT returned "
+                 "by that read: it is present in the database file as of its last checkpoint and "
+                 "absent once the log is applied. Recovery Method names the technique and Recovery "
+                 "Location says where in the evidence the row came from; both are empty on Live "
+                 "rows. The two sets cannot overlap, because a row is only reported as Recovered "
+                 "when its (client_conversation_id, client_message_id) primary key is absent from "
+                 "the live read.\n"
+                 "Why a Recovered row is not in the live read is NOT established by this artifact. "
+                 "Removal by the application, a server re-sync rewriting those pages, and deletion "
+                 "are all consistent with the same result. On the tested image most Recovered rows "
+                 "carried Team Snapchat broadcast content, which is consistent with a re-sync, and "
+                 "that is an observation about one image rather than a general property.\n"
+                 "Method: arroyo.db is opened twice through SQLite, once with immutable=1, which "
+                 "ignores the log and yields the file as of its last checkpoint, and once with "
+                 "mode=ro, which applies it. Both sides are consistent SQLite reads of the same "
+                 "bytes, so column names, type affinity and overflow pages are handled by SQLite "
+                 "rather than by a hand-written page parser. The comparison is on primary key, not "
+                 "row count: on the tested image counting flagged 2 of 30 tables in arroyo.db as "
+                 "diverging while comparing keys flagged 6, because four tables held the same "
+                 "number of rows under different keys.\n"
+                 "This is NOT deleted-record carving. It does not read freelist pages, unallocated "
+                 "space or freeblocks, and it does not parse WAL frames, so records that only ever "
+                 "existed inside the log are not recovered. It also compares keys rather than full "
+                 "row content, so a row whose key survives while its content changed is not "
+                 "reported. It yields no Recovered rows when no -wal file accompanies the "
+                 "database, verified by removing the sidecar and confirming both reads agreed at "
+                 "11 rows.\n"
                  "The glob keeps the -wal and -shm sidecars, because the write-ahead log carries "
                  "much of the live state. On the tested image the database file read on its own "
                  "(immutable=1) yielded 11 conversation_message rows, while the same file read with "
@@ -69,12 +99,12 @@ __artifacts_v2__ = {
                  "columns of the same row: protobuf 2 > 1 matches sender_id, 3 > 1 > 1 > 1 matches "
                  "client_conversation_id, 4 > 2 matches content_type, and 6 > 1 and 6 > 2 match "
                  "creation_timestamp and read_timestamp.\n"
-                 "In the tested image the 3 rows with content_type 1 carried a UTF-8 string at that "
-                 "path. The 5 rows with content_type 0, 2 and 3 carried media and sticker file "
-                 "names, CDN URLs, media dimensions and encryption key and IV fields, but no "
-                 "plaintext body; this artifact does not decrypt media payloads. Values of "
-                 "content_type other than 1 are reported as the stored integer with no label, "
-                 "because no source documenting the enum has been verified.\n"
+                 "In the tested image 6 of the 16 rows with content_type 1 carried a UTF-8 string "
+                 "at that path, 3 Live and 3 Recovered. Rows with content_type 0, 2 and 3 carried "
+                 "media and sticker file names, CDN URLs, media dimensions and encryption key and "
+                 "IV fields, but no plaintext body; this artifact does not decrypt media payloads. "
+                 "Values of content_type other than 1 are reported as the stored integer with no "
+                 "label, because no source documenting the enum has been verified.\n"
                  "Message Direction compares sender_id against the local account id, which is taken "
                  "from LAST_LOGGED_IN_USERNAME in identity_persistent_store.xml resolved through "
                  "Friend.userId in main.db, and failing that from the single distinct sender_id "
@@ -88,7 +118,8 @@ __artifacts_v2__ = {
                   '*/com.snapchat.android/shared_prefs/identity_persistent_store.xml'),
         "output_types": "standard", "artifact_icon": "message",
         "sample_data": {
-            "hc_pixel8pro_a17": "Android 17 | com.snapchat.android vc 302522 | 8 rows",
+            "hc_pixel8pro_a17": "Android 17 | com.snapchat.android vc 302522 | 16 rows "
+                                "(8 Live, 8 Recovered)",
         },
         "data_views": {
             "conversation": {
@@ -104,12 +135,29 @@ __artifacts_v2__ = {
     "get_snapchat_arroyo_conversations": {
         "name": "Snapchat - Conversations (arroyo.db)",
         "description": "Conversation records from the conversation and feed_entry tables in "
-                       "arroyo.db. Participant UUIDs are decoded from the conversation_metadata "
-                       "protobuf and resolved against the Friend table in main.db.",
+                       "arroyo.db, both the rows a normal read returns and rows that are present "
+                       "only before the write-ahead log is applied. Participant UUIDs are decoded "
+                       "from the conversation_metadata protobuf and resolved against the Friend "
+                       "table in main.db.",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07", "last_update_date": "2026-08-07",
         "requirements": "blackboxprotobuf", "category": "Snapchat",
-        "notes": "Rows are the union of client_conversation_id in the conversation and feed_entry "
+        "notes": "READ THE RECORD ORIGIN COLUMN. Record Origin 'Live' means the row is returned by "
+                 "a normal read of the database with its write-ahead log applied. Record Origin "
+                 "'Recovered' means the client_conversation_id is present in conversation or "
+                 "feed_entry as of the last checkpoint and in neither table once the log is "
+                 "applied. Recovery Method and Recovery Location are empty on Live rows. Method and "
+                 "limits are the same as Snapchat - Messages (arroyo.db); see that artifact's "
+                 "notes, including that why a Recovered row is absent is not established.\n"
+                 "Comparing row counts alone would not find these: on the tested image "
+                 "conversation, conversation_identifier and feed_entry each held 4 rows in both "
+                 "reads, and only comparing primary keys showed one identifier had been replaced "
+                 "by a different one.\n"
+                 "For Recovered rows the participants, message count and title are read from the "
+                 "same pre-checkpoint view, so they describe the conversation as it stood at that "
+                 "point. A participant absent from the Friend table in main.db is reported as a "
+                 "bare UUID; that is an unresolved identifier, not a finding about the account.\n"
+                 "Rows are the union of client_conversation_id in the conversation and feed_entry "
                  "tables, so a conversation present in only one of the two is still reported.\n"
                  "Participant IDs are read from the conversation_metadata protobuf, at repeated "
                  "field 3, sub-path 1 > 1, as 16 raw bytes formatted as a UUID. On the tested image "
@@ -122,85 +170,14 @@ __artifacts_v2__ = {
                  "conversation.tombstoned_at_timestamp column, which the schema comments in "
                  "arroyo.db describe as when the conversation was locally left by the user.\n"
                  "Message Count is a count of conversation_message rows carrying that "
-                 "client_conversation_id in this database, which is not necessarily the number of "
-                 "messages exchanged in the conversation.",
+                 "client_conversation_id in the matching view, which is not necessarily the number "
+                 "of messages exchanged in the conversation.",
         "paths": ('*/com.snapchat.android/databases/arroyo.db*',
                   '*/com.snapchat.android/databases/main.db*'),
         "output_types": "standard", "artifact_icon": "messages",
         "sample_data": {
-            "hc_pixel8pro_a17": "Android 17 | com.snapchat.android vc 302522 | 4 rows",
-        },
-    },
-    "get_snapchat_arroyo_superseded_messages": {
-        "name": "Snapchat - Messages Not In Committed State (arroyo.db)",
-        "description": "Rows from the conversation_message table in arroyo.db that are present "
-                       "when the database file is read as of its last checkpoint and absent when "
-                       "the write-ahead log is applied. Columns match Snapchat - Messages "
-                       "(arroyo.db), with a Record State column added.",
-        "author": "@AlexisBrignoni, Claude",
-        "creation_date": "2026-08-07", "last_update_date": "2026-08-07",
-        "requirements": "blackboxprotobuf", "category": "Snapchat",
-        "notes": "These rows are NOT in the live conversation view and must not be read as "
-                 "current messages. Snapchat - Messages (arroyo.db) is the committed state.\n"
-                 "Method: arroyo.db is opened twice through SQLite, once with immutable=1, which "
-                 "ignores the write-ahead log and yields the file as of its last checkpoint, and "
-                 "once with mode=ro, which applies the log and yields the committed state. Rows "
-                 "whose (client_conversation_id, client_message_id) primary key appears in the "
-                 "first result and not the second are reported here. Both sides are consistent "
-                 "SQLite reads of the same bytes, so column names, type affinity and overflow "
-                 "pages are handled by SQLite rather than by a hand-written page parser.\n"
-                 "Why a row did not survive into the committed state is NOT established by this "
-                 "artifact. Removal by the application, a server re-sync rewriting those pages, "
-                 "and deletion are all consistent with the same result. On the tested image most "
-                 "of these rows carried Team Snapchat broadcast content, which is consistent with "
-                 "a re-sync, and that is an observation about one image rather than a general "
-                 "property.\n"
-                 "This is NOT deleted-record carving. It does not read freelist pages, "
-                 "unallocated space or freeblocks, and it does not parse WAL frames, so records "
-                 "that only ever existed inside the log are not recovered. It returns nothing "
-                 "when no -wal file accompanies the database, which was verified by removing the "
-                 "sidecar and confirming both reads agreed at 11 rows.\n"
-                 "Timestamps here are the values stored on the rows and will overlap the "
-                 "committed artifact's range, so take care not to count a conversation twice "
-                 "across the two artifacts or in the timeline. No conversation data view is "
-                 "declared, deliberately, so these rows do not render as chat messages in LAVA.",
-        "paths": ('*/com.snapchat.android/databases/arroyo.db*',
-                  '*/com.snapchat.android/databases/main.db*',
-                  '*/com.snapchat.android/shared_prefs/identity_persistent_store.xml'),
-        "output_types": "standard", "artifact_icon": "alert-triangle",
-        "sample_data": {
-            "hc_pixel8pro_a17": "Android 17 | com.snapchat.android vc 302522 | 8 rows",
-        },
-    },
-    "get_snapchat_arroyo_superseded_conversations": {
-        "name": "Snapchat - Conversations Not In Committed State (arroyo.db)",
-        "description": "Rows from the conversation and feed_entry tables in arroyo.db that are "
-                       "present when the database file is read as of its last checkpoint and "
-                       "absent when the write-ahead log is applied.",
-        "author": "@AlexisBrignoni, Claude",
-        "creation_date": "2026-08-07", "last_update_date": "2026-08-07",
-        "requirements": "blackboxprotobuf", "category": "Snapchat",
-        "notes": "These rows are NOT in the live conversation list. Snapchat - Conversations "
-                 "(arroyo.db) is the committed state. Method and limits are the same as Snapchat "
-                 "- Messages Not In Committed State (arroyo.db); see that artifact's notes.\n"
-                 "A conversation is reported when its client_conversation_id is present in "
-                 "conversation or feed_entry as of the last checkpoint and in neither table once "
-                 "the log is applied. Comparing row counts alone would not find these: on the "
-                 "tested image conversation, conversation_identifier and feed_entry each held 4 "
-                 "rows in both reads, and it was only comparing primary keys that showed one "
-                 "identifier had been replaced by a different one.\n"
-                 "Participants, message counts and titles for these rows are read from the same "
-                 "pre-checkpoint view, so they describe the conversation as it stood at that "
-                 "point. A participant absent from the Friend table in main.db is reported as a "
-                 "bare UUID; that is an unresolved identifier, not a finding about the account.\n"
-                 "Message Count counts conversation_message rows carrying that "
-                 "client_conversation_id in the pre-checkpoint view, which is not necessarily the "
-                 "number of messages exchanged in the conversation.",
-        "paths": ('*/com.snapchat.android/databases/arroyo.db*',
-                  '*/com.snapchat.android/databases/main.db*'),
-        "output_types": "standard", "artifact_icon": "alert-triangle",
-        "sample_data": {
-            "hc_pixel8pro_a17": "Android 17 | com.snapchat.android vc 302522 | 1 row",
+            "hc_pixel8pro_a17": "Android 17 | com.snapchat.android vc 302522 | 5 rows "
+                                "(4 Live, 1 Recovered)",
         },
     },
     "get_snapchat_memories": {
@@ -281,6 +258,7 @@ __artifacts_v2__ = {
 }
 
 import datetime
+import os
 import sqlite3
 import xml.etree.ElementTree as ET
 
@@ -567,42 +545,52 @@ _MESSAGE_SQL = '''
 _MESSAGE_KEY = (12, 13)
 
 _MESSAGE_HEADERS = (('Creation Timestamp', 'datetime'), ('Read Timestamp', 'datetime'),
+                    'Record Origin',
                     'Sender Username', 'Sender Display Name', 'Sender ID', 'Message Direction',
                     'Conversation Participants', 'Message Text', 'Content Type (as stored)',
                     'Message State Type', 'Is Saved', 'Is Viewed By User', 'Created On Device',
                     'Remote Media Count', 'Replies Count', 'Quoted Server Message ID',
-                    'Conversation ID', 'Client Message ID', 'Server Message ID')
+                    'Conversation ID', 'Client Message ID', 'Server Message ID',
+                    'Recovery Method', 'Recovery Location')
 
 _CONVERSATION_HEADERS = (('Creation Timestamp', 'datetime'), ('Last Updated Timestamp', 'datetime'),
                          ('Display Timestamp', 'datetime'), ('Tombstoned At Timestamp', 'datetime'),
-                         ('Streak Expiration Timestamp', 'datetime'), 'Conversation Title',
+                         ('Streak Expiration Timestamp', 'datetime'),
+                         'Record Origin',
+                         'Conversation Title',
                          'Participants', 'Participant IDs', 'Message Count', 'Streak Count',
                          'Conversation Type (as stored)', 'Send State Type', 'Feed Item Creator',
                          'Feed Item Creator ID', 'Last Chat Sender', 'Last Chat Sender ID',
-                         'Tombstoned', 'Conversation ID')
+                         'Tombstoned', 'Conversation ID',
+                         'Recovery Method', 'Recovery Location')
 
-_RECORD_STATE = 'Record State'
-_STATE_SUPERSEDED = 'Present at last checkpoint, absent after WAL'
+# Provenance vocabulary. Record Origin is a closed two-value set so a viewer can branch on it;
+# Recovery Method names the technique and is empty on live rows; Recovery Location says where in
+# the evidence the row came from. Keep these strings stable, they are read by people and may be
+# read by LAVA.
+_ORIGIN_LIVE = 'Live'
+_ORIGIN_RECOVERED = 'Recovered'
+_METHOD_WAL_DIFF = 'WAL diff'
 
 
-def _add_state(headers, rows, state):
-    '''Add a record state column, inserted after the leading timestamp columns.
+def _provenance(source_path, origin):
+    '''The three provenance values for a row, as (origin, method, location).'''
+    if origin == _ORIGIN_LIVE:
+        return (_ORIGIN_LIVE, '', '')
+    name = os.path.basename(source_path) if source_path else 'database'
+    return (_ORIGIN_RECOVERED, _METHOD_WAL_DIFF, f'{name} (pre-checkpoint)')
 
-    Keeping every datetime column leftmost is the house ordering, so the insert point is
-    derived from the headers rather than hardcoded.
+
+def _by_creation(row):
+    '''Sort key on the first column, tolerating rows whose timestamp is blank.
+
+    The blank flag comes first so a datetime is never compared against a string.
     '''
-    index = 0
-    while (index < len(headers) and isinstance(headers[index], tuple)
-           and headers[index][1] == 'datetime'):
-        index += 1
-
-    def insert(values, value):
-        return tuple(values[:index]) + (value,) + tuple(values[index:])
-
-    return insert(headers, _RECORD_STATE), [insert(row, state) for row in rows]
+    return (row[0] == '', row[0])
 
 
-def _message_rows(rows, friends, participants, local_user_id):
+def _message_rows(rows, friends, participants, local_user_id, provenance):
+    origin, method, location = provenance
     data_list = []
     for row in rows:
         (created, read, sender_id, content_type, blob, state, saved, viewed, on_device,
@@ -613,15 +601,15 @@ def _message_rows(rows, friends, participants, local_user_id):
         else:
             direction = 'Outgoing' if sender_id == local_user_id else 'Incoming'
         data_list.append((
-            _ms_to_utc(created), _ms_to_utc(read),
+            _ms_to_utc(created), _ms_to_utc(read), origin,
             _friend_name(friends, sender_id), _friend_name(friends, sender_id, 1), sender_id,
             direction, participants.get(conversation_id, ('', ''))[1], text, content_type, state,
             _yes_no(saved), _yes_no(viewed), _yes_no(on_device), media_count, replies, quoted_id,
-            conversation_id, client_message_id, server_message_id))
+            conversation_id, client_message_id, server_message_id, method, location))
     return data_list
 
 
-def _conversation_rows(source_path, friends, reader, only_ids=None):
+def _conversation_rows(source_path, friends, reader, provenance, only_ids=None):
     participants = _participants(source_path, friends, reader)
     conversations = {row[0]: row[1:] for row in reader(source_path, '''
         SELECT client_conversation_id, creation_timestamp, tombstoned_at_timestamp, send_state_type
@@ -638,6 +626,7 @@ def _conversation_rows(source_path, friends, reader, only_ids=None):
         GROUP BY client_conversation_id
     '''))
 
+    origin, method, location = provenance
     wanted = set(conversations) | set(feeds)
     if only_ids is not None:
         wanted &= set(only_ids)
@@ -649,12 +638,12 @@ def _conversation_rows(source_path, friends, reader, only_ids=None):
          last_sender, tombstoned) = feeds.get(conversation_id, (None,) * 9)
         data_list.append((
             _ms_to_utc(created), _ms_to_utc(updated), _ms_to_utc(displayed),
-            _ms_to_utc(tombstoned_at), _ms_to_utc(streak_expiry), title,
+            _ms_to_utc(tombstoned_at), _ms_to_utc(streak_expiry), origin, title,
             participants.get(conversation_id, ('', ''))[1],
             participants.get(conversation_id, ('', ''))[0],
             counts.get(conversation_id, 0), streak, conversation_type, send_state,
             _friend_name(friends, creator), creator, _friend_name(friends, last_sender), last_sender,
-            _yes_no(tombstoned), conversation_id))
+            _yes_no(tombstoned), conversation_id, method, location))
     return data_list
 
 
@@ -670,44 +659,41 @@ def _superseded_conversation_ids(source_path):
 
 @artifact_processor
 def get_snapchat_arroyo_messages(context):
+    '''Live conversation_message rows, plus rows the write-ahead log removes.
+
+    Both sets are in one table so the recovered rows sit in chronological context. They are
+    disjoint by construction: _superseded only returns primary keys absent from the live read.
+    '''
     files_found = context.get_files_found()
     source_path = _find(files_found, 'arroyo.db')
     friends = _friends(_find(files_found, 'main.db'))
-    data_list = _message_rows(_rows(source_path, _MESSAGE_SQL), friends,
-                              _participants(source_path, friends),
-                              _local_user_id(files_found, source_path, friends))
+    local_user_id = _local_user_id(files_found, source_path, friends)
+
+    data_list = _message_rows(
+        _rows(source_path, _MESSAGE_SQL), friends, _participants(source_path, friends),
+        local_user_id, _provenance(source_path, _ORIGIN_LIVE))
+    data_list += _message_rows(
+        _superseded(source_path, _MESSAGE_SQL, _MESSAGE_KEY), friends,
+        _participants(source_path, friends, _rows_pre_wal), local_user_id,
+        _provenance(source_path, _ORIGIN_RECOVERED))
+    data_list.sort(key=_by_creation)
     return _MESSAGE_HEADERS, data_list, source_path
 
 
 @artifact_processor
-def get_snapchat_arroyo_superseded_messages(context):
-    files_found = context.get_files_found()
-    source_path = _find(files_found, 'arroyo.db')
-    friends = _friends(_find(files_found, 'main.db'))
-    rows = _message_rows(_superseded(source_path, _MESSAGE_SQL, _MESSAGE_KEY), friends,
-                         _participants(source_path, friends, _rows_pre_wal),
-                         _local_user_id(files_found, source_path, friends))
-    data_headers, data_list = _add_state(_MESSAGE_HEADERS, rows, _STATE_SUPERSEDED)
-    return data_headers, data_list, source_path
-
-
-@artifact_processor
 def get_snapchat_arroyo_conversations(context):
+    '''Live conversation and feed_entry rows, plus rows the write-ahead log removes.'''
     files_found = context.get_files_found()
     source_path = _find(files_found, 'arroyo.db')
     friends = _friends(_find(files_found, 'main.db'))
-    return _CONVERSATION_HEADERS, _conversation_rows(source_path, friends, _rows), source_path
 
-
-@artifact_processor
-def get_snapchat_arroyo_superseded_conversations(context):
-    files_found = context.get_files_found()
-    source_path = _find(files_found, 'arroyo.db')
-    friends = _friends(_find(files_found, 'main.db'))
-    rows = _conversation_rows(source_path, friends, _rows_pre_wal,
-                              _superseded_conversation_ids(source_path))
-    data_headers, data_list = _add_state(_CONVERSATION_HEADERS, rows, _STATE_SUPERSEDED)
-    return data_headers, data_list, source_path
+    data_list = _conversation_rows(source_path, friends, _rows,
+                                   _provenance(source_path, _ORIGIN_LIVE))
+    data_list += _conversation_rows(source_path, friends, _rows_pre_wal,
+                                    _provenance(source_path, _ORIGIN_RECOVERED),
+                                    _superseded_conversation_ids(source_path))
+    data_list.sort(key=_by_creation)
+    return _CONVERSATION_HEADERS, data_list, source_path
 
 
 @artifact_processor


### PR DESCRIPTION
Follow-up to #1051. Contributes to #957, where the reasoning behind the approach is written up.

## What prompted it

While validating #1051 I noticed the row count moves the wrong way. `arroyo.db` read on its own has 11 `conversation_message` rows. Read with its write-ahead log applied it has 8. The log carries removals, not just additions, so the smaller number is the correct current state and the larger one is stale.

Those rows are still in the database file as of its last checkpoint, and nothing surfaced them. Three of the eight decode to plaintext at the same protobuf path the live rows use. One whole conversation is present in `conversation`, `feed_entry` and `conversation_identifier` before the log is applied and absent from all three after, with a participant that does not appear in the `Friend` table in `main.db` at all.

## One table per subject, not two

An earlier revision of this PR added separate "Not In Committed State" artifacts. This version instead adds three provenance columns to the existing two artifacts, so recovered rows sit **in chronological context** with the live ones:

| column | values |
| --- | --- |
| `Record Origin` | `Live` or `Recovered`. Populated on every row. |
| `Recovery Method` | the technique, currently `WAL diff`. Empty on Live rows. |
| `Recovery Location` | where in the evidence the row came from. Empty on Live rows. |

`Record Origin` is a closed two-value set so a viewer can branch on it, and it is populated on every row rather than blank for live ones, because a blank cell is ambiguous between "live" and "not populated". `Recovery Method` is naturally empty on live rows. So whichever column an examiner picks to display under a LAVA conversation bubble, they get a sensible result: the first marks every message, the second marks only the recovered ones.

Combining also removes the timeline double-count that the split design carried.

## Naming was checked, not invented

Against all five cores before choosing:

- **`Record Source`** was the obvious pick and is **already taken**, meaning "which table did this row come from", in `allTrails.py` and `slack.py`.
- **`Source`** is overloaded 51 times across the cores (31 iLEAPP, 17 RLEAPP, 3 VLEAPP) for source file or table.
- **`Recovery Status`** is taken in `galleryVault.py` for how many bytes of a decrypted file came back.
- `L360noshowalerts.py` already does live-vs-recovered with `Source` / `WAL Location` / `WAL Offset`, which is the precedent this generalises.

`Record Origin`, `Recovery Method` and `Recovery Location` are unused anywhere in the five cores.

**Deliberately not called `Deleted`.** Seventeen ALEAPP artifacts already use `Deleted`, `Is Deleted`, `Deleted At` for the **app's own** deletion flag. Reusing that name for tool-recovery provenance would conflate "the app recorded this as deleted" with "our tool recovered this", which are different claims that can appear on the same row. `Recovered` says how the row was obtained, which is known, rather than what happened to it, which is not.

## Method

The same file is opened twice through SQLite, once with `immutable=1` which ignores the log, and once with `mode=ro` which applies it, and the results are compared on the primary key.

SQLite does the decoding on both sides, so named columns, type affinity and overflow pages come for free and there is no hand-written B-tree parser to maintain. That is the main argument for it over the frame parser in #956, and the two find different things, so neither replaces the other. Written up properly in #957.

**Comparing row counts would have missed most of this.** A count check flags 2 of 30 tables in `arroyo.db`; comparing primary keys flags 6. The four it misses hold the same number of rows under different keys, and the conversation finding is one of those four.

## What it is not

Not deleted-record carving. It does not read freelist pages, unallocated space or freeblocks, and it does not parse WAL frames, so records that only ever lived inside the log are not recovered. It compares keys rather than full row content, so a row whose key survives while its content changed is not reported either.

Why a Recovered row is not in the live read is **not** established, and the notes say so. Removal by the app, a server re-sync rewriting those pages, and deletion are all consistent with the same result. On this image most of the recovered message rows carry Team Snapchat broadcast content, which is consistent with a re-sync.

It yields no Recovered rows when no `-wal` accompanies the database, verified by removing the sidecar and confirming both reads agree at 11.

## Evidence handling

The `immutable=1` read is strictly read-only and, unlike `mode=ro`, does not even create a `-shm` sidecar. Confirmed against a lone copy of the database: no new files afterwards and the same MD5. It routes through the same `get_sqlite_db_path()` that `open_sqlite_db_readonly()` uses, so Windows long paths and URI-special characters behave identically.

## Scope

The diff helper is kept local to `snapchat.py` rather than put into `ilapfuncs.py`, so #957 gets to decide the shared shape rather than inheriting mine. It is written so lifting it into core is a move rather than a rewrite.

## Validation

Profile run against corpus key `hc_pixel8pro_a17` (Android 17, com.snapchat.android vc 302522).

| artifact | rows |
| --- | --- |
| Snapchat - Messages (arroyo.db) | 16 (8 Live, 8 Recovered) |
| Snapchat - Conversations (arroyo.db) | 5 (4 Live, 1 Recovered) |

- No parser errors.
- Zero primary keys appear under both origins, so no row is double reported.
- Live rows have both recovery columns empty; every Recovered row has both populated.
- Rows sort chronologically across the merged set.
- TSV parses to 16 and 5 records at a uniform 22 and 21 fields. One recovered message contains an embedded newline and `csv.writer` quotes it correctly; it needs a real CSV reader rather than a line-based check to verify.
- LAVA manifest counts correct, provenance columns present in the artifact table, `data_views` on the messages artifact only.

CI run locally: `check_claim_language.py` clean, `check_html_safety.py` clean, pylint 10.00/10 at CI flags, `lint_changed.py` no new warnings.

## Note on the LAVA side

Until the conversation view can display an arbitrary column under the bubble, recovered rows render there like any other message. The columns are visible immediately in the HTML report, the TSV and the LAVA table view, so only the bubble lags. James is building the picker that closes it.

## Not covered

One image. The zero case is proven by removing the sidecar rather than against a second corpus whose WAL is genuinely checkpointed, and that is the corpus I would most like to run this against.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>