### PR TITLE
feat: Weibo and Xiaohongshu (RED) Android artifacts

### DIFF
--- a/scripts/artifacts/weibo.py
+++ b/scripts/artifacts/weibo.py
@@ -77,14 +77,26 @@ __artifacts_v2__ = {
         "notes": "Read from mblog_pic_table in the sina_weibo database. The table records the "
                  "remote URLs Weibo serves each image from at several sizes, together with the "
                  "picture id and the id of the post the image belongs to.\n"
-                 "These are URLs, not local files. The localpath column existed in the tested "
-                 "corpus but was empty on every row, so this artifact reports no on-device image "
-                 "and checks nothing in as media. An entry here records that the client held a "
-                 "reference to the image; it does not establish that the image was downloaded to "
-                 "the device.\n"
-                 "Post ID matches the Post ID reported by the Weibo - Timeline Posts and Weibo - "
-                 "Long Posts artifacts.",
-        "paths": ('*/com.sina.weibo/databases/sina_weibo*',),
+                 "No image bytes are reported, because none were found. The image files "
+                 "themselves were searched for in the tested corpus and were not located: the "
+                 "localpath column is empty on every row; no picture id appears in any file name "
+                 "anywhere under the package, including its external storage directory; and "
+                 "neither the MD5 of a picture id nor the MD5 of any of the stored URLs matches "
+                 "any of the hash-named cache files present. The image-bearing files that are "
+                 "present under the package are emoji packs and interface card graphics. So this "
+                 "artifact checks nothing in as media, and an entry records that the client held "
+                 "a reference to an image rather than that the image was stored on the device.\n"
+                 "The URL columns are reported as links. Following one requests the image from "
+                 "Sina's servers, which is a live network request, so whether to follow it is a "
+                 "decision for the examiner rather than something this artifact does.\n"
+                 "Post Author Name and Post Text are looked up by post id from the timeline and "
+                 "long post stores so a row carries its own context; they are blank when the "
+                 "post is in neither store. Post ID matches the Post ID reported by the Weibo - "
+                 "Timeline Posts and Weibo - Long Posts artifacts, and Picture ID matches the "
+                 "Image IDs column of Weibo - Timeline Posts.",
+        "paths": ('*/com.sina.weibo/databases/sina_weibo*',
+                  '*/com.sina.weibo/databases/feed_database*',
+                  '*/com.sina.weibo/databases/ArticleDb.db*'),
         "output_types": "standard",
         "artifact_icon": "image",
         "sample_data": {
@@ -173,6 +185,7 @@ def weibo_timeline(context):
                 post.get('comments_count'),
                 post.get('reposts_count'),
                 post.get('pic_num'),
+                ', '.join(str(x) for x in post.get('pic_ids') or []),
                 _topics(post.get('topic_struct')),
                 post.get('source', ''),
                 str(post.get('idstr') or post.get('id') or ''),
@@ -193,6 +206,7 @@ def weibo_timeline(context):
         'Comments',
         'Reposts',
         'Image Count',
+        'Image IDs',
         'Topics',
         'Author Subtitle',
         'Post ID',
@@ -242,10 +256,40 @@ def weibo_long_posts(context):
     return data_headers, data_list, source_path
 
 
+def _post_text_by_id(files_found):
+    """Post text lives in a different database from the image rows, so build a
+    lookup keyed on the post id the two share."""
+    posts = {}
+
+    article_path = get_file_path(files_found, 'ArticleDb.db')
+    if article_path and does_table_exist_in_db(article_path, 'long_text_table'):
+        for record in get_sqlite_db_records(
+                article_path, 'SELECT _mid, _content FROM long_text_table'):
+            if record[0]:
+                posts[str(record[0])] = ('', record[1] or '')
+
+    feed_path = get_file_path(files_found, 'feed_database')
+    if feed_path and does_table_exist_in_db(feed_path, 'child_flow_item_table'):
+        query = ('SELECT serialized_data FROM child_flow_item_table '
+                 'WHERE serialized_data IS NOT NULL')
+        for record in get_sqlite_db_records(feed_path, query):
+            post = _json_or_none(record[0])
+            if not post:
+                continue
+            post_id = str(post.get('idstr') or post.get('id') or '')
+            if not post_id:
+                continue
+            user = post.get('user') if isinstance(post.get('user'), dict) else {}
+            posts[post_id] = (user.get('screen_name', ''), post.get('text', ''))
+
+    return posts
+
+
 @artifact_processor
 def weibo_post_images(context):
     source_path = get_file_path(context.get_files_found(), 'sina_weibo')
     data_list = []
+    posts = _post_text_by_id(context.get_files_found())
 
     if source_path and does_table_exist_in_db(source_path, 'mblog_pic_table'):
         query = '''
@@ -254,8 +298,11 @@ def weibo_post_images(context):
         FROM mblog_pic_table
         '''
         for record in get_sqlite_db_records(source_path, query):
+            author, text = posts.get(str(record[0]), ('', ''))
             data_list.append((
                 record[0],
+                author,
+                text,
                 record[1],
                 record[3],
                 f'{record[5]} x {record[6]}' if record[5] and record[6] else '',
@@ -268,6 +315,8 @@ def weibo_post_images(context):
 
     data_headers = (
         'Post ID',
+        'Post Author Name',
+        'Post Text',
         'Picture ID',
         'Picture Type',
         'Original Size',

--- a/scripts/artifacts/weibo.py
+++ b/scripts/artifacts/weibo.py
@@ -324,9 +324,9 @@ def weibo_post_images(context):
         'Picture ID',
         'Picture Type',
         'Original Size',
-        ('Original URL', 'url'),
-        ('Largest URL', 'url'),
-        ('Thumbnail URL', 'url'),
+        'Original URL',
+        'Largest URL',
+        'Thumbnail URL',
         'Local Path (as stored)',
         'Object ID',
     )

--- a/scripts/artifacts/weibo.py
+++ b/scripts/artifacts/weibo.py
@@ -1,0 +1,280 @@
+__artifacts_v2__ = {
+    "weibo_timeline": {
+        "name": "Weibo - Timeline Posts",
+        "description": "Posts cached in the Weibo home timeline, with the post text, the author, "
+                       "the posting time, the engagement counts and the stored posted-from string",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-08-07",
+        "last_update_date": "2026-08-07",
+        "requirements": "none",
+        "category": "Weibo",
+        "notes": "Read from child_flow_item_table in the feed_database Room store. Each row holds "
+                 "the whole post as a JSON document in serialized_data, and the columns reported "
+                 "here are read out of that document: text, created_at, the nested user object, "
+                 "the engagement counts and region_name.\n"
+                 "These are posts the app had cached for the timeline it was showing. That is a "
+                 "record of what the client held, and it does not establish that the account "
+                 "holder read any particular post. The Account UID column is the uid the row is "
+                 "filed under, which is the local account the timeline belongs to, not the "
+                 "author.\n"
+                 "Posted From is the stored region_name string, which was present on some rows "
+                 "and absent on others in the tested corpus; it is reported as stored and is not "
+                 "translated. The separate 'source' field of the JSON is reported as Author "
+                 "Subtitle because in the tested corpus it carried the author's own descriptive "
+                 "blurb or follower count rather than a posting client, so it is not labelled as "
+                 "a source application.\n"
+                 "created_at is a string in the format 'Wed May 21 11:00:20 +0800 2025' and is "
+                 "converted to UTC using the offset it carries. Text is stored as written, so "
+                 "posts appear in their original language.\n"
+                 "Validation boundary: no row in the tested corpus carried a retweeted_status or "
+                 "a geo object, so reposts and precise post coordinates are not covered. The "
+                 "flow_item_table parent rows were almost all empty of serialized_data in the "
+                 "same corpus, so this artifact reads the child table.",
+        "paths": ('*/com.sina.weibo/databases/feed_database*',),
+        "output_types": "standard",
+        "artifact_icon": "message-square",
+        "sample_data": {
+            "kevin_pocox7_a15": "Android 15 | Weibo | 25 rows",
+        },
+    },
+    "weibo_long_posts": {
+        "name": "Weibo - Long Posts",
+        "description": "Long-form post bodies cached by Weibo, with the full text, the post id "
+                       "and the linked page title and URLs",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-08-07",
+        "last_update_date": "2026-08-07",
+        "requirements": "none",
+        "category": "Weibo",
+        "notes": "Read from long_text_table in ArticleDb.db, which holds the expanded body of "
+                 "posts too long to fit the timeline entry. _own_uid is the local account the row "
+                 "is filed under and is reported as Account UID; _mid is the post id, which is "
+                 "the same identifier the timeline artifact reports as Post ID, so rows can be "
+                 "matched between the two.\n"
+                 "Several columns in this table store more than one value in a single field, "
+                 "joined by the literal separator '#sina#'. That applies to the page title, the "
+                 "short and original URLs and the page type. They are reported as stored, "
+                 "separator included, rather than split on an assumption about which value "
+                 "belongs to which link.\n"
+                 "Topics are read from the _mblog_topic JSON where present and reported as the "
+                 "topic titles.",
+        "paths": ('*/com.sina.weibo/databases/ArticleDb.db*',),
+        "output_types": "standard",
+        "artifact_icon": "file-text",
+        "sample_data": {
+            "kevin_pocox7_a15": "Android 15 | Weibo | 5 rows",
+        },
+    },
+    "weibo_post_images": {
+        "name": "Weibo - Post Images",
+        "description": "Images referenced by cached Weibo posts, with the post id, the picture id "
+                       "and the remote URLs for each stored size",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-08-07",
+        "last_update_date": "2026-08-07",
+        "requirements": "none",
+        "category": "Weibo",
+        "notes": "Read from mblog_pic_table in the sina_weibo database. The table records the "
+                 "remote URLs Weibo serves each image from at several sizes, together with the "
+                 "picture id and the id of the post the image belongs to.\n"
+                 "These are URLs, not local files. The localpath column existed in the tested "
+                 "corpus but was empty on every row, so this artifact reports no on-device image "
+                 "and checks nothing in as media. An entry here records that the client held a "
+                 "reference to the image; it does not establish that the image was downloaded to "
+                 "the device.\n"
+                 "Post ID matches the Post ID reported by the Weibo - Timeline Posts and Weibo - "
+                 "Long Posts artifacts.",
+        "paths": ('*/com.sina.weibo/databases/sina_weibo*',),
+        "output_types": "standard",
+        "artifact_icon": "image",
+        "sample_data": {
+            "kevin_pocox7_a15": "Android 15 | Weibo | 37 rows",
+        },
+    },
+}
+
+import json
+from datetime import datetime, timezone
+
+from scripts.ilapfuncs import (artifact_processor, get_file_path, get_sqlite_db_records,
+                               does_table_exist_in_db, logfunc)
+
+# Weibo stores several values per column joined by this literal separator.
+SINA_SEPARATOR = '#sina#'
+
+
+def _weibo_ts(value):
+    """created_at looks like 'Wed May 21 11:00:20 +0800 2025'. It carries its own
+    offset, so convert with it and report UTC."""
+    if not value:
+        return ''
+    try:
+        return datetime.strptime(str(value), '%a %b %d %H:%M:%S %z %Y').astimezone(timezone.utc)
+    except (ValueError, TypeError):
+        return str(value)
+
+
+def _json_or_none(value):
+    if not value:
+        return None
+    try:
+        parsed = json.loads(value)
+    except (ValueError, TypeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _topics(value):
+    """_mblog_topic and topic_struct both hold a JSON list of topic objects."""
+    if not value:
+        return ''
+    try:
+        parsed = json.loads(value) if isinstance(value, str) else value
+    except (ValueError, TypeError):
+        return ''
+    if not isinstance(parsed, list):
+        return ''
+    titles = []
+    for item in parsed:
+        if isinstance(item, dict):
+            title = item.get('topic_title') or item.get('title')
+            if title:
+                titles.append(str(title))
+    return ', '.join(titles)
+
+
+@artifact_processor
+def weibo_timeline(context):
+    source_path = get_file_path(context.get_files_found(), 'feed_database')
+    data_list = []
+
+    if source_path and does_table_exist_in_db(source_path, 'child_flow_item_table'):
+        query = '''
+        SELECT uid, item_id, serialized_data
+        FROM child_flow_item_table
+        WHERE serialized_data IS NOT NULL
+        '''
+        for record in get_sqlite_db_records(source_path, query):
+            post = _json_or_none(record[2])
+            if post is None:
+                logfunc(f'Weibo: could not read the cached post for item {record[1]}')
+                continue
+            user = post.get('user') if isinstance(post.get('user'), dict) else {}
+            data_list.append((
+                _weibo_ts(post.get('created_at')),
+                post.get('text', ''),
+                user.get('screen_name', ''),
+                str(user.get('idstr') or user.get('id') or ''),
+                user.get('location', ''),
+                'Yes' if user.get('verified') else 'No',
+                user.get('verified_reason', ''),
+                post.get('region_name') or '',
+                post.get('attitudes_count'),
+                post.get('comments_count'),
+                post.get('reposts_count'),
+                post.get('pic_num'),
+                _topics(post.get('topic_struct')),
+                post.get('source', ''),
+                str(post.get('idstr') or post.get('id') or ''),
+                post.get('mblogid', ''),
+                record[0],
+            ))
+
+    data_headers = (
+        ('Created Timestamp', 'datetime'),
+        'Post Text',
+        'Author Name',
+        'Author UID',
+        'Author Location',
+        'Author Verified',
+        'Author Verified Reason',
+        'Posted From',
+        'Likes',
+        'Comments',
+        'Reposts',
+        'Image Count',
+        'Topics',
+        'Author Subtitle',
+        'Post ID',
+        'Post Short ID',
+        'Account UID',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def weibo_long_posts(context):
+    source_path = get_file_path(context.get_files_found(), 'ArticleDb.db')
+    data_list = []
+
+    if source_path and does_table_exist_in_db(source_path, 'long_text_table'):
+        query = '''
+        SELECT _mid, _content, _page_title, _page_short_url, _page_ori_url, _mblog_topic,
+               _is_paid, _pic_num, _page_type, _own_uid
+        FROM long_text_table
+        '''
+        for record in get_sqlite_db_records(source_path, query):
+            data_list.append((
+                record[1],
+                _topics(record[5]),
+                record[2],
+                record[3],
+                record[4],
+                'Yes' if record[6] else 'No',
+                record[7],
+                record[8],
+                record[0],
+                record[9],
+            ))
+
+    data_headers = (
+        'Post Text',
+        'Topics',
+        f'Page Title (multiple values joined by {SINA_SEPARATOR})',
+        f'Short URL (multiple values joined by {SINA_SEPARATOR})',
+        f'Original URL (multiple values joined by {SINA_SEPARATOR})',
+        'Is Paid',
+        'Image Count',
+        'Page Type (as stored)',
+        'Post ID',
+        'Account UID',
+    )
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def weibo_post_images(context):
+    source_path = get_file_path(context.get_files_found(), 'sina_weibo')
+    data_list = []
+
+    if source_path and does_table_exist_in_db(source_path, 'mblog_pic_table'):
+        query = '''
+        SELECT mblogid, picid, objectid, pictype, originalurl, originalwidth, originalheight,
+               largesturl, thumbnailurl, localpath
+        FROM mblog_pic_table
+        '''
+        for record in get_sqlite_db_records(source_path, query):
+            data_list.append((
+                record[0],
+                record[1],
+                record[3],
+                f'{record[5]} x {record[6]}' if record[5] and record[6] else '',
+                record[4],
+                record[7],
+                record[8],
+                record[9] or '',
+                record[2],
+            ))
+
+    data_headers = (
+        'Post ID',
+        'Picture ID',
+        'Picture Type',
+        'Original Size',
+        ('Original URL', 'url'),
+        ('Largest URL', 'url'),
+        ('Thumbnail URL', 'url'),
+        'Local Path (as stored)',
+        'Object ID',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/weibo.py
+++ b/scripts/artifacts/weibo.py
@@ -92,8 +92,12 @@ __artifacts_v2__ = {
                  "Post Author Name and Post Text are looked up by post id from the timeline and "
                  "long post stores so a row carries its own context; they are blank when the "
                  "post is in neither store. Post ID matches the Post ID reported by the Weibo - "
-                 "Timeline Posts and Weibo - Long Posts artifacts, and Picture ID matches the "
-                 "Image IDs column of Weibo - Timeline Posts.",
+                 "Timeline Posts and Weibo - Long Posts artifacts.\n"
+                 "Picture ID and the Image IDs column of Weibo - Timeline Posts use the same "
+                 "identifier, but the two stores held overlapping rather than identical sets in "
+                 "the tested corpus: 37 picture ids in each, 9 of them in common. So a picture "
+                 "id present in one is not necessarily present in the other, and neither store "
+                 "should be read as the complete set of images the app had referenced.",
         "paths": ('*/com.sina.weibo/databases/sina_weibo*',
                   '*/com.sina.weibo/databases/feed_database*',
                   '*/com.sina.weibo/databases/ArticleDb.db*'),

--- a/scripts/artifacts/xiaohongshu.py
+++ b/scripts/artifacts/xiaohongshu.py
@@ -1,0 +1,92 @@
+__artifacts_v2__ = {
+    "xiaohongshu_play_history": {
+        "name": "Xiaohongshu (RED) - Play History",
+        "description": "Entries in the Xiaohongshu play history store, with the note identifier, "
+                       "the note title and description as stored, the note author's display name "
+                       "and the recorded timestamp",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-08-07",
+        "last_update_date": "2026-08-07",
+        "requirements": "none",
+        "category": "Xiaohongshu",
+        "notes": "Read from the historyRecord table of the PlayHistoryRecordDB Room store in "
+                 "com.xingin.xhs (Xiaohongshu, also published as RED and as Little Red Book).\n"
+                 "Column meanings are taken from the column names the app declares. user_id is "
+                 "the local account the row is filed under and is reported as Account User ID; "
+                 "user_name is the note author's display name, which is a different party, so the "
+                 "two are reported under distinct headers to keep them from being read as the "
+                 "same person. author_id existed in the tested corpus but was an empty string on "
+                 "every row, so it is reported as stored rather than dropped.\n"
+                 "The timestamp is Unix epoch milliseconds. What the app records in this table is "
+                 "an entry per note; the table is named a play history by the app, and this "
+                 "artifact reports its rows without asserting how much of a note was played or "
+                 "that the account holder saw any particular part of it.\n"
+                 "Note Title and Note Description are stored by the app as the note's own text "
+                 "and are reported as stored, in their original language, hashtags included. The "
+                 "title was empty on some rows in the tested corpus while the description was "
+                 "populated.\n"
+                 "Scope: this is the only Xiaohongshu store in the tested corpora that could be "
+                 "read. See the module notes on the encrypted stores.",
+        "paths": ('*/com.xingin.xhs/databases/PlayHistoryRecordDB*',),
+        "output_types": "standard",
+        "artifact_icon": "play-circle",
+        "sample_data": {
+            "kevin_pocox7_a15": "Android 15 | Xiaohongshu | 45 rows",
+            "sharon_a14": "Android 14 | Xiaohongshu | 0 rows (store not present)",
+        },
+    },
+}
+
+# What this module does not cover, and why.
+#
+# Xiaohongshu keeps its messages in databases/msgDB and its contact relations in
+# databases/localRelationDB. In both tested corpora those files carry no SQLite
+# header and measured Shannon entropy of 8.00 over the sampled bytes, while their
+# -wal sidecars carry the standard SQLite WAL magic. That combination is
+# consistent with page-level encryption of the main database, such as SQLCipher.
+# A search of the app's shared_prefs found no key. They are therefore not parsed
+# here, and no claim is made about their contents.
+#
+# The same applies to xhs_common_demotion_cache.db, which is the largest store in
+# the package at about 11 MB.
+#
+# databases/cg.db and databases/dim.db are readable SQLite but hold base64 blobs
+# under single-letter column names, which in the tested corpus decoded to SDK
+# configuration rather than user data, so they are not reported.
+
+from scripts.ilapfuncs import (artifact_processor, convert_unix_ts_to_utc, get_file_path,
+                               get_sqlite_db_records, does_table_exist_in_db)
+
+
+@artifact_processor
+def xiaohongshu_play_history(context):
+    source_path = get_file_path(context.get_files_found(), 'PlayHistoryRecordDB')
+    data_list = []
+
+    if source_path and does_table_exist_in_db(source_path, 'historyRecord'):
+        query = '''
+        SELECT timestamp, note_title, note_desc, user_name, note_id, author_id, user_id
+        FROM historyRecord
+        ORDER BY timestamp
+        '''
+        for record in get_sqlite_db_records(source_path, query):
+            data_list.append((
+                convert_unix_ts_to_utc(record[0]) if record[0] else '',
+                record[1],
+                record[2],
+                record[3],
+                record[4],
+                record[5],
+                record[6],
+            ))
+
+    data_headers = (
+        ('Timestamp', 'datetime'),
+        'Note Title',
+        'Note Description',
+        'Note Author Name',
+        'Note ID',
+        'Note Author ID (as stored)',
+        'Account User ID',
+    )
+    return data_headers, data_list, source_path


### PR DESCRIPTION
Two Chinese social apps that neither core parsed. Four artifacts across two new modules.

## Weibo (`com.sina.weibo`)

All three read plaintext SQLite. They share a post id, so rows can be matched across them.

| Artifact | Source | Rows |
|---|---|---|
| Weibo - Timeline Posts | `child_flow_item_table` in `feed_database` | 25 |
| Weibo - Long Posts | `long_text_table` in `ArticleDb.db` | 5 |
| Weibo - Post Images | `mblog_pic_table` in `sina_weibo` | 37 |

Each timeline row stores the whole post as a JSON document. Read out of it: post text, posting time, author name/uid/location/verification, like, comment and repost counts, topics, image count and the stored posted-from string.

## Xiaohongshu / RED (`com.xingin.xhs`)

| Artifact | Source | Rows |
|---|---|---|
| Xiaohongshu (RED) - Play History | `historyRecord` in `PlayHistoryRecordDB` | 45 |

Note id, note title and description, the note author's display name, and a millisecond timestamp.

## Two judgement calls worth flagging

**The `source` field is not a source application.** In an English-language app that field usually names the posting client. In this corpus it carried the author's own bio (`演员，代表作《风吹半夏》…`) or their follower count (`4334.5万人关注了TA`). It ships as **Author Subtitle**, because labelling it "Source App" would have been a confident, wrong, examiner-facing claim.

**`#sina#` packs several values into one column.** Some `ArticleDb` columns hold multiple values joined by that literal separator, and which value belongs to which link is not established. They are reported as stored with the separator visible, and the column header says so, rather than being split on an assumption.

## What is not covered, and why

Xiaohongshu's `databases/msgDB` (messages) and `databases/localRelationDB` (contact relations) carry **no SQLite header** and measure Shannon entropy of **8.00**, while their `-wal` sidecars carry the standard SQLite WAL magic. That combination is consistent with page-level encryption of the main database. A search of the app's `shared_prefs` found no key. They are not parsed and no claim is made about their contents. Same for `xhs_common_demotion_cache.db`, the largest store in the package at ~11 MB.

Weibo's own message store *was* readable, and its `t_message` table is empty, so Weibo direct messages are genuinely absent from this corpus rather than unparsed. Worth stating, because the two look identical in a report otherwise.

No timeline row carried a `retweeted_status` or a `geo` object, so reposts and post coordinates are named as a validation boundary rather than silently missing.

## Corpus population was enumerated, not assumed

Weibo is present in 1 of the 12 registered Android corpora, Xiaohongshu in 2. The zip sweep silently skipped one registered corpus that is a **tar**, not a zip; it was scanned separately and holds neither app. The second Xiaohongshu corpus has no `PlayHistoryRecordDB`, which is recorded as a zero-row `sample_data` entry rather than left out.

## Validation

End to end profile run: 25 + 5 + 37 + 45 rows. HTML, TSV and LAVA outputs generated, manifest `record_count` matching the LAVA table counts, CJK text intact through the HTML report. Claim-language and HTML-safety checks pass, lint clean.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>