### PR TITLE
feat: read the JusTalk MMKV stores for account identity and app state

### DIFF
--- a/admin/test/scripts/test_mmkv_parser.py
+++ b/admin/test/scripts/test_mmkv_parser.py
@@ -1,0 +1,130 @@
+"""Pin the on-disk contract the MMKV reader depends on.
+
+MMKV is append-only between rewrites, so the same key appears more than once and the last
+entry is the live one. A reader that collapses to a dict without honouring that order
+reports a stale value as current, which looks exactly like a correct answer. It also writes
+a removal as a zero-length value rather than deleting the entry, so a naive reader turns a
+removed key into an empty string.
+
+The other trap is varint width. Lengths in these files are small, so a reader that caps the
+varint walk at the five bytes a 32-bit value needs will pass every test written against
+string keys and then silently mis-read a millisecond epoch, which needs six. That is what
+happened here, and it surfaced as a timestamp column holding raw bytes.
+
+Buffers are built by hand rather than taken from an extraction, so this test carries no
+sample data.
+"""
+import pathlib
+import struct
+import sys
+import tempfile
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.mmkv_parser import (  # pylint: disable=wrong-import-position
+    MMKVError,
+    decode_value,
+    read_dict,
+    read_entries,
+)
+
+
+def _varint(value):
+    out = bytearray()
+    while True:
+        byte = value & 0x7F
+        value >>= 7
+        if value:
+            out.append(byte | 0x80)
+        else:
+            out.append(byte)
+            return bytes(out)
+
+
+def _string_value(text):
+    encoded = text.encode('utf-8')
+    return _varint(len(encoded)) + encoded
+
+
+def _entry(key, container):
+    encoded_key = key.encode('utf-8')
+    return _varint(len(encoded_key)) + encoded_key + _varint(len(container)) + container
+
+
+def _store(*entries):
+    """An MMKV file is [u32 size][u32 crc][data][zero padding to the page size]."""
+    data = b''.join(entries)
+    return struct.pack('<II', len(data), 0) + data + b'\x00' * 64
+
+
+class MMKVParserTest(unittest.TestCase):
+
+    def _write(self, payload):
+        handle = tempfile.NamedTemporaryFile(suffix='.mmkv', delete=False)
+        handle.write(payload)
+        handle.close()
+        self.addCleanup(lambda: pathlib.Path(handle.name).unlink(missing_ok=True))
+        return handle.name
+
+    def test_reads_strings_and_scalars(self):
+        path = self._write(_store(
+            _entry('channel', _string_value('googleplay')),
+            _entry('version', _varint(33)),
+        ))
+        self.assertEqual(read_dict(path), {'channel': 'googleplay', 'version': 33})
+
+    def test_scalar_wider_than_32_bits_is_not_truncated(self):
+        """A millisecond epoch needs six varint bytes; a five-byte cap returns raw bytes."""
+        milliseconds = 1785482702086
+        path = self._write(_store(_entry('ts', _varint(milliseconds))))
+        self.assertEqual(read_dict(path), {'ts': milliseconds})
+
+    def test_last_entry_for_a_key_wins_and_earlier_ones_remain_visible(self):
+        path = self._write(_store(
+            _entry('checked', _string_value('')),
+            _entry('checked', _string_value('8.11.4')),
+        ))
+        self.assertEqual(
+            read_entries(path),
+            [('checked', _string_value('')), ('checked', _string_value('8.11.4'))])
+        self.assertEqual(read_dict(path), {'checked': '8.11.4'})
+
+    def test_zero_length_value_removes_the_key_rather_than_emptying_it(self):
+        path = self._write(_store(
+            _entry('token', _string_value('abc')),
+            _entry('token', b''),
+        ))
+        self.assertEqual(len(read_entries(path)), 2)
+        self.assertNotIn('token', read_dict(path))
+        self.assertIsNone(decode_value(b''))
+
+    def test_empty_string_is_kept_and_is_not_a_removal(self):
+        path = self._write(_store(_entry('note', _string_value(''))))
+        self.assertEqual(read_dict(path), {'note': ''})
+
+    def test_only_the_recorded_data_region_is_read(self):
+        """Bytes past the recorded size are stale or uninitialised, not live entries."""
+        live = _entry('live', _string_value('yes'))
+        stale = _entry('stale', _string_value('no'))
+        payload = struct.pack('<II', len(live), 0) + live + stale
+        self.assertEqual(read_dict(self._write(payload)), {'live': 'yes'})
+
+    def test_truncated_walk_keeps_what_was_read(self):
+        good = _entry('first', _string_value('kept'))
+        payload = struct.pack('<II', len(good) + 4, 0) + good + b'\x7f\x7f\x7f\x7f'
+        self.assertEqual(read_dict(self._write(payload)), {'first': 'kept'})
+
+    def test_short_file_and_oversized_size_field_raise(self):
+        with self.assertRaises(MMKVError):
+            read_entries(self._write(b'\x00\x01'))
+        with self.assertRaises(MMKVError):
+            read_entries(self._write(struct.pack('<II', 4096, 0) + b'\x01'))
+
+    def test_empty_store_reads_as_no_entries(self):
+        self.assertEqual(read_entries(self._write(struct.pack('<II', 0, 0))), [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/artifacts/justalk.py
+++ b/scripts/artifacts/justalk.py
@@ -161,35 +161,89 @@ __artifacts_v2__ = {
                  "scheme. The separator differs between the two because the value is also used "
                  "as a directory name under files/JusTalk/profiles/. A value not in that shape "
                  "is reported unchanged in both columns.\n"
-                 "In the sample the split value was independently confirmed twice more, by a "
-                 "justalkId key in files/mmkv/JusProfileManager<account uid> and by a bare value "
-                 "in the per-profile provision-v1.xml. Neither of those files is parsed here; "
-                 "see the validation boundary below.\n"
+                 "The JusTalk ID column prefers the justalkId key of the local profile in "
+                 "files/mmkv/JusProfileManager<account uid>, which names the value directly, and "
+                 "falls back to splitting cur_prof_user when that store is absent. In the sample "
+                 "the two agreed, and a bare value in the per-profile provision-v1.xml agreed "
+                 "with both.\n"
+                 "The remaining account fields come from that same MMKV profile, which holds one "
+                 "JSON document under a single key. Field names there are the app's own: "
+                 "Basic.NickName, Ue.Email, Basic.Birthday, Phone.Country, loginCountry, "
+                 "signUpDate, lastLoginTimeMillis, uuid and loginToken. Birthday is reported as "
+                 "the app stored it, a plain date string with no time or zone. signUpDate is in "
+                 "seconds and lastLoginTimeMillis in milliseconds, as their names state.\n"
+                 "Ue.Facebook, Ue.Google and Ue.Huawei are linked-account slots. They were all "
+                 "empty in the sample, so an empty value here means the slot carries no value, "
+                 "not that a linked account was removed.\n"
+                 "loginToken is a bearer credential for the account, reported in full at the "
+                 "examiner's request. It is a JSON Web Token (RFC 7519), so its payload segment "
+                 "is base64url and carries the standard 'exp' expiry claim; Token Expiry is that "
+                 "claim decoded, and Token Subject is the payload's uid claim as stored. The "
+                 "signature is not verified and the token is not tested against any server, so "
+                 "these columns describe what the token asserts about itself and not whether it "
+                 "is currently valid.\n"
                  "The Realm header reports two top references, which is the store's normal "
                  "committed and uncommitted pair. Both are read and their row counts compared; "
                  "where they differ, content is present in one view and not the other. In the "
                  "sample they matched exactly.\n"
                  "shared_prefs/com.juphoon.justalk_preferences.xml was checked and carries only "
                  "advertising consent framework keys, no account identity, so it is not parsed.\n"
-                 "Not covered. files/mmkv/JusProfileManager<account uid> holds a fuller record of "
-                 "the local account than this artifact reports, including a nickname, an email "
-                 "address, a birthday, sign-up and last-login times and a session token. "
-                 "files/mmkv/mmkv.default holds a device id and the store channel. Both are MMKV "
-                 "stores and are not parsed yet.",
+                 "Validation boundary. Built from a single private sample holding one signed-in "
+                 "account, so every field here was seen populated exactly once, and the "
+                 "linked-account and family fields were never seen populated at all. An MMKV "
+                 "store can be written in an AES-encrypted mode, which this reader does not "
+                 "decrypt; a store written that way yields no keys, so an empty result is not "
+                 "evidence the store was empty.",
         "paths": ('*/com.juphoon.justalk/files/*.realm',
-                  '*/com.juphoon.justalk/files/JusTalk/profiles/provisions.xml'),
+                  '*/com.juphoon.justalk/files/JusTalk/profiles/provisions.xml',
+                  '*/com.juphoon.justalk/files/mmkv/*'),
         "output_types": "standard",
         "artifact_icon": "user",
+        "sample_data": {},
+    },
+    "justalk_app_state": {
+        "name": "JusTalk - App State",
+        "description": "Key and value pairs from the app's default MMKV store, covering the "
+                       "device identifier, the signed-in account id, the push token and the "
+                       "install channel, including values that later writes superseded",
+        "author": "@AlexisBrignoni, @Antho4n6, Claude",
+        "creation_date": "2026-08-07",
+        "last_update_date": "2026-08-07",
+        "requirements": "none",
+        "category": "JusTalk",
+        "notes": "Read from files/mmkv/mmkv.default with the shared mmkv_parser. Keys and values "
+                 "are reported as the app wrote them and are not renamed or interpreted.\n"
+                 "MMKV appends rather than edits, so changing a key writes a new entry and leaves "
+                 "the previous one in the file. Every entry is reported in file order. The Current "
+                 "Value column marks the last entry for a key, which is the one the app reads; "
+                 "rows marked otherwise are earlier values still present in the store. In the "
+                 "sample this preserved one superseded value, an empty VersionCheckerNewVersion "
+                 "written before the current one.\n"
+                 "A repeated entry is not by itself evidence the value changed. The app rewrites "
+                 "some keys with the value they already held, which is why most repeats here are "
+                 "identical.\n"
+                 "A zero-length value is how MMKV records a removal, and is shown as an empty "
+                 "Value with the type reported as removed. That is distinct from a key holding "
+                 "an empty string.\n"
+                 "Values are typed by the calling app, not on disk. The reader reports a string "
+                 "where the stored bytes are a length-prefixed string and an integer where they "
+                 "are a bare scalar, which is the only distinction the bytes support; a value "
+                 "shown as an integer may have been written as a boolean.",
+        "paths": ('*/com.juphoon.justalk/files/mmkv/*',),
+        "output_types": "standard",
+        "artifact_icon": "settings",
         "sample_data": {},
     },
 }
 
 import base64
 import hashlib
+import json
 import os
 import xml.etree.ElementTree as ET
 
 from scripts.ilapfuncs import artifact_processor, check_in_media, convert_unix_ts_to_utc
+from scripts.mmkv_parser import MMKVError, decode_value, read_dict, read_entries
 from scripts.realm_parser import parse_realm_file, realm_rows
 
 # Rows of class_CallLog carrying these type values are call records rather than chat
@@ -546,6 +600,79 @@ def _profile_user(files_found):
     return '', ''
 
 
+def _mmkv_path(files_found, basename_prefix, account_uid=''):
+    """Return the MMKV store whose file name starts with basename_prefix. The app writes one
+    profile store per identity it has held, so prefer the one named for the account uid."""
+    candidates = []
+    for file_found in files_found:
+        file_found = str(file_found)
+        parent, name = os.path.split(file_found)
+        if os.path.basename(parent) != 'mmkv' or not name.startswith(basename_prefix):
+            continue
+        if name.endswith('.crc'):
+            continue
+        candidates.append(file_found)
+    preferred = [p for p in candidates if account_uid and os.path.basename(p).endswith(account_uid)]
+    for path in preferred + candidates:
+        try:
+            if read_entries(path):
+                return path
+        except (MMKVError, OSError):
+            continue
+    return ''
+
+
+def _local_profile(files_found, account_uid):
+    """The local account's own profile, stored as one JSON document under a single MMKV key."""
+    path = _mmkv_path(files_found, 'JusProfileManager', account_uid)
+    if not path:
+        return {}, ''
+    try:
+        store = read_dict(path)
+    except (MMKVError, OSError):
+        return {}, path
+    for value in store.values():
+        if not isinstance(value, str):
+            continue
+        try:
+            document = json.loads(value)
+        except ValueError:
+            continue
+        if isinstance(document, dict):
+            return document, path
+    return {}, path
+
+
+def _epoch(value):
+    """The MMKV profile stores some epochs as JSON numbers and others as quoted strings,
+    so coerce before handing the value to the shared converter."""
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        return ''
+    if value <= 0:
+        return ''
+    return convert_unix_ts_to_utc(value)
+
+
+def _jwt_claims(token):
+    """Return the payload claims of a JSON Web Token (RFC 7519) without verifying it.
+
+    The signature is not checked and the token is not presented to any server, so this
+    reports what the token asserts about itself, nothing more."""
+    if not token or not isinstance(token, str):
+        return {}
+    parts = token.split('.')
+    if len(parts) != 3:
+        return {}
+    payload = parts[1] + '=' * (-len(parts[1]) % 4)
+    try:
+        claims = json.loads(base64.urlsafe_b64decode(payload))
+    except (ValueError, TypeError):
+        return {}
+    return claims if isinstance(claims, dict) else {}
+
+
 def _justalk_id(profile_user):
     """cur_prof_user is a scheme token joined to the account's JusTalk id, as in
     'username)lola6593'. The same store writes the peer form of that value as a URI,
@@ -587,9 +714,32 @@ def justalk_account(context):
     metadata = _rows(source_path, 'metadata')
     account_uid = os.path.basename(source_path)[:-len('.realm')] if source_path else ''
 
+    profile, mmkv_profile_path = _local_profile(files_found, account_uid)
+    token = profile.get('loginToken', '')
+    claims = _jwt_claims(token)
+
     data_list.append((
+        _epoch(profile.get('lastLoginTimeMillis')),
+        _epoch(profile.get('signUpDate')),
+        _epoch(claims.get('exp')),
         account_uid,
-        _justalk_id(profile_user),
+        profile.get('justalkId') or _justalk_id(profile_user),
+        profile.get('Basic.NickName', ''),
+        profile.get('Ue.Email', ''),
+        profile.get('phone', ''),
+        profile.get('Basic.Birthday', ''),
+        profile.get('Phone.Country', ''),
+        profile.get('loginCountry', ''),
+        profile.get('uuid', ''),
+        token,
+        claims.get('uid', ''),
+        profile.get('Ue.Facebook', ''),
+        profile.get('Ue.Google', ''),
+        profile.get('Ue.Huawei', ''),
+        profile.get('familyId', ''),
+        profile.get('parentPhone', ''),
+        profile.get('consecutiveLoginDays', ''),
+        profile.get('blockStrangers', ''),
         profile_user,
         metadata[0].get('version') if metadata else '',
         counts.get('active', ''),
@@ -597,6 +747,7 @@ def justalk_account(context):
         'Yes' if counts and counts.get('active') != counts.get('inactive') else 'No',
         context.get_relative_path(source_path) if source_path else '',
         context.get_relative_path(profile_path) if profile_path else '',
+        context.get_relative_path(mmkv_profile_path) if mmkv_profile_path else '',
     ))
 
     return _account_headers(), data_list, source_path or profile_path
@@ -604,8 +755,27 @@ def justalk_account(context):
 
 def _account_headers():
     return (
+        ('Last Login', 'datetime'),
+        ('Sign-Up Date', 'datetime'),
+        ('Token Expiry', 'datetime'),
         'Account UID',
         'JusTalk ID',
+        'Nickname',
+        'Email',
+        'Phone',
+        'Birthday (as stored)',
+        'Phone Country',
+        'Login Country (as stored)',
+        'Profile UUID',
+        'Login Token',
+        'Token Subject (as stored)',
+        'Linked Facebook',
+        'Linked Google',
+        'Linked Huawei',
+        'Family ID',
+        'Parent Phone',
+        'Consecutive Login Days',
+        'Block Strangers (as stored)',
         'Profile User (as stored)',
         'Realm Schema Version',
         'Rows in Committed View',
@@ -613,4 +783,51 @@ def _account_headers():
         'Views Differ',
         'Realm Store Path',
         'Provisioning File Path',
+        'MMKV Profile Path',
     )
+
+
+@artifact_processor
+def justalk_app_state(context):
+    files_found = context.get_files_found()
+    source_path = _mmkv_path(files_found, 'mmkv.default')
+    data_list = []
+
+    if source_path:
+        try:
+            entries = read_entries(source_path)
+        except (MMKVError, OSError):
+            entries = []
+        # The last entry for a key is the one the app reads; earlier ones are superseded
+        # values the append-only store still holds.
+        last_index = {key: index for index, (key, _) in enumerate(entries)}
+        for index, (key, container) in enumerate(entries):
+            value = decode_value(container)
+            if value is None:
+                value_type = 'removed'
+                rendered = ''
+            elif isinstance(value, str):
+                value_type = 'string'
+                rendered = value
+            elif isinstance(value, int):
+                value_type = 'integer'
+                rendered = value
+            else:
+                value_type = 'bytes'
+                rendered = value.hex()
+            data_list.append((
+                key,
+                rendered,
+                value_type,
+                'Yes' if last_index.get(key) == index else 'No',
+                index,
+            ))
+
+    data_headers = (
+        'Key',
+        'Value',
+        'Value Type',
+        'Current Value',
+        'Entry Order',
+    )
+    return data_headers, data_list, source_path

--- a/scripts/mmkv_parser.py
+++ b/scripts/mmkv_parser.py
@@ -1,0 +1,154 @@
+"""MMKV key-value store reader.
+
+MMKV is Tencent's mmap-backed key-value store, used by a number of Android and
+iOS apps in place of SharedPreferences or NSUserDefaults
+(github.com/Tencent/MMKV, BSD-3-Clause). Its on-disk layout is small enough to
+read directly:
+
+    [0:4]   actual size of the data region, uint32 little-endian
+    [4:8]   CRC of the data region, uint32 little-endian
+    [8:8+actual_size]
+            the data region: entries laid end to end, each one
+                varint  key length
+                bytes   key, UTF-8
+                varint  value container length
+                bytes   value container
+    the remainder of the file is zero padding out to the mmap page size
+
+The value container is untyped on disk. MMKV records the type in the calling
+code, not in the file, so this module returns the raw container and leaves the
+reading to the caller. `decode_value` applies the one distinction that can be
+made from the bytes alone: a container that is exactly a varint length followed
+by that many bytes is how MMKV writes a string, and anything else is read as a
+varint scalar, which is how it writes the integer and boolean types.
+
+Two properties matter when reading one of these files as evidence.
+
+**The store is append-only between rewrites.** Setting a key appends a new
+entry rather than editing the existing one, so a key that has been changed
+appears more than once and the earlier entries are superseded values still
+present in the file. `read_entries` returns every entry in file order so those
+remain visible; `read_dict` collapses to the last occurrence, which is the value
+the app reads.
+
+**A zero-length container marks a removal**, not an empty string. `read_dict`
+drops those keys, matching what the app sees. They stay visible in
+`read_entries`.
+
+Nothing here decrypts. MMKV supports an AES-encrypted mode, and a store written
+that way will not produce readable keys; callers should treat an empty or
+garbage result as possibly encrypted rather than as an empty store.
+"""
+
+import struct
+
+
+class MMKVError(Exception):
+    """Raised when a file cannot be read as an MMKV store."""
+
+
+_HEADER_LENGTH = 8
+# Ten sevens covers a 64-bit value, which is the widest scalar MMKV writes.
+# A varint longer than that means the walk has lost alignment.
+_MAX_VARINT_BYTES = 10
+
+
+def _read_varint(data, offset):
+    """Return (value, new_offset) for the varint at offset."""
+    result = 0
+    shift = 0
+    for _ in range(_MAX_VARINT_BYTES):
+        if offset >= len(data):
+            raise MMKVError('varint runs past end of data')
+        byte = data[offset]
+        offset += 1
+        result |= (byte & 0x7F) << shift
+        if not byte & 0x80:
+            return result, offset
+        shift += 7
+    raise MMKVError('varint longer than 5 bytes')
+
+
+def read_entries(path):
+    """Return [(key, value_container_bytes)] in file order.
+
+    Every entry is returned, including repeats of the same key. Later entries
+    supersede earlier ones; see the module docstring.
+    """
+    with open(path, 'rb') as handle:
+        data = handle.read()
+
+    if len(data) < _HEADER_LENGTH:
+        raise MMKVError('file shorter than an MMKV header')
+
+    actual_size = struct.unpack_from('<I', data, 0)[0]
+    end = _HEADER_LENGTH + actual_size
+    if actual_size == 0:
+        return []
+    if end > len(data):
+        raise MMKVError('recorded data size runs past the end of the file')
+
+    entries = []
+    offset = _HEADER_LENGTH
+    while offset < end:
+        try:
+            key_length, offset = _read_varint(data, offset)
+            if key_length == 0 or offset + key_length > end:
+                break
+            key = data[offset:offset + key_length].decode('utf-8')
+            offset += key_length
+            value_length, offset = _read_varint(data, offset)
+            if offset + value_length > end:
+                break
+        except (MMKVError, UnicodeDecodeError):
+            # Alignment is lost, so nothing after this point can be trusted.
+            # Keep what was read rather than discarding the whole store.
+            break
+        entries.append((key, data[offset:offset + value_length]))
+        offset += value_length
+
+    return entries
+
+
+def decode_value(container):
+    """Decode a value container to a str or an int.
+
+    A container that is exactly a varint length followed by that many bytes is
+    how MMKV writes a string; anything else is read as a varint scalar, which
+    covers its integer and boolean types. Returns None for a removal marker,
+    and the raw bytes when neither reading applies.
+    """
+    if not container:
+        return None
+    try:
+        length, offset = _read_varint(container, 0)
+    except MMKVError:
+        return container
+    if offset + length == len(container):
+        try:
+            return container[offset:offset + length].decode('utf-8')
+        except UnicodeDecodeError:
+            return container[offset:offset + length]
+    try:
+        value, offset = _read_varint(container, 0)
+    except MMKVError:
+        return container
+    if offset == len(container):
+        return value
+    return container
+
+
+def read_dict(path):
+    """Return {key: decoded value} using the last occurrence of each key.
+
+    Removed keys are omitted. Use read_entries when the superseded values
+    matter.
+    """
+    result = {}
+    for key, container in read_entries(path):
+        value = decode_value(container)
+        if value is None:
+            result.pop(key, None)
+        else:
+            result[key] = value
+    return result


### PR DESCRIPTION
Stacked on #1057, so the base is that branch and this should merge after it. GitHub will retarget this to `main` automatically once #1057 lands.

Adds `scripts/mmkv_parser.py`, a reader for Tencent's MMKV key-value store, and uses it for two things in the JusTalk module.

## Why a shared helper

No core had an MMKV reader. iLEAPP's `discordAcct.py` gets at one of these files with a printable-strings scan and index arithmetic, which works for two known keys and not in general. MMKV shows up well beyond JusTalk, so this lands beside `realm_parser.py` rather than inside an artifact.

## The format, and the two things that bite

```
[0:4]  data size, uint32 LE
[4:8]  CRC, uint32 LE
[8:8+size]  entries: varint key length, key, varint value length, value container
remainder: zero padding to the page size
```

**Append-only between rewrites.** Setting a key appends a new entry instead of editing the old one, so a changed key appears more than once and the earlier entries are superseded values still sitting in the file. `read_entries` keeps file order; `read_dict` collapses to the last entry, which is what the app reads. In the sample this preserved one superseded value.

**A removal is a zero-length container**, not a deletion, so it has to stay distinguishable from a key holding an empty string. `read_dict` drops it, `read_entries` shows it.

Values are untyped on disk. The reader reports a string where the bytes are a length-prefixed string and an integer where they are a bare scalar, which is the only distinction the bytes support, and the notes say a value shown as an integer may have been written as a boolean.

## What the artifacts now report

`justalk_account` gains the local account record from `files/mmkv/JusProfileManager<account uid>`, one JSON document under a single key: JusTalk id, nickname, email, birthday, phone country, login country, sign-up and last-login times, uuid, and the login token. `JusTalk ID` now prefers the store's own `justalkId` key and falls back to splitting `cur_prof_user`; on the sample the two agree, as does the bare value in `provision-v1.xml`.

The login token is reported in full at the examiner's request. It is a JSON Web Token (RFC 7519), so the payload's `exp` and `uid` claims are decoded into `Token Expiry` and `Token Subject`. The signature is not verified and the token is not presented to any server; the notes say those columns describe what the token asserts about itself, not whether it is currently valid.

`justalk_app_state` is new, reporting `files/mmkv/mmkv.default` entry by entry with a `Current Value` column marking the live one. Covers the device id, the signed-in account uid, the push token and its timestamp, the install channel and the ROM name.

## Validation

Same private sample. 52 / 4 / 150 / 1 / 1 / 44 rows across the six artifacts.

- account row fully populated, 29 columns, no width mismatch
- `Token Expiry` decodes to a date roughly six months after `Sign-Up Date`, consistent with the token being issued at sign-up
- app state: 44 entries, 23 current and 21 superseded, one of which differs from the current value
- all six JusTalk TSVs grep clean for the examiner's local path prefix
- 9 new unit tests, whole suite 92 tests passing
- full `aleapp.py` run clean, no duplicate artifact names
- `pylint --disable=C,R` 10.00/10 across all three files
- `admin/scripts/check_claim_language.py` clean

The varint-width test earns its place: it was written after a real bug. A five-byte cap reads every string key correctly and then silently returns raw bytes for a millisecond epoch, which needs six. Reintroducing the cap fails that test and nothing else.

## Not covered

MMKV supports an AES-encrypted mode, which this reader does not decrypt. A store written that way yields no keys, so the notes say an empty result is not evidence the store was empty. The sample had one signed-in account, so the linked-account and family fields were never seen populated.