### PR TITLE
fix: correct four inaccurate notes found by re-checking today's claims

### DIFF
--- a/scripts/artifacts/allTrails.py
+++ b/scripts/artifacts/allTrails.py
@@ -52,8 +52,11 @@ __artifacts_v2__ = {
                  "it as documented, and they spell metres per second out in full, because an "
                  "abbreviated m/s sanitizes to a column name ending in _ms that reads as "
                  "milliseconds.\n"
-                 "time_start and time_end are Unix epoch milliseconds and agree with the first "
-                 "and last trackpoint of the matching track, which cross-checks both readings.\n"
+                 "time_start and time_end are Unix epoch milliseconds. They are not identical to "
+                 "the first and last trackpoint of the matching track: on the tested corpus "
+                 "time_start is 0.9 seconds before the first point and time_end 2.6 seconds after "
+                 "the last, so the stats bracket the track rather than matching it exactly. That "
+                 "still cross-checks the epoch and the scale of both readings.\n"
                  "Activity ID and Privacy Level are reported as stored: the database carries no "
                  "table mapping the activity id to an activity name, and the privacy level is a "
                  "URN string.\n"
@@ -69,8 +72,8 @@ __artifacts_v2__ = {
     "alltrails_photos": {
         "name": "AllTrails - Photos",
         "description": "Photos attached to AllTrails maps and trails, with the recorded local "
-                       "path, the owning activity and the picture itself where it is present in "
-                       "the extraction",
+                       "path, any coordinates stored against the photo, the owning activity and "
+                       "the picture itself where it is present in the extraction",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
@@ -86,10 +89,12 @@ __artifacts_v2__ = {
                  "trail_photos rows carried no local_path in the tested corpus, so those rows are "
                  "reported without a picture. That is the absence of a locally stored copy, not "
                  "evidence the photo never existed.\n"
-                 "Where a photo is tied to a location record, the city, region and country from "
-                 "that record are reported. Those are place names stored against the photo, not "
-                 "coordinates: the locations table held no latitude or longitude on the tested "
-                 "corpus.",
+                 "Where a photo is tied to a location record, both the coordinates and the place "
+                 "names from that record are reported. On the tested corpus one of the five "
+                 "locations rows carried a latitude and longitude and it is the one the map photo "
+                 "points at, so that photo has coordinates while the rows holding only city, "
+                 "region and country do not. A place name is not a coordinate and the two are "
+                 "reported in separate columns for that reason.",
         "paths": ('*/com.alltrails.alltrails/databases/alltrails*',
                   '*/com.alltrails.alltrails/files/Pictures/*'),
         "output_types": "standard",
@@ -290,12 +295,18 @@ def alltrails_photos(context):
     pictures = _pictures(files_found)
 
     def place(location_id):
+        """Return (coordinates, place names). A locations row may carry either, or
+        neither; they are different kinds of claim and are kept apart."""
         if not location_id:
-            return ''
-        query = ('SELECT city, region, country_name FROM locations WHERE _id = ?')
-        for record in get_sqlite_db_records(source_path, query.replace('?', str(int(location_id)))):
-            return ', '.join(str(p) for p in record if p)
-        return ''
+            return '', '', ''
+        query = ('SELECT lat, lng, city, region, country_name FROM locations '
+                 f'WHERE _id = {int(location_id)}')
+        for record in get_sqlite_db_records(source_path, query):
+            names = ', '.join(str(part) for part in record[2:] if part)
+            lat = record[0] if record[0] is not None else ''
+            lng = record[1] if record[1] is not None else ''
+            return lat, lng, names
+        return '', '', ''
 
     def media_for(local_path):
         if not local_path:
@@ -314,9 +325,11 @@ def alltrails_photos(context):
         '''
         for record in get_sqlite_db_records(source_path, query):
             media, name = media_for(record[1])
+            lat, lng, names = place(record[5])
             data_list.append((
-                record[0], media, name, record[2] or '', record[3] or '', record[4] or '',
-                place(record[5]), record[6], record[7], 'map_photos', record[8], record[1] or '',
+                record[0], media, name, lat, lng, record[2] or '', record[3] or '',
+                record[4] or '', names, record[6], record[7], 'map_photos', record[8],
+                record[1] or '',
             ))
 
     if does_table_exist_in_db(source_path, 'trail_photos'):
@@ -327,10 +340,10 @@ def alltrails_photos(context):
         '''
         for record in get_sqlite_db_records(source_path, query):
             media, name = media_for(record[1])
+            lat, lng, names = place(record[4])
             data_list.append((
-                record[0], media, name, record[2] or '', record[3] or '', '',
-                place(record[4]), record[5], record[6], 'trail_photos', record[7],
-                record[1] or '',
+                record[0], media, name, lat, lng, record[2] or '', record[3] or '', '',
+                names, record[5], record[6], 'trail_photos', record[7], record[1] or '',
             ))
 
     return _PHOTO_HEADERS, data_list, source_path
@@ -340,6 +353,8 @@ _PHOTO_HEADERS = (
     'Created',
     ('Picture', 'media'),
     'File Name',
+    'Latitude',
+    'Longitude',
     'Title',
     'Description',
     'Activity Name',

--- a/scripts/artifacts/weibo.py
+++ b/scripts/artifacts/weibo.py
@@ -51,11 +51,12 @@ __artifacts_v2__ = {
                  "is filed under and is reported as Account UID; _mid is the post id, which is "
                  "the same identifier the timeline artifact reports as Post ID, so rows can be "
                  "matched between the two.\n"
-                 "Several columns in this table store more than one value in a single field, "
-                 "joined by the literal separator '#sina#'. That applies to the page title, the "
-                 "short and original URLs and the page type. They are reported as stored, "
-                 "separator included, rather than split on an assumption about which value "
-                 "belongs to which link.\n"
+                 "Some rows in this table store more than one value in a single field, joined "
+                 "by the literal separator '#sina#', across the page title, the short and "
+                 "original URLs and the page type. One of the five rows in the tested corpus did "
+                 "so. Those fields are reported as stored, separator included, rather than split "
+                 "on an assumption about which value belongs to which link, so most rows show a "
+                 "single plain value and some show the joined form.\n"
                  "Topics are read from the _mblog_topic JSON where present and reported as the "
                  "topic titles.",
         "paths": ('*/com.sina.weibo/databases/ArticleDb.db*',),

--- a/scripts/artifacts/xiaohongshu.py
+++ b/scripts/artifacts/xiaohongshu.py
@@ -15,8 +15,10 @@ __artifacts_v2__ = {
                  "the local account the row is filed under and is reported as Account User ID; "
                  "user_name is the note author's display name, which is a different party, so the "
                  "two are reported under distinct headers to keep them from being read as the "
-                 "same person. author_id existed in the tested corpus but was an empty string on "
-                 "every row, so it is reported as stored rather than dropped.\n"
+                 "same person. author_id is populated on some rows and an empty string on others: "
+                 "19 of the 45 rows in the tested corpus held an empty string. It is reported as "
+                 "stored, so an empty cell there means the app recorded no author id for that "
+                 "row rather than that the parser dropped it.\n"
                  "The timestamp is Unix epoch milliseconds. What the app records in this table is "
                  "an entry per note; the table is named a play history by the app, and this "
                  "artifact reports its rows without asserting how much of a note was played or "
@@ -41,9 +43,10 @@ __artifacts_v2__ = {
 #
 # Xiaohongshu keeps its messages in databases/msgDB and its contact relations in
 # databases/localRelationDB. In both tested corpora those files carry no SQLite
-# header and measured Shannon entropy of 8.00 over the sampled bytes, while their
-# -wal sidecars carry the standard SQLite WAL magic. That combination is
-# consistent with page-level encryption of the main database, such as SQLCipher.
+# header and measure Shannon entropy of 8.00 (msgDB) and 7.95 (localRelationDB)
+# over the sampled bytes, while their -wal sidecars carry the standard SQLite WAL
+# magic. That combination is consistent with page-level encryption of the main
+# database, such as SQLCipher.
 # A search of the app's shared_prefs found no key. They are therefore not parsed
 # here, and no claim is made about their contents.
 #


### PR DESCRIPTION
I re-checked every factual claim in the descriptions and notes written today against the actual data rather than against my own prose. Four were wrong. One was hiding evidence.

## The one that mattered: a geotagged photo I was not reporting

**AllTrails - Photos** notes said "the locations table held no latitude or longitude on the tested corpus."

That is false. One of the five `locations` rows carries coordinates, and it is precisely the row the map photo points at:

```
32974 | 38.78485277777778 | -77.25620833333333   <- map_photos.location_id
```

So the photo is geotagged, and the artifact was silently dropping it while reporting an empty "Recorded Place" instead. The recovered point sits inside the recorded track's bounding box, which is a consistency check in its favour.

Fixed: **Latitude and Longitude columns added**. Coordinates and place names are kept in separate columns, because "a photo was taken at this point" and "a photo has this city name stored against it" are different kinds of claim. The note now says which rows carry which.

## Three that were wrong but not load-bearing

**AllTrails activity times.** The note claimed `time_start` and `time_end` "agree with the first and last trackpoint". They do not:

| | stats | trackpoint | delta |
|---|---|---|---|
| start | 1722088887709 | 1722088888597 | 0.9 s before |
| end | 1722091107241 | 1722091104666 | 2.6 s after |

They **bracket** the track rather than matching it. That still cross-checks the epoch and the scale, which is what the note now says.

**Xiaohongshu `author_id`.** Claimed empty "on every row". Actually empty on **19 of 45**, so 26 rows do carry an author id. The note now gives the count and explains that an empty cell means the app recorded none, not that the parser dropped it.

**Xiaohongshu entropy.** Both encrypted stores were quoted at 8.00. `msgDB` is 8.00; `localRelationDB` is **7.95**. Now stated separately.

## Tightened

The Weibo `#sina#` note described the multi-value joined form as though it were the usual case. One of the five rows uses it. Reworded so a reader is not surprised to see plain values in most rows.

## What checked out

Everything else verified clean: all Wickr, Slack, AllTrails and BreadWallet row counts; the Wickr `ZFULLTYPE` 6000 to file-linked set equality (4 of 4); the Wickr entity-number drift (17 vs 18); the Slack schema comments quoted from `CREATE TABLE`; Slack conversation types; the AllTrails unit derivation (1.5784 × 2216 = 3497.75 against a stored 3497.75, exact); the BreadWallet 64-character key suffixes and the BTC/USD and BCH/USD rates.

Counts are unchanged: 809, 1, 2, 1 for AllTrails, 45 for the Xiaohongshu play history. Claim-language and HTML-safety checks pass, lint clean.

The equivalent iLEAPP correction is a separate PR.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>