### PR TITLE
fix: fill in the artifact author field left empty on 27 artifacts

### DIFF
--- a/scripts/artifacts/berealAndroid.py
+++ b/scripts/artifacts/berealAndroid.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
         "name": "BeReal Cached Media",
         "description": "Photos and videos recovered from the BeReal caches on disk, with the "
                        "source URL and cache date read from the OkHttp cache metadata where present",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-06",
         "last_update_date": "2026-08-06",
         "requirements": "none",
@@ -36,7 +36,7 @@ __artifacts_v2__ = {
         "description": "Friends recovered from cached responses of the relationships and friend "
                        "recommendation endpoints, with the user name, full name and status BeReal "
                        "returned",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-06",
         "last_update_date": "2026-08-06",
         "requirements": "none",
@@ -56,7 +56,7 @@ __artifacts_v2__ = {
         "name": "BeReal Cached API Responses",
         "description": "Index of the BeReal API responses held in the OkHttp network cache, with "
                        "the endpoint URL, the cached response date and a short summary of the body",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-06",
         "last_update_date": "2026-08-06",
         "requirements": "none",

--- a/scripts/artifacts/dropbox.py
+++ b/scripts/artifacts/dropbox.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
         "name": "Dropbox - Files",
         "description": "Cloud files and folders listed in the Dropbox app database, with the path, "
                        "size, MIME type and the modification times the service recorded",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
         "requirements": "none",
@@ -24,7 +24,7 @@ __artifacts_v2__ = {
         "name": "Dropbox - Account",
         "description": "The signed-in Dropbox account, with the email, display name, account id and "
                        "plan read from the account preference values",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
         "requirements": "none",
@@ -45,7 +45,7 @@ __artifacts_v2__ = {
         "name": "Dropbox - Thumbnails",
         "description": "Thumbnails the Dropbox app cached, with the cloud path they belong to and "
                        "the size and format that was cached",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
         "requirements": "none",

--- a/scripts/artifacts/galleryVault.py
+++ b/scripts/artifacts/galleryVault.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Recovers files hidden by GalleryVault from the encrypted objects stored "
                        "under the vault folder on external storage, together with the original "
                        "file name and creation time held in each object's own trailer",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-06",
         "last_update_date": "2026-08-06",
         "requirements": "none",
@@ -30,7 +30,7 @@ __artifacts_v2__ = {
         "name": "GalleryVault - Hidden Files (database)",
         "description": "Files hidden in GalleryVault as recorded in the file_v1 table, including "
                        "the path each file was taken from",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-06",
         "last_update_date": "2026-08-06",
         "requirements": "none",
@@ -48,7 +48,7 @@ __artifacts_v2__ = {
     "galleryvault_folders": {
         "name": "GalleryVault - Folders",
         "description": "GalleryVault folders, their child counts and creation times",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-06",
         "last_update_date": "2026-08-06",
         "requirements": "none",
@@ -67,7 +67,7 @@ __artifacts_v2__ = {
         "name": "GalleryVault - Break-in Reports",
         "description": "Failed unlock attempts recorded by GalleryVault, with the code that was "
                        "entered and the photo captured at the time",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-06",
         "last_update_date": "2026-08-06",
         "requirements": "none",
@@ -85,7 +85,7 @@ __artifacts_v2__ = {
         "name": "GalleryVault - Break-in Report Images",
         "description": "Images written to the BreakInReports folder on external storage, with the "
                        "capture time taken from the file name",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-06",
         "last_update_date": "2026-08-06",
         "requirements": "none",
@@ -104,7 +104,7 @@ __artifacts_v2__ = {
     "galleryvault_locked_apps": {
         "name": "GalleryVault - Locked Apps",
         "description": "Applications locked by the GalleryVault AppLock feature",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-06",
         "last_update_date": "2026-08-06",
         "requirements": "none",
@@ -121,7 +121,7 @@ __artifacts_v2__ = {
     "galleryvault_applock_break_ins": {
         "name": "GalleryVault - AppLock Break-in Reports",
         "description": "Failed unlock attempts recorded against individual locked applications",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-06",
         "last_update_date": "2026-08-06",
         "requirements": "none",
@@ -140,7 +140,7 @@ __artifacts_v2__ = {
         "description": "Entries in the browser_history table of the browser built into "
                        "GalleryVault, with the URL, host, title and last visit time the app "
                        "recorded",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-06",
         "last_update_date": "2026-08-06",
         "requirements": "none",
@@ -157,7 +157,7 @@ __artifacts_v2__ = {
     "galleryvault_browser_urls": {
         "name": "GalleryVault - Browser Start Pages",
         "description": "Entries in the web_url table used by the built-in browser start page",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-06",
         "last_update_date": "2026-08-06",
         "requirements": "none",
@@ -175,7 +175,7 @@ __artifacts_v2__ = {
     "galleryvault_downloads": {
         "name": "GalleryVault - Downloads",
         "description": "Download tasks created by the browser built into GalleryVault",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-06",
         "last_update_date": "2026-08-06",
         "requirements": "none",
@@ -193,7 +193,7 @@ __artifacts_v2__ = {
         "name": "GalleryVault - Unhide and Export History",
         "description": "Records of files taken back out of the vault, including the path they were "
                        "written to",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-06",
         "last_update_date": "2026-08-06",
         "requirements": "none",
@@ -211,7 +211,7 @@ __artifacts_v2__ = {
         "name": "GalleryVault - Recycle Bin",
         "description": "Vault files sitting in the GalleryVault recycle bin and when they were "
                        "deleted",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-06",
         "last_update_date": "2026-08-06",
         "requirements": "none",
@@ -229,7 +229,7 @@ __artifacts_v2__ = {
         "name": "GalleryVault - File Action Log",
         "description": "Action log kept next to the vault on external storage, recording vault "
                        "file paths and the time each action was carried out",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-06",
         "last_update_date": "2026-08-06",
         "requirements": "none",

--- a/scripts/artifacts/kikMessenger.py
+++ b/scripts/artifacts/kikMessenger.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
         "name": "Kik Messages",
         "description": "Messages from the Kik messagesTable, with the conversation partner, the "
                        "body, and the attachment metadata held against the message content id",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-06",
         "last_update_date": "2026-08-06",
         "requirements": "none",
@@ -39,7 +39,7 @@ __artifacts_v2__ = {
         "name": "Kik Users",
         "description": "Entries in the Kik contacts table, covering individual users and groups "
                        "with their display name, user name and roster flags",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-06",
         "last_update_date": "2026-08-06",
         "requirements": "none",
@@ -57,7 +57,7 @@ __artifacts_v2__ = {
         "name": "Kik Attachments",
         "description": "Attachment properties from the Kik content table, pivoted so each content "
                        "id gives one row with its file name, size, source app and URLs",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-06",
         "last_update_date": "2026-08-06",
         "requirements": "none",
@@ -83,7 +83,7 @@ __artifacts_v2__ = {
         "name": "Kik Chat Metadata",
         "description": "Rows from chatMetaInfTable, including the chat end time and the flags Kik "
                        "keeps for anonymously matched chats",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-06",
         "last_update_date": "2026-08-06",
         "requirements": "none",
@@ -101,7 +101,7 @@ __artifacts_v2__ = {
         "name": "Kik Local Account",
         "description": "Account rows from kikCoreDatabase, giving the core id used to name the "
                        "other databases and the user name held against it",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-06",
         "last_update_date": "2026-08-06",
         "requirements": "none",
@@ -119,7 +119,7 @@ __artifacts_v2__ = {
         "name": "Kik Roster and Contact Profiles",
         "description": "Bare JIDs held in the user roster and contact profile databases, with the "
                        "profile update time where the app records one",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-06",
         "last_update_date": "2026-08-06",
         "requirements": "none",

--- a/scripts/artifacts/what3words.py
+++ b/scripts/artifacts/what3words.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
         "name": "what3words - Saved Places",
         "description": "Places saved in what3words, with the three word address, the label given to "
                        "it, the nearest place and the coordinates",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
         "requirements": "none",
@@ -23,7 +23,7 @@ __artifacts_v2__ = {
         "name": "what3words - Location Lists",
         "description": "Lists that group saved what3words locations, with the list label, the number "
                        "of locations in it, who created it and when",
-        "author": "",
+        "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
         "requirements": "none",


### PR DESCRIPTION
Auditing the last two days of work turned up **45 artifacts shipped with an empty `author` string**, 27 of them in this repo.

| Module | Artifacts fixed |
|---|---|
| `galleryVault.py` | 13 |
| `kikMessenger.py` | 6 |
| `berealAndroid.py` | 3 |
| `dropbox.py` | 3 |
| `what3words.py` | 2 |

That field reaches the HTML report and the LAVA manifest, so it was rendering blank in output that gets quoted in casework, and it dropped attribution for work that had a named author.

## Safety of the change

Every artifact in all five modules was created inside the same two-day window, verified by parsing `creation_date` from each `__artifacts_v2__` block before editing. So nothing pre-existing is touched, and no artifact that deliberately carries a different author is affected. The value matches what the other artifacts written alongside these already use.

## Also checked while auditing

Every artifact created in that window was re-run against the corpora its own `sample_data` names, and the counts compared:

- **68 artifact/corpus pairs verified in this repo, 0 mismatches.**
- The artifacts that check in media could not run under the offline harness (they need the real `Context`), so those were verified by full end-to-end runs instead: GalleryVault, Kik and Calculator Lock all matched their recorded counts exactly on both `pixel7a_a14` and `hc_pixel8pro_a17`.
- Spot-checked the most consequential claim in the batch, that GalleryVault's vault-file recovery produces openable files: of 31 recovered items, 30 carry valid media signatures (17 PNG, 9 JPEG, 4 MP4) and the remaining one is a `.txt` note, correctly not an image.

No behaviour changes, no row counts move, lint clean, claim-language and HTML-safety checks pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>