### PR TITLE
fix: give every artifact an author, using the GitHub handle that sent it

### DIFF
--- a/scripts/artifacts/AVG.py
+++ b/scripts/artifacts/AVG.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_AVG": {
         "name": "AVG - Encryption Details",
         "description": "Recovers the AVG (com.antivirus) vault PIN/pattern and derives the decryption keys",
-        "author": "",
+        "author": "@Theincidentalchewtoy",
         "creation_date": "2022-05-03",
         "last_update_date": "2022-05-03",
         "requirements": "none",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     "get_AVG_media": {
         "name": "AVG - Media Files",
         "description": "Decrypts media hidden in the AVG (com.antivirus) vault",
-        "author": "",
+        "author": "@Theincidentalchewtoy",
         "creation_date": "2022-05-03",
         "last_update_date": "2022-05-03",
         "requirements": "none",

--- a/scripts/artifacts/ChessComAccount.py
+++ b/scripts/artifacts/ChessComAccount.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_ChessComAccount": {
         "name": "Chess.com Account",
         "description": "Parses Chess.com account credentials and session data",
-        "author": "",
+        "author": "@kibaffo33",
         "creation_date": "2022-03-27",
         "last_update_date": "2022-03-27",
         "requirements": "none",

--- a/scripts/artifacts/ChessComFriends.py
+++ b/scripts/artifacts/ChessComFriends.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_ChessComFriends": {
         "name": "ChessComFriends",
         "description": "Chess database",
-        "author": "",
+        "author": "@kibaffo33",
         "creation_date": "2022-02-23",
         "last_update_date": "2022-02-23",
         "requirements": "none",

--- a/scripts/artifacts/ChessComGames.py
+++ b/scripts/artifacts/ChessComGames.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_ChessComGames": {
         "name": "Chess.com Games",
         "description": "Parses Chess.com game records",
-        "author": "",
+        "author": "@kibaffo33",
         "creation_date": "2022-03-27",
         "last_update_date": "2022-03-27",
         "requirements": "none",

--- a/scripts/artifacts/ChessComMessages.py
+++ b/scripts/artifacts/ChessComMessages.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_ChessComMessages": {
         "name": "ChessComMessages",
         "description": "Chess database",
-        "author": "",
+        "author": "@kibaffo33",
         "creation_date": "2022-02-23",
         "last_update_date": "2022-02-23",
         "requirements": "none",

--- a/scripts/artifacts/ChessWithFriends.py
+++ b/scripts/artifacts/ChessWithFriends.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_ChessWithFriends": {
         "name": "Chess With Friends",
         "description": "Parses Chess With Friends game data",
-        "author": "",
+        "author": "@mastenp",
         "creation_date": "2020-03-21",
         "last_update_date": "2020-03-21",
         "requirements": "none",

--- a/scripts/artifacts/DocList.py
+++ b/scripts/artifacts/DocList.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_DocList": {
         "name": "DocList",
         "description": "Parses Google Drive file metadata (name, owner, type, created/modified/opened dates, URIs, MD5 and size) from the DocList.db database.",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2020-12-21",
         "last_update_date": "2020-12-21",
         "requirements": "none",

--- a/scripts/artifacts/HideX.py
+++ b/scripts/artifacts/HideX.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_HideX": {
         "name": "HideX",
         "description": "Parses the list of apps hidden or locked by the HideX privacy app (package name and active state) from hidex.db.",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2021-10-12",
         "last_update_date": "2021-10-12",
         "requirements": "none",

--- a/scripts/artifacts/NQ_Vault.py
+++ b/scripts/artifacts/NQ_Vault.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_NQVault": {
         "name": "NQ Vault Decrypted PINs",
         "description": "Recovers NQ Vault (com.netqin.ps) PINs by reversing the stored Java hashcode",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2023-05-19",
         "last_update_date": "2023-05-19",
         "requirements": "none",
@@ -16,7 +16,7 @@ __artifacts_v2__ = {
     "get_NQVault_media": {
         "name": "NQ Vault Decrypted Media",
         "description": "Decrypts media hidden by NQ Vault (com.netqin.ps) using the recovered PIN XOR key",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2023-05-19",
         "last_update_date": "2023-05-19",
         "requirements": "none",

--- a/scripts/artifacts/Oruxmaps.py
+++ b/scripts/artifacts/Oruxmaps.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_Oruxmaps": {
         "name": "Oruxmaps - POI",
         "description": "Parses saved points of interest (latitude, longitude, altitude, time and name) from the OruxMaps oruxmapstracks.db database.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2021-03-11",
         "last_update_date": "2021-03-11",
         "requirements": "none",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     "get_Oruxmaps_tracks": {
         "name": "Oruxmaps - Tracks",
         "description": "Parses recorded GPS tracks and their trackpoints (name, description, latitude, longitude, altitude and time) from the OruxMaps oruxmapstracks.db database.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2021-03-11",
         "last_update_date": "2021-03-11",
         "requirements": "none",

--- a/scripts/artifacts/Viber.py
+++ b/scripts/artifacts/Viber.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_Viber": {
         "name": "Viber - Call Logs",
         "description": "Parses Viber call logs (timestamp, phone number, direction, duration and call type) from the Viber databases.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2020-12-24",
         "last_update_date": "2026-08-01",
         "requirements": "none",
@@ -27,7 +27,7 @@ __artifacts_v2__ = {
     "get_Viber_contacts": {
         "name": "Viber - Contacts",
         "description": "Parses Viber contacts (display name and phone number) from the Viber databases.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2020-12-24",
         "last_update_date": "2020-12-24",
         "requirements": "none",
@@ -45,7 +45,7 @@ __artifacts_v2__ = {
     "get_Viber_messages": {
         "name": "Viber - Messages",
         "description": "Parses Viber messages (date, sender and recipients, thread, content, direction, unread flag and attachments) from the Viber databases.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2020-12-24",
         "last_update_date": "2026-08-01",
         "requirements": "none",
@@ -80,7 +80,7 @@ __artifacts_v2__ = {
     "get_Viber_additional": {
         "name": "Viber - Additional",
         "description": "Hidden chat PIN (brute-forced from the stored hash)",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2020-12-24",
         "last_update_date": "2020-12-24",
         "requirements": "none",

--- a/scripts/artifacts/WhatsApp.py
+++ b/scripts/artifacts/WhatsApp.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_whatsapp_contacts": {
         "name": "WhatsApp - Contacts",
         "description": "WhatsApp contacts (wa.db)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-03-11",
         "last_update_date": "2021-03-11",
         "requirements": "none",
@@ -24,7 +24,7 @@ __artifacts_v2__ = {
     "get_whatsapp_call_logs": {
         "name": "WhatsApp - Call Logs",
         "description": "WhatsApp call logs (msgstore.db)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-03-11",
         "last_update_date": "2021-03-11",
         "requirements": "none",
@@ -46,7 +46,7 @@ __artifacts_v2__ = {
     "get_whatsapp_messages": {
         "name": "WhatsApp - Messages",
         "description": "WhatsApp messages (legacy msgstore.db schema with messages.data)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-03-11",
         "last_update_date": "2021-03-11",
         "requirements": "none",
@@ -68,7 +68,7 @@ __artifacts_v2__ = {
     "get_whatsapp_one_to_one_messages": {
         "name": "WhatsApp - One To One Messages",
         "description": "WhatsApp 1:1 messages (modern msgstore.db schema)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-03-11",
         "last_update_date": "2026-07-03",
         "requirements": "none",
@@ -104,7 +104,7 @@ __artifacts_v2__ = {
     "get_whatsapp_group_messages": {
         "name": "WhatsApp - Group Messages",
         "description": "WhatsApp group messages (modern msgstore.db schema)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-03-11",
         "last_update_date": "2026-07-03",
         "requirements": "none",
@@ -139,7 +139,7 @@ __artifacts_v2__ = {
     "get_whatsapp_group_details": {
         "name": "WhatsApp - Group Details",
         "description": "WhatsApp group details (modern msgstore.db schema)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-03-11",
         "last_update_date": "2021-03-11",
         "requirements": "none",
@@ -162,7 +162,7 @@ __artifacts_v2__ = {
     "get_whatsapp_user_profile": {
         "name": "WhatsApp - User Profile",
         "description": "WhatsApp local user profile (shared_prefs xml)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-03-11",
         "last_update_date": "2021-03-11",
         "requirements": "none",

--- a/scripts/artifacts/WordsWithFriends.py
+++ b/scripts/artifacts/WordsWithFriends.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_WordsWithFriends": {
         "name": "WordsWithFriends",
         "description": "Parses in-game chat messages (creation time, message, sender name and email) from the Words With Friends wf_database.sqlite.",
-        "author": "",
+        "author": "@mastenp",
         "creation_date": "2020-03-21",
         "last_update_date": "2020-03-21",
         "requirements": "none",

--- a/scripts/artifacts/Xender.py
+++ b/scripts/artifacts/Xender.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_Xender": {
         "name": "Xender - Contacts",
         "description": "Parses Xender contact profiles (device ID and nickname) from the Xender trans-history database.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2020-12-24",
         "last_update_date": "2026-08-01",
         "requirements": "none",
@@ -17,7 +17,7 @@ __artifacts_v2__ = {
     "get_Xender_messages": {
         "name": "Xender - Messages",
         "description": "Parses Xender file transfer history (file path, name, size, timestamp, direction and sender and recipient details) from the Xender trans-history database.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2020-12-24",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/Zapya.py
+++ b/scripts/artifacts/Zapya.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_Zapya": {
         "name": "Zapya",
         "description": "Parses Zapya file transfer records (device, name, direction, timestamp, path and title) from the transfer20.db database.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2020-03-21",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/appLockerfishingnet.py
+++ b/scripts/artifacts/appLockerfishingnet.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_appLockerfishingnet": {
         "name": "App Locker",
         "description": "Decrypts media hidden by the App Locker / Calculator vault (.privacy_safe, AES-CBC)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-12-14",
         "last_update_date": "2021-12-14",
         "requirements": "none",

--- a/scripts/artifacts/appLockerfishingnetdb.py
+++ b/scripts/artifacts/appLockerfishingnetdb.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_appLockerfishingnetdb": {
         "name": "App Locker DB",
         "description": "Parses the stored unlock pattern for the App Locker privacy app (encrypted and decrypted pattern and key) from privacy_safe.db.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-12-14",
         "last_update_date": "2021-12-14",
         "requirements": "none",

--- a/scripts/artifacts/appLockerfishingnetpat.py
+++ b/scripts/artifacts/appLockerfishingnetpat.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_appLockerfishingnetpat": {
         "name": "App Locker Pat",
         "description": "Parses the App Locker unlock pattern (encrypted and decrypted) from the share_privacy_safe.xml preferences file.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-12-14",
         "last_update_date": "2021-12-14",
         "requirements": "none",

--- a/scripts/artifacts/appopSetupWiz.py
+++ b/scripts/artifacts/appopSetupWiz.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_appopSetupWiz": {
         "name": "appopSetupWiz",
         "description": "Setup Wizard app-op timestamps from appops.xml",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-08-15",
         "last_update_date": "2021-08-15",
         "requirements": "none",

--- a/scripts/artifacts/appops.py
+++ b/scripts/artifacts/appops.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_appops": {
         "name": "App Ops Permissions",
         "description": "App permission op timestamps from appops.xml (modern schema)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-08-15",
         "last_update_date": "2026-08-01",
         "requirements": "none",
@@ -25,7 +25,7 @@ __artifacts_v2__ = {
     "get_appops_legacy": {
         "name": "App Ops Permissions - Legacy",
         "description": "App permission op timestamps from appops.xml (Android 9 and below schema)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-08-15",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/atrackerdetect.py
+++ b/scripts/artifacts/atrackerdetect.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_atrackerdetect": {
         "name": "atrackerdetect",
         "description": "Parses preferences from the Apple Tracker Detect Android app (key, value and milliseconds from last boot) from its shared_prefs XML.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2022-01-08",
         "last_update_date": "2022-01-08",
         "requirements": "none",

--- a/scripts/artifacts/battery_usage_v4.py
+++ b/scripts/artifacts/battery_usage_v4.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_battery_usage_v4": {
         "name": "battery_usage_v4",
         "description": "Parses per-app battery usage (timestamp, application, power consumed, foreground and background usage, battery level and status) from the settings intelligence battery-usage-db-v4 database.",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2021-12-21",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/bittorrentClientpref.py
+++ b/scripts/artifacts/bittorrentClientpref.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_bittorrentClientpref": {
         "name": "BitTorrent Prefs",
         "description": "Parses BitTorrent client preferences (key, value and text) from the com.bittorrent.client preferences XML.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2023-03-26",
         "last_update_date": "2023-03-26",
         "requirements": "none",

--- a/scripts/artifacts/bittorrentDlhist.py
+++ b/scripts/artifacts/bittorrentDlhist.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_bittorrentDlhist": {
         "name": "bittorrentDlhist",
         "description": "Parses BitTorrent download history (timestamp, filename and download path) from the dlhistory config files.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2023-03-26",
         "last_update_date": "2023-03-26",
         "requirements": "none",

--- a/scripts/artifacts/bluetoothConnections.py
+++ b/scripts/artifacts/bluetoothConnections.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_bluetoothConnections": {
         "name": "Bluetooth Connections",
         "description": "Parses previously connected Bluetooth devices (first connected timestamp, device name, MAC address and link key) from bt_config.conf.",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2021-06-23",
         "last_update_date": "2021-06-23",
         "requirements": "none",
@@ -27,7 +27,7 @@ __artifacts_v2__ = {
     "get_bluetoothAdapter": {
         "name": "Bluetooth Adapter Information",
         "description": "Parses the local Bluetooth adapter information (key and value) from bt_config.conf.",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2021-06-23",
         "last_update_date": "2021-06-23",
         "requirements": "none",

--- a/scripts/artifacts/browserCachechrome.py
+++ b/scripts/artifacts/browserCachechrome.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_browserCachechrome": {
         "name": "Chrome Browser Cache",
         "description": "Cached web resources extracted from the Chrome browser disk cache",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2023-01-28",
         "last_update_date": "2023-01-28",
         "requirements": "none",

--- a/scripts/artifacts/browserCachefirefox.py
+++ b/scripts/artifacts/browserCachefirefox.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_browserCachefirefox": {
         "name": "Firefox Browser Cache",
         "description": "Cached web resources extracted from the Firefox browser disk cache (cache2)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2023-01-30",
         "last_update_date": "2023-01-30",
         "requirements": "none",

--- a/scripts/artifacts/browserlocation.py
+++ b/scripts/artifacts/browserlocation.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_browserlocation": {
         "name": "Browser Location",
         "description": "Parses cached geolocation positions (timestamp, latitude, longitude and accuracy) from the Android Browser CachedGeoposition.db.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2021-03-17",
         "last_update_date": "2021-03-17",
         "requirements": "none",

--- a/scripts/artifacts/build.py
+++ b/scripts/artifacts/build.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses device build properties (key and value) from the vendor "
                        "and system build.prop files. When both files are present the "
                        "vendor values are reported.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",

--- a/scripts/artifacts/cachelocation.py
+++ b/scripts/artifacts/cachelocation.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_cachelocation": {
         "name": "Cache Location",
         "description": "Parses cached cell and Wi-Fi location fixes (accuracy, confidence, latitude, longitude and read time) from the Google location cache files.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2021-03-17",
         "last_update_date": "2021-03-17",
         "requirements": "none",

--- a/scripts/artifacts/calllog.py
+++ b/scripts/artifacts/calllog.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_calllog": {
         "name": "Call logs ",
         "description": "Parses the call log (date, number, type, duration, location and transcription) from the contacts provider calllog.db.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-02",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/calllogs.py
+++ b/scripts/artifacts/calllogs.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_calllogs": {
         "name": "Call Logs",
         "description": "Parses call logs (number, start and end time, call type, direction and name) from the contacts and logs provider databases.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2021-03-17",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/cashApp.py
+++ b/scripts/artifacts/cashApp.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_cashApp": {
         "name": "Cash App",
         "description": "Parses Cash App transactions (date, sender and recipient display names, unique IDs and cashtags, amount, status and note) from cash_money.db.",
-        "author": "",
+        "author": "@gforce4n6",
         "creation_date": "2021-10-06",
         "last_update_date": "2021-10-06",
         "requirements": "none",

--- a/scripts/artifacts/chrome.py
+++ b/scripts/artifacts/chrome.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_chrome": {
         "name": "Web History",
         "description": "Parses Web History from Chromium based browsers",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-19",
         "last_update_date": "2020-03-19",
         "requirements": "none",
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
     "get_chromeWebVisits": {
         "name": "Web Visits",
         "description": "Parses Web Visits from Chromium based browsers",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-19",
         "last_update_date": "2026-08-01",
         "requirements": "none",
@@ -58,7 +58,7 @@ __artifacts_v2__ = {
     "get_chromeSearchTerms": {
         "name": "Search Terms",
         "description": "Parses Search Terms from Chromium based browsers",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-19",
         "last_update_date": "2020-03-19",
         "requirements": "none",
@@ -83,7 +83,7 @@ __artifacts_v2__ = {
     "get_chromeDownloads": {
         "name": "Downloads",
         "description": "Parses Downloads from Chromium based browsers",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-19",
         "last_update_date": "2026-08-01",
         "requirements": "none",
@@ -112,7 +112,7 @@ __artifacts_v2__ = {
     "get_chromeKeywordSearchTerms": {
         "name": "Keyword Search Terms",
         "description": "Parses Keyword Search Terms from Chromium based browsers",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-19",
         "last_update_date": "2020-03-19",
         "requirements": "none",

--- a/scripts/artifacts/chromeAutofill.py
+++ b/scripts/artifacts/chromeAutofill.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_chromeAutofill": {
         "name": "Chrome Autofill - Entries",
         "description": "Parses Chrome autofill entries",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2020-03-19",
         "last_update_date": "2026-07-10",
         "requirements": "none",
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
     "get_chromeAutofillProfiles": {
         "name": "Chrome Autofill - Profiles",
         "description": "Parses Chrome autofill profiles",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2020-03-19",
         "last_update_date": "2020-03-19",
         "requirements": "none",

--- a/scripts/artifacts/chromeBookmarks.py
+++ b/scripts/artifacts/chromeBookmarks.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_chromeBookmarks": {
         "name": "Bookmarks",
         "description": "Parses Bookmarks from Chromium Based Browsers",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-20",
         "last_update_date": "2020-03-20",
         "requirements": "none",

--- a/scripts/artifacts/chromeCookies.py
+++ b/scripts/artifacts/chromeCookies.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_chromeCookies": {
         "name": "Cookies",
         "description": "Parses Cookies from Chromium Based Browsers",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-21",
         "last_update_date": "2020-03-21",
         "requirements": "none",

--- a/scripts/artifacts/chromeLoginData.py
+++ b/scripts/artifacts/chromeLoginData.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_chromeLoginData": {
         "name": "Login Data",
         "description": "Parses saved Login Data from Chromium Based Browsers",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-20",
         "last_update_date": "2020-03-20",
         "requirements": "none",

--- a/scripts/artifacts/chromeMediaHistory.py
+++ b/scripts/artifacts/chromeMediaHistory.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_chromeMediaHistorySessions": {
         "name": "Media History - Sessions",
         "description": "Parses Media History playback sessions from Chromium Based Browsers",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2021-01-26",
         "last_update_date": "2021-01-26",
         "requirements": "none",
@@ -18,7 +18,7 @@ __artifacts_v2__ = {
     "get_chromeMediaHistoryPlaybacks": {
         "name": "Media History - Playbacks",
         "description": "Parses Media History playbacks from Chromium Based Browsers",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2021-01-26",
         "last_update_date": "2021-01-26",
         "requirements": "none",
@@ -34,7 +34,7 @@ __artifacts_v2__ = {
     "get_chromeMediaHistoryOrigins": {
         "name": "Media History - Origins",
         "description": "Parses Media History origins from Chromium Based Browsers",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2021-01-26",
         "last_update_date": "2021-01-26",
         "requirements": "none",

--- a/scripts/artifacts/chromeNetworkActionPredictor.py
+++ b/scripts/artifacts/chromeNetworkActionPredictor.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_chromeNetworkActionPredictor": {
         "name": "Network Action Predictor",
         "description": "Parses the Network Action Predictor from Chromium Based Browsers",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2020-03-19",
         "last_update_date": "2026-07-10",
         "requirements": "none",

--- a/scripts/artifacts/chromeOfflinePages.py
+++ b/scripts/artifacts/chromeOfflinePages.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_chromeOfflinePages": {
         "name": "Offline Pages",
         "description": "Parses Offline Pages from Chromium Based Browsers",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-04-02",
         "last_update_date": "2020-04-02",
         "requirements": "none",

--- a/scripts/artifacts/chromeTopSites.py
+++ b/scripts/artifacts/chromeTopSites.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_chromeTopSites": {
         "name": "Top Sites",
         "description": "Parses Top Sites from Chromium Based Browsers",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-21",
         "last_update_date": "2020-03-21",
         "requirements": "none",

--- a/scripts/artifacts/cmh.py
+++ b/scripts/artifacts/cmh.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_cmh": {
         "name": "cmh",
         "description": "Parses the Samsung CMH media store (image dates, title, bucket, latitude, longitude, address and path) from cmh.db.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-05",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/discordChats.py
+++ b/scripts/artifacts/discordChats.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_discordChats": {
         "name": "discordChats",
         "description": "Parses Discord chat messages from the kv-storage key-value store",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2023-09-18",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/discreteNative.py
+++ b/scripts/artifacts/discreteNative.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_discreteNative": {
         "name": "DiscreteNative",
         "description": "Parses discrete app-ops permission usage (timestamp, package, permission module and operation, and usage duration) from the system appops discrete records.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2022-01-19",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/errp.py
+++ b/scripts/artifacts/errp.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_errp": {
         "name": "Errp",
         "description": "Parses provisioning and error events (timestamp, event, code and details) from the system users eRR.p file.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-08-15",
         "last_update_date": "2021-08-15",
         "requirements": "none",

--- a/scripts/artifacts/etc_hosts.py
+++ b/scripts/artifacts/etc_hosts.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_etc_hosts": {
         "name": "Etc_hosts",
         "description": "Parses host-to-IP mappings (IP address and hostname) from the system etc/hosts file.",
-        "author": "",
+        "author": "@ydkhatri",
         "creation_date": "2020-10-09",
         "last_update_date": "2020-10-09",
         "requirements": "none",

--- a/scripts/artifacts/firefox.py
+++ b/scripts/artifacts/firefox.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_firefox_history": {
         "name": "Firefox - Web History",
         "description": "Firefox places.sqlite web history",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2022-01-12",
         "last_update_date": "2026-08-01",
         "requirements": "none",
@@ -18,7 +18,7 @@ __artifacts_v2__ = {
     "get_firefox_visits": {
         "name": "Firefox - Web Visits",
         "description": "Firefox places.sqlite individual page visits",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2022-01-12",
         "last_update_date": "2026-08-01",
         "requirements": "none",
@@ -34,7 +34,7 @@ __artifacts_v2__ = {
     "get_firefox_bookmarks": {
         "name": "Firefox - Bookmarks",
         "description": "Firefox places.sqlite bookmarks",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2022-01-12",
         "last_update_date": "2026-08-01",
         "requirements": "none",
@@ -50,7 +50,7 @@ __artifacts_v2__ = {
     "get_firefox_searches": {
         "name": "Firefox - Search Terms",
         "description": "Firefox places.sqlite search queries",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2022-01-12",
         "last_update_date": "2022-01-12",
         "requirements": "none",

--- a/scripts/artifacts/firefoxCookies.py
+++ b/scripts/artifacts/firefoxCookies.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_firefoxCookies": {
         "name": "Firefox - Cookies",
         "description": "Parses Firefox cookies (host, name, value, path, created, last accessed and expiration timestamps) from cookies.sqlite.",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2022-01-12",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/firefoxDownloads.py
+++ b/scripts/artifacts/firefoxDownloads.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_firefoxDownloads": {
         "name": "Firefox - Downloads",
         "description": "Parses Firefox downloads (created time, file name, URL, MIME type, size, status and destination) from the mozac downloads database. The Tor Browser path is also matched; in the samples examined it carried the same database.",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2022-01-12",
         "last_update_date": "2026-08-01",
         "notes": "Two schema variants are handled: destination_directory and directory_path. Reference: Mozilla android-components, 'DownloadState.Status (PAUSED=3, CANCELLED=4, FAILED=5, COMPLETED=6)', https://github.com/mozilla-firefox/firefox/blob/main/mobile/android/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/DownloadState.kt",

--- a/scripts/artifacts/firefoxFormHistory.py
+++ b/scripts/artifacts/firefoxFormHistory.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_firefoxFormHistory": {
         "name": "Firefox - Form History",
         "description": "Parses Firefox saved form entries (field name, value, times used, first and last used timestamps) from formhistory.sqlite.",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2022-01-12",
         "last_update_date": "2022-01-12",
         "requirements": "none",

--- a/scripts/artifacts/firefoxPermissions.py
+++ b/scripts/artifacts/firefoxPermissions.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_firefoxPermissions": {
         "name": "Firefox - Permissions",
         "description": "Parses Firefox site permissions (origin, permission type, status, modification and expiration timestamps) from permissions.sqlite.",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2022-01-12",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/firefoxRecentlyClosedTabs.py
+++ b/scripts/artifacts/firefoxRecentlyClosedTabs.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_firefoxRecentlyClosedTabs": {
         "name": "Firefox - Recently Closed Tabs",
         "description": "Parses Firefox recently closed tabs (timestamp, title and URL) from the recently_closed_tabs database.",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2022-01-12",
         "last_update_date": "2022-01-12",
         "requirements": "none",

--- a/scripts/artifacts/firefoxTopSites.py
+++ b/scripts/artifacts/firefoxTopSites.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_firefoxTopSites": {
         "name": "Firefox - Top Sites",
         "description": "Parses Firefox top sites (created timestamp, title, URL and default flag) from the top_sites database.",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2022-01-12",
         "last_update_date": "2022-01-12",
         "requirements": "none",

--- a/scripts/artifacts/galleryTrash.py
+++ b/scripts/artifacts/galleryTrash.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_galleryTrash": {
         "name": "Gallery Trash",
         "description": "Deleted media held in the Samsung Gallery trash (local.db trash table)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2023-04-25",
         "last_update_date": "2023-04-25",
         "requirements": "none",

--- a/scripts/artifacts/gboard.py
+++ b/scripts/artifacts/gboard.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_gboardCache": {
         "name": "Gboard - Clipboard",
         "description": "Gboard keyboard clipboard entries (gboard_clipboard.db)",
-        "author": "",
+        "author": "@ydkhatri",
         "creation_date": "2021-01-09",
         "last_update_date": "2021-01-09",
         "requirements": "none",
@@ -23,7 +23,7 @@ __artifacts_v2__ = {
     "get_gboardCache_keystrokes": {
         "name": "Gboard - Keystroke Cache",
         "description": "Text entries recorded in the Gboard training cache",
-        "author": "",
+        "author": "@ydkhatri",
         "creation_date": "2021-01-09",
         "last_update_date": "2026-08-01",
         "requirements": "none",
@@ -43,7 +43,7 @@ __artifacts_v2__ = {
     "get_gboardCache_sessions": {
         "name": "Gboard - Sessions",
         "description": "Gboard keyboard input sessions (trainingcachev3.db)",
-        "author": "",
+        "author": "@ydkhatri",
         "creation_date": "2021-01-09",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/googleAccountHistory.py
+++ b/scripts/artifacts/googleAccountHistory.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "History of Google accounts on the device recorded by Google Play "
                        "services (google_account_history.db, AccountHistory table). The "
                        "change type is stored as a raw integer and is reported as-is.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",

--- a/scripts/artifacts/googleCalendar.py
+++ b/scripts/artifacts/googleCalendar.py
@@ -56,7 +56,7 @@ __artifacts_v2__ = {
                        "database: start and end, title, description, the calendar and "
                        "account they belong to and the event web link, decoded from each "
                        "event's protobuf record.",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",

--- a/scripts/artifacts/googleCallScreen.py
+++ b/scripts/artifacts/googleCallScreen.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_googleCallScreen": {
         "name": "Google Call Screen",
         "description": "Transcripts and recordings from Google Assistant's Call Screen feature",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2021-08-06",
         "last_update_date": "2021-08-06",
         "requirements": "none",

--- a/scripts/artifacts/googleConstellation.py
+++ b/scripts/artifacts/googleConstellation.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Phone numbers of SIM cards verified on the device by Google Play "
                        "services (constellation.db, sim_verifications table), with the IMSI "
                        "and verification time and method.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",

--- a/scripts/artifacts/googleDialer.py
+++ b/scripts/artifacts/googleDialer.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
         "name": "Google Dialer Annotated Call Log",
         "description": "Call log kept by the Google Phone app (annotated_call_log.db). "
                        "Call types follow the Android CallLog.Calls constants.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",
@@ -26,7 +26,7 @@ __artifacts_v2__ = {
                        "app (phone_lookup_history.db). The contact name, label and lookup "
                        "URI come from the device contacts (Cp2Info) and the CNAP name from "
                        "the carrier, per the app's phone_lookup_info protobuf.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",
@@ -47,7 +47,7 @@ __artifacts_v2__ = {
         "name": "Google Dialer Smartdial",
         "description": "Contacts indexed for smart dialing by the Google Phone app "
                        "(dialer.db, smartdial_table).",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",
@@ -67,7 +67,7 @@ __artifacts_v2__ = {
         "name": "Google Dialer Cached Number Contacts",
         "description": "Caller-id lookups cached per phone number by the Google Phone app "
                        "(dialer.db, cached_number_contacts).",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",

--- a/scripts/artifacts/googleDuo.py
+++ b/scripts/artifacts/googleDuo.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_googleDuo": {
         "name": "Google Duo - Call History",
         "description": "Google Duo / Meet call history",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2021-07-28",
         "last_update_date": "2021-07-28",
         "requirements": "none",
@@ -27,7 +27,7 @@ __artifacts_v2__ = {
     "get_googleDuo_contacts": {
         "name": "Google Duo - Contacts",
         "description": "Google Duo / Meet contacts",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2021-07-28",
         "last_update_date": "2021-07-28",
         "requirements": "none",
@@ -52,7 +52,7 @@ __artifacts_v2__ = {
     "get_googleDuo_notes": {
         "name": "Google Duo - Notes",
         "description": "Google Duo / Meet notes (media messages)",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2021-07-28",
         "last_update_date": "2021-07-28",
         "requirements": "none",

--- a/scripts/artifacts/googleIcingContacts.py
+++ b/scripts/artifacts/googleIcingContacts.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Snapshot of device contacts kept by Google Play services "
                        "(icing_contacts.db, contacts table). Kept independently "
                        "of the Contacts database, so the two may diverge.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",
@@ -32,7 +32,7 @@ __artifacts_v2__ = {
                        "from the Google Play services contacts index (icing_contacts.db, "
                        "phones/emails/postals tables). The type is stored as a raw integer "
                        "and is reported as-is.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",

--- a/scripts/artifacts/googleInitiatedNav.py
+++ b/scripts/artifacts/googleInitiatedNav.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_googleInitiatedNav": {
         "name": "Google Initiated Navigation",
         "description": "Recent navigation destinations (new_recent_history_cache_navigated.cs)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2023-10-16",
         "last_update_date": "2023-10-16",
         "requirements": "none",

--- a/scripts/artifacts/googleKeepNotes.py
+++ b/scripts/artifacts/googleKeepNotes.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_googleKeepNotes": {
         "name": "Google Keep - Notes",
         "description": "Google Keep notes",
-        "author": "",
+        "author": "@bolisettynihith",
         "creation_date": "2021-05-17",
         "last_update_date": "2021-05-17",
         "requirements": "none",
@@ -22,7 +22,7 @@ __artifacts_v2__ = {
     "get_googleKeepNotes_sharing": {
         "name": "Google Keep - Notes Sharing",
         "description": "Google Keep note sharing",
-        "author": "",
+        "author": "@bolisettynihith",
         "creation_date": "2021-05-17",
         "last_update_date": "2021-05-17",
         "requirements": "none",

--- a/scripts/artifacts/googleLastTrip.py
+++ b/scripts/artifacts/googleLastTrip.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_googleLastTrip": {
         "name": "Google Maps Last Trip",
         "description": "Last saved trip start/end from Google Maps (saved_directions.data.cs)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2023-10-16",
         "last_update_date": "2023-10-16",
         "requirements": "none",

--- a/scripts/artifacts/googleMapsSearches.py
+++ b/scripts/artifacts/googleMapsSearches.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_googleMapsSearches": {
         "name": "Google Maps Searches",
         "description": "Recent Google Maps search history (new_recent_history_cache_search.cs)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2023-10-15",
         "last_update_date": "2023-10-15",
         "requirements": "none",

--- a/scripts/artifacts/googleNowPlaying.py
+++ b/scripts/artifacts/googleNowPlaying.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_googleNowPlaying": {
         "name": "GoogleNowPlaying",
         "description": "Now Playing history (songs recognised near the device)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-22",
         "last_update_date": "2020-03-22",
         "requirements": "none",

--- a/scripts/artifacts/googleOdlh.py
+++ b/scripts/artifacts/googleOdlh.py
@@ -6,7 +6,7 @@ __artifacts_v2__ = {
                        "whose semantic_segment protobuf embeds a coordinate pair the "
                        "latitude and longitude are decoded; the segment type is stored "
                        "as a raw integer and is reported as-is.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",
@@ -34,7 +34,7 @@ __artifacts_v2__ = {
         "description": "Entries in the edited_segment_table of Google's On Device Location "
                        "History (odlh-storage.db): segment time ranges with the block range "
                        "they belong to and whether the edit was uploaded.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",

--- a/scripts/artifacts/googlePhotos.py
+++ b/scripts/artifacts/googlePhotos.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_googlePhotos": {
         "name": "Google Photos - Local Media",
         "description": "Local media indexed by Google Photos (gphotos*.db local_media)",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2021-04-14",
         "last_update_date": "2026-08-01",
         "requirements": "none",
@@ -29,7 +29,7 @@ __artifacts_v2__ = {
     "get_googlePhotos_remote": {
         "name": "Google Photos - Remote Media",
         "description": "Remote (cloud) media indexed by Google Photos (gphotos*.db remote_media)",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2021-04-14",
         "last_update_date": "2026-08-01",
         "requirements": "none",
@@ -58,7 +58,7 @@ __artifacts_v2__ = {
     "get_googlePhotos_shared": {
         "name": "Google Photos - Shared Media",
         "description": "Shared media indexed by Google Photos (gphotos*.db shared_media)",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2021-04-14",
         "last_update_date": "2026-08-01",
         "requirements": "none",
@@ -87,7 +87,7 @@ __artifacts_v2__ = {
     "get_googlePhotos_folders": {
         "name": "Google Photos - Backup Folders",
         "description": "Folders listed in the backup_folders table (gphotos*.db)",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2021-04-14",
         "last_update_date": "2026-08-01",
         "requirements": "none",
@@ -113,7 +113,7 @@ __artifacts_v2__ = {
     "get_googlePhotos_cache": {
         "name": "Google Photos - Cache",
         "description": "Google Photos disk/glide cache entries with cached images",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2021-04-14",
         "last_update_date": "2021-04-14",
         "requirements": "none",
@@ -139,7 +139,7 @@ __artifacts_v2__ = {
     "get_googlePhotos_trash": {
         "name": "Google Photos - Local Trash",
         "description": "Google Photos local trash entries and the trash files still present (local_trash.db)",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2021-04-14",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/googleQuickSearchbox.py
+++ b/scripts/artifacts/googleQuickSearchbox.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_quicksearch": {
         "name": "Google Quick Search Queries",
         "description": "Search query sessions from the Google Search widget / Assistant (Google Now)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-22",
         "last_update_date": "2020-03-22",
         "requirements": "none",

--- a/scripts/artifacts/googleQuickSearchboxRecent.py
+++ b/scripts/artifacts/googleQuickSearchboxRecent.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_quicksearch_recent": {
         "name": "Google Quick Search Recent",
         "description": "Recent search terms and page entries recorded by the Google app (Google Now)",
-        "author": "",
+        "author": "@ydkhatri",
         "creation_date": "2020-03-22",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/googleTasks.py
+++ b/scripts/artifacts/googleTasks.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_googleTasks": {
         "name": "GoogleTasks",
         "description": "Parses Google Tasks (created, modified, completed and due times, task name, details and status) from the Google Tasks data.db.",
-        "author": "",
+        "author": "@bolisettynihith",
         "creation_date": "2021-08-21",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/googlemapaudio.py
+++ b/scripts/artifacts/googlemapaudio.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_googlemapaudio": {
         "name": "Google Maps Voice Guidance",
         "description": "Google Maps text-to-speech voice guidance audio (app_tts-cache)",
-        "author": "",
+        "author": "@kibaffo33",
         "creation_date": "2021-12-27",
         "last_update_date": "2021-12-27",
         "requirements": "none",

--- a/scripts/artifacts/googlemapaudioTemp.py
+++ b/scripts/artifacts/googlemapaudioTemp.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_googlemapaudioTemp": {
         "name": "Google Maps Voice Guidance (Temp)",
         "description": "Google Maps text-to-speech voice guidance audio (app_tts-temp)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2023-04-27",
         "last_update_date": "2026-07-12",
         "requirements": "none",

--- a/scripts/artifacts/googlemaplocation.py
+++ b/scripts/artifacts/googlemaplocation.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_googlemaplocation": {
         "name": "Googlemaplocation",
         "description": "Parses Google Maps navigation destinations (timestamp, destination and source coordinates, title and address) from the da_destination_history database.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2021-03-17",
         "last_update_date": "2021-03-17",
         "requirements": "none",

--- a/scripts/artifacts/imagemngCache.py
+++ b/scripts/artifacts/imagemngCache.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_imagemngCache": {
         "name": "Image Manager Cache",
         "description": "Cached images from app image_manager_disk_cache (Glide) directories, plus files with a .cnt extension observed holding cached image data in the samples examined",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2022-03-05",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/imo.py
+++ b/scripts/artifacts/imo.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_imo_account": {
         "name": "IMO - Account ID",
         "description": "Parses the local IMO account (account ID and name) from the IMO accountdb.db.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2021-03-11",
         "last_update_date": "2021-03-11",
         "requirements": "none",
@@ -19,7 +19,7 @@ __artifacts_v2__ = {
     "get_imo_messages": {
         "name": "IMO - Messages",
         "description": "Parses IMO messages (timestamp, sender and recipient IDs, message, direction, read status and attachments) from the IMO imofriends.db.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2021-03-11",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/installedappsGass.py
+++ b/scripts/artifacts/installedappsGass.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_installedappsGass": {
         "name": "installedappsGass",
         "description": "Parses application records (bundle ID, version code and SHA-256 hash) from the app_info table of the Google Play services gass.db.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-01",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/installedappsLibrary.py
+++ b/scripts/artifacts/installedappsLibrary.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_installedappsLibrary": {
         "name": "InstalledappsLibrary",
         "description": "Parses app purchase and ownership records (purchase time, account and doc ID) from the Play Store library.db.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-01",
         "last_update_date": "2020-03-01",
         "requirements": "none",

--- a/scripts/artifacts/installedappsVending.py
+++ b/scripts/artifacts/installedappsVending.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_installedappsVending": {
         "name": "InstalledappsVending",
         "description": "Parses application records (package, title, first download and last updated times, install reason and account) from the appstate table of the Play Store localappstate.db.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-01",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/lgRCS.py
+++ b/scripts/artifacts/lgRCS.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_lgRCS": {
         "name": "LG RCS Chats",
         "description": "RCS chat messages from LG phones (mmssms.db)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-01-06",
         "last_update_date": "2021-01-06",
         "requirements": "none",

--- a/scripts/artifacts/libretorrent.py
+++ b/scripts/artifacts/libretorrent.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_libretorrent": {
         "name": "Libretorrent",
         "description": "Parses torrents added in LibreTorrent/BitLord (timestamp, name, download path, magnet, paused state and visibility) from libretorrent.db.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2023-09-12",
         "last_update_date": "2023-09-12",
         "requirements": "none",

--- a/scripts/artifacts/libretorrentFR.py
+++ b/scripts/artifacts/libretorrentFR.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_libretorrentFR": {
         "name": "LibretorrentFR",
         "description": "Parses torrent fast-resume data (info hash, name, save path, total downloaded and uploaded counters) from the LibreTorrent libretorrent.db.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2023-09-15",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/likee.py
+++ b/scripts/artifacts/likee.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_likee": {
         "name": "LIKEE - User Location",
         "description": "Address/location text recovered from LIKEE *_location.kv files",
-        "author": "",
+        "author": "@falcon217836",
         "creation_date": "2024-05-20",
         "last_update_date": "2024-05-20",
         "requirements": "none",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     "get_likee_users": {
         "name": "LIKEE - Users",
         "description": "LIKEE user search history (like_pub.db)",
-        "author": "",
+        "author": "@falcon217836",
         "creation_date": "2024-05-20",
         "last_update_date": "2024-05-20",
         "requirements": "none",
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
     "get_likee_messages": {
         "name": "LIKEE - Messages",
         "description": "LIKEE messages (message_u*.db)",
-        "author": "",
+        "author": "@falcon217836",
         "creation_date": "2024-05-20",
         "last_update_date": "2024-05-20",
         "requirements": "none",

--- a/scripts/artifacts/line.py
+++ b/scripts/artifacts/line.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_line": {
         "name": "Line - Contacts",
         "description": "Parses LINE contacts (user ID and name) from the LINE databases.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2021-03-15",
         "last_update_date": "2021-03-15",
         "requirements": "none",
@@ -19,7 +19,7 @@ __artifacts_v2__ = {
     "get_line_messages": {
         "name": "Line - Messages",
         "description": "Parses LINE messages (time, sender and recipient IDs, direction, thread, message and attachments) from the LINE databases.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2021-03-15",
         "last_update_date": "2026-08-01",
         "requirements": "none",
@@ -51,7 +51,7 @@ __artifacts_v2__ = {
     "get_line_calls": {
         "name": "Line - Call Logs",
         "description": "Parses LINE call logs (start and end time, participant IDs, direction and call type) from the LINE databases.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2021-03-15",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/mega_transfers.py
+++ b/scripts/artifacts/mega_transfers.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_mega_transfers": {
         "name": "mega_transfers",
         "description": "Parses MEGA transfer records (timestamp, folder, filename, size, direction and state) from the completedtransfers table of the MEGA megapreferences database.",
-        "author": "",
+        "author": "@kibaffo33",
         "creation_date": "2022-06-04",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/mewe.py
+++ b/scripts/artifacts/mewe.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_mewe_chat": {
         "name": "MeWe - Chat",
         "description": "Parses MeWe chat messages (timestamp, thread, user, message text, direction, type and attachments) from the MeWe chat database (app_database on older builds, app_v3.db on newer ones).",
-        "author": "",
+        "author": "@A-725-K",
         "creation_date": "2021-11-10",
         "last_update_date": "2026-08-01",
         "requirements": "none",
@@ -239,7 +239,7 @@ __artifacts_v2__ = {
     "get_mewe_session": {
         "name": "MeWe - SGSession",
         "description": "Parses MeWe session preferences (key and value) from the SGSession.xml file.",
-        "author": "",
+        "author": "@A-725-K",
         "creation_date": "2021-11-10",
         "last_update_date": "2021-11-10",
         "requirements": "none",

--- a/scripts/artifacts/offlinePages.py
+++ b/scripts/artifacts/offlinePages.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_offlinePages": {
         "name": "Offline Pages (MHTML)",
         "description": "Saved offline web pages (MHTML/MHT archives) with source URL, subject and capture time",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2023-01-25",
         "last_update_date": "2023-01-25",
         "requirements": "none",

--- a/scripts/artifacts/oldpowerOffReset.py
+++ b/scripts/artifacts/oldpowerOffReset.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_oldpowerOffReset": {
         "name": "oldpowerOffReset",
         "description": "Parses power-off and reset reasons (timestamp and reason) from the power_off_reset_reason log files.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2023-03-14",
         "last_update_date": "2023-03-14",
         "requirements": "none",

--- a/scripts/artifacts/pSettings.py
+++ b/scripts/artifacts/pSettings.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_pSettings": {
         "name": "pSettings",
         "description": "Parses Google partner settings (name and value) from the Google services framework googlesettings.db.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-21",
         "last_update_date": "2020-03-21",
         "requirements": "none",

--- a/scripts/artifacts/packageGplinks.py
+++ b/scripts/artifacts/packageGplinks.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_packageGplinks": {
         "name": "packageGplinks",
         "description": "Parses installed package names and their possible Google Play Store links from the system packages.list.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-03-18",
         "last_update_date": "2021-03-18",
         "requirements": "none",

--- a/scripts/artifacts/packageInfo.py
+++ b/scripts/artifacts/packageInfo.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_package_info": {
         "name": "package_info",
         "description": "Represents an app",
-        "author": "",
+        "author": "@ydkhatri",
         "creation_date": "2020-11-03",
         "last_update_date": "2026-07-10",
         "requirements": "none",

--- a/scripts/artifacts/permissions.py
+++ b/scripts/artifacts/permissions.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_permissions_trees": {
         "name": "Permission Trees",
         "description": "Parses declared permission trees (name and package) from the system packages.xml.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-01-28",
         "last_update_date": "2021-01-28",
         "requirements": "none",
@@ -27,7 +27,7 @@ __artifacts_v2__ = {
     "get_permissions_list": {
         "name": "Permissions",
         "description": "Parses declared permissions (name, package and protection level) from the system packages.xml.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-01-28",
         "last_update_date": "2021-01-28",
         "requirements": "none",
@@ -52,7 +52,7 @@ __artifacts_v2__ = {
     "get_permissions_packages": {
         "name": "Package and Shared User",
         "description": "Parses packages and their shared user IDs with granted permissions from the system packages.xml.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-01-28",
         "last_update_date": "2021-01-28",
         "requirements": "none",

--- a/scripts/artifacts/persistentProp.py
+++ b/scripts/artifacts/persistentProp.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_persistentProp": {
         "name": "persistentProp",
         "description": "Parses persistent system properties and their set times (timestamp and event) from the persistent_properties file.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-08-18",
         "last_update_date": "2021-08-18",
         "requirements": "none",

--- a/scripts/artifacts/pikpakCloudlist.py
+++ b/scripts/artifacts/pikpakCloudlist.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_pikpakCloudlist": {
         "name": "PikPak Cloud List",
         "description": "Parses PikPak cloud-stored files (create, modify, delete and update times, user, name, kind, URL and thumbnail) from the PikPak files database.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2023-03-24",
         "last_update_date": "2023-03-24",
         "requirements": "none",

--- a/scripts/artifacts/pikpakDownloads.py
+++ b/scripts/artifacts/pikpakDownloads.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_pikpakDownloads": {
         "name": "PikPak Downloads",
         "description": "Parses PikPak downloads (create and modify times, title, local storage path and URL) from the PikPak downloads database.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2023-03-24",
         "last_update_date": "2023-03-24",
         "requirements": "none",

--- a/scripts/artifacts/pikpakPlay.py
+++ b/scripts/artifacts/pikpakPlay.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_pikpakPlay": {
         "name": "PikPak Play",
         "description": "Parses PikPak video playback history (last play timestamp, duration, played time and name) from the PikPak greendao.db.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2023-03-24",
         "last_update_date": "2023-03-24",
         "requirements": "none",

--- a/scripts/artifacts/playgroundVault.py
+++ b/scripts/artifacts/playgroundVault.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_playgroundVault": {
         "name": "Playground Vault",
         "description": "Decrypts media hidden by the Playground AppLocker vault (AES-GCM)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2022-01-16",
         "last_update_date": "2022-01-16",
         "requirements": "none",

--- a/scripts/artifacts/protonVPN.py
+++ b/scripts/artifacts/protonVPN.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_protonvpn_device_info": {
         "name": "ProtonVPN - Device Info",
         "description": "Parses ProtonVPN device and server-list-updater information (key and value) from the ServerListUpdater.xml preferences.",
-        "author": "",
+        "author": "@nxb1t",
         "creation_date": "2022-09-04",
         "last_update_date": "2022-09-04",
         "requirements": "none",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     "get_protonvpn_connection_history": {
         "name": "ProtonVPN - Connection History",
         "description": "Parses ProtonVPN connection history (server address and timestamp) from the ProtonVPN Data.log.",
-        "author": "",
+        "author": "@nxb1t",
         "creation_date": "2022-09-04",
         "last_update_date": "2026-07-31",
         "requirements": "none",
@@ -31,7 +31,7 @@ __artifacts_v2__ = {
     "get_protonvpn_user_info": {
         "name": "ProtonVPN - User Info",
         "description": "Parses the ProtonVPN user account (email, name, username, display name and account state) from the ProtonVPN database.",
-        "author": "",
+        "author": "@nxb1t",
         "creation_date": "2022-09-04",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/protonmail.py
+++ b/scripts/artifacts/protonmail.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_protonmail_messages": {
         "name": "ProtonMail - Messages",
         "description": "Parses ProtonMail messages (timestamp, subject, sender, direction, status, size, folder, attachments and recipient lists) from the ProtonMail messages database.",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2023-04-26",
         "last_update_date": "2023-04-26",
         "requirements": "none",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     "get_protonmail_contacts": {
         "name": "ProtonMail - Contacts",
         "description": "Parses ProtonMail contacts (creation and modified timestamps, name and email) from the ProtonMail contacts database.",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2023-04-26",
         "last_update_date": "2023-04-26",
         "requirements": "none",

--- a/scripts/artifacts/rarlabPreferences.py
+++ b/scripts/artifacts/rarlabPreferences.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_rarlabPreferences": {
         "name": "rarlabPreferences",
         "description": "Parses RAR (RARLAB) application preferences (key, text and value) from the com.rarlab.rar preferences XML.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2023-03-29",
         "last_update_date": "2023-03-29",
         "requirements": "none",

--- a/scripts/artifacts/roles.py
+++ b/scripts/artifacts/roles.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_roles": {
         "name": "roles",
         "description": "Parses assigned system role holders (source path variant, user, role and holder package) from the roles.xml file.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-01-25",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/runtimePerms.py
+++ b/scripts/artifacts/runtimePerms.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_runtimePerms": {
         "name": "runtimePerms",
         "description": "Parses granted runtime permissions (user, type, name, permission, granted state and flags) from the runtime-permissions.xml file.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-01-25",
         "last_update_date": "2021-01-25",
         "requirements": "none",

--- a/scripts/artifacts/sRecoveryhist.py
+++ b/scripts/artifacts/sRecoveryhist.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_sRecoveryhist": {
         "name": "sRecoveryhist",
         "description": "Parses Samsung recovery history (timestamp, wipe events, reason, reboot reason and locale) from the efs recovery history file.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-08-15",
         "last_update_date": "2021-08-15",
         "requirements": "none",

--- a/scripts/artifacts/sWipehist.py
+++ b/scripts/artifacts/sWipehist.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_sWipehist": {
         "name": "sWipehist",
         "description": "Parses Samsung wipe and recovery events (timestamp, wipe events, reason, provider and reboot reason) from the recovery history files.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-08-15",
         "last_update_date": "2021-08-15",
         "requirements": "none",

--- a/scripts/artifacts/samsungBadgeProvider.py
+++ b/scripts/artifacts/samsungBadgeProvider.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "App icon badge counts recorded by the Samsung badge provider "
                        "(badge.db, apps table): the package and activity each badge belongs "
                        "to, its count and whether it is hidden.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",

--- a/scripts/artifacts/samsungBatteryStats.py
+++ b/scripts/artifacts/samsungBatteryStats.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
                        "Manager Service (sec_batterystats_history, APP_HISTORY table): power "
                        "drain, foreground/background time, CPU, wakelocks, network packets, "
                        "GPS and audio use per uid.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
         "description": "Device-wide screen and discharge figures recorded in time windows by "
                        "the Samsung Device Health Manager Service (sec_batterystats_history, "
                        "DEVICE_HISTORY table).",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",
@@ -53,7 +53,7 @@ __artifacts_v2__ = {
                        "(sec_batterystats_history, BATTERY_EVENT_HISTORY table). Event type "
                        "and value are stored as raw integers and their encoding differs "
                        "between One UI versions, so they are reported as-is.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",
@@ -77,7 +77,7 @@ __artifacts_v2__ = {
                        "Health Manager Service (sec_batterystats_history, SYSTEM_HISTORY "
                        "table). The drain type is stored as a raw integer and is reported "
                        "as-is.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",

--- a/scripts/artifacts/samsungLauncher.py
+++ b/scripts/artifacts/samsungLauncher.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
                        "(OneUI.db, item table): each item's title, component, position, "
                        "container and hidden flag. Type and container codes are stored as "
                        "raw values and are reported as-is.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",
@@ -25,7 +25,7 @@ __artifacts_v2__ = {
         "description": "App icon cache of the Samsung One UI launcher (Icon.db, icon "
                        "table): the component name, displayed label, Android user profile "
                        "and when the entry was last updated.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",

--- a/scripts/artifacts/samsungMediaProvider.py
+++ b/scripts/artifacts/samsungMediaProvider.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
                        "table): file path and name, taken/added/modified times, "
                        "coordinates and packed address, the URL and app a captured file "
                        "came from, and the favorite/hidden/trashed/deleted flags.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
         "description": "Reverse-geocoded places recorded by the Samsung media provider "
                        "(media.db, location table): coordinates with the resolved country, "
                        "locality, street and full address text.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",

--- a/scripts/artifacts/samsungPrivacyDashboard.py
+++ b/scripts/artifacts/samsungPrivacyDashboard.py
@@ -6,7 +6,7 @@ __artifacts_v2__ = {
                        "package, permission group, access time and whether the access "
                        "happened in the background. The operation code is stored as a raw "
                        "integer and is reported as-is.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",

--- a/scripts/artifacts/samsungScpm.py
+++ b/scripts/artifacts/samsungScpm.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Devices recorded by the Samsung Cloud Platform Manager (scpmv2.db, "
                        "devices table): device alias, model, OS version, country and SIM "
                        "codes, with the registration and last access times.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",

--- a/scripts/artifacts/samsungSleepDetection.py
+++ b/scripts/artifacts/samsungSleepDetection.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
                        "detection (SleepDetection.db, screen_data table), with the user "
                        "present and keyguard flags. State values are stored as raw integers "
                        "and are reported as-is.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",
@@ -23,7 +23,7 @@ __artifacts_v2__ = {
         "description": "Sleep windows computed by the Samsung Continuity Service sleep "
                        "detection (SleepDetection.db, sleep_time table): the recorded start "
                        "and end of each window and when the record was written.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",

--- a/scripts/artifacts/samsungStoryService.py
+++ b/scripts/artifacts/samsungStoryService.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
                        "table): taken/added times, file path, coordinates with the "
                        "resolved place names, detected scene names, face count and the "
                        "moment each entry belongs to.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",
@@ -27,7 +27,7 @@ __artifacts_v2__ = {
         "description": "Moments grouped by the Samsung story service (dme.db, moment "
                        "table): the time range each moment covers, its creation time, "
                        "title, media count and recorded place information.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",

--- a/scripts/artifacts/samsungWeatherClock.py
+++ b/scripts/artifacts/samsungWeatherClock.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_samsungWeatherClockInfo": {
         "name": "Samsung Weather Clock - Info",
         "description": "Parses current conditions from the Samsung Weather Clock (timestamp, timezone, location, temperature, conditions, sunrise and sunset) from the WeatherClock database.",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2021-10-13",
         "last_update_date": "2021-10-13",
         "requirements": "none",
@@ -22,7 +22,7 @@ __artifacts_v2__ = {
     "get_samsungWeatherClockDaily": {
         "name": "Samsung Weather Clock - Daily",
         "description": "Parses the Samsung Weather Clock daily forecast (timestamp, location, temperature, conditions and daily high and low) from the WeatherClock database.",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2021-10-13",
         "last_update_date": "2021-10-13",
         "requirements": "none",
@@ -42,7 +42,7 @@ __artifacts_v2__ = {
     "get_samsungWeatherClockHourly": {
         "name": "Samsung Weather Clock - Hourly",
         "description": "Parses the Samsung Weather Clock hourly forecast (timestamp, location, temperature, conditions, rain probability and wind) from the WeatherClock database.",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2021-10-13",
         "last_update_date": "2021-10-13",
         "requirements": "none",

--- a/scripts/artifacts/samsungWifiDatabases.py
+++ b/scripts/artifacts/samsungWifiDatabases.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Saved Wi-Fi networks recorded in the Samsung WifiConfigStore.db "
                        "(configs table): SSID with security type and, where present, the "
                        "creation time.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",
@@ -29,7 +29,7 @@ __artifacts_v2__ = {
                        "longitude come from the base columns when set and from the "
                        "*_major columns otherwise; the Coordinate Source column names which "
                        "pair supplied them.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",

--- a/scripts/artifacts/scontextLog.py
+++ b/scripts/artifacts/scontextLog.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_scontextLog": {
         "name": "scontextLog",
         "description": "Parses app foreground usage sessions (start and stop time, timezone, app ID and duration) from the Samsung ContextLog.db.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-04-18",
         "last_update_date": "2020-04-18",
         "requirements": "none",

--- a/scripts/artifacts/settingsGlobalSystem.py
+++ b/scripts/artifacts/settingsGlobalSystem.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
         "name": "Settings Global",
         "description": "Device-wide settings (name, value and owning package) parsed "
                        "from the settings_global.xml file of each Android user.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",
@@ -29,7 +29,7 @@ __artifacts_v2__ = {
         "name": "Settings System",
         "description": "Per-user settings (name, value and owning package) parsed "
                        "from the settings_system.xml file of each Android user.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",

--- a/scripts/artifacts/settingsSecure.py
+++ b/scripts/artifacts/settingsSecure.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
         "name": "settingsSecure",
         "description": "Selected values (android_id, bluetooth name and address, "
                        "mock_location) from settings_secure.xml of each Android user",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-04-02",
         "last_update_date": "2026-07-30",
         "requirements": "none",

--- a/scripts/artifacts/setupWizardinfo.py
+++ b/scripts/artifacts/setupWizardinfo.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_setupWizardinfo": {
         "name": "setupWizardinfo",
         "description": "Parses device setup wizard events (timestamp and name) from the setup_wizard_info.xml preferences.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-08-15",
         "last_update_date": "2021-08-15",
         "requirements": "none",

--- a/scripts/artifacts/shareit.py
+++ b/scripts/artifacts/shareit.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_shareit": {
         "name": "shareit",
         "description": "Parses SHAREit file transfer history (direction, sender and recipient IDs, device name, description, timestamp and file path) from the SHAREit history.db.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2021-03-11",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/siminfo.py
+++ b/scripts/artifacts/siminfo.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_siminfo": {
         "name": "siminfo",
         "description": "SIM card details (number, IMSI, ICCID, carrier) from the telephony provider database",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-02",
         "last_update_date": "2020-03-02",
         "requirements": "none",

--- a/scripts/artifacts/skout.py
+++ b/scripts/artifacts/skout.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_skout_messages": {
         "name": "Skout Messages",
         "description": "Parses Skout messages (timestamp, user, message, type, picture and gift URLs and thread) from the Skout database.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-05-10",
         "last_update_date": "2021-05-10",
         "requirements": "none",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     "get_skout_users": {
         "name": "Skout Users",
         "description": "Parses Skout users (last message timestamp, user name, picture URL and user ID) from the Skout database.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-05-10",
         "last_update_date": "2021-05-10",
         "requirements": "none",

--- a/scripts/artifacts/skype.py
+++ b/scripts/artifacts/skype.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_skype_call_logs": {
         "name": "Skype - Call Logs",
         "description": "Parses Skype call logs (start and end time, participant IDs and direction) from the Skype live database.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2021-03-15",
         "last_update_date": "2026-08-01",
         "requirements": "none",
@@ -22,7 +22,7 @@ __artifacts_v2__ = {
     "get_skype_messages": {
         "name": "Skype - Messages",
         "description": "Parses Skype messages (send time, thread, content, direction, sender and recipient IDs and attachments) from the Skype live database.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2021-03-15",
         "last_update_date": "2026-08-01",
         "requirements": "none",
@@ -50,7 +50,7 @@ __artifacts_v2__ = {
     "get_skype_contacts": {
         "name": "Skype - Contacts",
         "description": "Parses Skype contacts (entry ID and name) from the Skype live database.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2021-03-15",
         "last_update_date": "2021-03-15",
         "requirements": "none",

--- a/scripts/artifacts/slopes.py
+++ b/scripts/artifacts/slopes.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_slopes": {
         "name": "Slopes - Resort Details",
         "description": "Parses ski resort details (name, location, coordinates, contact numbers, altitudes and run counts) recorded by the Slopes app from slopes.db.",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2022-04-27",
         "last_update_date": "2022-04-27",
         "requirements": "none",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     "get_slopes_actions": {
         "name": "Slopes - Actions",
         "description": "Parses recorded ski and snowboard actions (start and end time, duration, type, distance, coordinates, speed and altitude) from the Slopes slopes.db.",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2022-04-27",
         "last_update_date": "2022-04-27",
         "requirements": "none",
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
     "get_slopes_lift": {
         "name": "Slopes - Lift Details",
         "description": "Parses ski lift details (name, type, capacity, start and end coordinates and resort) from the Slopes slopes.db.",
-        "author": "",
+        "author": "@stark4n6",
         "creation_date": "2022-04-27",
         "last_update_date": "2022-04-27",
         "requirements": "none",

--- a/scripts/artifacts/smanagerCrash.py
+++ b/scripts/artifacts/smanagerCrash.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_smanagerCrash": {
         "name": "smanagerCrash",
         "description": "Parses application crash records (timestamp and package name) from the Samsung device manager sm.db.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-21",
         "last_update_date": "2020-03-21",
         "requirements": "none",

--- a/scripts/artifacts/smanagerLow.py
+++ b/scripts/artifacts/smanagerLow.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_smanagerLow": {
         "name": "smanagerLow",
         "description": "Parses app usage sessions logged by the Samsung low-power context service (start and end time, package and timestamps) from the lowpowercontext-system database.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-21",
         "last_update_date": "2020-03-21",
         "requirements": "none",

--- a/scripts/artifacts/smembersAppInv.py
+++ b/scripts/artifacts/smembersAppInv.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_smembersAppInv": {
         "name": "smembersAppInv",
         "description": "Parses the Samsung Members app inventory (last used, display and package name, system-app flag, hashes and classification) from the com_pocketgeek_sdk_app_inventory database.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-21",
         "last_update_date": "2020-03-21",
         "requirements": "none",

--- a/scripts/artifacts/smembersEvents.py
+++ b/scripts/artifacts/smembersEvents.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_smembersEvents": {
         "name": "smembersEvents",
         "description": "Parses Samsung Members device events (created time, type, value and snapshot flag) from the com_pocketgeek_sdk database.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-21",
         "last_update_date": "2020-03-21",
         "requirements": "none",

--- a/scripts/artifacts/smsmms.py
+++ b/scripts/artifacts/smsmms.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_sms_mms": {
         "name": "SMS Messages",
         "description": "SMS messages from mmssms.db (incl. LG extended types and Samsung spam_sms)",
-        "author": "",
+        "author": "@ydkhatri",
         "creation_date": "2020-03-10",
         "last_update_date": "2026-08-01",
         "requirements": "none",
@@ -38,7 +38,7 @@ __artifacts_v2__ = {
     "get_sms_mms_mms": {
         "name": "MMS Messages",
         "description": "MMS messages and attachments from mmssms.db",
-        "author": "",
+        "author": "@ydkhatri",
         "creation_date": "2020-03-10",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/smsmmsBackup.py
+++ b/scripts/artifacts/smsmmsBackup.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_mms_from_backup": {
         "name": "SMS and MMS Backup - MMS",
         "description": "MMS messages recovered from backup.ab telephony backup files",
-        "author": "",
+        "author": "@ydkhatri",
         "creation_date": "2024-08-15",
         "last_update_date": "2026-07-03",
         "requirements": "none",
@@ -26,7 +26,7 @@ __artifacts_v2__ = {
     "get_sms_from_backup": {
         "name": "SMS and MMS Backup - SMS",
         "description": "SMS messages recovered from backup.ab telephony backup files",
-        "author": "",
+        "author": "@ydkhatri",
         "creation_date": "2024-08-15",
         "last_update_date": "2026-07-03",
         "requirements": "none",

--- a/scripts/artifacts/smyFiles.py
+++ b/scripts/artifacts/smyFiles.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_smyFiles": {
         "name": "My Files - Download History",
         "description": "Parses Samsung My Files download history (timestamp, name, full path, hidden and trashed flags and source) from the My Files database.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-12-17",
         "last_update_date": "2020-12-17",
         "requirements": "none",
@@ -16,7 +16,7 @@ __artifacts_v2__ = {
     "get_smyFiles_legacy": {
         "name": "My Files - Download History (Legacy)",
         "description": "Pre-Android 12 download_history schema",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-12-17",
         "last_update_date": "2020-12-17",
         "requirements": "none",
@@ -29,7 +29,7 @@ __artifacts_v2__ = {
     "get_smyFiles_recent": {
         "name": "My Files - Recent Files (MyFiles DB)",
         "description": "Parses Samsung My Files recent files (timestamp, name, full path, hidden and trashed flags and source) from the My Files database.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-12-17",
         "last_update_date": "2020-12-17",
         "requirements": "none",

--- a/scripts/artifacts/smyFiles2.py
+++ b/scripts/artifacts/smyFiles2.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_smyFiles2": {
         "name": "My Files - Download History (FileInfo)",
         "description": "Download history recorded by Samsung My Files (FileInfo.db)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-12-17",
         "last_update_date": "2020-12-17",
         "requirements": "none",
@@ -22,7 +22,7 @@ __artifacts_v2__ = {
     "get_smyFiles2_gdrive": {
         "name": "My Files - Google Drive",
         "description": "Google Drive entries cached by Samsung My Files (FileInfo.db) with thumbnails",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-12-17",
         "last_update_date": "2020-12-17",
         "requirements": "none",

--- a/scripts/artifacts/smyfilesRecents.py
+++ b/scripts/artifacts/smyfilesRecents.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_smyfilesRecents": {
         "name": "My Files - Recent Files",
         "description": "Parses Samsung My Files recent files (modified timestamp, name, size, path, extension and source) from the My Files database.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-21",
         "last_update_date": "2020-03-21",
         "requirements": "none",
@@ -23,7 +23,7 @@ __artifacts_v2__ = {
     "get_smyfilesRecents_fileinfo": {
         "name": "My Files - Recent Files (FileInfo)",
         "description": "Parses Samsung My Files recent files (recent and modified timestamps, file ID, package, path, size and download, hidden and trashed flags) from the My Files FileInfo database.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-21",
         "last_update_date": "2020-03-21",
         "requirements": "none",

--- a/scripts/artifacts/smyfilesStored.py
+++ b/scripts/artifacts/smyfilesStored.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_smyfilesStored": {
         "name": "smyfilesStored",
         "description": "Parses cached file records (timestamp, storage, path, size and latest access) from the Samsung My Files FileCache.db.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-19",
         "last_update_date": "2020-03-19",
         "requirements": "none",

--- a/scripts/artifacts/smyfilescache.py
+++ b/scripts/artifacts/smyfilescache.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_smyfilescache": {
         "name": "My Files Cache",
         "description": "Media cached by Samsung My Files (FileCache.db) with the cached thumbnails",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2022-06-23",
         "last_update_date": "2022-06-23",
         "requirements": "none",

--- a/scripts/artifacts/snapchat.py
+++ b/scripts/artifacts/snapchat.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_snapchat_feeds": {
         "name": "Snapchat - Feeds",
         "description": "Snapchat feed (last interaction per conversation)",
-        "author": "", "creation_date": "2021-11-10", "last_update_date": "2021-11-10",
+        "author": "@A-725-K", "creation_date": "2021-11-10", "last_update_date": "2021-11-10",
         "requirements": "none", "category": "Snapchat", "notes": "",
         "paths": ('*/com.snapchat.android/databases/main.db*', '*/com.snapchat.android/databases/tcspahn.db*'),
         "output_types": "standard", "artifact_icon": "rss",
@@ -19,7 +19,7 @@ __artifacts_v2__ = {
     "get_snapchat_friends": {
         "name": "Snapchat - Friends",
         "description": "Snapchat friends / contacts",
-        "author": "", "creation_date": "2021-11-10", "last_update_date": "2021-11-10",
+        "author": "@A-725-K", "creation_date": "2021-11-10", "last_update_date": "2021-11-10",
         "requirements": "none", "category": "Snapchat", "notes": "",
         "paths": ('*/com.snapchat.android/databases/main.db*', '*/com.snapchat.android/databases/tcspahn.db*'),
         "output_types": "standard", "artifact_icon": "users",
@@ -35,7 +35,7 @@ __artifacts_v2__ = {
     "get_snapchat_messages": {
         "name": "Snapchat - Messages",
         "description": "Snapchat chat messages",
-        "author": "", "creation_date": "2021-11-10", "last_update_date": "2021-11-10",
+        "author": "@A-725-K", "creation_date": "2021-11-10", "last_update_date": "2021-11-10",
         "requirements": "none", "category": "Snapchat", "notes": "",
         "paths": ('*/com.snapchat.android/databases/main.db*', '*/com.snapchat.android/databases/tcspahn.db*'),
         "output_types": "standard", "artifact_icon": "message",
@@ -134,7 +134,7 @@ __artifacts_v2__ = {
     "get_snapchat_memories": {
         "name": "Snapchat - Memories",
         "description": "Snapchat memories entries",
-        "author": "", "creation_date": "2021-11-10", "last_update_date": "2021-11-10",
+        "author": "@A-725-K", "creation_date": "2021-11-10", "last_update_date": "2021-11-10",
         "requirements": "none", "category": "Snapchat", "notes": "",
         "paths": ('*/com.snapchat.android/databases/memories.db*',),
         "output_types": "standard", "artifact_icon": "photo",
@@ -148,7 +148,7 @@ __artifacts_v2__ = {
     "get_snapchat_meo": {
         "name": "Snapchat - MEO My Eyes Only",
         "description": "Snapchat My Eyes Only confidential data; recovers the 4-digit passcode via bcrypt",
-        "author": "", "creation_date": "2021-11-10", "last_update_date": "2021-11-10",
+        "author": "@A-725-K", "creation_date": "2021-11-10", "last_update_date": "2021-11-10",
         "requirements": "none", "category": "Snapchat",
         "notes": "Passcode recovery brute-forces the 4-digit MEO code (bcrypt); can be slow.",
         "paths": ('*/com.snapchat.android/databases/memories.db*',),
@@ -163,7 +163,7 @@ __artifacts_v2__ = {
     "get_snapchat_snap_media": {
         "name": "Snapchat - Snap Media",
         "description": "Snapchat memories snap media (incl. geolocation)",
-        "author": "", "creation_date": "2021-11-10", "last_update_date": "2021-11-10",
+        "author": "@A-725-K", "creation_date": "2021-11-10", "last_update_date": "2021-11-10",
         "requirements": "none", "category": "Snapchat", "notes": "",
         "paths": ('*/com.snapchat.android/databases/memories.db*',),
         "output_types": "all", "artifact_icon": "photo",
@@ -177,7 +177,7 @@ __artifacts_v2__ = {
     "get_snapchat_identity": {
         "name": "Snapchat - Identity Persistent Store",
         "description": "Snapchat identity_persistent_store.xml",
-        "author": "", "creation_date": "2021-11-10", "last_update_date": "2021-11-10",
+        "author": "@A-725-K", "creation_date": "2021-11-10", "last_update_date": "2021-11-10",
         "requirements": "none", "category": "Snapchat", "notes": "",
         "paths": ('*/com.snapchat.android/shared_prefs/identity_persistent_store.xml',),
         "output_types": "standard", "artifact_icon": "user",
@@ -193,7 +193,7 @@ __artifacts_v2__ = {
     "get_snapchat_login_signup": {
         "name": "Snapchat - Login Signup Store",
         "description": "Snapchat LoginSignupStore.xml",
-        "author": "", "creation_date": "2021-11-10", "last_update_date": "2021-11-10",
+        "author": "@A-725-K", "creation_date": "2021-11-10", "last_update_date": "2021-11-10",
         "requirements": "none", "category": "Snapchat", "notes": "",
         "paths": ('*/com.snapchat.android/shared_prefs/LoginSignupStore.xml',),
         "output_types": "standard", "artifact_icon": "login-2",

--- a/scripts/artifacts/suggestions.py
+++ b/scripts/artifacts/suggestions.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_suggestions": {
         "name": "suggestions",
         "description": "Parses settings suggestion events (timestamp and name) from the settings intelligence suggestions.xml.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-08-15",
         "last_update_date": "2021-08-15",
         "requirements": "none",

--- a/scripts/artifacts/swellbeing.py
+++ b/scripts/artifacts/swellbeing.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "samsung_wellbeing": {
         "name": "Samsung Digital Wellbeing",
         "description": "Parses Samsung Digital Wellbeing app usage events (timestamp, event ID, package and event type) from dwbCommon.db.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-05-21",
         "last_update_date": "2026-08-03",
         "requirements": "none",

--- a/scripts/artifacts/syncAccounts.py
+++ b/scripts/artifacts/syncAccounts.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Per-account sync authorities from /data/system/sync/accounts.xml: "
                        "which data types each account on the device syncs, whether syncing "
                        "is enabled and the syncable state.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2026-07-30",
         "last_update_date": "2026-07-30",
         "requirements": "none",

--- a/scripts/artifacts/tangomessage.py
+++ b/scripts/artifacts/tangomessage.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_tangomessage": {
         "name": "tangomessage",
         "description": "Parses Tango messages (create time, direction and message) from the Tango tc.db.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2021-03-11",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/teams.py
+++ b/scripts/artifacts/teams.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_teams": {
         "name": "Teams - Messages",
         "description": "Parses Microsoft Teams messages (timestamp, user, content, topic, delete time and conversation) from SkypeTeams.db.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-04-29",
         "last_update_date": "2021-04-29",
         "requirements": "none",
@@ -19,7 +19,7 @@ __artifacts_v2__ = {
     "get_teams_users": {
         "name": "Teams - Users",
         "description": "Parses Microsoft Teams users (last sync, name, email, phone numbers and account flags) from SkypeTeams.db.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-04-29",
         "last_update_date": "2021-04-29",
         "requirements": "none",
@@ -35,7 +35,7 @@ __artifacts_v2__ = {
     "get_teams_calllog": {
         "name": "Teams - Call Log",
         "description": "Parses Microsoft Teams call logs (connect and end time, state, type, originator, direction and participant) from SkypeTeams.db.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-04-29",
         "last_update_date": "2021-04-29",
         "requirements": "none",
@@ -51,7 +51,7 @@ __artifacts_v2__ = {
     "get_teams_activity": {
         "name": "Teams - Activity Feed",
         "description": "Parses the Microsoft Teams activity feed (timestamp, display name, message preview, activity type and read state) from SkypeTeams.db.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-04-29",
         "last_update_date": "2021-04-29",
         "requirements": "none",
@@ -67,7 +67,7 @@ __artifacts_v2__ = {
     "get_teams_fileinfo": {
         "name": "Teams - File Info",
         "description": "Parses Microsoft Teams file references (modified time, file name, type, object URL, folder flag and last modified by) from SkypeTeams.db.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-04-29",
         "last_update_date": "2021-04-29",
         "requirements": "none",

--- a/scripts/artifacts/teleguard.py
+++ b/scripts/artifacts/teleguard.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_teleguard": {
         "name": "Teleguard - Messages",
         "description": "Teleguard messenger messages",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2024-01-09",
         "last_update_date": "2026-07-03",
         "requirements": "none",
@@ -31,7 +31,7 @@ __artifacts_v2__ = {
     "get_teleguard_posts": {
         "name": "Teleguard - Posts",
         "description": "Teleguard channel posts",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2024-01-09",
         "last_update_date": "2024-01-09",
         "requirements": "none",
@@ -48,7 +48,7 @@ __artifacts_v2__ = {
     "get_teleguard_contacts": {
         "name": "Teleguard - Contacts",
         "description": "Teleguard contacts with avatars",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2024-01-09",
         "last_update_date": "2024-01-09",
         "requirements": "none",
@@ -65,7 +65,7 @@ __artifacts_v2__ = {
     "get_teleguard_channels": {
         "name": "Teleguard - Channels",
         "description": "Teleguard channels",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2024-01-09",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/textnow.py
+++ b/scripts/artifacts/textnow.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_textnow_call_logs": {
         "name": "Text Now - Call Logs",
         "description": "Parses TextNow call logs (start and end time, participant IDs and direction) from the TextNow textnow_data.db.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2021-03-15",
         "last_update_date": "2026-08-01",
         "requirements": "none",
@@ -23,7 +23,7 @@ __artifacts_v2__ = {
     "get_textnow_messages": {
         "name": "Text Now - Messages",
         "description": "Parses TextNow messages (timestamp, sender and recipient IDs, direction, message, read state and attachments) from the TextNow textnow_data.db.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2021-03-15",
         "last_update_date": "2026-08-01",
         "requirements": "none",
@@ -38,7 +38,7 @@ __artifacts_v2__ = {
     "get_textnow_contacts": {
         "name": "Text Now - Contacts",
         "description": "Parses TextNow contacts (number and name) from the TextNow textnow_data.db.",
-        "author": "",
+        "author": "@markmckinnon",
         "creation_date": "2021-03-15",
         "last_update_date": "2021-03-15",
         "requirements": "none",

--- a/scripts/artifacts/tikTok.py
+++ b/scripts/artifacts/tikTok.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_tikTok": {
         "name": "TikTok - Messages",
         "description": "Parses TikTok direct messages (timestamp, user, nickname, message, links, read state and conversation) from the TikTok IM databases.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-03-02",
         "last_update_date": "2026-07-03",
         "requirements": "none",
@@ -36,7 +36,7 @@ __artifacts_v2__ = {
     "get_tikTok_contacts": {
         "name": "TikTok - Contacts",
         "description": "Parses TikTok contacts (UID, nickname, unique ID, avatar and follow status) from the TikTok IM databases.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-03-02",
         "last_update_date": "2021-03-02",
         "requirements": "none",

--- a/scripts/artifacts/torThumbs.py
+++ b/scripts/artifacts/torThumbs.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_torThumbs": {
         "name": "TOR Thumbnails",
         "description": "Page thumbnails cached by the Tor Browser (mozac_browser_thumbnails)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-12-23",
         "last_update_date": "2021-12-23",
         "requirements": "none",

--- a/scripts/artifacts/torrentData.py
+++ b/scripts/artifacts/torrentData.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_TorrentData": {
         "name": "TorrentData",
         "description": "Parses torrent metadata (torrent name, info hash and file paths) from .torrent files.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2023-09-15",
         "last_update_date": "2023-09-15",
         "requirements": "none",

--- a/scripts/artifacts/torrentResumeinfo.py
+++ b/scripts/artifacts/torrentResumeinfo.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_torrentResumeinfo": {
         "name": "torrentResumeinfo",
         "description": "Parses torrent resume data (file, info hash and data) from .resume files.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2023-03-26",
         "last_update_date": "2023-03-26",
         "requirements": "none",

--- a/scripts/artifacts/torrentinfo.py
+++ b/scripts/artifacts/torrentinfo.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_torrentinfo": {
         "name": "torrentinfo",
         "description": "Parses torrent file metadata (file, info hash and data) from .torrent files.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2023-03-26",
         "last_update_date": "2023-03-26",
         "requirements": "none",

--- a/scripts/artifacts/usageHistory.py
+++ b/scripts/artifacts/usageHistory.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_usageHistory": {
         "name": "Usagehistory",
         "description": "Parses application usage history (timestamp, package and component) from the usage-history.xml file.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2022-07-06",
         "last_update_date": "2022-07-06",
         "requirements": "none",

--- a/scripts/artifacts/usageapps.py
+++ b/scripts/artifacts/usageapps.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
         "name": "usageapps",
         "description": "App usage events from the Device Personalization Services "
                        "reflection_gel_events database (includes deleted apps)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-04-11",
         "last_update_date": "2020-04-11",
         "requirements": "none",

--- a/scripts/artifacts/userDict.py
+++ b/scripts/artifacts/userDict.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_userDict": {
         "name": "userDict",
         "description": "Parses the personal user dictionary (word, frequency, locale, app ID and shortcut) from the user dictionary database.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-21",
         "last_update_date": "2020-03-21",
         "requirements": "none",

--- a/scripts/artifacts/vaulty_files.py
+++ b/scripts/artifacts/vaulty_files.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_vaulty_files": {
         "name": "vaulty_files",
         "description": "Vaulty (com.theronrogers.vaultyfree) media database. Research at https://kibaffo33.data.blog/2022/03/05/decoding-vaulty/",
-        "author": "",
+        "author": "@kibaffo33",
         "creation_date": "2022-02-23",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/vaulty_info.py
+++ b/scripts/artifacts/vaulty_info.py
@@ -3,7 +3,7 @@ __artifacts_v2__ = {
     "get_vaulty_info": {
         "name": "vaulty_info",
         "description": "Prefs File",
-        "author": "",
+        "author": "@kibaffo33",
         "creation_date": "2022-02-23",
         "last_update_date": "2022-02-23",
         "requirements": "none",

--- a/scripts/artifacts/vlcMedia.py
+++ b/scripts/artifacts/vlcMedia.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_vlcMedia": {
         "name": "VLC",
         "description": "Parses VLC media library entries (insertion and last played dates, filename, path and favorite flag) from vlc_media.db.",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-03-01",
         "last_update_date": "2021-03-01",
         "requirements": "none",

--- a/scripts/artifacts/vlcThumbs.py
+++ b/scripts/artifacts/vlcThumbs.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_vlcThumbs": {
         "name": "VLC Thumbnails",
         "description": "Thumbnail images cached by VLC in the medialib folder",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-03-01",
         "last_update_date": "2021-03-01",
         "requirements": "none",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     "get_vlcThumbs_data": {
         "name": "VLC Thumbnail Data",
         "description": "VLC media library entries (play count, dates) with their cached thumbnails",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2021-03-01",
         "last_update_date": "2021-03-01",
         "requirements": "none",

--- a/scripts/artifacts/vlcthumbsADB.py
+++ b/scripts/artifacts/vlcthumbsADB.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_vlcthumbsADB": {
         "name": "VLC Thumbnails (ADB)",
         "description": "VLC thumbnail cache from an ADB extraction (ef/medialib/thumbnails)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2022-08-23",
         "last_update_date": "2022-08-23",
         "requirements": "none",
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
     "get_vlcthumbsADB_medialib": {
         "name": "VLC Media Lib (ADB)",
         "description": "VLC media library images from an ADB extraction (ef/medialib)",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2022-08-23",
         "last_update_date": "2022-08-23",
         "requirements": "none",

--- a/scripts/artifacts/walStrings.py
+++ b/scripts/artifacts/walStrings.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_walStrings": {
         "name": "walStrings",
         "description": "If  we only want ascii, use 'ascii_chars_re' below",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-04-17",
         "last_update_date": "2026-07-10",
         "requirements": "none",

--- a/scripts/artifacts/wellbeingaccount.py
+++ b/scripts/artifacts/wellbeingaccount.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_wellbeingaccount": {
         "name": "wellbeingaccount",
         "description": "Parses account data from the Google Digital Wellbeing AccountData protobuf file.",
-        "author": "",
+        "author": "@ydkhatri",
         "creation_date": "2020-02-25",
         "last_update_date": "2020-02-25",
         "requirements": "none",

--- a/scripts/artifacts/wifiConfigstore2.py
+++ b/scripts/artifacts/wifiConfigstore2.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_wifiConfigstore": {
         "name": "WiFi Config Store",
         "description": "Saved Wi-Fi network configuration details from WifiConfigStore.xml",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2023-05-11",
         "last_update_date": "2023-05-11",
         "requirements": "none",

--- a/scripts/artifacts/wifiHotspot.py
+++ b/scripts/artifacts/wifiHotspot.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_wifiHotspot": {
         "name": "wifiHotspot",
         "description": "Parses the Wi-Fi hotspot (SoftAP) configuration (SSID and passphrase, plus security type where the configuration is in XML form) from the softap configuration files.",
-        "author": "",
+        "author": "@ydkhatri",
         "creation_date": "2020-11-18",
         "last_update_date": "2026-08-01",
         "requirements": "none",

--- a/scripts/artifacts/wifiProfiles.py
+++ b/scripts/artifacts/wifiProfiles.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "get_wifiProfiles": {
         "name": "wifiProfiles",
         "description": "Saved Wi-Fi network profiles (SSID, keys, gateway MAC address, timestamps) from WifiConfigStore.xml",
-        "author": "",
+        "author": "@abrignoni",
         "creation_date": "2020-03-23",
         "last_update_date": "2026-08-01",
         "requirements": "none",


### PR DESCRIPTION
254 artifacts in this repo carried `"author": ""`. That field reaches the HTML report and the LAVA manifest, so it rendered blank in output that gets quoted in casework, and it credited nobody for the work.

(Handles below are in backticks deliberately, so opening this PR does not fire a notification at every contributor named in it.)

## How the value was derived

The GitHub account that **created the file** the artifact lives in, resolved through the GitHub API from that file's first commit (`.author.login`). That is the account GitHub itself attaches to the commit, not a guess parsed out of a git name string.

Nothing existing is changed. Where someone is already credited under a different form, this only fills the empty entries alongside them.

## What was tried and rejected

Deriving per artifact key rather than per file. Many of these artifacts were converted from the v1 format in a later commit, so the v2 key first appears in that conversion rather than in the original contribution. Validated against 60 artifacts whose author is already declared, that method attributed several contributors' work to whoever performed the conversion. The file-creation method reproduces the declared author in the large majority of cases, and the apparent misses are almost all the same person under a second handle (`KevinPagano3` and `stark4n6`, `Marco Neumann {kalinko@...}` and `kalink0`, `Heather Charpentier` and `charpy4n6`).

## Four files worth a reviewer's eye

In these the existing artifacts credit one person while the file was created by another, so the handle added is the file creator and may not be the writer of that particular artifact:

| File | Existing artifacts credit | Handle added | Empty entries filled |
|---|---|---|---|
| `mewe.py` | `AlexisBrignoni` | `A-725-K` | 2 |
| `snapchat.py` | `AlexisBrignoni, Claude` | `A-725-K` | 8 |
| `googleCalendar.py` | `KevinPagano3` | `stark4n6` | 1 |
| `swellbeing.py` | `stark4n6` | `abrignoni` | 1 |

The first two are different people. The other two are the same person under a second handle, so they are harmless. Happy to correct any of these on request.

## Spread

134 files resolve to `abrignoni`, 23 to `stark4n6`, 14 to `markmckinnon`, 11 to `ydkhatri`, 8 to `kibaffo33`, and the remainder across a dozen other contributors.

## Validation

The diff touches the `author` field and nothing else, verified by checking that no changed line lacks `"author"`. Claim-language and HTML-safety checks pass. No behaviour, paths or row counts change.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>