### PR TITLE
docs: put a real row count in the sample_data entries that had none

### DIFF
--- a/scripts/artifacts/berealAndroid.py
+++ b/scripts/artifacts/berealAndroid.py
@@ -27,8 +27,8 @@ __artifacts_v2__ = {
         "output_types": "standard",
         "artifact_icon": "image",
         "sample_data": {
-            "pixel7a_a14": "Android 14 | com.bereal.ft | media recovered from caches",
-            "hc_pixel8pro_a17": "Android 17 | com.bereal.ft | media recovered from caches",
+            "pixel7a_a14": "Android 14 | com.bereal.ft | 71 rows",
+            "hc_pixel8pro_a17": "Android 17 | com.bereal.ft | 13 rows",
         },
     },
     "bereal_friends": {
@@ -48,7 +48,7 @@ __artifacts_v2__ = {
         "output_types": "standard",
         "artifact_icon": "users",
         "sample_data": {
-            "pixel7a_a14": "Android 14 | com.bereal.ft | cached relationships responses",
+            "pixel7a_a14": "Android 14 | com.bereal.ft | 0 rows",
             "hc_pixel8pro_a17": "Android 17 | com.bereal.ft | 1 friend cached",
         },
     },
@@ -68,8 +68,8 @@ __artifacts_v2__ = {
         "output_types": "standard",
         "artifact_icon": "server",
         "sample_data": {
-            "pixel7a_a14": "Android 14 | com.bereal.ft | cached API responses",
-            "hc_pixel8pro_a17": "Android 17 | com.bereal.ft | cached API responses",
+            "pixel7a_a14": "Android 14 | com.bereal.ft | 15 rows",
+            "hc_pixel8pro_a17": "Android 17 | com.bereal.ft | 4 rows",
         },
     },
 }

--- a/scripts/artifacts/dropbox.py
+++ b/scripts/artifacts/dropbox.py
@@ -38,7 +38,7 @@ __artifacts_v2__ = {
         "output_types": "standard",
         "artifact_icon": "user",
         "sample_data": {
-            "hc_pixel8pro_a17": "Android 17 | com.dropbox.android | account reported",
+            "hc_pixel8pro_a17": "Android 17 | com.dropbox.android | 11 rows",
         },
     },
     "dropbox_thumbnails": {


### PR DESCRIPTION
Some `sample_data` entries described a result in prose instead of giving a number, so they said nothing about how much the artifact actually found. Each one here now carries a count taken from a real `aleapp.py` run against that corpus.

| Artifact | Corpus | Was | Now |
|---|---|---|---|
| BeReal Cached Media | `pixel7a_a14` | "media recovered from caches" | **71 rows** |
| BeReal Cached Media | `hc_pixel8pro_a17` | "media recovered from caches" | **13 rows** |
| BeReal Cached API Responses | `pixel7a_a14` | "cached API responses" | **15 rows** |
| BeReal Cached API Responses | `hc_pixel8pro_a17` | "cached API responses" | **4 rows** |
| BeReal Friends | `pixel7a_a14` | "cached relationships responses" | **0 rows** |
| Dropbox - Account | `hc_pixel8pro_a17` | "account reported" | **11 rows** |

## What was deliberately left alone

This started from 117 entries without a count. Most should not be changed:

- **Entries that say WHY a result is empty** — `"AppLock.db not present"`, `"table absent"`, `"no vault folder present"`. These are *more* useful than `0 rows`, because they distinguish a store that is missing from one that is present and empty.
- **Entries that already embed a number in prose** — `"409 cookies across 33 container files"` carries more information than a bare count would.
- **`"1 friend cached"`** already states a quantity, so it stays as written.

Only entries conveying no quantity at all were changed.

Diff is `sample_data` strings only; no other line changed. Claim-language check passes.

The equivalent iLEAPP change is a separate PR.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>