### PR TITLE
docs: record sample_data for artifacts that had never been validated

### DIFF
--- a/scripts/artifacts/c2paProvenance.py
+++ b/scripts/artifacts/c2paProvenance.py
@@ -34,6 +34,13 @@ __artifacts_v2__ = {
         ),
         "output_types": "all",
         "artifact_icon": "certificate",
+        "sample_data": {
+            "anne_a15": "2 rows",
+            "kevin_pocox7_a15": "11 rows",
+            "pixel7a_a14": "3 rows",
+            "samsungs20_a13": "4 rows",
+            "sharon_a14": "44 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/signalAndroid.py
+++ b/scripts/artifacts/signalAndroid.py
@@ -11,6 +11,11 @@ __artifacts_v2__ = {
         "paths": ('*/org.thoughtcrime.securesms/databases/signal.db*',),
         "output_types": "standard",
         "artifact_icon": "message-circle",
+        "sample_data": {
+            "hc_pixel8pro_a16": "20 rows",
+            "pixel7a_a14": "34 rows",
+            "sharon_a14": "45 rows",
+        },
     },
     "get_signalCalls": {
         "name": "Signal - Calls",
@@ -24,6 +29,11 @@ __artifacts_v2__ = {
         "paths": ('*/org.thoughtcrime.securesms/databases/signal.db*',),
         "output_types": "standard",
         "artifact_icon": "phone",
+        "sample_data": {
+            "hc_pixel8pro_a16": "3 rows",
+            "pixel7a_a14": "4 rows",
+            "sharon_a14": "3 rows",
+        },
     },
     "get_signalContacts": {
         "name": "Signal - Contacts",
@@ -37,6 +47,12 @@ __artifacts_v2__ = {
         "paths": ('*/org.thoughtcrime.securesms/databases/signal.db*',),
         "output_types": "standard",
         "artifact_icon": "users",
+        "sample_data": {
+            "hc_pixel8pro_a16": "4 rows",
+            "pixel7a_a14": "15 rows",
+            "russell_pixel6a_a13": "6 rows",
+            "sharon_a14": "25 rows",
+        },
     },
     "get_signalGroups": {
         "name": "Signal - Groups",
@@ -50,6 +66,9 @@ __artifacts_v2__ = {
         "paths": ('*/org.thoughtcrime.securesms/databases/signal.db*',),
         "output_types": "standard",
         "artifact_icon": "users",
+        "sample_data": {
+            "sharon_a14": "1 row",
+        },
     },
     "get_signalAttachments": {
         "name": "Signal - Attachments",
@@ -64,6 +83,11 @@ __artifacts_v2__ = {
                   '*/org.thoughtcrime.securesms/app_parts/*'),
         "output_types": "standard",
         "artifact_icon": "paperclip",
+        "sample_data": {
+            "hc_pixel8pro_a16": "7 rows",
+            "pixel7a_a14": "9 rows",
+            "sharon_a14": "10 rows",
+        },
     },
 }
 

--- a/scripts/artifacts/swellbeing.py
+++ b/scripts/artifacts/swellbeing.py
@@ -38,6 +38,10 @@ __artifacts_v2__ = {
         "paths": ('*/com.samsung.android.forest/databases/dwbCommon.db*',),
         "output_types": "standard",
         "artifact_icon": "clock",
+        "sample_data": {
+            "galaxys10_a10": "1 row",
+            "sharon_a14": "1 row",
+        },
     }
 }
 

--- a/scripts/artifacts/telegramAndroid.py
+++ b/scripts/artifacts/telegramAndroid.py
@@ -56,6 +56,15 @@ __artifacts_v2__ = {
                   '*/org.telegram.messenger*/files/Telegram/**'),
         "output_types": "standard",
         "artifact_icon": "message-circle",
+        "sample_data": {
+            "anne_a15": "240 rows",
+            "hc_pixel8pro_a16": "6 rows",
+            "hc_pixel8pro_a17": "17 | 6 rows",
+            "kevin_pocox7_a15": "1609 rows",
+            "pixel7a_a14": "34 rows",
+            "russell_pixel6a_a13": "3 rows",
+            "sharon_a14": "1 row",
+        },
     },
     "get_telegramContacts": {
         "name": "Telegram - Contacts",
@@ -76,6 +85,15 @@ __artifacts_v2__ = {
         "paths": ('*/org.telegram.messenger*/files/cache4.db*',),
         "output_types": "standard",
         "artifact_icon": "address-book",
+        "sample_data": {
+            "anne_a15": "4 rows",
+            "hc_pixel8pro_a16": "1 row",
+            "hc_pixel8pro_a17": "17 | 1 row",
+            "kevin_pocox7_a15": "9 rows",
+            "pixel7a_a14": "4 rows",
+            "russell_pixel6a_a13": "1 row",
+            "sharon_a14": "15 rows",
+        },
     },
     "get_telegramUsers": {
         "name": "Telegram - Users",
@@ -98,6 +116,16 @@ __artifacts_v2__ = {
         "paths": ('*/org.telegram.messenger*/files/cache4.db*',),
         "output_types": "standard",
         "artifact_icon": "users",
+        "sample_data": {
+            "anne_a15": "111 rows",
+            "hc_pixel8pro_a16": "48 rows",
+            "hc_pixel8pro_a17": "17 | 80 rows",
+            "kevin_pocox7_a15": "523 rows",
+            "pixel7a_a14": "46 rows",
+            "russell_pixel6a_a13": "2 rows",
+            "samsungs20_a13": "4 rows",
+            "sharon_a14": "8 rows",
+        },
     },
     "get_telegramChats": {
         "name": "Telegram - Chats",
@@ -117,6 +145,15 @@ __artifacts_v2__ = {
         "paths": ('*/org.telegram.messenger*/files/cache4.db*',),
         "output_types": "standard",
         "artifact_icon": "messages",
+        "sample_data": {
+            "anne_a15": "6 rows",
+            "hc_pixel8pro_a16": "1 row",
+            "hc_pixel8pro_a17": "17 | 1 row",
+            "kevin_pocox7_a15": "42 rows",
+            "pixel7a_a14": "4 rows",
+            "russell_pixel6a_a13": "1 row",
+            "sharon_a14": "1 row",
+        },
     },
     "get_telegramAccounts": {
         "name": "Telegram - Accounts",
@@ -145,6 +182,15 @@ __artifacts_v2__ = {
         "paths": ('*/org.telegram.messenger*/shared_prefs/userconf*.xml',),
         "output_types": "standard",
         "artifact_icon": "user-circle",
+        "sample_data": {
+            "hc_pixel8pro_a16": "1 row",
+            "hc_pixel8pro_a17": "17 | 1 row",
+            "kevin_pocox7_a15": "1 row",
+            "pixel7a_a14": "1 row",
+            "russell_pixel6a_a13": "1 row",
+            "samsungs20_a13": "1 row",
+            "sharon_a14": "1 row",
+        },
     },
     "get_telegramPeerDetails": {
         "name": "Telegram - Peer Details",
@@ -171,6 +217,16 @@ __artifacts_v2__ = {
         "paths": ('*/org.telegram.messenger*/files/cache4.db*',),
         "output_types": "standard",
         "artifact_icon": "address-book",
+        "sample_data": {
+            "anne_a15": "6 rows",
+            "hc_pixel8pro_a16": "2 rows",
+            "hc_pixel8pro_a17": "17 | 2 rows",
+            "kevin_pocox7_a15": "45 rows",
+            "pixel7a_a14": "3 rows",
+            "russell_pixel6a_a13": "2 rows",
+            "samsungs20_a13": "1 row",
+            "sharon_a14": "3 rows",
+        },
     },
     "get_telegramChatDetails": {
         "name": "Telegram - Chat Details",
@@ -197,6 +253,10 @@ __artifacts_v2__ = {
         "paths": ('*/org.telegram.messenger*/files/cache4.db*',),
         "output_types": "standard",
         "artifact_icon": "users-group",
+        "sample_data": {
+            "anne_a15": "1 row",
+            "kevin_pocox7_a15": "4 rows",
+        },
     },
     "get_telegramSaveToGallery": {
         "name": "Telegram - Save to Gallery Settings",
@@ -223,6 +283,16 @@ __artifacts_v2__ = {
         "paths": ('*/org.telegram.messenger*/shared_prefs/mainconfig.xml',),
         "output_types": "standard",
         "artifact_icon": "photo",
+        "sample_data": {
+            "anne_a15": "3 rows",
+            "hc_pixel8pro_a16": "3 rows",
+            "hc_pixel8pro_a17": "17 | 3 rows",
+            "kevin_pocox7_a15": "3 rows",
+            "pixel7a_a14": "3 rows",
+            "russell_pixel6a_a13": "3 rows",
+            "samsungs20_a13": "3 rows",
+            "sharon_a14": "3 rows",
+        },
     },
     "get_telegramChannelMembers": {
         "name": "Telegram - Channel & Group Members",
@@ -246,6 +316,10 @@ __artifacts_v2__ = {
         "paths": ('*/org.telegram.messenger*/files/cache4.db*',),
         "output_types": "standard",
         "artifact_icon": "users-group",
+        "sample_data": {
+            "anne_a15": "32 rows",
+            "kevin_pocox7_a15": "64 rows",
+        },
     },
     "get_telegramChatHints": {
         "name": "Telegram - Frequent Chats",
@@ -267,6 +341,14 @@ __artifacts_v2__ = {
         "paths": ('*/org.telegram.messenger*/files/cache4.db*',),
         "output_types": "standard",
         "artifact_icon": "star",
+        "sample_data": {
+            "anne_a15": "4 rows",
+            "hc_pixel8pro_a16": "1 row",
+            "hc_pixel8pro_a17": "17 | 1 row",
+            "pixel7a_a14": "1 row",
+            "russell_pixel6a_a13": "1 row",
+            "sharon_a14": "1 row",
+        },
     },
     "get_telegramVoipLogs": {
         "name": "Telegram - VoIP Call Logs",
@@ -293,6 +375,9 @@ __artifacts_v2__ = {
         "paths": ('*/org.telegram.messenger*/cache/voip_logs/*',),
         "output_types": "standard",
         "artifact_icon": "phone",
+        "sample_data": {
+            "pixel7a_a14": "1 row",
+        },
     },
     "get_telegramAutoDownload": {
         "name": "Telegram - Auto-Download Settings",
@@ -319,6 +404,16 @@ __artifacts_v2__ = {
         "paths": ('*/org.telegram.messenger*/shared_prefs/mainconfig.xml',),
         "output_types": "standard",
         "artifact_icon": "download",
+        "sample_data": {
+            "anne_a15": "12 rows",
+            "hc_pixel8pro_a16": "12 rows",
+            "hc_pixel8pro_a17": "17 | 12 rows",
+            "kevin_pocox7_a15": "12 rows",
+            "pixel7a_a14": "12 rows",
+            "russell_pixel6a_a13": "12 rows",
+            "samsungs20_a13": "12 rows",
+            "sharon_a14": "12 rows",
+        },
     },
 }
 


### PR DESCRIPTION
423 artifacts declared `paths` but carried **no `sample_data` at all**, so nothing recorded that they had ever produced a row. That was 27% of the tree with no evidence of working.

All 423 were run against every registered corpus. **51 produced rows on at least one**; those now carry the counts. 19 of them are in this repo, gaining **92 entries** across Telegram, Signal, Samsung Wellbeing and C2PA provenance.

## Where the numbers come from

Real `aleapp.py` profile runs — 27 runs across both repos — not an offline harness. Every recorded number was checked back against the run that produced it (**0 mismatches**), and a spot re-run reproduces them.

## What was deliberately not recorded

**372 artifacts produced rows nowhere, and none of them got a `sample_data` entry.**

An app being absent from an image is not the same as an artifact finding nothing. Writing `"0 rows"` there would read as validated coverage when nothing was validated, so those entries were left out entirely rather than filled with a fabricated zero.

## A real defect this surfaced, not fixed here

Five artifacts **error** on specific corpora rather than degrading gracefully:

| Artifact | Corpus | Error |
|---|---|---|
| `get_signalMessages` | `russell_pixel6a_a13` | `no such column: sender.e164` |
| `get_signalCalls` | `russell_pixel6a_a13` | `no such column: peer.e164` |
| `get_signalGroups` | `russell_pixel6a_a13` | `no such column: recipient.e164` |
| `get_signalAttachments` | `russell_pixel6a_a13` | same family |
| `get_telegramChatHints` | `kevin_pocox7_a15` | errored |

This is schema drift: Signal's `recipient` table no longer has `e164` on that version. Notably the module **already** guards its `message` table columns through `_table_columns`/`_select_list`, but the `recipient` columns are hardcoded, so the same protection just needs extending.

The Signal artifacts work fine on three other corpora, so this is version-specific rather than a wholesale break. I have not fixed it here because the corpus is SQLCipher-encrypted and confirming the replacement column needs its own investigation — worth doing properly rather than guessing. Flagging it for a follow-up.

## Validation

Metadata only. All changed files compile, claim-language and HTML-safety checks pass, and no behaviour, paths or row counts change.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>