### PR TITLE
fix: read Chrome's current autofill address schema, and repair three broken error handlers

### DIFF
--- a/scripts/artifacts/chromeAutofill.py
+++ b/scripts/artifacts/chromeAutofill.py
@@ -30,23 +30,25 @@ __artifacts_v2__ = {
         "description": "Parses Chrome autofill profiles",
         "author": "@stark4n6",
         "creation_date": "2020-03-19",
-        "last_update_date": "2020-03-19",
+        "last_update_date": "2026-08-08",
         "requirements": "none",
         "category": "Chromium",
-        "notes": "",
+        "notes": "Chrome stores autofill address profiles in two layouts and both are read. Older releases use autofill_profiles joined to autofill_profile_names, _emails and _phones. Current releases use a single addresses table whose field values live in address_type_tokens, keyed by Chromium's FieldType enum; the values read are 3 NAME_FIRST, 4 NAME_MIDDLE, 5 NAME_LAST, 9 EMAIL_ADDRESS, 14 PHONE_HOME_WHOLE_NUMBER, 33 ADDRESS_HOME_CITY, 34 ADDRESS_HOME_STATE, 35 ADDRESS_HOME_ZIP, 60 COMPANY_NAME and 77 ADDRESS_HOME_STREET_ADDRESS. Field types outside that set are not reported rather than labelled, so a later Chrome field cannot reach the report under a guessed column; ADDRESS_HOME_COUNTRY and NAME_FULL are present in tested samples and are among those not reported. A third spelling, local_addresses, was seen empty on two tested images and is not read. Reference: Chromium, 'components/autofill/core/browser/field_types.h', https://github.com/chromium/chromium/blob/e90fec8693b4bd68806f3a5addec6722c0bc3939/components/autofill/core/browser/field_types.h",
         "paths": ('*/app_chrome/Default/Web Data*', '*/app_sbrowser/Default/Web Data*', '*/data/*/app_opera/Web Data*', '*/app_webview/Default/Web Data*'),
         "output_types": "standard",
         "artifact_icon": "globe",
         "sample_data": {
             "anne_a15": "Android 15 | 0 rows",
             "galaxys10_a10": "Android 10 | 0 rows",
-            "hc_pixel8pro_a16": "Android 16 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | 2 rows",
+            "hc_pixel8pro_a17": "Android 17 | 2 rows",
             "kevin_pocox7_a15": "Android 15 | 0 rows",
             "pixel7a_a14": "Android 14 | 0 rows",
-            "samsunga53_a14": "Android 14 | 0 rows",
-            "samsungs20_a13": "Android 13 | 0 rows",
-            "sharon_a14": "Android 14 | 0 rows",
             "russell_pixel6a_a13": "Android 13 | 0 rows",
+            "s20fe_a13": "Android 13 | 0 rows",
+            "samsunga53_a14": "Android 14 | 0 rows",
+            "samsungs20_a13": "Android 13 | 3 rows",
+            "sharon_a14": "Android 14 | 0 rows",
             "userb2_a13": "Android 13 | 0 rows",
         },
     }
@@ -125,6 +127,53 @@ def get_chromeAutofill(context):
     return all_data_headers, all_data, report_file
 
 
+# Chrome retired the autofill_profiles / autofill_profile_* join in favour of a
+# single addresses table whose field values live in address_type_tokens, keyed by
+# the FieldType enum. Both layouts are read, so one parser covers both generations.
+# The type numbers are Chromium's own, checked against the pinned blob below.
+# Reference: Chromium, 'components/autofill/core/browser/field_types.h',
+# https://github.com/chromium/chromium/blob/e90fec8693b4bd68806f3a5addec6722c0bc3939/components/autofill/core/browser/field_types.h
+CHROME_FIELD_TYPES = {
+    'first_name': 3,     # NAME_FIRST
+    'middle_name': 4,    # NAME_MIDDLE
+    'last_name': 5,      # NAME_LAST
+    'email': 9,          # EMAIL_ADDRESS
+    'phone': 14,         # PHONE_HOME_WHOLE_NUMBER
+    'city': 33,          # ADDRESS_HOME_CITY
+    'state': 34,         # ADDRESS_HOME_STATE
+    'zip': 35,           # ADDRESS_HOME_ZIP
+    'company': 60,       # COMPANY_NAME
+    'street': 77,        # ADDRESS_HOME_STREET_ADDRESS
+}
+
+
+def _table_exists(cursor, table):
+    cursor.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,))
+    return cursor.fetchone() is not None
+
+
+def _modern_autofill_profiles(cursor):
+    """Read the addresses / address_type_tokens layout.
+
+    Field types the map does not name are left out rather than guessed, so a
+    later Chrome field cannot reach the report under an invented column.
+    """
+    tokens = {}
+    cursor.execute('SELECT guid, type, value FROM address_type_tokens')
+    for guid, field_type, value in cursor.fetchall():
+        tokens.setdefault(guid, {})[field_type] = value
+
+    cursor.execute('SELECT guid, date_modified, use_date, use_count FROM addresses')
+    rows = []
+    for guid, date_modified, use_date, use_count in cursor.fetchall():
+        field = tokens.get(guid, {})
+        rows.append((date_modified, guid) + tuple(
+            field.get(CHROME_FIELD_TYPES[name], '') for name in
+            ('first_name', 'middle_name', 'last_name', 'email', 'phone',
+             'company', 'street', 'city', 'state', 'zip')) + (use_date, use_count))
+    return rows
+
+
 @artifact_processor
 def get_chromeAutofillProfiles(context):
     files_found = context.get_files_found()
@@ -152,28 +201,34 @@ def get_chromeAutofillProfiles(context):
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         try:
-            cursor.execute('''
-                select
-                    date_modified,
-                    autofill_profiles.guid,
-                    autofill_profile_names.first_name,
-                    autofill_profile_names.middle_name,
-                    autofill_profile_names.last_name,
-                    autofill_profile_emails.email,
-                    autofill_profile_phones.number,
-                    autofill_profiles.company_name,
-                    autofill_profiles.street_address,
-                    autofill_profiles.city,
-                    autofill_profiles.state,
-                    autofill_profiles.zipcode,
-                    use_date,
-                    autofill_profiles.use_count
-                from autofill_profiles
-                inner join autofill_profile_emails ON autofill_profile_emails.guid = autofill_profiles.guid
-                inner join autofill_profile_phones ON autofill_profiles.guid = autofill_profile_phones.guid
-                inner join autofill_profile_names ON autofill_profile_phones.guid = autofill_profile_names.guid
-            ''')
-            rows = cursor.fetchall()
+            if _table_exists(cursor, 'autofill_profiles'):
+                cursor.execute('''
+                    select
+                        date_modified,
+                        autofill_profiles.guid,
+                        autofill_profile_names.first_name,
+                        autofill_profile_names.middle_name,
+                        autofill_profile_names.last_name,
+                        autofill_profile_emails.email,
+                        autofill_profile_phones.number,
+                        autofill_profiles.company_name,
+                        autofill_profiles.street_address,
+                        autofill_profiles.city,
+                        autofill_profiles.state,
+                        autofill_profiles.zipcode,
+                        use_date,
+                        autofill_profiles.use_count
+                    from autofill_profiles
+                    inner join autofill_profile_emails ON autofill_profile_emails.guid = autofill_profiles.guid
+                    inner join autofill_profile_phones ON autofill_profiles.guid = autofill_profile_phones.guid
+                    inner join autofill_profile_names ON autofill_profile_phones.guid = autofill_profile_names.guid
+                ''')
+                rows = cursor.fetchall()
+            elif _table_exists(cursor, 'addresses'):
+                # Chrome release without the legacy tables
+                rows = _modern_autofill_profiles(cursor)
+            else:
+                rows = []
         except Exception as e:
             logfunc(str(e))
             rows = []

--- a/scripts/artifacts/notificationHistory.py
+++ b/scripts/artifacts/notificationHistory.py
@@ -169,6 +169,10 @@ def get_notificationHistory(context):
 
     for file_found in files_found:
         file_found = str(file_found)
+        if not os.path.isfile(file_found):
+            # The glob also returns the enclosing history directory on some
+            # extractions; only the per-notification files are protobufs.
+            continue
         file_name = os.path.basename(file_found)
         source_path = os.path.dirname(file_found)
         try:

--- a/scripts/artifacts/speedtest.py
+++ b/scripts/artifacts/speedtest.py
@@ -60,15 +60,15 @@ def speedtest_tests(context):
         cur.execute('SELECT date, connectionType, ssid, userLatitude, userLongitude, externalIp, internalIp, downloadKbps, uploadKbps FROM UnivSpeedTestResult')
         result = cur.fetchall()
     except Exception as ex:
-        logfunc('Error retrieving Speedtest test results: ', ex)
+        logfunc(f'Error retrieving Speedtest test results: {ex}')
 
     timestamped_result = []
     for row in result:
         row = list(row)
         try:
             row[0] = convert_unix_ts_to_utc(row[0])
-        except Exception:
-            logfunc('Error converting timestamp for Speedtest test result: ', ex)
+        except Exception as ex:
+            logfunc(f'Error converting timestamp for Speedtest test result: {ex}')
         timestamped_result.append(row)
 
     return headers, timestamped_result, file_path
@@ -88,7 +88,7 @@ def speedtest_reports_location(context):
         cur.execute('SELECT DATA FROM REPORT')
         result = cur.fetchall()
     except Exception as ex:
-        logfunc('Error retrieving Speedtest reports: ', ex)
+        logfunc(f'Error retrieving Speedtest reports: {ex}')
 
     if result:
         for row in result:
@@ -104,7 +104,7 @@ def speedtest_reports_location(context):
 
                     reports.append((report_timestamp, latitude, longitude, altitude, accuracy))
             except Exception as ex:
-                logfunc('Error retrieving Speedtest reports: ', ex)
+                logfunc(f'Error retrieving Speedtest reports: {ex}')
 
     return headers, reports, file_path
 
@@ -122,7 +122,7 @@ def speedtest_reports_wifi(context):
         cur.execute('SELECT DATA FROM REPORT')
         result = cur.fetchall()
     except Exception as ex:
-        logfunc('Error retrieving Speedtest reports: ', ex)
+        logfunc(f'Error retrieving Speedtest reports: {ex}')
 
     if result:
         for row in result:
@@ -141,11 +141,11 @@ def speedtest_reports_wifi(context):
                         ssid = scan_result.get('SSID')
                         level = scan_result.get('level')
                     except Exception as ex:
-                        logfunc('Error retrieving Speedtest Wi-Fi scan data: ', ex)
+                        logfunc(f'Error retrieving Speedtest Wi-Fi scan data: {ex}')
 
                     results.append((timestamp, bssid, ssid, level))
 
             except Exception as ex:
-                logfunc('Error retrieving Speedtest reports: ', ex)
+                logfunc(f'Error retrieving Speedtest reports: {ex}')
 
     return headers, results, file_path

--- a/scripts/artifacts/zepplife.py
+++ b/scripts/artifacts/zepplife.py
@@ -39,7 +39,7 @@ def extract_zepplife_heartrate(context):
                 try:
                     row[0] = datetime.fromtimestamp(row[0], timezone.utc)
                 except Exception as ex:
-                    logfunc('Error processing timestamp: ', ex)
+                    logfunc(f'Error processing timestamp: {ex}')
 
                 data_list.append(row)
             


### PR DESCRIPTION
ALEAPP carries roughly 24 open pull requests titled "fix schema compatibility" or "fix parsing errors", mostly from one December 2025 cohort, touching 24 distinct artifact modules with heavy overlap. Rather than review 24 diffs, I built one profile of all 55 artifacts from those modules and ran it against all 12 registered Android corpora.

**Two of the 24 modules actually fail today.** The rest either were fixed on main since December or only fail on images not in the corpus. This fixes both real failures, plus a class of broken exception handler found statically.

## 1. Chrome autofill profiles (the one that was losing evidence)

Chrome replaced `autofill_profiles` + `autofill_profile_names` / `_emails` / `_phones` with a single `addresses` table whose field values live in `address_type_tokens`, keyed by the `FieldType` enum. The parser only knew the retired layout, so it logged `no such table: autofill_profiles` on **10 of 12 corpora** and reported nothing.

Both layouts are now read. The field type numbers are Chromium's own, taken from `field_types.h`, pinned to commit `e90fec8` and verified by fetching the blob back and asserting each of the 13 lines. Field types outside the mapped set are left out rather than labelled, so a later Chrome field cannot reach the report under a guessed column name. The notes say which types are read and which observed ones are not.

A third spelling, `local_addresses`, was seen empty on two images and is not read; that is stated too.

## 2. Notification history

The glob also returns the enclosing `history` directory, which the parser tried to open as a protobuf: `[Errno 21] Is a directory`. Non-files are now skipped. The handler was inside the per-file loop, so this was log noise rather than lost rows.

## 3. Broken exception handlers

`logfunc` is `def logfunc(message="")`. Eight calls passed two positional arguments (7 in `speedtest.py`, 1 in `zepplife.py`), **every one inside an `except` block** — so the handler raised `TypeError` precisely when something else had already gone wrong, replacing the real error with a confusing one. `speedtest.py:71` additionally referenced `ex` in an `except Exception:` that never bound it.

## Validation

Full profile runs, 12 corpora, before and after:

| | before | after |
|---|---|---|
| error lines | 231 | **0** |
| artifact/corpus pairs identical | — | **367** |
| gains | — | 3 |
| regressions | — | **0** |

`Chrome Autofill - Profiles` recovers 2 rows on `hc_pixel8pro_a16`, 2 on `hc_pixel8pro_a17` and 3 on `samsungs20_a13` — complete address profiles with names, emails, phone numbers and postal addresses that previously showed as empty.

Worth noting: the artifact's recorded `sample_data` said "0 rows" on all 10 listed corpora, so it was documenting the defect as if it were a fact about the data. It now carries the real counts.

## Also checked, and not broken

`Google Duo - Call History` and `Google Duo - Notes` return 0 on all 12 corpora because `activity_history` and `messages` are genuinely empty, while `duo_users` holds up to 26 rows. Those are correct results, not the bug some of the open PRs describe.

`check_claim_language.py`, `check_html_safety.py` and `lint_changed.py` all pass with no new warnings.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>