### PR TITLE
fix: realm_rows raised on a missing file instead of yielding nothing

### DIFF
--- a/scripts/realm_parser.py
+++ b/scripts/realm_parser.py
@@ -80,6 +80,7 @@ from __future__ import annotations
 
 import decimal
 import math
+import os
 import re
 import struct
 import uuid as _uuid_mod
@@ -2263,6 +2264,10 @@ def realm_rows(path, class_name, section="active"):
     is 'active' (live objects) or 'inactive' (the other top-ref: older/removed
     schema state). Missing table or file yields nothing.
     """
+    if not path or not os.path.isfile(path):
+        # Artifacts pass '' when the app's Realm is not in the extraction. The
+        # docstring above promises nothing rather than an exception, so honour it.
+        return
     table = parse_realm_file(path).get(section, {}).get(class_name)
     if not table:
         return


### PR DESCRIPTION
`realm_rows()` documents that a missing file yields nothing:

> Missing table or file yields nothing.

It does not. `parse_realm_file` raises `FileNotFoundError` on the empty string artifacts pass when the app's Realm is not in the extraction, so the artifact dies rather than reporting no rows. Both `what3words.py` and `justalk.py` resolve to `''` that way.

```python
>>> list(realm_rows('', 'class_LocationRealm'))
FileNotFoundError: [Errno 2] No such file or directory: ''
```

The fix makes the code honour its own docstring.

**Found by porting an iLEAPP fix.** The identical defect was killing six artifacts across nine corpora there ([iLEAPP #1912](https://github.com/abrignoni/iLEAPP/pull/1912)); `realm_parser.py` is meant to stay the same in both cores, so ALEAPP carried the same latent bug. No ALEAPP corpus currently has these apps installed *and* absent, which is exactly why it had never surfaced.

Verified against `sharon_a14`, `pixel7a_a14` and `kevin_pocox7_a15`: 9 artifacts each, zero errors, no change in results. `check_claim_language.py`, `check_html_safety.py` and `lint_changed.py` all pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>