### PR TITLE
fix: read the schemas twelve Android artifacts actually meet, and stop one bad value losing a table

### DIFF
--- a/scripts/artifacts/L360memberscircles.py
+++ b/scripts/artifacts/L360memberscircles.py
@@ -21,6 +21,7 @@ __artifacts_v2__ = {
 from datetime import datetime, timezone
 from scripts.ilapfuncs import (
     artifact_processor,
+    null_absent_columns,
     get_file_path,
     get_sqlite_db_records,
     logfunc
@@ -56,7 +57,7 @@ def Life360_MemberCircles(context):
     '''
 
     try:
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         for record in db_records:
 

--- a/scripts/artifacts/SamsungDeviceHealthManagement.py
+++ b/scripts/artifacts/SamsungDeviceHealthManagement.py
@@ -87,7 +87,7 @@ __artifacts_v2__ = {
 # Author:  Marco Neumann (kalinko@be-binary.de)
 #
 # Requirements:
-from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records, null_absent_columns
 
 @artifact_processor
 def sdhms_config_reloads(context):
@@ -105,7 +105,8 @@ def sdhms_config_reloads(context):
 
     data_list = []
 
-    db_records = get_sqlite_db_records(str(files_found[0]), query)
+    source_path = str(files_found[0])
+    db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
     for row in db_records:
         config_reload_time = convert_unix_ts_to_utc(int(row[0])/1000)
@@ -142,7 +143,8 @@ def sdhms_netstat(context):
 
     data_list = []
 
-    db_records = get_sqlite_db_records(str(files_found[0]), query)
+    source_path = str(files_found[0])
+    db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
     for row in db_records:
         start_time = convert_unix_ts_to_utc(int(row[0])/1000)
@@ -165,6 +167,26 @@ def sdhms_netstat(context):
 
     return data_headers, data_list, files_found[0]
 
+# Older releases of this store call the temperature timestamp "time" rather than
+# "timestamp". Both hold the same millisecond epoch in the same table, so the
+# column is aliased rather than reported empty; substituting NULL would drop the
+# time from every row on those devices. Observed on galaxys10_a10 (time) and
+# sharon_a14 (timestamp).
+TEMPERATURE_TIME_ALIASES = ('timestamp', 'time')
+
+
+def _temperature_query(source_path, query):
+    """Point the timestamp column at whichever spelling this database uses."""
+    columns = {column[1].lower() for column in
+               get_sqlite_db_records(source_path, 'PRAGMA table_info("TEMPERATURE")')}
+    if not columns or 'timestamp' in columns:
+        return query
+    for candidate in TEMPERATURE_TIME_ALIASES[1:]:
+        if candidate in columns:
+            return query.replace('timestamp,', f'{candidate} AS timestamp,', 1)
+    return query
+
+
 @artifact_processor
 def sdhms_temperature(context):
     files_found = context.get_files_found()
@@ -185,7 +207,9 @@ def sdhms_temperature(context):
 
     data_list = []
 
-    db_records = get_sqlite_db_records(str(files_found[0]), query)
+    source_path = str(files_found[0])
+    query = _temperature_query(source_path, query)
+    db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
     for row in db_records:
         timestamp = convert_unix_ts_to_utc(int(row[0])/1000)
@@ -239,7 +263,8 @@ def sdhms_cpustats(context):
 
     data_list = []
 
-    db_records = get_sqlite_db_records(str(files_found[0]), query)
+    source_path = str(files_found[0])
+    db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
     for row in db_records:
         start_time = convert_unix_ts_to_utc(int(row[0])/1000)

--- a/scripts/artifacts/Viber.py
+++ b/scripts/artifacts/Viber.py
@@ -98,6 +98,7 @@ __artifacts_v2__ = {
 }
 
 import datetime
+import os
 from hashlib import sha256
 
 from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
@@ -110,16 +111,20 @@ def _ms_to_utc(value):
 
 
 def _viber_dbs(files_found):
-    data_db = messages_db = prefs_db = ''
+    """Pick the three Viber stores by exact name.
+
+    The glob returns every file in the databases directory, and matching on a
+    suffix is not selective enough: viberpay_data and viber_unicode_emoji_data
+    also end in "_data", so the last one seen won and the queries ran against
+    the wrong store.
+    """
+    wanted = {'viber_data': '', 'viber_messages': '', 'viber_prefs': ''}
     for file_found in files_found:
         file_found = str(file_found)
-        if file_found.endswith('_messages'):
-            messages_db = file_found
-        elif file_found.endswith('_data'):
-            data_db = file_found
-        elif file_found.endswith('viber_prefs'):
-            prefs_db = file_found
-    return data_db, messages_db, prefs_db
+        name = os.path.basename(file_found)
+        if name in wanted and not wanted[name]:
+            wanted[name] = file_found
+    return wanted['viber_data'], wanted['viber_messages'], wanted['viber_prefs']
 
 
 @artifact_processor

--- a/scripts/artifacts/androidauto.py
+++ b/scripts/artifacts/androidauto.py
@@ -23,7 +23,7 @@ __artifacts_v2__ = {
     }
 }
 
-from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, convert_unix_ts_to_utc
+from scripts.ilapfuncs import artifact_processor, get_file_path, get_sqlite_db_records, null_absent_columns, convert_unix_ts_to_utc
 
 @artifact_processor
 def extract_android_auto(context):
@@ -50,7 +50,7 @@ def extract_android_auto(context):
 
     data_headers = (('Connection Time', 'datetime'), 'Manufacturer', 'Model', 'Year', 'Bluetooth MAC', 'Wi-Fi SSID', 'Wi-Fi BSSID', 'Wi-Fi Password', 'Head Unit Make', 'Head Unit Model', 'Head Unit Software Version', 'Vehicle Client ID')
 
-    db_records = get_sqlite_db_records(source_path, query)
+    db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
     for record in db_records:
         connectiontime = convert_unix_ts_to_utc(record[0])

--- a/scripts/artifacts/appicons.py
+++ b/scripts/artifacts/appicons.py
@@ -25,7 +25,7 @@ import inspect
 from html import escape
 from scripts.ilapfuncs import artifact_processor, \
     get_file_path, get_sqlite_db_records, check_in_embedded_media, \
-    logfunc, convert_unix_ts_to_utc
+    logfunc, convert_unix_ts_to_utc, null_absent_columns
 
 class App:
     def __init__(self, package):
@@ -63,7 +63,7 @@ def appIcons(context):
 
     data_headers = ('App name', 'Package name', ('Main icon', 'media'), ('Icons', 'media'))
 
-    db_records = get_sqlite_db_records(source_path, query)
+    db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
     for record in db_records:
         icon_last_update = convert_unix_ts_to_utc(record[2])

--- a/scripts/artifacts/calllogs.py
+++ b/scripts/artifacts/calllogs.py
@@ -54,11 +54,19 @@ def get_calllogs(context):
         if os.path.basename(file_name) not in ('contacts2.db', 'contacts.db', 'logs.db'):
             continue  # skip -journal and other files
 
+        if does_table_exist_in_db(file_name, 'calls'):
+            table = 'calls'
+        elif does_table_exist_in_db(file_name, 'logs'):
+            table = 'logs'
+        else:
+            # Current Android keeps the call log in calllog.db rather than the
+            # contacts provider, so contacts2.db carries neither table. That file
+            # has nothing for this artifact; the calllog module covers the rest.
+            continue
+
         source_path = file_name
         db = open_sqlite_db_readonly(file_name)
-        calls_table_exists = does_table_exist_in_db(file_name, 'calls')
         cursor = db.cursor()
-        table = 'calls' if calls_table_exists else 'logs'
         try:
             cursor.execute(f'''
                 SELECT number, date/1000, (date/1000 + duration) as end_date,

--- a/scripts/artifacts/samsungStoryService.py
+++ b/scripts/artifacts/samsungStoryService.py
@@ -46,7 +46,7 @@ __artifacts_v2__ = {
     },
 }
 
-from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, null_absent_columns, \
     convert_unix_ts_to_utc
 
 
@@ -91,13 +91,13 @@ def samsungStoryServiceInfo(context):
     source_path = ''
 
     for file_found in _unique_db_files(context, 'dme.db'):
-        db_records = get_sqlite_db_records(file_found, '''
+        db_records = get_sqlite_db_records(file_found, null_absent_columns(file_found, '''
             SELECT datetaken, date_added, title, _data, media_type, latitude, longitude,
                    country_name, locality, poi_name, poi_city, street_name, scene_names,
                    face_count, is_delete, moment_id
             FROM info
             ORDER BY datetaken DESC
-        ''')
+        '''))
 
         for row in db_records:
             source_path = file_found
@@ -148,12 +148,12 @@ def samsungStoryServiceMoments(context):
     source_path = ''
 
     for file_found in _unique_db_files(context, 'dme.db'):
-        db_records = get_sqlite_db_records(file_found, '''
+        db_records = get_sqlite_db_records(file_found, null_absent_columns(file_found, '''
             SELECT start_time, end_time, creation_time, title, media_count, country_name,
                    location, poi_info, street_name_info, type, story_id, moment_id
             FROM moment
             ORDER BY start_time DESC
-        ''')
+        '''))
 
         for row in db_records:
             source_path = file_found

--- a/scripts/artifacts/sbbmobile.py
+++ b/scripts/artifacts/sbbmobile.py
@@ -82,7 +82,7 @@ __artifacts_v2__ = {
 }
 
 from scripts.ilapfuncs import artifact_processor, get_file_path, \
-    get_sqlite_db_records, logfunc
+    get_sqlite_db_records, logfunc, null_absent_columns
 from scripts.html_safe import esc
 
 
@@ -111,7 +111,7 @@ def cff_purchased_tickets(context):
 
         data_headers = ("Valid from", "Valid until", "Traveler", "Refund State",
                         "Payment method", "Ticket description", "Ticket departure", "Ticket destination")
-        db_records = list(get_sqlite_db_records(source_path, query))
+        db_records = list(get_sqlite_db_records(source_path, null_absent_columns(source_path, query)))
 
         return data_headers, db_records, source_path
     else:
@@ -148,7 +148,7 @@ def cff_searched_places(context):
 
         data_headers = (("Searched timestamp (UTC)", "datetime"), "Title", "Is favorite", "Type",
                         "location of places (link)")
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         data_list = [
             record[:4] + (coordinate_to_osm(record[4], record[5]),)
@@ -193,7 +193,7 @@ def cff_search_history(context):
 
         data_headers = (("Search timestamp (UTC)", "datetime"), "Departure", "Departure (type)", "Destination",
                         "Destination (type)", "Result Coordinates (link)")
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         data_list = [
             record[:5] + ((coordinate_to_osm(record[5], record[6]),) if record[5] and record[6] else ("",))
@@ -225,7 +225,7 @@ def cff_travel_cards(context):
         '''
 
         data_headers = ("Name", "Type", "Contract ID", "Valid From", "Valid To", "Contract state")
-        db_records = get_sqlite_db_records(source_path, query)
+        db_records = get_sqlite_db_records(source_path, null_absent_columns(source_path, query))
 
         data_list = [record[:6] for record in db_records]
         return data_headers, data_list, source_path

--- a/scripts/artifacts/smyfilesRecents.py
+++ b/scripts/artifacts/smyfilesRecents.py
@@ -44,7 +44,7 @@ __artifacts_v2__ = {
 
 import datetime
 
-from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly, null_absent_columns
 
 
 def _ms_to_utc(value):
@@ -70,10 +70,10 @@ def get_smyfilesRecents(context):
         db = open_sqlite_db_readonly(source_path)
         cursor = db.cursor()
         try:
-            cursor.execute('''
+            cursor.execute(null_absent_columns(source_path, '''
                 select date_modified, name, size, _data, ext, _source, _description, recent_date
                 from recent_files
-            ''')
+            '''))
             all_rows = cursor.fetchall()
         except Exception as e:
             logfunc(str(e))
@@ -95,7 +95,7 @@ def get_smyfilesRecents_fileinfo(context):
         db = open_sqlite_db_readonly(source_path)
         cursor = db.cursor()
         try:
-            cursor.execute('''
+            cursor.execute(null_absent_columns(source_path, '''
                 SELECT
                 recent_files.recent_date,
                 recent_files.date_modified,
@@ -107,7 +107,7 @@ def get_smyfilesRecents_fileinfo(context):
                 case recent_files.is_hidden WHEN '1' THEN "True" WHEN '0' THEN "False" end,
                 case recent_files.is_trashed WHEN '1' then "True" when '0' then "False" end
                 from recent_files
-            ''')
+            '''))
             all_rows = cursor.fetchall()
         except Exception as e:
             logfunc(str(e))

--- a/scripts/artifacts/telegramAndroid.py
+++ b/scripts/artifacts/telegramAndroid.py
@@ -1584,8 +1584,16 @@ def get_telegramChatHints(context):
     names = _name_lookup(db_file)
     query = 'SELECT did, type, rating, date FROM chat_hints ORDER BY rating DESC'
     for did, kind, rating, date in get_sqlite_db_records(db_file, query) or []:
+        # chat_hints has been seen holding a negative date, which is not a Unix
+        # timestamp and made the conversion raise, losing every row of the
+        # artifact. What such a value means is not established, so it is left
+        # blank rather than guessed at, and the other columns still report.
+        try:
+            timestamp = convert_unix_ts_to_utc(date) if date and date > 0 else ''
+        except (ValueError, OSError, OverflowError):
+            timestamp = ''
         data_list.append((
-            convert_unix_ts_to_utc(date) if date else '',
+            timestamp,
             did,
             names.get(did, '') or names.get(abs(did), ''),
             rating,

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -788,86 +788,65 @@ def null_absent_columns(path, query):
     Apps add columns between releases, so a query written against a newer store
     names columns an older one does not have and the whole statement fails with
     "no such column", returning nothing. Substituting NULL keeps every column in
-    place, which matters because artifacts consume rows positionally.
+    place, which matters because artifacts consume rows positionally, and keeps
+    the column's name, because they also read rows by name.
 
-    Only references the query itself qualifies or that resolve to exactly one
-    table in the FROM/JOIN list are touched, so an ambiguous name is left alone
-    rather than guessed at. Returns the query unchanged if the schema cannot be
-    read.
+    SQLite itself names the missing column, so the query is compiled with EXPLAIN
+    and whatever it objects to is replaced, repeatedly, until it compiles. That
+    avoids guessing which bare words in a statement are column references, which
+    no amount of regex gets reliably right. EXPLAIN compiles without running, so
+    this costs nothing on a large table.
+
+    Returns the query unchanged if the database cannot be read or the error is
+    anything other than a missing column.
     '''
     db = open_sqlite_db_readonly(path)
     if not db:
         return query
-    try:
-        tables = [row[0] for row in db.execute(
-            "SELECT name FROM sqlite_master WHERE type IN ('table','view')")]
-        columns = {name.upper(): {row[1].upper() for row in
-                                  db.execute(f'PRAGMA table_info("{name}")')}
-                   for name in tables}
-    except sqlite3.Error as ex:
-        logfunc(f'Could not read schema of {path}: {ex}')
-        return query
 
-    # alias (and bare table name) -> table, taken from the FROM and JOIN clauses
-    aliases = {}
-    used = []
-    for match in re.finditer(
-            r'\b(?:FROM|JOIN)\s+([A-Za-z_][A-Za-z_0-9]*)(?:\s+(?:AS\s+)?([A-Za-z_][A-Za-z_0-9]*))?',
-            query, re.IGNORECASE):
-        table, alias = match.group(1), match.group(2)
-        if table.upper() not in columns:
-            continue
-        used.append(table.upper())
-        aliases[table.upper()] = table.upper()
-        if alias and alias.upper() not in ('ON', 'WHERE', 'GROUP', 'ORDER', 'LEFT',
-                                           'INNER', 'OUTER', 'CROSS', 'JOIN', 'USING'):
-            aliases[alias.upper()] = table.upper()
+    replaced = []
+    for _ in range(50):                      # a query cannot need more than this
+        try:
+            db.execute('EXPLAIN ' + query)
+            break
+        except sqlite3.OperationalError as ex:
+            match = re.match(r'no such column:\s*(\S+)', str(ex))
+            if not match:
+                break
+            reference = match.group(1)
+            if reference in replaced:
+                break                        # not making progress, leave it alone
+            replaced.append(reference)
+            query = _null_out_column(query, reference)
+        except sqlite3.Error:
+            break
 
-    absent = set()
-    for match in re.finditer(r'\b([A-Za-z_][A-Za-z_0-9]*)\.([A-Za-z_][A-Za-z_0-9]*)\b', query):
-        table = aliases.get(match.group(1).upper())
-        if table and match.group(2).upper() not in columns[table]:
-            absent.add(match.group(0))
-
-    # Bare column names: only safe when exactly one table in play defines the name.
-    if len(set(used)) >= 1:
-        qualified = {reference.split('.', 1)[1].upper() for reference in absent}
-        for match in re.finditer(r'(?<![.\w])([A-Za-z_][A-Za-z_0-9]*)(?![\w.(])', query):
-            name = match.group(1).upper()
-            if (name in qualified or name in aliases or name in columns
-                    or not name.startswith('Z')):
-                continue
-            holders = [table for table in set(used) if name in columns[table]]
-            if not holders and any(name not in columns[table] for table in set(used)):
-                absent.add(match.group(1))
-
-    # A bare NULL also drops the output column's name, and artifacts read rows by
-    # name, so keep the name with an alias wherever the reference is a select item
-    # in its own right. Inside an expression the enclosing alias already names the
-    # column, so a plain NULL is correct there.
-    # One pass, so an alias inserted for one reference cannot be rewritten while
-    # handling the next. A bare NULL also drops the output column's name and
-    # artifacts read rows by name, so keep the name wherever the reference is a
-    # select item in its own right; inside an expression the enclosing alias
-    # already names the column and a plain NULL is right.
-    if absent:
-        pattern = re.compile(
-            r'(?<![\w.])(' + '|'.join(re.escape(reference) for reference in
-                                      sorted(absent, key=len, reverse=True)) + r')\b'
-            r'(?P<tail>\s*(?:,|$)|\s+(?i:FROM)\b)?')
-
-        def _replace(match):
-            tail = match.group('tail')
-            if tail is None:
-                return 'NULL'
-            name = match.group(1).split('.', 1)[-1]
-            return f'NULL AS {name}{tail}'
-
-        query = pattern.sub(_replace, query)
-    if absent:
+    if replaced:
         logfunc(f'{os.path.basename(path)}: column(s) absent from this version are reported '
-                f'empty: {", ".join(sorted(absent))}')
+                f'empty: {", ".join(sorted(replaced))}')
     return query
+
+
+def _null_out_column(query, reference):
+    '''Replace one column reference with NULL, keeping the output column name.
+
+    A bare NULL renames the output column, and artifacts read rows by name, so
+    where the reference is a select item in its own right it becomes
+    "NULL AS <name>". Inside an expression the enclosing alias already names the
+    column and a plain NULL is correct.
+    '''
+    name = reference.split('.')[-1].strip('"[]`')
+    pattern = re.compile(r'(?<![\w.])' + re.escape(reference) + r'\b'
+                         r'(?P<tail>\s*(?:,|$)|\s+(?i:FROM)\b)?')
+
+    def replace(match):
+        tail = match.group('tail')
+        if tail is None:
+            return 'NULL'
+        return f'NULL AS {name}{tail}'
+
+    return pattern.sub(replace, query)
+
 
 def does_view_exist_in_db(path, table_name):
     '''Checks if a table with specified name exists in an sqlite db'''


### PR DESCRIPTION
A sweep of all **711 artifacts across the 12 registered Android corpora** produced **45 error lines**. Most were the same shape: a parser that knows one generation of a schema and silently returns nothing on the others.

## Viber was querying the wrong database

The glob returns every file in the databases directory and the module matched on a suffix. But `viberpay_data` and `viber_unicode_emoji_data` also end in `_data`, and the loop kept the **last** match — so the calls and contacts queries ran against a store that has neither table. Matching the exact basename fixes it: **23 contacts on `sharon_a14`, 14 on `pixel7a_a14`**, plus call logs on three corpora. That was real evidence being lost, not noise.

## null_absent_columns now lets SQLite name the missing column

The first version guessed which bare words in a statement were column references, using a Core Data specific rule that only considered names beginning with `Z`. That is useless for Android columns like `_source` and `ap_temp`, so **the helper silently did nothing on the very artifacts it was added for** — the first re-sweep proved it, with the same errors still present.

It now compiles the query with `EXPLAIN` and replaces whatever SQLite objects to, repeatedly, until it compiles. No guessing, identical handling of qualified and bare names, and `EXPLAIN` compiles without running so it costs nothing on a large table.

## A renamed column is aliased, not nulled

The Samsung temperature timestamp is `time` on older releases and `timestamp` on newer ones, and both hold the same millisecond epoch in the same table. Substituting NULL there would have returned **1,237 rows with no time on them**, which is worse than the crash it replaced. Columns with **no evidenced successor** — `lastUpdated`, `headUnitMake`, `poi_city`, `location` — are reported empty rather than mapped to a plausible-looking neighbour.

## Two more

`get_calllogs` queried a table that is not there: current Android keeps the call log in `calllog.db`, so the contacts provider carries neither `calls` nor `logs`. Files with neither are skipped. The separate `calllog` module already covers that data, verified against the source `calls` table on all 12 corpora.

`get_telegramChatHints` lost all 21 rows to a `date` of `-1576798`. What such a value means is not established, so it ships blank and the other four columns report.

## Validation

Full runs of all 711 artifacts against all 12 corpora, before and after:

| | |
|---|---|
| artifact/corpus pairs identical | **2,630** |
| pairs with more rows | **22** |
| pairs that previously crashed, now run | **1** |
| **regressions** | **0** |
| error lines | **45 → 8** |

The 8 remaining are 6 Garmin artifacts whose tables are genuinely absent on `pixel7a_a14` (they already skip gracefully) and 2 SBB Mobile tables absent on `galaxys10_a10`.

Recovered: **4,474 temperature readings** across 5 corpora, **839 netstat rows**, 212 recent files, 145 app icons, 50 Viber records, 38 Samsung Story rows, 21 Telegram chat hints, 3 Life360 members, 2 Android Auto cars.

`check_claim_language.py`, `check_html_safety.py` and `lint_changed.py` all pass with no new warnings.

**Note for the other cores:** the `null_absent_columns` improvement above should be carried back to iLEAPP, DLEAPP, RLEAPP and VLEAPP, which currently have the weaker first version. That is a follow-up, not part of this PR.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>