### PR TITLE
fix: close the connections the sqlite probes open

### DIFF
--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -756,17 +756,20 @@ def does_column_exist_in_db(path, table_name, col_name):
     '''Checks if a specific col exists'''
     db = open_sqlite_db_readonly(path)
     col_name = col_name.lower()
-    try:
-        db.row_factory = sqlite3.Row # For fetching columns by name
+    if db:
         query = f"pragma table_info('{table_name}');"
-        cursor = db.cursor()
-        cursor.execute(query)
-        all_rows = cursor.fetchall()
-        for row in all_rows:
-            if row['name'].lower() == col_name:
-                return True
-    except sqlite3.Error as ex:
-        logfunc(f"Query error, query={query} Error={str(ex)}")
+        try:
+            db.row_factory = sqlite3.Row # For fetching columns by name
+            cursor = db.cursor()
+            cursor.execute(query)
+            all_rows = cursor.fetchall()
+            for row in all_rows:
+                if row['name'].lower() == col_name:
+                    return True
+        except sqlite3.Error as ex:
+            logfunc(f"Query error, query={query} Error={str(ex)}")
+        finally:
+            db.close()
     return False
 
 def does_table_exist_in_db(path, table_name):
@@ -780,6 +783,8 @@ def does_table_exist_in_db(path, table_name):
                 return True
         except sqlite3.Error as ex:
             logfunc(f"Query error, query={query} Error={str(ex)}")
+        finally:
+            db.close()
     return False
 
 def null_absent_columns(path, query):
@@ -805,21 +810,26 @@ def null_absent_columns(path, query):
         return query
 
     replaced = []
-    for _ in range(50):                      # a query cannot need more than this
-        try:
-            db.execute('EXPLAIN ' + query)
-            break
-        except sqlite3.OperationalError as ex:
-            match = re.match(r'no such column:\s*(\S+)', str(ex))
-            if not match:
+    try:
+        for _ in range(50):                  # a query cannot need more than this
+            try:
+                db.execute('EXPLAIN ' + query)
                 break
-            reference = match.group(1)
-            if reference in replaced:
-                break                        # not making progress, leave it alone
-            replaced.append(reference)
-            query = _null_out_column(query, reference)
-        except sqlite3.Error:
-            break
+            except sqlite3.OperationalError as ex:
+                match = re.match(r'no such column:\s*(\S+)', str(ex))
+                if not match:
+                    break
+                reference = match.group(1)
+                if reference in replaced:
+                    break                    # not making progress, leave it alone
+                replaced.append(reference)
+                query = _null_out_column(query, reference)
+            except sqlite3.Error:
+                break
+    finally:
+        # Artifacts call this once per query, so an unclosed handle here is one
+        # leak per query for the whole run rather than a one-off.
+        db.close()
 
     if replaced:
         logfunc(f'{os.path.basename(path)}: column(s) absent from this version are reported '
@@ -859,6 +869,8 @@ def does_view_exist_in_db(path, table_name):
                 return True
         except sqlite3.Error as ex:
             logfunc(f"Query error, query={query} Error={str(ex)}")
+        finally:
+            db.close()
     return False
 
 


### PR DESCRIPTION
Follow-up to the connection-leak fix in [iLEAPP #1778](https://github.com/abrignoni/iLEAPP/pull/1778), which fixed three helpers there. This brings the same fix to this core and covers a fourth function that #1778 predates.

## What leaks

Each of `does_table_exist_in_db`, `does_view_exist_in_db` and `does_column_exist_in_db` opens a connection through `open_sqlite_db_readonly`, returns a bool, and leaves the connection to the garbage collector. `null_absent_columns` does the same. Artifacts probe the same database repeatedly, so this is one held handle per probe for the length of a run.

`does_column_exist_in_db` also lacked the `if db:` guard its two siblings have. When `open_sqlite_db_readonly` returns `None` for an unreadable database it raised `AttributeError: 'NoneType' object has no attribute 'row_factory'` — not a `sqlite3.Error`, so the local handler missed it and the whole artifact died. One bad file costing an examiner every row.

All four now close in a `finally`, so the early `return True` path closes too, and the guard is consistent across the three.

## Measured, by counting open file descriptors

Garbage collection disabled so a leak cannot be hidden by collection:

| | before | after |
|---|---|---|
| 150 `null_absent_columns` calls | **+150 open fds** | **+0** |
| 450 `does_*_exist_in_db` calls | **+450 open fds** | **+0** |

One leaked handle per call, in both cases, now zero. Behaviour is unchanged: the same query still comes back with the absent column reported as `NULL` under its own name.

A `ResourceWarning`-based test was tried first and is **not** adequate: the warning is raised during garbage collection, where CPython prints "Exception ignored" instead of propagating, so the test reported "no leak" against the unfixed code as well. Descriptor counting was verified to fail on the unfixed version before being trusted.

Levelled across all five cores so they stay identical.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>