### PR TITLE
fix: strip rollback journals alongside the other sqlite sidecars

### DIFF
--- a/scripts/artifacts/BadooConnections.py
+++ b/scripts/artifacts/BadooConnections.py
@@ -25,7 +25,8 @@ from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readon
 def get_badoo_conn(context):
     files_found = context.get_files_found()
 
-    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
+    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')
+                   and not str(x).endswith('journal')]
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()

--- a/scripts/artifacts/FairEmail.py
+++ b/scripts/artifacts/FairEmail.py
@@ -61,7 +61,8 @@ from scripts.html_safe import safe_source
 @artifact_processor
 def get_fair_mail_accounts(context):
     files_found = context.get_files_found()
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')
+                   and not x.endswith('journal')]
         
     query = ('''
         SELECT
@@ -98,7 +99,8 @@ def get_fair_mail_accounts(context):
 @artifact_processor
 def get_fair_mail_contacts(context):
     files_found = context.get_files_found()
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')
+                   and not x.endswith('journal')]
     
     query = ('''
         SELECT

--- a/scripts/artifacts/GarminActivities.py
+++ b/scripts/artifacts/GarminActivities.py
@@ -34,7 +34,8 @@ def _ms_to_utc(value):
 def get_garmin_activities(context):
     files_found = context.get_files_found()
     logfunc("Processing data for Garmin Activities")
-    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
+    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')
+                   and not str(x).endswith('journal')]
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()

--- a/scripts/artifacts/GarminChart.py
+++ b/scripts/artifacts/GarminChart.py
@@ -33,7 +33,8 @@ def _ms_to_utc(value):
 def get_garmin_chart(context):
     files_found = context.get_files_found()
     logfunc("Processing data for Garmin Chart")
-    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
+    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')
+                   and not str(x).endswith('journal')]
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()

--- a/scripts/artifacts/GarminDailies.py
+++ b/scripts/artifacts/GarminDailies.py
@@ -75,7 +75,8 @@ FIELDS = [
 def get_garmin_dailies(context):
     files_found = context.get_files_found()
     logfunc("Processing data for Garmin User Dailies")
-    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
+    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')
+                   and not str(x).endswith('journal')]
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()

--- a/scripts/artifacts/GarminResponse.py
+++ b/scripts/artifacts/GarminResponse.py
@@ -43,7 +43,8 @@ def _pretty_json(raw):
 def get_garmin_response(context):
     files_found = context.get_files_found()
     logfunc("Processing data for Garmin Response")
-    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
+    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')
+                   and not str(x).endswith('journal')]
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()

--- a/scripts/artifacts/GarminSPo2.py
+++ b/scripts/artifacts/GarminSPo2.py
@@ -26,7 +26,8 @@ from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readon
 def get_garmin_spo2(context):
     files_found = context.get_files_found()
     logfunc("Processing data for Garmin Pulse Ox details")
-    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
+    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')
+                   and not str(x).endswith('journal')]
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()

--- a/scripts/artifacts/GarminSleep.py
+++ b/scripts/artifacts/GarminSleep.py
@@ -33,7 +33,8 @@ def _ms_to_utc(value):
 def get_garmin_sleep(context):
     files_found = context.get_files_found()
     logfunc("Processing data for Garmin Sleep")
-    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
+    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')
+                   and not str(x).endswith('journal')]
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()

--- a/scripts/artifacts/GarminWeight.py
+++ b/scripts/artifacts/GarminWeight.py
@@ -27,7 +27,8 @@ from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readon
 def get_garmin_weight(context):
     files_found = context.get_files_found()
     logfunc("Processing data for Garmin Weight")
-    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
+    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')
+                   and not str(x).endswith('journal')]
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()

--- a/scripts/artifacts/LinkedIn.py
+++ b/scripts/artifacts/LinkedIn.py
@@ -134,7 +134,8 @@ def linkedin_account(context):
 @artifact_processor
 def linkedin_messages(context):
     files_found = context.get_files_found()
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')
+                   and not x.endswith('journal')]
 
     query = ('''
             SELECT

--- a/scripts/artifacts/MicrosoftAuthenticator.py
+++ b/scripts/artifacts/MicrosoftAuthenticator.py
@@ -22,7 +22,8 @@ def get_MSAuth_accounts(context):
     files_found = context.get_files_found()
     logfunc("Processing data for Microsoft Authenticator - Accounts")
 
-    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
+    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')
+                   and not str(x).endswith('journal')]
 
     data_list = []
     source_path = ''

--- a/scripts/artifacts/PumaUsers.py
+++ b/scripts/artifacts/PumaUsers.py
@@ -25,7 +25,8 @@ from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readon
 def get_puma_users(context):
     files_found = context.get_files_found()
 
-    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')]
+    files_found = [x for x in files_found if not str(x).endswith('wal') and not str(x).endswith('shm')
+                   and not str(x).endswith('journal')]
     source_path = str(files_found[0])
     db = open_sqlite_db_readonly(source_path)
     cursor = db.cursor()

--- a/scripts/artifacts/RandoChat.py
+++ b/scripts/artifacts/RandoChat.py
@@ -65,7 +65,8 @@ from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sq
 @artifact_processor
 def randochat_messages(context):
     files_found = context.get_files_found()
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]   
+    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')
+                   and not x.endswith('journal')]   
 
 
     # Get the different files found and store their pathes in corresponding lists to work with them
@@ -134,7 +135,8 @@ def randochat_messages(context):
 @artifact_processor
 def randochat_account(context):
     files_found = context.get_files_found()
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]   
+    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')
+                   and not x.endswith('journal')]   
 
 
     # Get the different files found and store their pathes in corresponding lists to work with them
@@ -193,7 +195,8 @@ def randochat_account(context):
 @artifact_processor
 def randochat_contacts(context):
     files_found = context.get_files_found()
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]   
+    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')
+                   and not x.endswith('journal')]   
     main_db = ''
 
     for file_found in files_found:

--- a/scripts/artifacts/RomeoDatingApp.py
+++ b/scripts/artifacts/RomeoDatingApp.py
@@ -60,7 +60,8 @@ from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sq
 @artifact_processor
 def romeo_dating_messages(context):
     files_found = context.get_files_found()
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')
+                   and not x.endswith('journal')]
 
     main_db = ''
     data_list = []
@@ -138,7 +139,8 @@ def romeo_dating_messages(context):
 @artifact_processor
 def romeo_dating_contacts(context):
     files_found = context.get_files_found()
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')
+                   and not x.endswith('journal')]
 
 
     main_db = ''
@@ -237,7 +239,8 @@ def romeo_dating_contacts(context):
 @artifact_processor
 def romeo_dating_accounts(context):
     files_found = context.get_files_found()
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')
+                   and not x.endswith('journal')]
     main_db = ''
 
     for file_found in files_found:

--- a/scripts/artifacts/SamsungDeviceHealthManagement.py
+++ b/scripts/artifacts/SamsungDeviceHealthManagement.py
@@ -92,7 +92,8 @@ from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sq
 @artifact_processor
 def sdhms_config_reloads(context):
     files_found = context.get_files_found()
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')
+                   and not x.endswith('journal')]
 
     query = ('''
         SELECT
@@ -128,7 +129,8 @@ def sdhms_config_reloads(context):
 @artifact_processor
 def sdhms_netstat(context):
     files_found = context.get_files_found()
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')
+                   and not x.endswith('journal')]
 
     query = ('''
         SELECT
@@ -190,7 +192,8 @@ def _temperature_query(source_path, query):
 @artifact_processor
 def sdhms_temperature(context):
     files_found = context.get_files_found()
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')
+                   and not x.endswith('journal')]
 
     query = ('''
         SELECT
@@ -247,7 +250,8 @@ def sdhms_temperature(context):
 @artifact_processor
 def sdhms_cpustats(context):
     files_found = context.get_files_found()
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')
+                   and not x.endswith('journal')]
 
     query = ('''
         SELECT

--- a/scripts/artifacts/WithingsHealthMate.py
+++ b/scripts/artifacts/WithingsHealthMate.py
@@ -128,7 +128,8 @@ from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sq
 @artifact_processor
 def healthmate_accounts(context):
     files_found = context.get_files_found()
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')
+                   and not x.endswith('journal')]
     file_found = str(files_found[0])
 
     query = '''
@@ -205,7 +206,8 @@ def healthmate_accounts(context):
 @artifact_processor
 def healthmate_trackings(context):
     files_found = context.get_files_found()
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')
+                   and not x.endswith('journal')]
 
     room_db = next((str(f) for f in files_found if 'room-healthmate' in str(f).lower()), None)
     wiscale_db = next((str(f) for f in files_found if 'withings-scale' in str(f).lower()), None)
@@ -283,7 +285,8 @@ def healthmate_trackings(context):
 @artifact_processor
 def healthmate_locations(context):
     files_found = context.get_files_found()
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')
+                   and not x.endswith('journal')]
 
     file_found = str(files_found[0])
     query = '''
@@ -334,7 +337,8 @@ def healthmate_locations(context):
 @artifact_processor
 def healthmate_messages(context):
     files_found = context.get_files_found()
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')
+                   and not x.endswith('journal')]
 
     query = ('''
         SELECT *
@@ -375,7 +379,8 @@ def healthmate_messages(context):
 @artifact_processor
 def healthmate_contacts(context):
     files_found = context.get_files_found()
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')
+                   and not x.endswith('journal')]
 
     query = '''
         SELECT *
@@ -422,7 +427,8 @@ def healthmate_contacts(context):
 @artifact_processor
 def healthmate_measurements(context):
     files_found = context.get_files_found()
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')
+                   and not x.endswith('journal')]
 
     query = '''
         Select *
@@ -501,7 +507,8 @@ def healthmate_measurements(context):
 @artifact_processor
 def healthmate_devices(context):
     files_found = context.get_files_found()
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')
+                   and not x.endswith('journal')]
 
     query = ('''
         SELECT *

--- a/scripts/artifacts/shistorylog.py
+++ b/scripts/artifacts/shistorylog.py
@@ -23,7 +23,8 @@ from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
 @artifact_processor
 def history_log(context):
     files_found = context.get_files_found()
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')
+                   and not x.endswith('journal')]
      
     query = ('''
         SELECT 

--- a/scripts/artifacts/thunderbird.py
+++ b/scripts/artifacts/thunderbird.py
@@ -73,7 +73,8 @@ def _map_uuid_to_account(file):
 @artifact_processor
 def thunderbird_accounts(context):
     files_found = context.get_files_found()
-    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
+    files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')
+                   and not x.endswith('journal')]
      
     query = ('''
         SELECT *


### PR DESCRIPTION
Artifacts that strip SQLite sidecars from their matched-file list enumerate the suffixes, and most of them list only `wal` and `shm`. A rollback journal survives that filter:

```python
files_found = [x for x in files_found if not x.endswith('wal') and not x.endswith('shm')]
```

Given `foo.db`, `foo.db-wal`, `foo.db-shm`, `foo.db-journal`, the filter returns the database **and the journal**. Where the artifact then takes `files_found[0]`, whichever the seeker returned first is opened as a database.

`journal` is now stripped alongside the other two, completing a set that two lines in the codebase already had.

## This is completeness, not a bug fix

I checked whether the hazard actually occurs before proposing the change. Every glob from every affected module was run against all registered zip corpora, iOS and Android: **zero cases where a `-journal` file survives the filter.** Nothing currently misbehaves because of this.

It is worth closing anyway because the state is entirely reachable, unlike genuinely dead code. The rollback journal is SQLite's *default*-mode sidecar, journals do appear in real extractions, and these globs end in a wildcard that would match one. Our corpora simply happen not to pair a hot journal with these particular databases.

## Why suffix stripping rather than selecting the database by name

Selecting positively, `x.endswith('<the database>')`, is the better idiom and is what the rest of the codebase does. It was rejected here as the larger change: 22 modules would each need their real database name looked up, it alters *which* file is chosen so every one needs corpus verification, and it lands immediately before the core consolidation. Adding one suffix changes no selection behaviour and has nothing to regress.

## Scope

| core | lines | modules |
|---|---|---|
| iLEAPP | 9 | 2 |
| ALEAPP | 32 | 18 |
| DLEAPP, RLEAPP, VLEAPP | 0 | none — they select databases by name already |

Verified by AST across both cores: no comprehension filters `wal` without also filtering `journal`. Behaviour confirmed directly — given a database plus all three sidecars, the filter now returns the database alone.

`check_claim_language.py`, `check_html_safety.py` and `lint_changed.py` pass with no new warnings.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>