### PR TITLE
fix: probe only real databases and guard generation-specific tables

### DIFF
--- a/scripts/artifacts/samsungSecureFolderHistoryLog.py
+++ b/scripts/artifacts/samsungSecureFolderHistoryLog.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         ),
         "author": "4n6Wizard",
         "creation_date": "2026-06-30",
-        "last_update_date": "2026-06-30",
+        "last_update_date": "2026-08-09",
         "requirements": "none",
         "category": "Knox Secure Folder",
         "notes": (
@@ -484,6 +484,11 @@ def samsungSecureFolderHistoryLog(context):
 
     for file_found in context.get_files_found():
         file_found = str(file_found)
+        # The glob matches every file in the databases directory, so skip the
+        # SQLite sidecars before probing; opening a -wal/-shm/-journal file
+        # logs "file is not a database" without ever holding the table.
+        if file_found.endswith(('-wal', '-shm', '-journal')):
+            continue
         if not does_table_exist_in_db(file_found, HISTORY_TABLE):
             continue
 

--- a/scripts/artifacts/sbbmobile.py
+++ b/scripts/artifacts/sbbmobile.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "List of places searched in the past with last time used",
         "author": "jerome.arn@vd.ch",
         "creation_date": "2026-03-26",
-        "last_update_date": "2026-08-01",
+        "last_update_date": "2026-08-09",
         "requirements": "none",
         "category": "Travel",
         "notes": (
@@ -48,7 +48,7 @@ __artifacts_v2__ = {
         "description": "Information about public transportation pass linked to application",
         "author": "jerome.arn@vd.ch",
         "creation_date": "2026-03-26",
-        "last_update_date": "2026-03-26",
+        "last_update_date": "2026-08-09",
         "requirements": "none",
         "category": "Travel",
         "notes": "",
@@ -82,7 +82,7 @@ __artifacts_v2__ = {
 }
 
 from scripts.ilapfuncs import artifact_processor, get_file_path, \
-    get_sqlite_db_records, logfunc, null_absent_columns
+    get_sqlite_db_records, logfunc, null_absent_columns, does_table_exist_in_db
 from scripts.html_safe import esc
 
 
@@ -123,6 +123,13 @@ def cff_searched_places(context):
     files_found = context.get_files_found()
     source_path = get_file_path(files_found, "SbbMobile.db")
     data_list = []
+
+    if source_path and not does_table_exist_in_db(source_path, 'SearchedPlaces'):
+        # Older app generations have no SearchedPlaces table (their searches
+        # live in SearchHistory, covered by the CFF search history artifact).
+        logfunc(f'CFF searched places: {source_path} has no SearchedPlaces table; no rows reported')
+        return (("Searched timestamp (UTC)", "datetime"), "Title", "Is favorite", "Type",
+                "location of places (link)"), data_list, source_path
 
     if source_path:
         query = '''
@@ -210,6 +217,11 @@ def cff_travel_cards(context):
     files_found = context.get_files_found()
     source_path = get_file_path(files_found, "SbbMobile.db")
     data_list = []
+
+    if source_path and not does_table_exist_in_db(source_path, 'SwissPassTravelCards'):
+        # Older app generations have no SwissPassTravelCards table.
+        logfunc(f'CFF travel cards: {source_path} has no SwissPassTravelCards table; no rows reported')
+        return ("Name", "Type", "Contract ID", "Valid From", "Valid To", "Contract state"), data_list, source_path
 
     if source_path:
         query = '''


### PR DESCRIPTION
## What

Two modules logged SQLite errors on the registered Android corpora. Both results were already correct empties; the fixes remove the error noise without changing any selection or row.

- **samsungSecureFolderHistoryLog**: the declared glob `*/com.samsung.knox.securefolder/databases/*` matches every file in the directory, so the artifact probed `-wal`/`-shm`/`-journal` sidecars for the HistoryLog table and the open logged `file is not a database` (galaxys10_a10, samsungs20_a13). Sidecars are now skipped before probing.
- **sbbmobile** (`cff_searched_places`, `cff_travel_cards`): the galaxys10_a10 app generation has no `SearchedPlaces` or `SwissPassTravelCards` table. Its searches live in `SearchHistory`, which the separate CFF search history artifact already reports (4 rows on that image), so nothing is lost. Both artifacts now probe for their table and report a clean empty with an explanatory log line.

**Left alone on purpose:** the six garmin artifacts flagged by the same sweep (`no such table` on pixel7a_a14) already catch `sqlite3.OperationalError` and log a deliberate "unsupported schema version?" skip; their `activity_summaries` table on that image is present but empty, so there is no data to recover. That is working as designed, not a defect.

## Validation

The 5 artifacts of the two touched modules swept across the 12 registered Android corpora from a detached worktree pinned to this commit, compared against the current-main reference runs:

- **9 artifact/corpus pairs identical, 0 changes** (correct empties stay empty, `cff_search_history` keeps its 4 rows)
- SQLite error pairs among these artifacts: **4 before → 0 after**
- `admin/scripts/lint_changed.py`: no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)