### PR TITLE
fix: carry schema-generation guards reported by community PRs

### DIFF
--- a/scripts/artifacts/FacebookMessenger.py
+++ b/scripts/artifacts/FacebookMessenger.py
@@ -93,7 +93,7 @@ __artifacts_v2__ = {
         "description": "Facebook/Messenger chat messages (threads_db2)",
         "author": "Kevin Pagano",
         "creation_date": "2021-03-03",
-        "last_update_date": "2021-03-03",
+        "last_update_date": "2026-08-10",
         "requirements": "none",
         "category": "Facebook Messenger",
         "notes": "",
@@ -131,7 +131,7 @@ __artifacts_v2__ = {
         "description": "Facebook/Messenger contacts (threads_db2)",
         "author": "Kevin Pagano",
         "creation_date": "2021-03-03",
-        "last_update_date": "2021-03-03",
+        "last_update_date": "2026-08-10",
         "requirements": "none",
         "category": "Facebook Messenger",
         "notes": "",
@@ -150,7 +150,7 @@ __artifacts_v2__ = {
 import datetime
 import sqlite3
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, null_absent_columns, open_sqlite_db_readonly
 
 
 def _str_to_utc(value):
@@ -359,6 +359,27 @@ def get_fb_msys_contacts(context):
     return data_headers, data_list, source
 
 
+_REACTION_TS_COLUMNS = ('reaction_timestamp', 'reaction_timestamp_ms',
+                        'reaction_creation_timestamp_ms', 'reaction_creation_time_ms')
+
+
+def _reaction_ts_expr(cursor):
+    """Pick the reaction-timestamp spelling this database carries.
+
+    Four spellings have been reported across threads_db2 generations
+    (community report, PR #638). Only reaction_timestamp is corpus-verified
+    here; a database with none of the four reports the reaction with no time.
+    """
+    try:
+        cols = {row[1] for row in cursor.execute('PRAGMA table_info(message_reactions)')}
+    except sqlite3.Error:
+        cols = set()
+    for name in _REACTION_TS_COLUMNS:
+        if name in cols:
+            return f"datetime(message_reactions.{name}/1000,'unixepoch')"
+    return 'NULL'
+
+
 @artifact_processor
 def get_fb_threads_chats(context):
     files_found = context.get_files_found()
@@ -379,7 +400,7 @@ def get_fb_threads_chats(context):
             json_extract(messages.shares, '$[0].description'),
             json_extract(messages.shares, '$[0].href'),
             message_reactions.reaction,
-            datetime(message_reactions.reaction_timestamp/1000,'unixepoch'),
+            {reaction_ts},
             messages.msg_id
         FROM messages, threads
         LEFT JOIN message_reactions ON message_reactions.msg_id = messages.msg_id
@@ -400,7 +421,7 @@ def get_fb_threads_chats(context):
             json_extract(messages.shares, '$[0].description'),
             json_extract(messages.shares, '$[0].href'),
             message_reactions.reaction,
-            datetime(message_reactions.reaction_timestamp/1000,'unixepoch'),
+            {reaction_ts},
             messages.msg_id
         FROM messages, threads
         LEFT JOIN message_reactions ON message_reactions.msg_id = messages.msg_id
@@ -416,11 +437,12 @@ def get_fb_threads_chats(context):
         rel = _src(file_found, seeker)
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
+        reaction_ts = _reaction_ts_expr(cursor)
         try:
-            cursor.execute(primary)
+            cursor.execute(primary.format(reaction_ts=reaction_ts))
             rows, has_snippet = cursor.fetchall(), True
         except sqlite3.Error:
-            rows, has_snippet = _q(cursor, fallback), False
+            rows, has_snippet = _q(cursor, fallback.format(reaction_ts=reaction_ts)), False
         for row in rows:
             if has_snippet:
                 data_list.append((_str_to_utc(row[0]), row[1], row[2], row[3], row[4], row[5], row[6],
@@ -489,7 +511,7 @@ def get_fb_threads_contacts(context):
         rel = _src(file_found, seeker)
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
-        rows = _q(cursor, '''
+        rows = _q(cursor, null_absent_columns(file_found, '''
         SELECT
             substr(user_key,10), first_name, last_name, username,
             json_extract(profile_pic_square, '$[0].url'),
@@ -497,7 +519,7 @@ def get_fb_threads_contacts(context):
             CASE is_friend WHEN 0 THEN 'No' WHEN 1 THEN 'Yes' END,
             friendship_status, contact_relationship_status
         FROM thread_users
-        ''')
+        '''))
         for row in rows:
             data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8],
                               rel))

--- a/scripts/artifacts/firefox.py
+++ b/scripts/artifacts/firefox.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Firefox places.sqlite web history",
         "author": "@stark4n6",
         "creation_date": "2022-01-12",
-        "last_update_date": "2026-08-01",
+        "last_update_date": "2026-08-10",
         "requirements": "none",
         "category": "Firefox",
         "notes": "Reference: Mozilla application-services, 'places Timestamp is milliseconds on Android (desktop PRTime is microseconds)', https://github.com/mozilla/application-services/blob/main/components/support/types/src/lib.rs",
@@ -52,7 +52,7 @@ __artifacts_v2__ = {
         "description": "Firefox places.sqlite search queries",
         "author": "@stark4n6",
         "creation_date": "2022-01-12",
-        "last_update_date": "2022-01-12",
+        "last_update_date": "2026-08-10",
         "requirements": "none",
         "category": "Firefox",
         "notes": "",
@@ -69,7 +69,7 @@ import datetime
 import os
 import sqlite3
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, does_table_exist_in_db, logfunc, open_sqlite_db_readonly
 
 
 def _ms_to_utc(value):
@@ -109,7 +109,13 @@ def _run(source_path, sql):
 def get_firefox_history(context):
     files_found = context.get_files_found()
     source_path = _db(files_found)
-    rows = _run(source_path, '''
+    # Older Firefox databases have no moz_places_metadata table, and the inner
+    # join silently returned nothing on them (community report, PR #628). The
+    # join selects no columns, so it is only applied where the table exists.
+    metadata_join = ('INNER JOIN moz_places_metadata ON moz_places.id = moz_places_metadata.id'
+                     if source_path and does_table_exist_in_db(source_path, 'moz_places_metadata')
+                     else '')
+    rows = _run(source_path, f'''
         SELECT moz_places.last_visit_date_local, moz_places.url, moz_places.title,
         moz_places.visit_count_local, moz_places.description,
         CASE moz_places.hidden WHEN 0 THEN 'No' WHEN 1 THEN 'Yes' END,
@@ -117,7 +123,7 @@ def get_firefox_history(context):
         moz_places.frecency, moz_places.preview_image_url
         FROM moz_places
         INNER JOIN moz_historyvisits ON moz_places.origin_id = moz_historyvisits.id
-        INNER JOIN moz_places_metadata ON moz_places.id = moz_places_metadata.id
+        {metadata_join}
         ORDER BY moz_places.last_visit_date_local ASC
     ''')
     data_list = [(_ms_to_utc(r[0]), r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8]) for r in rows]
@@ -173,9 +179,16 @@ def get_firefox_bookmarks(context):
 def get_firefox_searches(context):
     files_found = context.get_files_found()
     source_path = _db(files_found)
-    rows = _run(source_path, '''
-        SELECT id, term FROM moz_places_metadata_search_queries ORDER BY id ASC
-    ''')
+    # Older Firefox databases have no search-queries table (community report,
+    # PR #628).
+    if source_path and not does_table_exist_in_db(source_path, 'moz_places_metadata_search_queries'):
+        logfunc('moz_places_metadata_search_queries not present; this Firefox generation records no search terms table')
+        source_path_rows = []
+        rows = source_path_rows
+    else:
+        rows = _run(source_path, '''
+            SELECT id, term FROM moz_places_metadata_search_queries ORDER BY id ASC
+        ''')
     data_list = [(r[0], r[1]) for r in rows]
     data_headers = ('ID', 'Search Term')
     return data_headers, data_list, source_path

--- a/scripts/artifacts/googleDuo.py
+++ b/scripts/artifacts/googleDuo.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Google Duo / Meet call history",
         "author": "@stark4n6",
         "creation_date": "2021-07-28",
-        "last_update_date": "2021-07-28",
+        "last_update_date": "2026-08-10",
         "requirements": "none",
         "category": "Google Duo",
         "notes": "",
@@ -54,7 +54,7 @@ __artifacts_v2__ = {
         "description": "Google Duo / Meet notes (media messages)",
         "author": "@stark4n6",
         "creation_date": "2021-07-28",
-        "last_update_date": "2021-07-28",
+        "last_update_date": "2026-08-10",
         "requirements": "none",
         "category": "Google Duo",
         "notes": "",
@@ -81,7 +81,7 @@ import datetime
 import os
 import sqlite3
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, check_in_media
+from scripts.ilapfuncs import artifact_processor, null_absent_columns, open_sqlite_db_readonly, check_in_media
 
 
 def _ms_to_utc(value):
@@ -128,7 +128,9 @@ def _run(source_path, sql):
 def get_googleDuo(context):
     files_found = context.get_files_found()
     source_path = _tachyon_db(files_found)
-    rows = _run(source_path, '''
+    # Older TachyonDb generations lack some activity_history columns
+    # (community report, PR #633); absent columns are read as NULL.
+    rows = _run(source_path, null_absent_columns(source_path, '''
         SELECT timestamp_usec, substr(self_id, 0, instr(self_id, '|')),
         substr(other_id, 0, instr(other_id, '|')), duo_users.contact_display_name,
         CASE activity_type WHEN 1 THEN 'Call' WHEN 2 THEN 'Note' WHEN 4 THEN 'Reaction' END,
@@ -136,7 +138,7 @@ def get_googleDuo(context):
         CASE outgoing WHEN 0 THEN 'Incoming' WHEN 1 THEN 'Outgoing' END
         FROM activity_history
         LEFT JOIN duo_users ON duo_users.user_id = substr(other_id, 0, instr(other_id, '|'))
-    ''')
+    '''))
     data_list = [(_us_to_utc(r[0]), r[1], r[2], r[3], r[4], r[5], r[6]) for r in rows]
     data_headers = (('Timestamp', 'datetime'), 'Local User', 'Remote User', 'Contact Name',
                     'Activity Type', 'Call Status', 'Direction')
@@ -162,14 +164,14 @@ def get_googleDuo_contacts(context):
 def get_googleDuo_notes(context):
     files_found = context.get_files_found()
     source_path = _tachyon_db(files_found)
-    rows = _run(source_path, '''
+    rows = _run(source_path, null_absent_columns(source_path, '''
         SELECT sent_timestamp_millis, received_timestamp_millis, seen_timestamp_millis,
         sender_id, recipient_id, content_uri,
         replace(content_uri, rtrim(content_uri, replace(content_uri, '/', '')), ''),
         content_size_bytes,
         CASE saved_status WHEN 0 THEN '' WHEN 1 THEN 'Yes' END
         FROM messages
-    ''')
+    '''))
     data_list = []
     for r in rows:
         file_name = r[6]

--- a/scripts/artifacts/googleMapsGmm.py
+++ b/scripts/artifacts/googleMapsGmm.py
@@ -30,7 +30,7 @@ __artifacts_v2__ = {
         "description": "Parse Google Maps GMM labeled places (gmm_myplaces.db)",
         "author": "@AlexisBrignoni",
         "creation_date": "2022-12-30",
-        "last_update_date": "2026-08-01",
+        "last_update_date": "2026-08-10",
         "requirements": "none",
         "category": "GEO Location",
         "notes": ("Updated 2023-12-12 by @segumarc\n"
@@ -65,7 +65,7 @@ import struct
 
 from scripts.ilapfuncs import decode_protobuf
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, does_table_exist_in_db, logfunc, open_sqlite_db_readonly
 
 
 def _ms_to_utc(value):
@@ -143,6 +143,11 @@ def get_googleMapsGmm_places(context):
         if not file_found.endswith('gmm_myplaces.db'):
             continue
         source_path = file_found
+        # Older gmm_myplaces.db generations have no sync_item table
+        # (community report, PR #633).
+        if not does_table_exist_in_db(file_found, 'sync_item'):
+            logfunc(f'sync_item table not present in {file_found}; this gmm_myplaces.db generation is not covered')
+            continue
         rows = _run(file_found, '''
             SELECT rowid, key_string, round(latitude*.000001, 6), round(longitude*.000001, 6),
             sync_item, timestamp

--- a/scripts/artifacts/googleMessages.py
+++ b/scripts/artifacts/googleMessages.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Google Messages",
         "author": "Josh Hickman (josh@thebinaryhick.blog)",
         "creation_date": "2021-01-30",
-        "last_update_date": "2026-08-01",
+        "last_update_date": "2026-08-10",
         "requirements": "None",
         "category": "Google Messages",
         "notes": ("Direction comes from the sending participant's sub_id. AOSP treats -2 as the "
@@ -46,7 +46,7 @@ __artifacts_v2__ = {
 
 import datetime
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, null_absent_columns, open_sqlite_db_readonly
 
 
 @artifact_processor
@@ -65,7 +65,10 @@ def get_googleMessages(context):
         source_path = file_found
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
-        cursor.execute('''
+        # Older bugle_db generations lack file_size_bytes and local_cache_path
+        # on parts (community report, PR #638/#633); absent columns are read
+        # as NULL so the query works across generations.
+        cursor.execute(null_absent_columns(file_found, '''
         SELECT
         parts.timestamp,
         parts.content_type AS "Message Type",
@@ -89,7 +92,7 @@ def get_googleMessages(context):
         JOIN participants ON participants._id=messages.sender_id
         JOIN conversations ON conversations._id=parts.conversation_id
         ORDER BY parts.timestamp ASC
-        ''')
+        '''))
         all_rows = cursor.fetchall()
         db.close()
 

--- a/scripts/artifacts/keepNotes.py
+++ b/scripts/artifacts/keepNotes.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses Google Keep Notes",
         "author": "Heather Charpentier",
         "creation_date": "2024-12-02",
-        "last_update_date": "2024-12-02",
+        "last_update_date": "2026-08-10",
         "requirements": "none",
         "category": "Google Keep Notes",
         "notes": "",
@@ -23,7 +23,7 @@ __artifacts_v2__ = {
 
 import os
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_human_ts_to_utc
+from scripts.ilapfuncs import artifact_processor, does_table_exist_in_db, open_sqlite_db_readonly, convert_human_ts_to_utc
 
 
 @artifact_processor
@@ -39,17 +39,35 @@ def get_keepNotes(context):
             source_path = file_found
             db = open_sqlite_db_readonly(file_found)
             cursor = db.cursor()
-            cursor.execute('''
-            SELECT
-                datetime(tree_entity.time_created/1000, 'unixepoch') AS "Time Created",
-                datetime(tree_entity.time_last_updated/1000, 'unixepoch') AS "Time Last Updated",
-                datetime(tree_entity.user_edited_timestamp/1000, 'unixepoch') AS "User Edited Timestamp",
-                tree_entity.title AS Title,
-                text_search_note_content_content.c0text AS "Text",
-                tree_entity.last_modifier_email AS "Last Modifier Email"
-            FROM text_search_note_content_content
-            INNER JOIN tree_entity ON text_search_note_content_content.docid = tree_entity._id
-            ''')
+            if does_table_exist_in_db(file_found, 'text_search_note_content_content'):
+                cursor.execute('''
+                SELECT
+                    datetime(tree_entity.time_created/1000, 'unixepoch') AS "Time Created",
+                    datetime(tree_entity.time_last_updated/1000, 'unixepoch') AS "Time Last Updated",
+                    datetime(tree_entity.user_edited_timestamp/1000, 'unixepoch') AS "User Edited Timestamp",
+                    tree_entity.title AS Title,
+                    text_search_note_content_content.c0text AS "Text",
+                    tree_entity.last_modifier_email AS "Last Modifier Email"
+                FROM text_search_note_content_content
+                INNER JOIN tree_entity ON text_search_note_content_content.docid = tree_entity._id
+                ''')
+            else:
+                # Older keep.db generations have no FTS shadow table; note text
+                # lives in list_item instead. Fallback from community PR #638,
+                # exercised against the contributor's database only, not a
+                # registered corpus image.
+                cursor.execute('''
+                SELECT
+                    datetime(tree_entity.time_created/1000, 'unixepoch') AS "Time Created",
+                    datetime(tree_entity.time_last_updated/1000, 'unixepoch') AS "Time Last Updated",
+                    datetime(tree_entity.user_edited_timestamp/1000, 'unixepoch') AS "User Edited Timestamp",
+                    tree_entity.title AS Title,
+                    list_item.text AS "Text",
+                    tree_entity.last_modifier_email AS "Last Modifier Email"
+                FROM tree_entity
+                LEFT JOIN list_item ON tree_entity._id = list_item._id
+                WHERE tree_entity.title IS NOT NULL OR list_item.text IS NOT NULL
+                ''')
 
             all_rows = cursor.fetchall()
             for row in all_rows:

--- a/scripts/artifacts/wellbeing.py
+++ b/scripts/artifacts/wellbeing.py
@@ -31,7 +31,7 @@ __artifacts_v2__ = {
         "description": "Parses Digital Wellbeing events recorded against a package component",
         "author": "@AlexisBrignoni",
         "creation_date": "2020-02-02",
-        "last_update_date": "2026-08-01",
+        "last_update_date": "2026-08-10",
         "requirements": "none",
         "category": "Digital Wellbeing",
         "notes": (
@@ -58,7 +58,7 @@ __artifacts_v2__ = {
 
 import datetime
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, does_table_exist_in_db, open_sqlite_db_readonly
 
 
 def _ms_to_utc(value):
@@ -115,7 +115,9 @@ def get_wellbeing_url(context):
     files_found = context.get_files_found()
     data_list = []
     source_path = _app_usage_db(files_found)
-    if source_path:
+    # Older app_usage generations have no component_events table
+    # (community report, PR #633).
+    if source_path and does_table_exist_in_db(source_path, 'component_events'):
         db = open_sqlite_db_readonly(source_path)
         cursor = db.cursor()
         cursor.execute('''

--- a/scripts/artifacts/wireMessenger.py
+++ b/scripts/artifacts/wireMessenger.py
@@ -39,7 +39,7 @@ __artifacts_v2__ = {
         "description": "Parses messages and call history for Wire Messenger",
         "author": "@cf-eglendye",
         "creation_date": "2024-04-24",
-        "last_update_date": "2026-08-01",
+        "last_update_date": "2026-08-10",
         "requirements": "None",
         "category": "Wire Messenger",
         "notes": "Tested on: Android 13 Wire v.3.81.35. Rows taken from the MsgDeletion table carry "
@@ -71,14 +71,48 @@ MESSAGES_SQL = '''
     json_extract(Messages.content, '$[0].content'),
     CASE Likings."action" WHEN 1 THEN 'Liked' END,
     datetime(Likings."timestamp"/1000,'unixepoch'), Users1.name,
-    time(Messages.duration/1000,'unixepoch'), Assets2.name
+    time(Messages.duration/1000,'unixepoch'), {asset_name}
     FROM Messages
     LEFT JOIN Users ON Users._id = Messages.user_id
     LEFT JOIN Likings ON Messages._id = Likings.message_id
     LEFT JOIN Users Users1 ON Likings.user_id = Users1._id
-    LEFT JOIN Assets2 ON Messages.asset_id = Assets2._id
+    {asset_join}
     ORDER BY Messages.time
 '''
+
+
+def _asset_source(source_path):
+    """Resolve the asset table this Wire release uses.
+
+    Newer databases keep attachments in Assets2, older ones in Assets, and a
+    Messages table without asset_id has nothing to join. Returns the SELECT
+    expression and JOIN clause for MESSAGES_SQL. Only the Assets2 shape is
+    corpus-verified; the Assets fallback comes from a community-reported
+    older database (PR #633) and has not been exercised here.
+    """
+    db = open_sqlite_db_readonly(source_path)
+    try:
+        cursor = db.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        tables = {row[0] for row in cursor.fetchall()}
+        cursor.execute('PRAGMA table_info(Messages)')
+        has_asset_id = 'asset_id' in {row[1] for row in cursor.fetchall()}
+    except sqlite3.Error:
+        tables, has_asset_id = set(), False
+    finally:
+        db.close()
+    for table in ('Assets2', 'Assets'):
+        if has_asset_id and table in tables:
+            db = open_sqlite_db_readonly(source_path)
+            try:
+                has_name = 'name' in {row[1] for row in db.execute(f'PRAGMA table_info({table})')}
+            except sqlite3.Error:
+                has_name = False
+            finally:
+                db.close()
+            name_expr = f'{table}.name' if has_name else "''"
+            return name_expr, f'LEFT JOIN {table} ON Messages.asset_id = {table}._id'
+    return "''", ''
 
 
 def _str_to_utc(value):
@@ -195,7 +229,8 @@ def get_wire_messages(context):
     files_found = context.get_files_found()
     source_path = _user_db(files_found)
     data_list = []
-    for r in _run(source_path, MESSAGES_SQL):
+    asset_name, asset_join = _asset_source(source_path) if source_path else ("''", '')
+    for r in _run(source_path, MESSAGES_SQL.format(asset_name=asset_name, asset_join=asset_join)):
         data_list.append((_str_to_utc(r[0]), r[1], r[2], r[3], r[4], r[5], _str_to_utc(r[6]), r[7], r[8], r[9],
                           ''))
 


### PR DESCRIPTION
Community PRs #628, #633 and #638 carry real schema-generation knowledge from older Android images our corpora do not include. This ports that knowledge onto current main in the repo's guard style (column resolvers, table guards, null_absent_columns), with none of the broad exception wrapping the originals used, and credits the three contributors as co-authors.

What each module gains is in the commit message. Two validation statements, tiered honestly:

- **Current generations, corpus-verified**: all 137 artifact/corpus pairs for the touched modules are byte-identical to the final 12-corpus baseline. The guards change nothing where the modern schema is present, which is the designed result.
- **Older generations, code-present and unexercised here**: no registered image carries the legacy shapes, so those paths rest on the contributors' own databases (Android 9-13 school images). The keepNotes fallback and the Wire Assets branch are labeled as such in comments. A corpus image carrying any of these generations would be welcome.

One behavior recovery worth naming: Firefox history's `moz_places_metadata` inner join selects no columns, so on older Firefox it silently returned zero rows; history now reads on those databases too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)