### PR TITLE
fix: drop the unimplemented bytes header type

### DIFF
--- a/scripts/artifacts/honorMediaLibrary.py
+++ b/scripts/artifacts/honorMediaLibrary.py
@@ -88,7 +88,7 @@ def honorMediaLibrary(context):
         'Path',
         'Title',
         'Display Name',
-        ('File Size', 'bytes'),
+        'File Size',
         'Latitude',
         'Longitude',
         'Time Zone',


### PR DESCRIPTION
honorMediaLibrary declared a ('File Size', 'bytes') header. No consumer implements a bytes type (report and LAVA writers branch only on media and datetime), so it fails open: ignored at render, but written into the LAVA manifest's object_columns where it would activate retroactively the day a renderer exists. Stripped to plain text, same reasoning as the removed url type (#1060). The matching iLEAPP case in filesApp.py gets its own PR. smartSidebarFileDock had the same type removed during the #958 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF