### PR TITLE
feat: show Record Origin under the Snapchat conversation bubble

### DIFF
--- a/scripts/artifacts/snapchat.py
+++ b/scripts/artifacts/snapchat.py
@@ -58,7 +58,7 @@ __artifacts_v2__ = {
                        "rows where content_type is 1. WAL frames are not parsed, so absence of a "
                        "message here is not evidence it did not exist.",
         "author": "@AlexisBrignoni, Claude",
-        "creation_date": "2026-08-07", "last_update_date": "2026-08-10",
+        "creation_date": "2026-08-07", "last_update_date": "2026-08-11",
         "requirements": "blackboxprotobuf", "category": "Snapchat",
         "notes": "Newer Snapchat builds keep conversations in arroyo.db; the older Snapchat - "
                  "Messages artifact reads main.db and tcspahn.db and returns nothing on them.\n"
@@ -112,6 +112,10 @@ __artifacts_v2__ = {
                 "directionSentValue": "Outgoing",
                 "timeColumn": "Creation Timestamp",
                 "senderColumn": "Sender Username",
+                # Shows Live or Recovered under every bubble, so a recovered row cannot be
+                # read as a live message. Record Origin is populated on every row, unlike
+                # Recovery Method and Recovery Location, which stay available in the picker.
+                "extraColumns": ["Record Origin"],
             }
         },
     },


### PR DESCRIPTION
One line on the arroyo.db messages conversation view:

```python
"extraColumns": ["Record Origin"],
```

Every bubble now carries `Live` or `Recovered` without the examiner having to know the column picker exists. That closes the last gap from #1053: the provenance was visible in the table and invisible in the chat view, which is exactly where a recovered row could be misread as a live message.

`Record Origin` alone rather than all three. It is populated on every row, so every bubble gets a marker, while `Recovery Method` and `Recovery Location` stay one click away in the picker and would only add noise under a live message.

## Dependency

Needs **LAVA PR [#166](https://github.com/abrignoni/LAVA/pull/166)** (`feat/convo-extras`), which introduces `extraColumns`. It is not on LAVA `main` yet. Alexis confirmed shipping ahead of that merge is fine.

## Verified, not assumed

An unrecognised declarative option fails open silently, so this got checked properly rather than eyeballed:

| check | result |
| --- | --- |
| does the literal exist in the consumer? | yes, `conversationExtras.js:104`, `conversationParams?.extraColumns` |
| is it on LAVA `main`? | **no**, PR #166 only |
| James's resolver against this artifact's real manifest | `"Record Origin"` → `record_origin`, a real column in the artifact table |
| current LAVA `main` against the same manifest | array coerces to a string via JS key lookup, nothing reads it, **no throw**, all required layout fields still resolve |
| tolerant to either spelling? | yes: display `"Record Origin"` and sanitized `"record_origin"` both resolve, so it survives `lavafuncs` later sanitizing this key like the others |
| collides with a layout column? | no, and the view ignores those anyway |

So the field is **inert rather than harmful** on current LAVA, and correct once #166 lands.

Worth noting for James: `lavafuncs` sanitizes the other `data_views` column values to snake_case before writing the manifest but passes `extraColumns` through as the display name. It works because the resolver checks the reverse map first, and it keeps working if that changes, but the asymmetry is there.

## Validation

Corpus `hc_pixel8pro_a17`: 16 message rows and 5 conversation rows, unchanged. 765 plugins load with no duplicate names. `check_claim_language.py` clean, `check_html_safety.py` clean, pylint 10.00/10, `lint_changed.py` no new warnings.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>