### PR TITLE
ci: install a modern PyInstaller despite the packaging pin

### DIFF
--- a/.github/workflows/test_builds.yml
+++ b/.github/workflows/test_builds.yml
@@ -43,9 +43,15 @@ jobs:
           python-version: '3.14'
 
       - name: Install dependencies
+        # pyinstaller is installed after the requirements, in its own command:
+        # requirements.txt pins packaging==20.1, and resolving pyinstaller in the
+        # same command drags it back to 4.5.1 (the last release satisfied by that
+        # pin), which imports pkg_resources and cannot run on Python 3.14. The
+        # separate install lets pip upgrade packaging for the build environment.
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt pyinstaller
+          pip install -r requirements.txt
+          pip install "pyinstaller>=6.22"
 
       - name: Build CLI and GUI with PyInstaller
         working-directory: scripts/pyinstaller
@@ -105,9 +111,15 @@ jobs:
           python -c "import tkinter" || { echo "tkinter unavailable in this Python"; exit 1; }
 
       - name: Install dependencies
+        # pyinstaller is installed after the requirements, in its own command:
+        # requirements.txt pins packaging==20.1, and resolving pyinstaller in the
+        # same command drags it back to 4.5.1 (the last release satisfied by that
+        # pin), which imports pkg_resources and cannot run on Python 3.14. The
+        # separate install lets pip upgrade packaging for the build environment.
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt pyinstaller
+          pip install -r requirements.txt
+          pip install "pyinstaller>=6.22"
 
       - name: Build CLI and GUI with PyInstaller
         working-directory: scripts/pyinstaller


### PR DESCRIPTION
The first dispatch of the test_builds workflow (run 31440335999) failed identically on all four legs: requirements.txt pins packaging==20.1, so resolving pyinstaller in the same pip command dragged it to 4.5.1, the last release satisfied by that pin. That version imports pkg_resources, which no longer exists on Python 3.14, so every job died before building anything. Worth noting the Windows arm64 leg got through its dependency install fine, including the bcrypt source build, so this was the only wall.

Fix: install pyinstaller>=6.22 in its own pip command after the requirements, letting pip upgrade packaging for the build environment only. Verified locally on 3.14 against this repo's requirements: packaging upgrades to 26.3 and PyInstaller 6.22 imports cleanly.

I will re-dispatch the workflow after merge and report the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)