### PR TITLE
fix: collect the packages artifacts import into frozen builds

### DIFF
--- a/scripts/pyinstaller/aleapp.spec
+++ b/scripts/pyinstaller/aleapp.spec
@@ -2,7 +2,7 @@
 
 block_cipher = None
 
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
 # mister_skinnylegs discovers its plugins at runtime via a filesystem glob
 # (PLUGIN_PATH.glob("*_plugin.py")), so PyInstaller's import-graph analysis
@@ -16,6 +16,16 @@ a = Analysis(
    binaries=[],
    datas=[('..\\', '.\\scripts'), *msl_plugin_datas],
    hiddenimports=[
+      # Artifacts are bundled as data files and imported from disk at runtime,
+      # so PyInstaller's import-graph analysis never sees what they import.
+      # hook-plugin_loader.py was meant to cover this but targets a bare
+      # 'plugin_loader' module that no longer exists (it moved to
+      # scripts.plugin_loader), so it never fires. Collect the packages
+      # artifacts import wholesale; a missing submodule here is a startup
+      # crash in the frozen build only.
+      *collect_submodules('Crypto'),
+      *collect_submodules('google.protobuf'),
+      *collect_submodules('leapp_functions'),
       'bcrypt',
       'bencoding',
       'bs4',

--- a/scripts/pyinstaller/aleappGUI.spec
+++ b/scripts/pyinstaller/aleappGUI.spec
@@ -2,7 +2,7 @@
 
 block_cipher = None
 
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
 # mister_skinnylegs discovers its plugins at runtime via a filesystem glob
 # (PLUGIN_PATH.glob("*_plugin.py")), so PyInstaller's import-graph analysis
@@ -21,6 +21,16 @@ a = Analysis(
       *msl_plugin_datas
    ],
    hiddenimports=[
+      # Artifacts are bundled as data files and imported from disk at runtime,
+      # so PyInstaller's import-graph analysis never sees what they import.
+      # hook-plugin_loader.py was meant to cover this but targets a bare
+      # 'plugin_loader' module that no longer exists (it moved to
+      # scripts.plugin_loader), so it never fires. Collect the packages
+      # artifacts import wholesale; a missing submodule here is a startup
+      # crash in the frozen build only.
+      *collect_submodules('Crypto'),
+      *collect_submodules('google.protobuf'),
+      *collect_submodules('leapp_functions'),
       'bcrypt',
       'bencoding',
       'bs4',

--- a/scripts/pyinstaller/aleappGUI_Linux.spec
+++ b/scripts/pyinstaller/aleappGUI_Linux.spec
@@ -1,6 +1,6 @@
 # -*- mode: python ; coding: utf-8 -*-
 
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
 # mister_skinnylegs discovers its plugins at runtime via a filesystem glob
 # (PLUGIN_PATH.glob("*_plugin.py")), so PyInstaller's import-graph analysis
@@ -19,6 +19,16 @@ a = Analysis(
         *msl_plugin_datas
         ],
     hiddenimports=[
+        # Artifacts are bundled as data files and imported from disk at runtime,
+        # so PyInstaller's import-graph analysis never sees what they import.
+        # hook-plugin_loader.py was meant to cover this but targets a bare
+        # 'plugin_loader' module that no longer exists (it moved to
+        # scripts.plugin_loader), so it never fires. Collect the packages
+        # artifacts import wholesale; a missing submodule here is a startup
+        # crash in the frozen build only.
+        *collect_submodules('Crypto'),
+        *collect_submodules('google.protobuf'),
+        *collect_submodules('leapp_functions'),
         'bcrypt',
         'bencoding',
         'bs4',

--- a/scripts/pyinstaller/aleappGUI_macOS.spec
+++ b/scripts/pyinstaller/aleappGUI_macOS.spec
@@ -1,6 +1,6 @@
 # -*- mode: python ; coding: utf-8 -*-
 
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
 # mister_skinnylegs discovers its plugins at runtime via a filesystem glob
 # (PLUGIN_PATH.glob("*_plugin.py")), so PyInstaller's import-graph analysis
@@ -19,6 +19,16 @@ a = Analysis(
         *msl_plugin_datas
     ],
     hiddenimports=[
+        # Artifacts are bundled as data files and imported from disk at runtime,
+        # so PyInstaller's import-graph analysis never sees what they import.
+        # hook-plugin_loader.py was meant to cover this but targets a bare
+        # 'plugin_loader' module that no longer exists (it moved to
+        # scripts.plugin_loader), so it never fires. Collect the packages
+        # artifacts import wholesale; a missing submodule here is a startup
+        # crash in the frozen build only.
+        *collect_submodules('Crypto'),
+        *collect_submodules('google.protobuf'),
+        *collect_submodules('leapp_functions'),
         'bcrypt',
         'bencoding',
         'bs4',

--- a/scripts/pyinstaller/aleapp_Linux.spec
+++ b/scripts/pyinstaller/aleapp_Linux.spec
@@ -1,6 +1,6 @@
 # -*- mode: python ; coding: utf-8 -*-
 
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
 # mister_skinnylegs discovers its plugins at runtime via a filesystem glob
 # (PLUGIN_PATH.glob("*_plugin.py")), so PyInstaller's import-graph analysis
@@ -14,6 +14,16 @@ a = Analysis(
     binaries=[],
     datas=[('../', 'scripts'), *msl_plugin_datas],
     hiddenimports=[
+        # Artifacts are bundled as data files and imported from disk at runtime,
+        # so PyInstaller's import-graph analysis never sees what they import.
+        # hook-plugin_loader.py was meant to cover this but targets a bare
+        # 'plugin_loader' module that no longer exists (it moved to
+        # scripts.plugin_loader), so it never fires. Collect the packages
+        # artifacts import wholesale; a missing submodule here is a startup
+        # crash in the frozen build only.
+        *collect_submodules('Crypto'),
+        *collect_submodules('google.protobuf'),
+        *collect_submodules('leapp_functions'),
         'bcrypt',
         'bencoding',
         'bs4',

--- a/scripts/pyinstaller/aleapp_macOS.spec
+++ b/scripts/pyinstaller/aleapp_macOS.spec
@@ -1,6 +1,6 @@
 # -*- mode: python ; coding: utf-8 -*-
 
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
 # mister_skinnylegs discovers its plugins at runtime via a filesystem glob
 # (PLUGIN_PATH.glob("*_plugin.py")), so PyInstaller's import-graph analysis
@@ -14,6 +14,16 @@ a = Analysis(
     binaries=[],
     datas=[('../', 'scripts'), *msl_plugin_datas],
     hiddenimports=[
+        # Artifacts are bundled as data files and imported from disk at runtime,
+        # so PyInstaller's import-graph analysis never sees what they import.
+        # hook-plugin_loader.py was meant to cover this but targets a bare
+        # 'plugin_loader' module that no longer exists (it moved to
+        # scripts.plugin_loader), so it never fires. Collect the packages
+        # artifacts import wholesale; a missing submodule here is a startup
+        # crash in the frozen build only.
+        *collect_submodules('Crypto'),
+        *collect_submodules('google.protobuf'),
+        *collect_submodules('leapp_functions'),
         'bcrypt',
         'bencoding',
         'bs4',


### PR DESCRIPTION
The new test_builds workflow's first working dispatch (run 31440664845) caught the frozen CLI crashing at startup while loading signalAndroid.py: `ImportError: cannot import name Counter from Crypto.Util`. This is a real defect in current frozen builds, not a workflow problem.

Cause: artifacts are bundled as data files and imported from disk at runtime, so PyInstaller's import-graph analysis never sees what they import. The specs' hand-kept hiddenimports list covered only 2 of the 6 Crypto submodules artifacts actually use, none of google.protobuf (which the vendored blackboxprotobuf imports internals from), and none of the leapp_functions.data_sources modules that only artifacts import. The existing hook-plugin_loader.py was meant to cover exactly this, but it targets a bare `plugin_loader` module and the loader moved to `scripts.plugin_loader`, so the hook never fires (its own TODO comment predicted this). The hook is left in place untouched; repairing it is a possible follow-up, and the spec comment documents why it is inert.

Fix: all six specs collect Crypto, google.protobuf and leapp_functions wholesale via collect_submodules, the same pattern iLEAPP's specs use for google.protobuf. A missing submodule in this list is a startup crash that only executing a frozen binary can catch.

Verified locally: built aleapp_macOS.spec on Python 3.14 with the patched spec and ran the frozen CLI end to end (--help plus an empty-input run). 764 modules loaded, exit 0, zero errors in the log. I will re-dispatch test_builds after merge to prove the Windows and Linux legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)