### PR TITLE
ci: one pip command per step so a failed install stops the job

### DIFF
--- a/.github/workflows/test_builds.yml
+++ b/.github/workflows/test_builds.yml
@@ -43,15 +43,19 @@ jobs:
           python-version: '3.14'
 
       - name: Install dependencies
-        # pyinstaller is installed after the requirements, in its own command:
-        # requirements.txt pins packaging==20.1, and resolving pyinstaller in the
-        # same command drags it back to 4.5.1 (the last release satisfied by that
-        # pin), which imports pkg_resources and cannot run on Python 3.14. The
-        # separate install lets pip upgrade packaging for the build environment.
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install "pyinstaller>=6.22"
+        # Requirements install alone in this step: a pwsh multi-line run does not
+        # stop on a failed command, so bundling more commands after it lets a
+        # failed install pass silently and surface later as a missing-module
+        # crash in the frozen exe (seen on RLEAPP's arm64 leg, run 31444496033).
+        run: pip install -r requirements.txt
+
+      - name: Install PyInstaller
+        # Separate from the requirements on purpose: requirements.txt pins
+        # packaging==20.1, and resolving pyinstaller in the same command drags it
+        # back to 4.5.1 (the last release satisfied by that pin), which imports
+        # pkg_resources and cannot run on Python 3.14. Installing afterwards lets
+        # pip upgrade packaging for the build environment.
+        run: pip install "pyinstaller>=6.22"
 
       - name: Build CLI and GUI with PyInstaller
         working-directory: scripts/pyinstaller
@@ -111,15 +115,19 @@ jobs:
           python -c "import tkinter" || { echo "tkinter unavailable in this Python"; exit 1; }
 
       - name: Install dependencies
-        # pyinstaller is installed after the requirements, in its own command:
-        # requirements.txt pins packaging==20.1, and resolving pyinstaller in the
-        # same command drags it back to 4.5.1 (the last release satisfied by that
-        # pin), which imports pkg_resources and cannot run on Python 3.14. The
-        # separate install lets pip upgrade packaging for the build environment.
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install "pyinstaller>=6.22"
+        # Requirements install alone in this step: a pwsh multi-line run does not
+        # stop on a failed command, so bundling more commands after it lets a
+        # failed install pass silently and surface later as a missing-module
+        # crash in the frozen exe (seen on RLEAPP's arm64 leg, run 31444496033).
+        run: pip install -r requirements.txt
+
+      - name: Install PyInstaller
+        # Separate from the requirements on purpose: requirements.txt pins
+        # packaging==20.1, and resolving pyinstaller in the same command drags it
+        # back to 4.5.1 (the last release satisfied by that pin), which imports
+        # pkg_resources and cannot run on Python 3.14. Installing afterwards lets
+        # pip upgrade packaging for the build environment.
+        run: pip install "pyinstaller>=6.22"
 
       - name: Build CLI and GUI with PyInstaller
         working-directory: scripts/pyinstaller


### PR DESCRIPTION
Levels the fix from RLEAPP #409. A pwsh multi-line run does not stop on a failed command, so if the requirements install fails, the step still passes and the failure surfaces later as a missing-module crash in the frozen exe, pointing away from the actual cause. RLEAPP's Windows arm64 leg hit exactly this (run 31444496033: cryptography source build failed, step went green, frozen exe crashed on missing pytz). ALEAPP's workflow has the identical step layout, so the hazard is latent here.

The pip installs are now single-command steps; the pyinstaller-after-requirements ordering and its packaging==20.1 rationale are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)