### PR TITLE
Guard schema drift in 4 artifacts found sweeping new Android corpora

### DIFF
--- a/scripts/artifacts/airtagAndroid.py
+++ b/scripts/artifacts/airtagAndroid.py
@@ -85,7 +85,7 @@ __artifacts_v2__ = {
 from scripts.ilapfuncs import decode_protobuf
 from scripts.ilapfuncs import artifact_processor, \
     get_file_path, get_sqlite_db_records, get_binary_file_content, \
-    convert_unix_ts_to_utc
+    convert_unix_ts_to_utc, does_column_exist_in_db
 
 
 @artifact_processor
@@ -93,16 +93,22 @@ def airtagAlerts(context):
     files_found = context.get_files_found()
     source_path = get_file_path(files_found, "personalsafety_db")
     data_list = []
-    
-    query = '''
-    SELECT 
+
+    # older GmsCore personalsafety_db schemas do not carry these two columns
+    device_type_col = 'deviceType' if does_column_exist_in_db(
+        source_path, 'DeviceData', 'deviceType') else "NULL AS deviceType"
+    optional_data_col = 'optionalDeviceData' if does_column_exist_in_db(
+        source_path, 'DeviceData', 'optionalDeviceData') else "NULL AS optionalDeviceData"
+
+    query = f'''
+    SELECT
         creationTimestampMillis,
         lastUpdatedTimestampMillis,
         macAddress,
-        deviceType,
-        optionalDeviceData,
+        {device_type_col},
+        {optional_data_col},
         alertLifecycleId,
-        alertStatus 
+        alertStatus
     FROM DeviceData
     '''
 
@@ -163,15 +169,24 @@ def airtagScans(context):
         creation_timestamp = convert_unix_ts_to_utc(record[0])
         last_updated_timestamp = convert_unix_ts_to_utc(record[1])
 
-        blescan_proto, _ = decode_protobuf(blescan)
-        posrssi = (blescan_proto['2'])
-        
-        location_scan_proto, _ = decode_protobuf(location_scan)
-        latitude = (location_scan_proto['4']/1e7)
-        longitude = (location_scan_proto['5']/1e7)
-        
+        blescan_proto = {}
+        if blescan:
+            blescan_proto, _ = decode_protobuf(blescan)
+            blescan_proto = blescan_proto or {}
+        posrssi = blescan_proto.get('2', '')
+
+        # a scan row without a location fix carries no lat/long fields
+        location_scan_proto = {}
+        if location_scan:
+            location_scan_proto, _ = decode_protobuf(location_scan)
+            location_scan_proto = location_scan_proto or {}
+        lat_raw = location_scan_proto.get('4')
+        lon_raw = location_scan_proto.get('5')
+        latitude = lat_raw / 1e7 if isinstance(lat_raw, (int, float)) else ''
+        longitude = lon_raw / 1e7 if isinstance(lon_raw, (int, float)) else ''
+
         data_list.append((
-            creation_timestamp, last_updated_timestamp, mac_address, 
+            creation_timestamp, last_updated_timestamp, mac_address,
             state, posrssi, latitude, longitude))
 
     return data_headers, data_list, source_path

--- a/scripts/artifacts/samsungScpm.py
+++ b/scripts/artifacts/samsungScpm.py
@@ -23,7 +23,7 @@ __artifacts_v2__ = {
 }
 
 from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
-    convert_unix_ts_to_utc
+    convert_unix_ts_to_utc, does_table_exist_in_db
 
 
 def _unique_db_files(context, name_suffix):
@@ -52,6 +52,10 @@ def samsungScpmDevices(context):
     source_path = ''
 
     for file_found in _unique_db_files(context, 'scpmv2.db'):
+        # some One UI builds (seen on an SM-G991B image) ship scpmv2.db without a
+        # devices table; skip those rather than raising "no such table: devices"
+        if not does_table_exist_in_db(file_found, 'devices'):
+            continue
         db_records = get_sqlite_db_records(file_found, '''
             SELECT registration_time, last_access_time, alias, type, model_name,
                    model_code, os_type, os_version, platform_version, country_code,

--- a/scripts/artifacts/samsungWifiDatabases.py
+++ b/scripts/artifacts/samsungWifiDatabases.py
@@ -87,9 +87,12 @@ def samsungWifiConfigStoreDb(context):
         # older One UI versions do not have the CREATION_TIME column
         creation_column = 'CREATION_TIME' if does_column_exist_in_db(
             file_found, 'configs', 'CREATION_TIME') else "''"
+        # older One UI versions (seen on Android 11) also lack NETWORK_DISABLE_REASON
+        disable_reason_column = 'NETWORK_DISABLE_REASON' if does_column_exist_in_db(
+            file_found, 'configs', 'NETWORK_DISABLE_REASON') else "''"
         db_records = get_sqlite_db_records(file_found, f'''
             SELECT {creation_column}, CONFIG_KEY, NETWORK_SCORE, CAPTIVE_PORTAL, LOCK_DOWN,
-                   NO_INTERNET_ACCESS_EXPECTED, NETWORK_DISABLE_REASON
+                   NO_INTERNET_ACCESS_EXPECTED, {disable_reason_column}
             FROM configs
             ORDER BY _ID
         ''')


### PR DESCRIPTION
Sweeping two newly added Android corpora, a Cookbook Android 11 image (Samsung SM-G991U) and the Cellebrite CTF23 Sharon image (Android 13, SM-G991B), turned up four artifacts that crashed on schema or data-shape drift and returned nothing. All four are leaf-level guards, each validated with a real aleapp.py run against the image, not a mock harness.

**samsungWifiConfigStoreDb**: older One UI builds have no NETWORK_DISABLE_REASON column in the configs table, so the SELECT threw "no such column" and dropped every saved WiFi config. Guarded the column the same way the function already guards CREATION_TIME. Recovered the saved config on the Android 11 image.

**airtagAlerts**: this build's DeviceData table has no deviceType or optionalDeviceData column. Guarded both, substitute NULL when absent.

**airtagScans**: a scan row with no location fix has a locationScan protobuf with no field 4/5, so proto['4'] raised KeyError and killed the whole artifact. Made the protobuf reads defensive. Recovered all 20 BLE tracker-scan records on the Sharon image, where it had been returning zero. Latitude and longitude stay blank when the scan recorded no coordinates, confirmed by decoding the actual blobs: this schema's locationScan carries only fields 1, 2 and 3.

**samsungScpmDevices**: this build's scpmv2.db has no devices table at all (it uses wearable_device, empty here), so the query threw "no such table". The columns are not reachable under another table on this schema, so there is nothing to remap. Guarded with does_table_exist_in_db. The four corpora that carry a devices table are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)