### PR TITLE
Bound speculative nested-message guessing in vendored blackboxprotobuf

### DIFF
--- a/scripts/blackboxprotobuf/lib/interface.py
+++ b/scripts/blackboxprotobuf/lib/interface.py
@@ -61,6 +61,10 @@ def decode_message(buf, message_type=None):
         else:
             message_type = known_messages[message_type]
 
+    # LEAPP addition: fresh speculation budget for each top-level decode
+    # (see the note above decode_guess in types/length_delim.py).
+    scripts.blackboxprotobuf.lib.types.length_delim.reset_guess_budget()
+
     value, typedef, _ = scripts.blackboxprotobuf.lib.types.length_delim.decode_message(buf, message_type)
     return value, typedef
 

--- a/scripts/blackboxprotobuf/lib/types/length_delim.py
+++ b/scripts/blackboxprotobuf/lib/types/length_delim.py
@@ -1,5 +1,6 @@
 # pylint: skip-file
-# Vendored third-party code (blackboxprotobuf 1.0.1) - kept as released.
+# Vendored third-party code (blackboxprotobuf 1.0.1) - kept as released,
+# except for the speculation bound below (see LEAPP note above decode_guess).
 """Module for encoding and decoding length delimited fields"""
 import copy
 import sys
@@ -9,13 +10,50 @@ from google.protobuf.internal import wire_format, encoder, decoder
 import scripts.blackboxprotobuf.lib.types
 from scripts.blackboxprotobuf.lib.types import varint
 
+# LEAPP addition: bound on speculative "is this bytes field a nested message?"
+# decoding. decode_guess tries the message interpretation first and falls back
+# to bytes on failure. A blob whose bytes re-parse as valid messages at many
+# offsets makes that speculation combinatorial: a 7.7 KB Google Maps cache blob
+# was observed running 3.4 million decode_message calls in 15 seconds (healthy
+# blobs of the same file type need a few hundred to a few thousand) and hanging
+# an entire run for 90+ minutes. Upstream (bbpb master, checked 2026-08-11)
+# threads a depth parameter through these functions but never enforces it.
+#
+# The counters reset at every public entry (interface.decode_message). When the
+# budget or depth limit is hit, decode_guess stops speculating and returns the
+# bytes fallback - the same result a failed guess already produces - so the
+# decode completes and typedef-driven fields are unaffected. budget_exceeded
+# is left set for callers that want to log the degradation.
+GUESS_WORK_BUDGET = 250000  # decode_message calls allowed per top-level decode
+GUESS_DEPTH_LIMIT = 100     # nested speculative decodes allowed
+
+_work_count = 0
+_guess_depth = 0
+budget_exceeded = False
+
+
+def reset_guess_budget():
+    """Reset the speculation counters. Called at each public decode entry."""
+    global _work_count, _guess_depth, budget_exceeded
+    _work_count = 0
+    _guess_depth = 0
+    budget_exceeded = False
+
+
 def decode_guess(buf, pos):
     """Try to decode as an empty message first, then just do as bytes
        Returns the value + the type"""
+    global _guess_depth, budget_exceeded
+    if _work_count > GUESS_WORK_BUDGET or _guess_depth >= GUESS_DEPTH_LIMIT:
+        budget_exceeded = True
+        return decode_bytes(buf, pos), 'bytes'
+    _guess_depth += 1
     try:
         return decode_lendelim_message(buf, {}, pos), 'message'
     except Exception as exc:
         return decode_bytes(buf, pos), 'bytes'
+    finally:
+        _guess_depth -= 1
 
 
 def encode_bytes(value):
@@ -135,6 +173,11 @@ def encode_message(data, typedef, group=False):
 
 def decode_message(buf, typedef=None, pos=0, end=None, group=False):
     """Decode a protobuf message with no length delimiter"""
+    # LEAPP addition: count decoding work so decode_guess can stop speculating
+    # on pathological self-similar blobs (see note above decode_guess).
+    global _work_count
+    _work_count += 1
+
     if end is None:
         end = len(buf)
 

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -672,8 +672,18 @@ def decode_protobuf(data, typedef=None):
     fields that are not messages decode as bytes, and fields with alternate
     typedefs split into 'N-M' keys. See scripts/blackboxprotobuf/README.md
     for why the library is vendored.
+
+    Speculative nested-message guessing is bounded (see the note above
+    decode_guess in scripts/blackboxprotobuf/lib/types/length_delim.py); when
+    the bound trips, the affected ambiguous fields decode as bytes and the
+    degradation is logged here rather than hanging the run.
     '''
-    return blackboxprotobuf.decode_message(data, typedef)
+    result = blackboxprotobuf.decode_message(data, typedef)
+    from scripts.blackboxprotobuf.lib.types import length_delim
+    if length_delim.budget_exceeded:
+        logfunc('decode_protobuf: speculation budget exceeded; '
+                'ambiguous protobuf fields returned as bytes for this blob')
+    return result
 
 def get_sqlite_db_path(path):
     if is_platform_windows():


### PR DESCRIPTION
A 7.7 KB Google Maps search cache blob (new_recent_history_cache_search.cs, Pixel 3 Android 11 image) hung an entire ALEAPP run for 90+ minutes at 100% CPU. faulthandler traced it to blackboxprotobuf's decode_guess: for every length-delimited field not covered by a typedef it first tries to decode the bytes as a nested message, recursively, with no depth or work limit. Bytes that happen to re-parse as valid messages at many offsets make that speculation combinatorial. The blob ran 3.4 million decode_message calls in 15 seconds; healthy blobs of the same file need a few hundred to a few thousand. Upstream bbpb master (checked 2026-08-11) threads a depth parameter through these functions but never enforces it, so there is no upstream fix to take.

The change: a work budget of 250,000 decode_message calls per top-level decode (about 50x the largest healthy usage observed across all corpora) plus a speculation depth limit of 100 (healthy blobs reach 52). Both reset at the public interface.decode_message entry and are enforced only in decode_guess, which on exhaustion returns the same bytes fallback a failed guess already produces. Typedef-driven fields never consult the budget, so declared schemas decode unchanged. No exceptions are involved: decode_guess's blanket except swallows anything raised beneath it (measured, it ate a SIGALRM), so the bound decides before speculating instead of raising from within. decode_protobuf in ilapfuncs logs when the budget trips, so the degradation is visible in the run log instead of silent.

Validation, all from real aleapp.py runs:

The pathological blob: 90+ minute hang becomes a 1.17 second decode, and get_googleMapsSearches now recovers its 8 searches (places, coordinates, timestamps) that were unreachable before.

Corpus regression diff, every protobuf-decoding artifact (79 plugin functions) across all 18 registered Android corpora, baseline from an unpatched main worktree vs this branch:

- pixel3_a11: baseline timed out at 15 minutes with zero artifacts recorded, since the hang killed the whole run. Patched completes in 20 seconds with 21 artifacts / 458 records: 225 Gmail emails, Google Dialer call logs, Snapchat messages, Maps searches, FCM TikTok and Instagram, and more. The hang was suppressing every artifact on the image, not just Maps.
- Three corpora carried near-pathological blobs that completed but wasted minutes grinding: pixel3_a12 460s to 40s, russell_pixel6a_a13 200s to 20s, sharon_a14 160s to 20s. Their outputs are byte-identical with the budget in place.
- The other 14 corpora: identical record counts and identical TSV output. The only hash mismatches in the whole diff were the harness's own baseline/patched output paths embedded in source-path columns, verified identical after path normalization.

Byte-identical leveling to iLEAPP (same vendored library, same two files) is in the companion iLEAPP PR, validated there against all 24 iOS corpora with zero output differences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)