### PR TITLE
Fix Samsung recovery history reporting zero rows on current devices

### DIFF
--- a/scripts/artifacts/sRecoveryhist.py
+++ b/scripts/artifacts/sRecoveryhist.py
@@ -1,21 +1,25 @@
 __artifacts_v2__ = {
     "get_sRecoveryhist": {
         "name": "sRecoveryhist",
-        "description": "Parses Samsung recovery history (timestamp, wipe events, reason, reboot reason and locale) from the efs recovery history file.",
+        "description": "Parses Samsung recovery history (timestamp, firmware build, wipe events, reason, reboot reason and locale) from the efs recovery history file.",
         "author": "@abrignoni",
         "creation_date": "2021-08-15",
-        "last_update_date": "2021-08-15",
+        "last_update_date": "2026-08-14",
         "requirements": "none",
         "category": "Wipe & Setup",
-        "notes": "",
+        "notes": "Each record begins with a '+ [tag | timestamp | build]' header. Older devices end "
+                 "each record with a lone '-' line; newer devices write no separator and the next "
+                 "'+' header ends the previous record. Both layouts are read. Timestamps are stored "
+                 "in the device's local time. A record with --wipe_data or --prompt_and_wipe_data is "
+                 "a factory reset; records with --carry_out=open_fota are firmware (FOTA) updates.",
         "paths": ('*/efs/recovery/history',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "file",
         "sample_data": {
-            "anne_a15": "Android 15 | 0 rows",
             "galaxys10_a10": "Android 10 | 4 rows",
-            "samsunga53_a14": "Android 14 | 0 rows",
-            "sharon_a14": "Android 14 | 0 rows",
+            "anne_a15": "Android 15 | 9 rows",
+            "sharon_a14": "Android 14 | 13 rows",
+            "samsunga53_a14": "Android 14 | 50 rows",
         },
     }
 }
@@ -23,60 +27,91 @@ __artifacts_v2__ = {
 from scripts.ilapfuncs import artifact_processor
 
 
+_EMPTY = {
+    'timestamp': '', 'tag': '', 'build': '', 'wipe': '', 'promptwipe': '',
+    'reason': '', 'rebootreason': '', 'locale': '', 'carryout': '',
+    'reqtime': '', 'updateorg': '', 'updatepkg': '',
+}
+
+
+def _record_row(rec, rel_path):
+    return (
+        rec['timestamp'], rec['reqtime'], rec['build'], rec['tag'],
+        rec['wipe'], rec['promptwipe'], rec['reason'], rec['rebootreason'],
+        rec['locale'], rec['carryout'], rec['updateorg'], rec['updatepkg'],
+        rel_path)
+
+
+def _parse_header(line):
+    """A '+ [tag | 2022/01/24 14:11:57 | BUILD]' header into (tag, timestamp, build)."""
+    inner = line.lstrip('+').strip().strip('[]')
+    if '|' in inner:
+        parts = [p.strip() for p in inner.split('|')]
+        tag = parts[0]
+        timestamp = parts[1].replace('/', '-') if len(parts) > 1 else ''
+        build = parts[2] if len(parts) > 2 else ''
+        return tag, timestamp, build
+    # Fallback for an older header shape without pipes: '+ ... : timestamp'
+    if ':' in inner:
+        timestamp = inner.split(':', 1)[1].strip().replace('/', '-')
+        return '', timestamp, ''
+    return '', inner, ''
+
+
 @artifact_processor
 def get_sRecoveryhist(context):
-    files_found = context.get_files_found()
-
+    data_headers = (
+        'Timestamp', 'Request Timestamp', 'Build', 'Entry Tag (as stored)',
+        'Wipe', 'Prompt & Wipe', 'Reason', 'Reboot Reason', 'Locale',
+        'Carry Out', 'Update ORG', 'Update PKG', 'Source File')
     data_list = []
-    source_path = ''
-    for file_found in files_found:
+    sources = []
+
+    for file_found in context.get_files_found():
         file_found = str(file_found)
         if not file_found.endswith('history'):
             continue  # Skip all other files
 
-        source_path = file_found
-        timestamp = wipe = promptwipe = reason = rebootreason = locale = updateorg = updatepkg = reqtime = ''
+        rel_path = context.get_relative_path(file_found)
+        record = None
+        rows_before = len(data_list)
+
         with open(file_found, 'r', encoding='utf-8', errors='replace') as f:
             for line in f:
+                line = line.rstrip('\n')
                 if line.startswith('+'):
-                    if '|' in line:
-                        timestamp = line.split('|')
-                        timestamp = timestamp[1].strip()
-                        timestamp = timestamp.replace('/', '-')
-                    else:
-                        timestamp = line.split(':', 1)
-                        timestamp = timestamp[1].strip()
-                        timestamp = timestamp.replace(']', '')
-                        timestamp = timestamp.replace('/', '-')
+                    if record is not None:
+                        data_list.append(_record_row(record, rel_path))
+                    record = dict(_EMPTY)
+                    record['tag'], record['timestamp'], record['build'] = _parse_header(line)
+                    continue
+                if record is None:
+                    continue  # content before the first header
                 if line.startswith('--wipe_data'):
-                    wipe = 'Yes'
-                if line.startswith('--reason'):
-                    reason = line.split('=')
-                    reason = reason[1]
-                if line.startswith('reboot_reason'):
-                    rebootreason = line.split('=')
-                    rebootreason = rebootreason[1]
-                if line.startswith('reboot reason'):
-                    rebootreason = line.split(':', 1)
-                    rebootreason = rebootreason[1]
-                if line.startswith('--locale'):
-                    locale = line.split('=')
-                    locale = locale[1]
-                if line.startswith('--requested_time'):
-                    reqtime = line.split('=')
-                    reqtime = reqtime[1].replace('/', '-')
-                if line.startswith('--update_org_package'):
-                    updateorg = line.split('=')
-                    updateorg = updateorg[1]
-                if line.startswith('--update_package'):
-                    updatepkg = line.split('=')
-                    updatepkg = updatepkg[1]
-                if line.startswith('--prompt_and_wipe_data'):
-                    promptwipe = 'Yes'
-                    wipe = 'Yes'
-                if line.startswith('-\n'):
-                    data_list.append((timestamp, wipe, promptwipe, reason, rebootreason, locale, reqtime, updateorg, updatepkg))
-                    timestamp = wipe = promptwipe = reason = rebootreason = locale = updateorg = updatepkg = reqtime = ''
+                    record['wipe'] = 'Yes'
+                elif line.startswith('--prompt_and_wipe_data'):
+                    record['promptwipe'] = 'Yes'
+                    record['wipe'] = 'Yes'
+                elif line.startswith('--reason'):
+                    record['reason'] = line.split('=', 1)[1] if '=' in line else ''
+                elif line.startswith('--locale'):
+                    record['locale'] = line.split('=', 1)[1] if '=' in line else ''
+                elif line.startswith('--carry_out'):
+                    record['carryout'] = line.split('=', 1)[1] if '=' in line else ''
+                elif line.startswith('--requested_time'):
+                    record['reqtime'] = line.split('=', 1)[1].replace('/', '-') if '=' in line else ''
+                elif line.startswith('--update_org_package'):
+                    record['updateorg'] = line.split('=', 1)[1] if '=' in line else ''
+                elif line.startswith('--update_package'):
+                    record['updatepkg'] = line.split('=', 1)[1] if '=' in line else ''
+                elif line.startswith('reboot_reason'):
+                    record['rebootreason'] = line.split('=', 1)[1] if '=' in line else ''
+                elif line.startswith('reboot reason'):
+                    record['rebootreason'] = line.split(':', 1)[1].strip() if ':' in line else ''
+            if record is not None:
+                data_list.append(_record_row(record, rel_path))  # last record has no trailing header
 
-    data_headers = ('Timestamp', 'Wipe', 'Prompt & Wipe', 'Reason', 'Reboot Reason', 'Locale', 'Request Timestamp', 'Update ORG', 'Update PKG')
-    return data_headers, data_list, source_path
+        if len(data_list) > rows_before:
+            sources.append(rel_path)
+
+    return data_headers, data_list, ', '.join(dict.fromkeys(sources))


### PR DESCRIPTION
## Summary

`sRecoveryhist` appended a record only when it hit a line that is exactly a lone `-`. Older devices (the Galaxy S10 image) end each record that way and parsed fine (4 rows). Current devices write **no separator** — each record runs until the next `+ [tag | timestamp | build]` header — so the append never fired and the artifact reported **zero rows** even with `/efs/recovery/history` present and populated. Mattia Epifani reported this.

## Changes

- Records are now closed by the next `+` header or end of file, so both the old (lone-dash) and new (no-separator) layouts parse.
- Capture the header's **firmware build** and entry tag; add `--carry_out`.
- `reboot_reason` is split on the first `=` only — it contains more than one `=`, so the old `split('=')` dropped the tail.
- Added a Source File column and multi-file source handling.

The Samsung EFS partition is not wiped when the user wipes the phone, so this recovers the device's firmware-update and factory-reset history from images where it was silently dropped.

## Validation (real aleapp.py profile runs)

| corpus | before | after | notes |
|---|---|---|---|
| galaxys10_a10 (A10) | 4 | 4 | no regression (old lone-dash format) |
| anne_a15 (A15) | 0 | **9** | 3 wipe events |
| sharon_a14 (A14) | 0 | **13** | 2 wipe events |
| samsunga53_a14 (A14) | 0 | **50** | 5 `--wipe_data` factory resets, 16 distinct firmware builds |

LAVA record counts match; output has all 13 columns; `wipe='Yes'` populates on factory-reset records. Also parsed clean against two Android 15/16 `history` files supplied by the reporter (22 and 23 records). Pylint 10.00, claim-language and validate_sample_data clean. Reporter samples are private and not committed; `sample_data` records counts from the registered corpora only.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)