### PR TITLE
Fix Errp missing the current eRR.p path and crashing on NUL-padded files

### DIFF
--- a/scripts/artifacts/errp.py
+++ b/scripts/artifacts/errp.py
@@ -1,16 +1,32 @@
 __artifacts_v2__ = {
     "get_errp": {
         "name": "Errp",
-        "description": "Parses provisioning and error events (timestamp, event, code and details) from the system users eRR.p file.",
+        "description": "Parses power on/off, reboot and shutdown events (timestamp, event, code and details) from the system users eRR.p file.",
         "author": "@abrignoni",
         "creation_date": "2021-08-15",
-        "last_update_date": "2021-08-15",
+        "last_update_date": "2026-08-14",
         "requirements": "none",
         "category": "Wipe & Setup",
-        "notes": "",
-        "paths": ('*/system/users/service/eRR.p',),
+        "notes": "The file moved to a data subfolder: current devices store it at "
+                 "system/users/service/data/eRR.p (both the registered Android 10-16 corpora and "
+                 "reporter-supplied Android 15 and 16 samples use that path), while the earlier "
+                 "system/users/service/eRR.p is kept for older images. Each line is "
+                 "'timestamp | event | code | details'; the timestamp carries the device's UTC "
+                 "offset and is also converted to UTC.",
+        "paths": ('*/system/users/service/eRR.p',
+                  '*/system/users/service/data/eRR.p'),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "file",
+        "sample_data": {
+            "galaxys10_a10": "Android 10 | 24 rows",
+            "cookbook_a11": "Android 11 | 50 rows",
+            "samsungs20_a13": "Android 13 | 35 rows",
+            "s20fe_a13": "Android 13 | 52 rows",
+            "sharon_a13": "Android 13 | 44 rows",
+            "samsunga53_a14": "Android 14 | 18 rows",
+            "sharon_a14": "Android 14 | 175 rows",
+            "anne_a15": "Android 15 | 61 rows",
+        },
     }
 }
 
@@ -31,13 +47,21 @@ def get_errp(context):
         source_path = file_found
         with open(file_found, 'r', encoding='utf-8', errors='replace') as f:
             for line in f:
-                line = line.strip()
+                # The file opens with a binary LOGM header, and on some devices its
+                # NUL padding is prepended to the first record with no newline, so
+                # strip NUL bytes before looking for the timestamp.
+                line = line.replace('\x00', '').strip()
                 if line.startswith('LOGM') or line == '':
                     continue
 
                 parts = line.split('|')
                 timestamp = parts[0].strip()
-                timestamp_utc = str(convert_local_to_utc(timestamp))
+                try:
+                    timestamp_utc = str(convert_local_to_utc(timestamp))
+                except (ValueError, TypeError):
+                    # A line whose timestamp will not parse must not lose the whole
+                    # file; keep the row with the value as stored and no UTC form.
+                    timestamp_utc = ''
                 event = parts[1].strip() if len(parts) >= 2 else ''
                 code = parts[2].strip() if len(parts) >= 3 else ''
                 details = parts[3].strip() if len(parts) >= 4 else ''


### PR DESCRIPTION
## Summary

Two defects, the second exposed by fixing the first. Mattia Epifani reported the path.

**Path**: the glob only matched `*/system/users/service/eRR.p`, but current devices store the file at `.../service/data/eRR.p`. All **8** registered Android corpora carrying the file use the `data/` path, so the artifact returned zero on every one of them (and on Mattia's Android 15/16 devices). Both paths are now matched (disjoint patterns, no Windows double-count); the older one is kept for older images.

**Crash**: the file opens with a binary `LOGM` header whose NUL padding is, on some devices, prepended to the first record with no newline. `line.strip()` does not remove NUL bytes, so the timestamp failed `strptime` and the **unhandled exception killed the whole artifact**, losing every row. NULs are now stripped before parsing, and a timestamp that still won't parse keeps its row (value as stored, no UTC) instead of failing the file.

## Validation (real aleapp.py profile runs, all 8 corpora)

| corpus | before | after |
|---|---|---|
| galaxys10_a10 (A10) | 0 | 24 |
| cookbook_a11 (A11) | 0 | 50 |
| samsungs20_a13 (A13) | 0 | 35 |
| s20fe_a13 (A13) | **crash** | 52 |
| sharon_a13 (A13) | **crash** | 44 |
| samsunga53_a14 (A14) | 0 | 18 |
| sharon_a14 (A14) | **crash** | 175 |
| anne_a15 (A15) | 0 | 61 |

Zero errors across all eight; on the previously-crashing files every timestamp converts to UTC (0 blank). Also parsed clean against Mattia's Android 16 and 15 samples (231, 74, 14 records). Pylint 10.00, claim-language and validate_sample_data clean. Reporter samples are private and not committed; sample_data records counts from the registered corpora only.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)