### PR TITLE
Stop siminfo crashing when a telephony.db cannot be opened

### DIFF
--- a/scripts/artifacts/siminfo.py
+++ b/scripts/artifacts/siminfo.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "SIM card details (number, IMSI, ICCID, carrier) from the telephony provider database",
         "author": "@abrignoni",
         "creation_date": "2020-03-02",
-        "last_update_date": "2020-03-02",
+        "last_update_date": "2026-08-14",
         "requirements": "none",
         "category": "Device Information",
         "notes": "",
@@ -64,6 +64,10 @@ def get_siminfo(context):
             continue
 
         db = open_sqlite_db_readonly(file_found)
+        if db is None:
+            # open_sqlite_db_readonly returns None (and logs the reason) when the
+            # database cannot be opened; skip it rather than crashing the artifact.
+            continue
         cursor = db.cursor()
         try:
             cursor.execute(PRIMARY_SQL)


### PR DESCRIPTION
## Summary

`get_siminfo` called `db.cursor()` on the return of `open_sqlite_db_readonly` without checking it. That helper returns `None` (and logs the reason) when a database can't be opened, so a single unreadable `telephony.db` raised `'NoneType' object has no attribute 'cursor'` and the unhandled exception **failed the whole artifact**, losing every SIM record including those from databases that opened fine.

Mattia Epifani reported this. On his Windows setup the open failed with `unable to open database file` because a very long output path produced a mangled extended-length (`\\?\`) URI.

## Fix

Guard the `None` return and `continue`, so the artifact logs the open failure (the helper already does) and moves on to the next file.

```python
db = open_sqlite_db_readonly(file_found)
if db is None:
    continue
cursor = db.cursor()
```

## Validation

`aleapp.py` profile run over two staged copies of a real `telephony.db`: one readable (parsed, **1 record**, all 8 columns), and one made unreadable to force the exact `unable to open database file` → `None` path Mattia saw. The run now logs the failure, parses the readable database, and completes with **no error and exit 0**; before the change that `None` crashed the whole artifact.

Pylint 10.00, claim-language and validate_sample_data clean. Reporter's database is private and not committed.

## Note (separate, not in this PR)

The underlying open failure is a Windows extended-length-path (`\\?\`) issue in the core path/URI handling that affects every SQLite artifact, not just siminfo, and needs testing on Windows. This PR stops the crash so the tool degrades gracefully; recovering the data on very long Windows paths is a separate core change.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)