### PR TITLE
Stop the Samsung My Files artifacts crashing when a database won't open

### DIFF
--- a/scripts/artifacts/smyFiles.py
+++ b/scripts/artifacts/smyFiles.py
@@ -64,6 +64,8 @@ def _query(source_path, sql):
     if not source_path:
         return []
     db = open_sqlite_db_readonly(source_path)
+    if db is None:
+        return []
     cursor = db.cursor()
     try:
         cursor.execute(sql)

--- a/scripts/artifacts/smyFiles2.py
+++ b/scripts/artifacts/smyFiles2.py
@@ -70,6 +70,8 @@ def _rows(db_path, sql):
     if not db_path:
         return []
     db = open_sqlite_db_readonly(db_path)
+    if db is None:
+        return []
     cursor = db.cursor()
     try:
         cursor.execute(sql)

--- a/scripts/artifacts/smyfilesOpHistory.py
+++ b/scripts/artifacts/smyfilesOpHistory.py
@@ -53,6 +53,8 @@ def process_string(old_string):
 
 def get_db_data(file_found):
     db = open_sqlite_db_readonly(file_found)
+    if db is None:
+        return 0
     cursor = db.cursor()
     try:
         cursor.execute("""Select * from operation_history""")

--- a/scripts/artifacts/smyfilesRecents.py
+++ b/scripts/artifacts/smyfilesRecents.py
@@ -66,8 +66,8 @@ def get_smyfilesRecents(context):
     files_found = context.get_files_found()
     data_list = []
     source_path = _myfiles_db(files_found)
-    if source_path:
-        db = open_sqlite_db_readonly(source_path)
+    db = open_sqlite_db_readonly(source_path) if source_path else None
+    if db is not None:
         cursor = db.cursor()
         try:
             cursor.execute(null_absent_columns(source_path, '''
@@ -91,8 +91,8 @@ def get_smyfilesRecents_fileinfo(context):
     files_found = context.get_files_found()
     data_list = []
     source_path = _myfiles_db(files_found)
-    if source_path:
-        db = open_sqlite_db_readonly(source_path)
+    db = open_sqlite_db_readonly(source_path) if source_path else None
+    if db is not None:
         cursor = db.cursor()
         try:
             cursor.execute(null_absent_columns(source_path, '''

--- a/scripts/artifacts/smyfilescache.py
+++ b/scripts/artifacts/smyfilescache.py
@@ -57,8 +57,8 @@ def get_smyfilescache(context):
             break
 
     data_list = []
-    if db_path:
-        db = open_sqlite_db_readonly(db_path)
+    db = open_sqlite_db_readonly(db_path) if db_path else None
+    if db is not None:
         cursor = db.cursor()
         rows = []
         for sql in SQL_VARIANTS:


### PR DESCRIPTION
## Summary

`open_sqlite_db_readonly` returns `None` (and logs the reason) when a database can't be opened. **Five** of the Samsung My Files artifacts called `db.cursor()` on that return without checking it, so a single database that failed to open raised `'NoneType' object has no attribute 'cursor'` and the unhandled exception failed the artifact.

Mattia Epifani reported almost all the My Files plugins failing this way. On his Windows setup a very long output path made the open fail with `unable to open database file` (same root cause fixed for `siminfo` in [#1111](https://github.com/abrignoni/ALEAPP/pull/1111)); because these artifacts all target the same app, they all fell over together.

## Fix

Guard the `None` return in `smyFiles`, `smyFiles2`, `smyfilesOpHistory`, `smyfilesRecents` and `smyfilescache` so an unopenable database is skipped and the artifact continues. `smyfilesStored` already caught this (bare `except`) and is unchanged.

## Validation

- With `open_sqlite_db_readonly` forced to return `None`, the three undecorated query helpers (`_query`, `_rows`, `get_db_data`) now return `[]`/`0` instead of raising `AttributeError`; before the change `db.cursor()` on `None` raised exactly Mattia's error.
- A full My Files profile run against a real `com.sec.android.app.myfiles` extraction is unchanged: `smyfilesStored` 2048, `My Files Cache` 2048, `Recent Files` 100 and 100; the genuinely-empty `download_history`/`googledrive` still report no data; no errors, exit 0.

Pylint 10.00, claim-language and validate_sample_data clean. Reporter's extraction is private and not committed.

## Notes (not in this PR)

- The underlying Windows extended-length-path (`\\?\`) open failure is a core issue affecting every SQLite artifact (already flagged separately). This PR makes the My Files artifacts degrade gracefully; recovering the data on very long Windows paths is the separate core fix.
- `My Files Operation History` is intentionally gated to Android 10-12 and its path cipher differs on Android 13+ (it flags those entries `*unsupported entry*`). Decoding the newer cipher is separate research, not this crash fix.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)