### PR TITLE
Fix smyfilesStored file selection and schema fallback

### DIFF
--- a/scripts/artifacts/smyfilesStored.py
+++ b/scripts/artifacts/smyfilesStored.py
@@ -1,11 +1,10 @@
-# pylint: disable=W0702
 __artifacts_v2__ = {
     "get_smyfilesStored": {
         "name": "smyfilesStored",
         "description": "Parses cached file records (timestamp, storage, path, size and latest access) from the Samsung My Files FileCache.db.",
         "author": "@abrignoni",
         "creation_date": "2020-03-19",
-        "last_update_date": "2020-03-19",
+        "last_update_date": "2026-08-14",
         "requirements": "none",
         "category": "My Files",
         "notes": "",
@@ -21,52 +20,50 @@ __artifacts_v2__ = {
     }
 }
 
+import sqlite3
+
 from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, convert_human_ts_to_utc
+
+# Newer FileCache uses date_modified/_data, older uses date/path. Try newer first
+# and fall back only when it yields nothing, so a failed second query cannot wipe
+# a good result from the first.
+SQL_VARIANTS = (
+    '''SELECT datetime(date_modified / 1000, "unixepoch"), storage, _data, size,
+              datetime(latest / 1000, "unixepoch")
+       FROM FileCache WHERE _data IS NOT NULL''',
+    '''SELECT datetime(date / 1000, "unixepoch"), storage, path, size,
+              datetime(latest / 1000, "unixepoch")
+       FROM FileCache WHERE path IS NOT NULL''',
+)
 
 
 @artifact_processor
 def get_smyfilesStored(context):
     files_found = context.get_files_found()
 
-    source_path = str(files_found[0])
-    all_rows = []
-    try:
-        db = open_sqlite_db_readonly(source_path)
-        cursor = db.cursor()
-        cursor.execute('''
-        SELECT
-        datetime(date / 1000, "unixepoch"),
-        storage,
-        path,
-        size,
-        datetime(latest /1000, "unixepoch")
-        from FileCache
-        where path is not NULL
-        ''')
-
-        all_rows = cursor.fetchall()
-    except:
-        all_rows = []
-
-    try:
-        db = open_sqlite_db_readonly(source_path)
-        cursor = db.cursor()
-        cursor.execute('''
-        SELECT
-            datetime(date_modified / 1000, "unixepoch"),
-            storage,
-            _data,
-            size,
-            datetime(latest /1000, "unixepoch")
-            from FileCache
-            where _data is not NULL
-        ''')
-
-        all_rows = cursor.fetchall()
-    except:
-        all_rows = []
+    source_path = ''
+    for file_found in files_found:
+        file_found = str(file_found)
+        # The glob also collects -wal/-shm sidecars; open the database itself.
+        if file_found.endswith('FileCache.db'):
+            source_path = file_found
+            break
 
     data_list = []
+    all_rows = []
+    db = open_sqlite_db_readonly(source_path) if source_path else None
+    if db is not None:
+        cursor = db.cursor()
+        for sql in SQL_VARIANTS:
+            try:
+                cursor.execute(sql)
+                all_rows = cursor.fetchall()
+                if all_rows:
+                    break
+            except sqlite3.Error:
+                continue
+        db.close()
+
     for row in all_rows:
         data_list.append((convert_human_ts_to_utc(row[0]),row[1],row[2],row[3],convert_human_ts_to_utc(row[4])))
 


### PR DESCRIPTION
## Summary

Two problems in `smyfilesStored`, both raised while reviewing the My Files family:

1. **File selection**: it used `files_found[0]` as the database, but the glob (`*/FileCache.db*`) also collects the `-wal`/`-shm` sidecars, so the first match could be a sidecar; an empty `files_found` would also raise `IndexError`.
2. **Schema fallback wipe**: the two schema queries each overwrote `all_rows` unconditionally. On an older-schema FileCache the first (`date`/`path`) query succeeded and the second (`date_modified`/`_data`) query then failed and reset `all_rows` to `[]`, dropping every row.

## Fix

Select the file ending in `FileCache.db`, guard the `None` the opener returns when it can't open the database, and try the two schema variants in order, keeping the first that returns rows.

## Validation

`aleapp.py` profile runs: galaxys10_a10 **1024**; samsungs20_a13, sharon_a14, anne_a15 **2048** each — unchanged from the recorded `sample_data`, no errors. Pylint 10.00, claim-language and validate_sample_data clean.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)