### PR TITLE
fix: skip an unopenable database in usageapps instead of crashing

### DIFF
--- a/scripts/artifacts/usageapps.py
+++ b/scripts/artifacts/usageapps.py
@@ -70,6 +70,10 @@ def get_usageapps(context):
         source_path = file_found
 
         db = open_sqlite_db_readonly(file_found)
+        if db is None:
+            # open_sqlite_db_readonly returns None (and logs the reason) when the
+            # database cannot be opened; skip it rather than crashing the artifact.
+            continue
         cursor = db.cursor()
         cursor.execute('SELECT timestamp, id, proto, generated_from FROM reflection_event')
         all_rows = cursor.fetchall()


### PR DESCRIPTION
## What

`get_usageapps` did `db = open_sqlite_db_readonly(file_found)` and then `db.cursor()` with no
`None` check. `open_sqlite_db_readonly` returns `None` (and logs why) when the database cannot
be opened, so an unreadable `reflection_gel_events.db` raised `AttributeError`. The main loop
catches it as "Reading ... artifact had errors!" and the artifact loses its rows.

Guard the `None` and skip the file, identical to the fix `siminfo` already carries (#1111).

## Why just this one

This is the leaf follow-up to the Windows long-path fix (#1113). An audit found 315 direct
`open_sqlite_db_readonly` call sites across the cores that use the result without a `None`
check, but per fix-what-fails only `siminfo` was ever observed failing, and that cause
(a >260-char path making the open return `None`) is now fixed at the source in #1113.
`usageapps` is `siminfo`'s exact twin, the only other artifact that normalises the path to
forward slashes before opening, so it gets the same guard. The remaining sites are
reachable-but-unobserved and are left for opportunistic guarding when each artifact is next
touched.

## Testing

- The audit checker no longer flags `usageapps` after the change.
- pylint 10.00/10, module imports.
