### PR TITLE
fix: report LINE messages and calls when the contact tables are empty

### DIFF
--- a/scripts/artifacts/line.py
+++ b/scripts/artifacts/line.py
@@ -13,7 +13,10 @@ __artifacts_v2__ = {
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "users",
         "sample_data": {
-            "pixel7a_a14": "Android 14 | jp.naver.line.android vc 141220285 | 0 rows",
+            "pixel3_a11": "Android 11 | jp.naver.line.android | 6 rows",
+            "pixel3_a12": "Android 12 | jp.naver.line.android | 5 rows",
+            "pixel7a_a14": "Android 14 | jp.naver.line.android vc 141220285 | 0 rows, "
+                           "contacts table empty while chat_history holds rows",
         },
     },
     "get_line_messages": {
@@ -21,7 +24,7 @@ __artifacts_v2__ = {
         "description": "Parses LINE messages (time, sender and recipient IDs, direction, thread, message and attachments) from the LINE databases.",
         "author": "@markmckinnon",
         "creation_date": "2021-03-15",
-        "last_update_date": "2026-08-01",
+        "last_update_date": "2026-08-15",
         "requirements": "none",
         "category": "Line",
         "notes": ("Direction is decoded from the chat_history 'status' column. Direction/status "
@@ -30,12 +33,17 @@ __artifacts_v2__ = {
                   "In the conversation view only rows labelled Outgoing are shown as sent by the "
                   "device owner; a row whose direction value is blank or unrecognized is not "
                   "attributed to the owner.\n"
-                  "To ID is filled only for rows recognized as outgoing."),
+                  "To ID is filled only for rows recognized as outgoing.\n"
+                  "Messages are reported even when the contacts and membership tables are "
+                  "empty; on a tested Android 14 image both were empty while chat_history "
+                  "held rows, and the previous inner join dropped every message."),
         "paths": ('*/jp.naver.line.android/databases/**',),
         "output_types": "standard",
         "artifact_icon": "message",
         "sample_data": {
-            "pixel7a_a14": "Android 14 | jp.naver.line.android vc 141220285 | 0 rows",
+            "pixel3_a11": "Android 11 | jp.naver.line.android | 12 rows",
+            "pixel3_a12": "Android 12 | jp.naver.line.android | 26 rows",
+            "pixel7a_a14": "Android 14 | jp.naver.line.android vc 141220285 | 26 rows",
         },
         "data_views": {
             "conversation": {
@@ -53,19 +61,24 @@ __artifacts_v2__ = {
         "description": "Parses LINE call logs (start and end time, participant IDs, direction and call type) from the LINE databases.",
         "author": "@markmckinnon",
         "creation_date": "2021-03-15",
-        "last_update_date": "2026-08-01",
+        "last_update_date": "2026-08-15",
         "requirements": "none",
         "category": "Line",
         "notes": ("Direction is decoded from the last character of the call_history 'call_type' "
                   "column and Call Type from the 'voip_type' letter. Direction/status value "
                   "mappings were established through testing; unrecognized values are reported as "
                   "stored.\n"
-                  "To ID is filled only for rows recognized as outgoing."),
+                  "To ID is filled only for rows recognized as outgoing.\n"
+                  "Calls are reported even when the contacts and membership tables are empty; "
+                  "on a tested Android 14 image both were empty while call_history held rows, "
+                  "and the previous inner join dropped every call."),
         "paths": ('*/jp.naver.line.android/databases/**',),
         "output_types": "standard",
         "artifact_icon": "phone-call",
         "sample_data": {
-            "pixel7a_a14": "Android 14 | jp.naver.line.android vc 141220285 | 0 rows",
+            "pixel3_a11": "Android 11 | jp.naver.line.android | 4 rows",
+            "pixel3_a12": "Android 12 | jp.naver.line.android | 4 rows",
+            "pixel7a_a14": "Android 14 | jp.naver.line.android vc 141220285 | 4 rows",
         },
     }
 }
@@ -120,17 +133,24 @@ def get_line_messages(context):
         db = open_sqlite_db_readonly(msg_db)
         cursor = db.cursor()
         try:
+            # LEFT JOIN from chat_history: newer app versions leave the contacts
+            # and membership tables empty while chat_history still holds rows,
+            # and an inner join against that empty contact book dropped every
+            # message. COALESCE keeps the chat id for rows with no match, and
+            # guards the type filter against a NULL attachement_type.
             cursor.execute('''
-                SELECT contact_book_w_groups.id, contact_book_w_groups.members, messages.from_mid,
+                SELECT COALESCE(contact_book_w_groups.id, messages.chat_id),
+                       contact_book_w_groups.members, messages.from_mid,
                        messages.content, messages.created_time/1000, messages.attachement_type,
                        messages.attachement_local_uri,
                        case messages.status when 1 then "Incoming" when 2 then "Outgoing" else messages.status end status
-                FROM   (SELECT id, Group_concat(M.m_id) AS members
-                        FROM   membership AS M GROUP BY id
-                        UNION
-                        SELECT m_id, NULL FROM contacts) AS contact_book_w_groups
-                       JOIN chat_history AS messages ON messages.chat_id = contact_book_w_groups.id
-                WHERE  attachement_type != 6
+                FROM   chat_history AS messages
+                       LEFT JOIN (SELECT id, Group_concat(M.m_id) AS members
+                                  FROM   membership AS M GROUP BY id
+                                  UNION
+                                  SELECT m_id, NULL FROM contacts) AS contact_book_w_groups
+                              ON messages.chat_id = contact_book_w_groups.id
+                WHERE  COALESCE(messages.attachement_type, -1) != 6
             ''')
             all_rows = cursor.fetchall()
         except Exception as e:
@@ -172,11 +192,12 @@ def get_line_calls(context):
                        case when Substr(calls.call_type, -1) = "O" then contact_book_w_groups.members else null end AS group_members,
                        calls.caller_mid,
                        case calls.voip_type when "V" then "Video" when "A" then "Audio" when "G" then calls.voip_gc_media_type else calls.voip_type end AS call_type
-                FROM   (SELECT id, Group_concat(M.m_id) AS members
-                        FROM   membership AS M GROUP BY id
-                        UNION
-                        SELECT m_id, NULL FROM naver_line.contacts) AS contact_book_w_groups
-                       JOIN call_history AS calls ON calls.caller_mid = contact_book_w_groups.id
+                FROM   call_history AS calls
+                       LEFT JOIN (SELECT id, Group_concat(M.m_id) AS members
+                                  FROM   membership AS M GROUP BY id
+                                  UNION
+                                  SELECT m_id, NULL FROM naver_line.contacts) AS contact_book_w_groups
+                              ON calls.caller_mid = contact_book_w_groups.id
             ''')
             all_rows = cursor.fetchall()
         except Exception as e:


### PR DESCRIPTION
## What

`get_line_messages` and `get_line_calls` built a contact book from `contacts` + `membership` and **inner joined** the message and call tables against it. On a tested Android 14 image both of those tables are empty while `chat_history` holds 30 rows and `call_history` holds 4, so the join dropped every row. The artifacts reported nothing and raised no error, which is indistinguishable from the app not being used.

Both queries now LEFT JOIN from the data side:

- driven from `chat_history` / `call_history` rather than from the contact book
- `COALESCE(contact_book.id, messages.chat_id)` keeps the chat id when no contact row matches
- `COALESCE(messages.attachement_type, -1) != 6` keeps the type filter from dropping NULL rows

## Verification

Profile runs against three corpora, with the baseline captured from a pristine `main` worktree:

| corpus | before | after |
|---|---|---|
| pixel7a_a14 | 0 messages, 0 calls | **26 messages, 4 calls** |
| pixel3_a11 | 12 messages, 4 calls | 12 messages, 4 calls (unchanged) |
| pixel3_a12 | 25 messages, 4 calls | 26 messages, 4 calls |

The single extra row on pixel3_a12 was diffed against the baseline set: it is a real `chat_history` row whose `chat_id` has no contact-book entry, not a duplicate, and nothing present before was lost.

`sample_data` updated for all three, including `get_line`'s genuinely empty `contacts` table on the Android 14 image (recorded as 0 rows with the reason, not left implying absence of data).

Pylint 10.00/10, claim-language checker clean, no duplicate artifact names on a full load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)