### PR TITLE
fix: drop concat() from the LinkedIn messages query

### DIFF
--- a/scripts/artifacts/LinkedIn.py
+++ b/scripts/artifacts/LinkedIn.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "requirements": "xml, json",
         "category": "LinkedIn",
         "notes": "",
-        "paths": ('*/com.linkedin.android/shared_prefs/linkedInPrefsName.xml'),
+        "paths": ('*/com.linkedin.android/shared_prefs/linkedInPrefsName.xml',),
         "output_types": "standard",
         "artifact_icon": "user",
         "sample_data": {
@@ -22,11 +22,15 @@ __artifacts_v2__ = {
         "description": "Messages sent and received from LinkedIn App",
         "author": "Marco Neumann {kalinko@be-binary.de}",
         'creation_date': '2025-04-26',
-        'last_update_date': '2026-05-14',
+        'last_update_date': '2026-08-15',
         "requirements": "",
         "category": "LinkedIn",
-        "notes": "",
-        "paths": ('*/com.linkedin.android/databases/messenger-sdk*'),
+        "notes": "The query uses only SQL functions available across the SQLite versions bundled "
+                 "with supported Python builds; an earlier revision used concat(), which SQLite "
+                 "added in 3.44.0 (2023-11-01, sqlite.org/changes.html), so on older SQLite "
+                 "builds the query failed and the artifact reported no rows while the same "
+                 "statement succeeded in tools carrying a newer SQLite.",
+        "paths": ('*/com.linkedin.android/databases/messenger-sdk*',),
         "output_types": "standard",
         "data_views": {
             "conversation": {
@@ -144,7 +148,7 @@ def linkedin_messages(context):
                 THEN 'Delivered'
                 ELSE 'Unknown'
             END[Status],
-            concat(json_extract(pd.entityData, '$.participantType.member.firstName.text'), ' ',  json_extract(pd.entityData, '$.participantType.member.lastName.text')) [Sender Name],
+            TRIM(COALESCE(json_extract(pd.entityData, '$.participantType.member.firstName.text'), '') || ' ' || COALESCE(json_extract(pd.entityData, '$.participantType.member.lastName.text'), '')) [Sender Name],
             json_extract(pd.entityData, '$.participantType.member.headline.text') [Sender Headline],
             json_extract(pd.entityData, '$.participantType.member.profileUrl') [Sender Profile URL],
             json_extract(pd.entityData, '$.participantType.member.distance') [Sender Distance],
@@ -189,7 +193,7 @@ def linkedin_messages(context):
 
     data_list = []
     for row in db_records:
-        delivery_date = convert_unix_ts_to_utc(int(row[0])/1000)
+        delivery_date = convert_unix_ts_to_utc(int(row[0])/1000) if row[0] is not None else ''
         delivery_status = row[1]
         sender_name = row[2]
         sender_headline = row[3]


### PR DESCRIPTION
## What

`linkedin_messages` built the sender name with `concat()`. SQLite added that function in **3.44.0 (2023-11-01)** ([sqlite.org/changes.html](https://sqlite.org/changes.html)). On a Python whose bundled SQLite predates that release the statement fails to compile, the artifact logs the error and returns nothing, while the identical query pasted into a DB browser carrying a newer SQLite works fine.

That combination is exactly the reported symptom: the query works when run by hand, and the artifact never generates results.

Changes:

- `concat(a, ' ', b)` → `TRIM(COALESCE(a, '') || ' ' || COALESCE(b, ''))`, available in every SQLite these versions ship, and equivalent for a missing first or last name
- `deliveredAt` NULL guard, so a row without a delivery timestamp renders empty instead of raising in `int()`
- both `paths` values were missing their trailing comma, making them strings rather than one-element tuples. The entry point already falls back to treating a non-tuple as a single pattern so behaviour is unchanged, but the declared type now matches the documented block.

## Verification

Profile run against `anne_a15`, the one registered corpus carrying LinkedIn data: output is **byte-identical** to the pre-change run (1 account row, 1 message row), so this is a compatibility fix rather than a change in results. The environments that were already working keep working; the ones that silently returned nothing now parse.

Swept all five cores for other uses of `concat()` in artifact SQL: none.

Pylint 10.00/10, claim-language checker clean, no duplicate artifact names on a full load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)