### PR TITLE
Key the duplicate-path dedupe on the evidence-relative path

### DIFF
--- a/scripts/artifacts/googleAccountHistory.py
+++ b/scripts/artifacts/googleAccountHistory.py
@@ -20,13 +20,15 @@ __artifacts_v2__ = {
             "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 1 row",
             "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 1 row",
             "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 2 rows",
-            "samsunga53_a14": "Android 14 | com.google.android.gms | 4 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 2 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 2 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 1 row",
-            "userb2_a13": "Android 13 | com.google.android.gms | 2 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 1 row",
         },
     },
 }
+
+import re
 
 from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
 
@@ -34,16 +36,21 @@ from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
 def _unique_db_files(context, name_suffix):
     '''Database files matching the suffix, without -journal/-wal/-shm sidecars and
     without the duplicates extractions carry for the same file (data_mirror, and
-    /data/data next to /data/user/0).'''
+    /data/data next to /data/user/0).
+
+    The dedupe key is the evidence-relative path, not the extracted path: the report's own
+    data folder ends in /data, so a raw-path replace can rewrite the harness boundary
+    instead of the evidence path on archives whose members start with data/.'''
     seen = set()
     result = []
     for file_found in context.get_files_found():
         file_found = str(file_found)
         if not file_found.endswith(name_suffix):
             continue
-        if 'data_mirror' in file_found:
+        relative = str(context.get_relative_path(file_found)).replace('\\', '/')
+        if 'data_mirror' in relative:
             continue
-        normalized = file_found.replace('\\', '/').replace('/data/data/', '/data/user/0/')
+        normalized = re.sub(r'(^|/)data/data/', r'\1data/user/0/', relative)
         if normalized in seen:
             continue
         seen.add(normalized)

--- a/scripts/artifacts/googleCalendar.py
+++ b/scripts/artifacts/googleCalendar.py
@@ -77,6 +77,7 @@ __artifacts_v2__ = {
 }
 
 import datetime
+import re
 import sqlite3
 
 from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, \
@@ -158,16 +159,21 @@ def get_calendar_calendars(context):
 def _unique_db_files(context, name_suffix):
     '''Database files matching the suffix, without -wal/-shm sidecars and without the
     duplicates extractions carry for the same file (data_mirror, and /data/data next
-    to /data/user/0).'''
+    to /data/user/0).
+
+    The dedupe key is the evidence-relative path, not the extracted path: the report's own
+    data folder ends in /data, so a raw-path replace can rewrite the harness boundary
+    instead of the evidence path on archives whose members start with data/.'''
     seen = set()
     result = []
     for file_found in context.get_files_found():
         file_found = str(file_found)
         if not file_found.endswith(name_suffix):
             continue
-        if 'data_mirror' in file_found:
+        relative = str(context.get_relative_path(file_found)).replace('\\', '/')
+        if 'data_mirror' in relative:
             continue
-        normalized = file_found.replace('\\', '/').replace('/data/data/', '/data/user/0/')
+        normalized = re.sub(r'(^|/)data/data/', r'\1data/user/0/', relative)
         if normalized in seen:
             continue
         seen.add(normalized)

--- a/scripts/artifacts/googleConstellation.py
+++ b/scripts/artifacts/googleConstellation.py
@@ -22,13 +22,15 @@ __artifacts_v2__ = {
             "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 2 rows",
             "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 0 rows",
             "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 2 rows",
-            "samsunga53_a14": "Android 14 | com.google.android.gms | 2 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 1 row",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 1 row",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 2 rows",
             "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
         },
     },
 }
+
+import re
 
 from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
     convert_unix_ts_to_utc, does_column_exist_in_db
@@ -37,16 +39,21 @@ from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
 def _unique_db_files(context, name_suffix):
     '''Database files matching the suffix, without -journal/-wal/-shm sidecars and
     without the duplicates extractions carry for the same file (data_mirror, and
-    /data/data next to /data/user/0).'''
+    /data/data next to /data/user/0).
+
+    The dedupe key is the evidence-relative path, not the extracted path: the report's own
+    data folder ends in /data, so a raw-path replace can rewrite the harness boundary
+    instead of the evidence path on archives whose members start with data/.'''
     seen = set()
     result = []
     for file_found in context.get_files_found():
         file_found = str(file_found)
         if not file_found.endswith(name_suffix):
             continue
-        if 'data_mirror' in file_found:
+        relative = str(context.get_relative_path(file_found)).replace('\\', '/')
+        if 'data_mirror' in relative:
             continue
-        normalized = file_found.replace('\\', '/').replace('/data/data/', '/data/user/0/')
+        normalized = re.sub(r'(^|/)data/data/', r'\1data/user/0/', relative)
         if normalized in seen:
             continue
         seen.add(normalized)

--- a/scripts/artifacts/googleIcingContacts.py
+++ b/scripts/artifacts/googleIcingContacts.py
@@ -20,7 +20,7 @@ __artifacts_v2__ = {
             "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 9 rows",
             "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 4 rows",
             "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 3 rows",
-            "samsunga53_a14": "Android 14 | com.google.android.gms | 8 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 4 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 5 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 19 rows",
             "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
@@ -48,13 +48,15 @@ __artifacts_v2__ = {
             "kevin_pocox7_a15": "Android 15 | com.google.android.gms | 19 rows",
             "pixel7a_a14": "Android 14 | com.google.android.gms vc 242632038 | 16 rows",
             "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 4 rows",
-            "samsunga53_a14": "Android 14 | com.google.android.gms | 8 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gms | 4 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 6 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 26 rows",
             "userb2_a13": "Android 13 | com.google.android.gms | 0 rows",
         },
     },
 }
+
+import re
 
 from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
     convert_unix_ts_to_utc, does_column_exist_in_db
@@ -63,16 +65,21 @@ from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
 def _unique_db_files(context, name_suffix):
     '''Database files matching the suffix, without -journal/-wal/-shm sidecars and
     without the duplicates extractions carry for the same file (data_mirror, and
-    /data/data next to /data/user/0).'''
+    /data/data next to /data/user/0).
+
+    The dedupe key is the evidence-relative path, not the extracted path: the report's own
+    data folder ends in /data, so a raw-path replace can rewrite the harness boundary
+    instead of the evidence path on archives whose members start with data/.'''
     seen = set()
     result = []
     for file_found in context.get_files_found():
         file_found = str(file_found)
         if not file_found.endswith(name_suffix):
             continue
-        if 'data_mirror' in file_found:
+        relative = str(context.get_relative_path(file_found)).replace('\\', '/')
+        if 'data_mirror' in relative:
             continue
-        normalized = file_found.replace('\\', '/').replace('/data/data/', '/data/user/0/')
+        normalized = re.sub(r'(^|/)data/data/', r'\1data/user/0/', relative)
         if normalized in seen:
             continue
         seen.add(normalized)

--- a/scripts/artifacts/googleOdlh.py
+++ b/scripts/artifacts/googleOdlh.py
@@ -26,7 +26,7 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 0 rows",
-            "userb2_a13": "Android 13 | com.google.android.gms | 254 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 127 rows",
         },
     },
     "gmsOdlhEditedSegments": {
@@ -57,6 +57,8 @@ __artifacts_v2__ = {
     },
 }
 
+import re
+
 from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
     convert_unix_ts_to_utc, decode_protobuf
 
@@ -64,16 +66,21 @@ from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
 def _unique_db_files(context, name_suffix):
     '''Database files matching the suffix, without -journal/-wal/-shm sidecars and
     without the duplicates extractions carry for the same file (data_mirror, and
-    /data/data next to /data/user/0).'''
+    /data/data next to /data/user/0).
+
+    The dedupe key is the evidence-relative path, not the extracted path: the report's own
+    data folder ends in /data, so a raw-path replace can rewrite the harness boundary
+    instead of the evidence path on archives whose members start with data/.'''
     seen = set()
     result = []
     for file_found in context.get_files_found():
         file_found = str(file_found)
         if not file_found.endswith(name_suffix):
             continue
-        if 'data_mirror' in file_found:
+        relative = str(context.get_relative_path(file_found)).replace('\\', '/')
+        if 'data_mirror' in relative:
             continue
-        normalized = file_found.replace('\\', '/').replace('/data/data/', '/data/user/0/')
+        normalized = re.sub(r'(^|/)data/data/', r'\1data/user/0/', relative)
         if normalized in seen:
             continue
         seen.add(normalized)

--- a/scripts/artifacts/samsungBadgeProvider.py
+++ b/scripts/artifacts/samsungBadgeProvider.py
@@ -16,12 +16,14 @@ __artifacts_v2__ = {
         "sample_data": {
             "anne_a15": "Android 15 | com.sec.android.provider.badge | 18 rows",
             "galaxys10_a10": "Android 10 | com.sec.android.provider.badge | 11 rows",
-            "samsunga53_a14": "Android 14 | com.sec.android.provider.badge | 20 rows",
+            "samsunga53_a14": "Android 14 | com.sec.android.provider.badge | 10 rows",
             "samsungs20_a13": "Android 13 | com.sec.android.provider.badge | 19 rows",
             "sharon_a14": "Android 14 | com.sec.android.provider.badge | 24 rows",
         },
     },
 }
+
+import re
 
 from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
 
@@ -29,16 +31,21 @@ from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
 def _unique_db_files(context, name_suffix):
     '''Database files matching the suffix, without -journal/-wal/-shm sidecars and
     without the duplicates extractions carry for the same file (data_mirror, and
-    /data/data next to /data/user/0).'''
+    /data/data next to /data/user/0).
+
+    The dedupe key is the evidence-relative path, not the extracted path: the report's own
+    data folder ends in /data, so a raw-path replace can rewrite the harness boundary
+    instead of the evidence path on archives whose members start with data/.'''
     seen = set()
     result = []
     for file_found in context.get_files_found():
         file_found = str(file_found)
         if not file_found.endswith(name_suffix):
             continue
-        if 'data_mirror' in file_found:
+        relative = str(context.get_relative_path(file_found)).replace('\\', '/')
+        if 'data_mirror' in relative:
             continue
-        normalized = file_found.replace('\\', '/').replace('/data/data/', '/data/user/0/')
+        normalized = re.sub(r'(^|/)data/data/', r'\1data/user/0/', relative)
         if normalized in seen:
             continue
         seen.add(normalized)

--- a/scripts/artifacts/samsungLauncher.py
+++ b/scripts/artifacts/samsungLauncher.py
@@ -16,7 +16,7 @@ __artifacts_v2__ = {
         "artifact_icon": "grid",
         "sample_data": {
             "anne_a15": "Android 15 | com.sec.android.app.launcher | 90 rows",
-            "samsunga53_a14": "Android 14 | com.sec.android.app.launcher | 236 rows",
+            "samsunga53_a14": "Android 14 | com.sec.android.app.launcher | 118 rows",
             "sharon_a14": "Android 14 | com.sec.android.app.launcher | 111 rows",
         },
     },
@@ -36,11 +36,13 @@ __artifacts_v2__ = {
         "artifact_icon": "package",
         "sample_data": {
             "anne_a15": "Android 15 | com.sec.android.app.launcher | 62 rows",
-            "samsunga53_a14": "Android 14 | com.sec.android.app.launcher | 184 rows",
+            "samsunga53_a14": "Android 14 | com.sec.android.app.launcher | 92 rows",
             "sharon_a14": "Android 14 | com.sec.android.app.launcher | 90 rows",
         },
     },
 }
+
+import re
 
 from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
     convert_unix_ts_to_utc
@@ -49,16 +51,21 @@ from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
 def _unique_db_files(context, name_suffix):
     '''Database files matching the suffix, without -wal/-shm sidecars and without the
     duplicates extractions carry for the same file (data_mirror, and /data/data next
-    to /data/user/0).'''
+    to /data/user/0).
+
+    The dedupe key is the evidence-relative path, not the extracted path: the report's own
+    data folder ends in /data, so a raw-path replace can rewrite the harness boundary
+    instead of the evidence path on archives whose members start with data/.'''
     seen = set()
     result = []
     for file_found in context.get_files_found():
         file_found = str(file_found)
         if not file_found.endswith(name_suffix):
             continue
-        if 'data_mirror' in file_found:
+        relative = str(context.get_relative_path(file_found)).replace('\\', '/')
+        if 'data_mirror' in relative:
             continue
-        normalized = file_found.replace('\\', '/').replace('/data/data/', '/data/user/0/')
+        normalized = re.sub(r'(^|/)data/data/', r'\1data/user/0/', relative)
         if normalized in seen:
             continue
         seen.add(normalized)

--- a/scripts/artifacts/samsungMediaProvider.py
+++ b/scripts/artifacts/samsungMediaProvider.py
@@ -18,7 +18,7 @@ __artifacts_v2__ = {
         "sample_data": {
             "anne_a15": "Android 15 | com.samsung.android.providers.media | 223 rows",
             "galaxys10_a10": "Android 10 | com.samsung.android.providers.media | 32 rows",
-            "samsunga53_a14": "Android 14 | com.samsung.android.providers.media | 4 rows",
+            "samsunga53_a14": "Android 14 | com.samsung.android.providers.media | 2 rows",
             "samsungs20_a13": "Android 13 | com.samsung.android.providers.media | 16 rows",
             "sharon_a14": "Android 14 | com.samsung.android.providers.media | 1439 rows",
         },
@@ -47,6 +47,8 @@ __artifacts_v2__ = {
     },
 }
 
+import re
+
 from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
     convert_unix_ts_to_utc
 
@@ -54,16 +56,21 @@ from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
 def _unique_db_files(context, name_suffix):
     '''Database files matching the suffix, without -wal/-shm sidecars and without the
     duplicates extractions carry for the same file (data_mirror, and /data/data next
-    to /data/user/0).'''
+    to /data/user/0).
+
+    The dedupe key is the evidence-relative path, not the extracted path: the report's own
+    data folder ends in /data, so a raw-path replace can rewrite the harness boundary
+    instead of the evidence path on archives whose members start with data/.'''
     seen = set()
     result = []
     for file_found in context.get_files_found():
         file_found = str(file_found)
         if not file_found.endswith(name_suffix):
             continue
-        if 'data_mirror' in file_found:
+        relative = str(context.get_relative_path(file_found)).replace('\\', '/')
+        if 'data_mirror' in relative:
             continue
-        normalized = file_found.replace('\\', '/').replace('/data/data/', '/data/user/0/')
+        normalized = re.sub(r'(^|/)data/data/', r'\1data/user/0/', relative)
         if normalized in seen:
             continue
         seen.add(normalized)

--- a/scripts/artifacts/samsungPrivacyDashboard.py
+++ b/scripts/artifacts/samsungPrivacyDashboard.py
@@ -19,12 +19,14 @@ __artifacts_v2__ = {
         "artifact_icon": "eye",
         "sample_data": {
             "anne_a15": "Android 15 | com.samsung.android.privacydashboard | 3758 rows",
-            "samsunga53_a14": "Android 14 | com.samsung.android.privacydashboard | 652 rows",
+            "samsunga53_a14": "Android 14 | com.samsung.android.privacydashboard | 326 rows",
             "samsungs20_a13": "Android 13 | com.samsung.android.privacydashboard | 239 rows",
             "sharon_a14": "Android 14 | com.samsung.android.privacydashboard | 2232 rows",
         },
     },
 }
+
+import re
 
 from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
     convert_unix_ts_to_utc, does_column_exist_in_db
@@ -33,16 +35,21 @@ from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
 def _unique_db_files(context, name_suffix):
     '''Database files matching the suffix, without -journal/-wal/-shm sidecars and
     without the duplicates extractions carry for the same file (data_mirror, and
-    /data/data next to /data/user/0).'''
+    /data/data next to /data/user/0).
+
+    The dedupe key is the evidence-relative path, not the extracted path: the report's own
+    data folder ends in /data, so a raw-path replace can rewrite the harness boundary
+    instead of the evidence path on archives whose members start with data/.'''
     seen = set()
     result = []
     for file_found in context.get_files_found():
         file_found = str(file_found)
         if not file_found.endswith(name_suffix):
             continue
-        if 'data_mirror' in file_found:
+        relative = str(context.get_relative_path(file_found)).replace('\\', '/')
+        if 'data_mirror' in relative:
             continue
-        normalized = file_found.replace('\\', '/').replace('/data/data/', '/data/user/0/')
+        normalized = re.sub(r'(^|/)data/data/', r'\1data/user/0/', relative)
         if normalized in seen:
             continue
         seen.add(normalized)

--- a/scripts/artifacts/samsungScpm.py
+++ b/scripts/artifacts/samsungScpm.py
@@ -15,12 +15,14 @@ __artifacts_v2__ = {
         "artifact_icon": "cloud",
         "sample_data": {
             "anne_a15": "Android 15 | com.samsung.android.scpm | 1 row",
-            "samsunga53_a14": "Android 14 | com.samsung.android.scpm | 2 rows",
+            "samsunga53_a14": "Android 14 | com.samsung.android.scpm | 1 row",
             "samsungs20_a13": "Android 13 | com.samsung.android.scpm | 1 row",
             "sharon_a14": "Android 14 | com.samsung.android.scpm | 1 row",
         },
     },
 }
+
+import re
 
 from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
     convert_unix_ts_to_utc, does_table_exist_in_db
@@ -29,16 +31,21 @@ from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
 def _unique_db_files(context, name_suffix):
     '''Database files matching the suffix, without -wal/-shm sidecars and without the
     duplicates extractions carry for the same file (data_mirror, and /data/data next
-    to /data/user/0).'''
+    to /data/user/0).
+
+    The dedupe key is the evidence-relative path, not the extracted path: the report's own
+    data folder ends in /data, so a raw-path replace can rewrite the harness boundary
+    instead of the evidence path on archives whose members start with data/.'''
     seen = set()
     result = []
     for file_found in context.get_files_found():
         file_found = str(file_found)
         if not file_found.endswith(name_suffix):
             continue
-        if 'data_mirror' in file_found:
+        relative = str(context.get_relative_path(file_found)).replace('\\', '/')
+        if 'data_mirror' in relative:
             continue
-        normalized = file_found.replace('\\', '/').replace('/data/data/', '/data/user/0/')
+        normalized = re.sub(r'(^|/)data/data/', r'\1data/user/0/', relative)
         if normalized in seen:
             continue
         seen.add(normalized)

--- a/scripts/artifacts/samsungSleepDetection.py
+++ b/scripts/artifacts/samsungSleepDetection.py
@@ -38,6 +38,8 @@ __artifacts_v2__ = {
     },
 }
 
+import re
+
 from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
     convert_unix_ts_to_utc
 
@@ -45,16 +47,21 @@ from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
 def _unique_db_files(context, name_suffix):
     '''Database files matching the suffix, without -journal/-wal/-shm sidecars and
     without the duplicates extractions carry for the same file (data_mirror, and
-    /data/data next to /data/user/0).'''
+    /data/data next to /data/user/0).
+
+    The dedupe key is the evidence-relative path, not the extracted path: the report's own
+    data folder ends in /data, so a raw-path replace can rewrite the harness boundary
+    instead of the evidence path on archives whose members start with data/.'''
     seen = set()
     result = []
     for file_found in context.get_files_found():
         file_found = str(file_found)
         if not file_found.endswith(name_suffix):
             continue
-        if 'data_mirror' in file_found:
+        relative = str(context.get_relative_path(file_found)).replace('\\', '/')
+        if 'data_mirror' in relative:
             continue
-        normalized = file_found.replace('\\', '/').replace('/data/data/', '/data/user/0/')
+        normalized = re.sub(r'(^|/)data/data/', r'\1data/user/0/', relative)
         if normalized in seen:
             continue
         seen.add(normalized)

--- a/scripts/artifacts/samsungStoryService.py
+++ b/scripts/artifacts/samsungStoryService.py
@@ -17,7 +17,7 @@ __artifacts_v2__ = {
         "sample_data": {
             "anne_a15": "Android 15 | com.samsung.storyservice | 0 rows",
             "galaxys10_a10": "Android 10 | com.samsung.storyservice | 32 rows",
-            "samsunga53_a14": "Android 14 | com.samsung.storyservice | 4 rows",
+            "samsunga53_a14": "Android 14 | com.samsung.storyservice | 2 rows",
             "samsungs20_a13": "Android 13 | com.samsung.storyservice | 16 rows",
             "sharon_a14": "Android 14 | com.samsung.storyservice | 1435 rows",
         },
@@ -39,12 +39,14 @@ __artifacts_v2__ = {
         "sample_data": {
             "anne_a15": "Android 15 | com.samsung.storyservice | 0 rows",
             "galaxys10_a10": "Android 10 | com.samsung.storyservice | 6 rows",
-            "samsunga53_a14": "Android 14 | com.samsung.storyservice | 2 rows",
+            "samsunga53_a14": "Android 14 | com.samsung.storyservice | 1 row",
             "samsungs20_a13": "Android 13 | com.samsung.storyservice | 4 rows",
             "sharon_a14": "Android 14 | com.samsung.storyservice | 62 rows",
         },
     },
 }
+
+import re
 
 from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, null_absent_columns, \
     convert_unix_ts_to_utc
@@ -53,16 +55,21 @@ from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, null_ab
 def _unique_db_files(context, name_suffix):
     '''Database files matching the suffix, without -wal/-shm sidecars and without the
     duplicates extractions carry for the same file (data_mirror, and /data/data next
-    to /data/user/0).'''
+    to /data/user/0).
+
+    The dedupe key is the evidence-relative path, not the extracted path: the report's own
+    data folder ends in /data, so a raw-path replace can rewrite the harness boundary
+    instead of the evidence path on archives whose members start with data/.'''
     seen = set()
     result = []
     for file_found in context.get_files_found():
         file_found = str(file_found)
         if not file_found.endswith(name_suffix):
             continue
-        if 'data_mirror' in file_found:
+        relative = str(context.get_relative_path(file_found)).replace('\\', '/')
+        if 'data_mirror' in relative:
             continue
-        normalized = file_found.replace('\\', '/').replace('/data/data/', '/data/user/0/')
+        normalized = re.sub(r'(^|/)data/data/', r'\1data/user/0/', relative)
         if normalized in seen:
             continue
         seen.add(normalized)


### PR DESCRIPTION
Fixes a double-count in twelve artifact modules that dedupe the /data/data and /data/user/0 copies of a database.

The helpers ran a string replace on the extracted file path. The report's own data folder ends in /data, so on an extraction whose members start with data/ the replace rewrote the harness boundary instead of the evidence path. Both copies kept different keys, both survived, and every row was reported twice. The dedupe is now keyed on the evidence-relative path with the rewrite anchored to a path segment, matching tikTok.py.

Modules: googleAccountHistory, googleCalendar, googleConstellation, googleIcingContacts, googleOdlh, samsungBadgeProvider, samsungLauncher, samsungMediaProvider, samsungPrivacyDashboard, samsungScpm, samsungSleepDetection, samsungStoryService.

Observed on the pixel3_a11 and userb2 tars and the samsunga53 zip, where every affected artifact halved to the row count in the database. A Dump-rooted image (samsungs20) is unchanged. Inflated sample_data counts are corrected from those re-runs.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>