### PR TITLE
Fold local storage view dedupe helpers onto the shared helper

### DIFF
--- a/scripts/artifacts/chromePaymentsCustomerData.py
+++ b/scripts/artifacts/chromePaymentsCustomerData.py
@@ -24,8 +24,9 @@ __artifacts_v2__ = {
                  "Chrome package. A Web Data file left with a hot rollback journal cannot be "
                  "recovered through a read-only handle; such a file is logged and skipped so it "
                  "does not end the run before the other browsers on the device are read. One such "
-                 "file was found in the tested images, at a data_mirror path that is filtered "
-                 "before opening, so the skip was exercised by staging that same file at an "
+                 "file was found in the tested images, at a data_mirror path that the storage "
+                 "view dedupe excludes before opening, so the skip was exercised by staging "
+                 "that same file at an "
                  "ordinary path, where it was logged and the run went on to report another "
                  "browser's row. Extractions carry the same database at more than one path "
                  "(data_mirror, and /data/data next to /data/user/0), so files are deduplicated on "
@@ -62,11 +63,11 @@ __artifacts_v2__ = {
 }
 
 import os
-import re
 import sqlite3
 
 from scripts.ilapfuncs import logfunc, artifact_processor, open_sqlite_db_readonly
 from scripts.artifacts.chrome import get_browser_name
+from scripts.artifacts.storagePathViews import unique_files
 
 
 def _table_exists(cursor, table):
@@ -75,26 +76,18 @@ def _table_exists(cursor, table):
 
 
 def _unique_web_data(context):
-    '''The context's Web Data files, without the duplicate paths extractions carry for the
-    same file (data_mirror, and /data/data next to /data/user/0), keyed on the
-    evidence-relative path so the report's own data folder cannot be rewritten instead.'''
-    seen = set()
-    result = []
+    '''The context's Web Data files, one copy per duplicate storage view, skipping
+    .magisk mirror copies.'''
+    kept = []
     for file_found in context.get_files_found():
         file_found = str(file_found)
         if os.path.basename(file_found) != 'Web Data':  # skip -journal and other files
             continue
         relative = str(context.get_relative_path(file_found)).replace('\\', '/')
-        if 'data_mirror' in relative:
-            continue
         if '.magisk' in relative and 'mirror' in relative:
             continue
-        normalized = re.sub(r'(^|/)data/data/', r'\1data/user/0/', relative)
-        if normalized in seen:
-            continue
-        seen.add(normalized)
-        result.append(file_found)
-    return result
+        kept.append(file_found)
+    return unique_files(context, kept)
 
 
 @artifact_processor

--- a/scripts/artifacts/instagram.py
+++ b/scripts/artifacts/instagram.py
@@ -246,6 +246,7 @@ import sqlite3
 import xml.etree.ElementTree as ET
 
 from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
+from scripts.artifacts.storagePathViews import unique_files
 
 _EPOCH = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
 
@@ -300,32 +301,13 @@ def _loads(raw):
     return parsed if isinstance(parsed, dict) else {}
 
 
-# /data/user/<n>/ and /data_mirror/data_ce/null/<n>/ are bind mounts of /data/data;
-# extractions that keep more than one view carry the same app directory two or
-# three times.
-_MIRROR_PREFIXES = re.compile(r'/data/user/\d+/|/data_mirror/data_[a-z]+/null/\d+/')
+def _files_ending(context, *suffixes):
+    return [f for f in unique_files(context)
+            if f.replace('\\', '/').endswith(suffixes)]
 
 
-def _dedupe_mirrored(paths):
-    '''Report each app file once when an extraction holds several mirror views of
-    it, preferring the /data/data/ copy.'''
-    normalized_seen = {}
-    for path in sorted(paths):
-        forward = path.replace('\\', '/')
-        normalized = _MIRROR_PREFIXES.sub('/data/data/', forward)
-        preferred = normalized_seen.get(normalized)
-        if preferred is None or _MIRROR_PREFIXES.search(preferred.replace('\\', '/')):
-            normalized_seen[normalized] = path
-    return sorted(normalized_seen.values())
-
-
-def _files_ending(files_found, *suffixes):
-    return _dedupe_mirrored(str(f) for f in files_found
-                            if str(f).replace('\\', '/').endswith(suffixes))
-
-
-def _direct_dbs(files_found):
-    return _files_ending(files_found, '/direct.db')
+def _direct_dbs(context):
+    return _files_ending(context, '/direct.db')
 
 
 def _account_entries(file_found):
@@ -353,10 +335,10 @@ def _account_entries(file_found):
     return [(key, user) for key, user in entries if isinstance(user, dict)]
 
 
-def _account_username_map(files_found):
+def _account_username_map(context):
     '''user id -> username for every signed-in account found in the preferences.'''
     usernames = {}
-    for file_found in _files_ending(files_found,
+    for file_found in _files_ending(context,
                                     'com.instagram.android_preferences.xml'):
         for _key, user in _account_entries(file_found):
             user_id = str(user.get('id') or user.get('instagram_pk')
@@ -432,12 +414,11 @@ def _media_fields(message):
 
 @artifact_processor
 def instagramDirectMessages(context):
-    files_found = context.get_files_found()
     data_list = []
     sources = []
 
-    account_usernames = _account_username_map(files_found)
-    for source_path in _direct_dbs(files_found):
+    account_usernames = _account_username_map(context)
+    for source_path in _direct_dbs(context):
         own_id = _session_user_id(source_path)
         titles, users = _thread_maps(source_path)
         rows = _rows(source_path, '''
@@ -492,12 +473,11 @@ def instagramDirectMessages(context):
 
 @artifact_processor
 def instagramDirectCalls(context):
-    files_found = context.get_files_found()
     data_list = []
     sources = []
 
-    account_usernames = _account_username_map(files_found)
-    for source_path in _direct_dbs(files_found):
+    account_usernames = _account_username_map(context)
+    for source_path in _direct_dbs(context):
         own_id = _session_user_id(source_path)
         titles, users = _thread_maps(source_path)
         rows = _rows(source_path, '''
@@ -547,11 +527,10 @@ def instagramDirectCalls(context):
 
 @artifact_processor
 def instagramDirectThreads(context):
-    files_found = context.get_files_found()
     data_list = []
     sources = []
 
-    for source_path in _direct_dbs(files_found):
+    for source_path in _direct_dbs(context):
         rows = _rows(source_path, '''
             SELECT last_activity_time, thread_id, thread_info FROM threads
             ORDER BY last_activity_time
@@ -596,11 +575,10 @@ def instagramDirectThreads(context):
 
 @artifact_processor
 def instagramAccounts(context):
-    files_found = context.get_files_found()
     data_list = []
     sources = []
 
-    for file_found in _files_ending(files_found,
+    for file_found in _files_ending(context,
                                     'com.instagram.android_preferences.xml'):
         entries = _account_entries(file_found)
         if entries:
@@ -640,13 +618,12 @@ def instagramAccounts(context):
 
 @artifact_processor
 def instagramContacts(context):
-    files_found = context.get_files_found()
     data_list = []
     sources = []
 
-    for source_path in _dedupe_mirrored(
-            str(f) for f in files_found
-            if not str(f).endswith(('-wal', '-shm', '-journal'))):
+    for source_path in unique_files(context):
+        if source_path.endswith(('-wal', '-shm', '-journal')):
+            continue
         rows = _rows(source_path, '''
             SELECT id, name, first_name, last_name, username, phone_number,
                    email_address, is_messenger_user, contact_type,
@@ -697,11 +674,10 @@ def instagramContacts(context):
 
 @artifact_processor
 def instagramTimeInApp(context):
-    files_found = context.get_files_found()
     data_list = []
     sources = []
 
-    for source_path in _dedupe_mirrored(str(f) for f in files_found):
+    for source_path in unique_files(context):
         base = os.path.basename(source_path)
         match = re.fullmatch(r'time_in_app_(\d+)\.db', base)
         if not match:

--- a/scripts/artifacts/tikTok.py
+++ b/scripts/artifacts/tikTok.py
@@ -236,6 +236,7 @@ import sqlite3
 import xml.etree.ElementTree as ET
 
 from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.artifacts.storagePathViews import unique_files
 
 _ACCOUNT_DB_RE = re.compile(r'(\d+)_im\.db$')
 
@@ -265,34 +266,16 @@ def _rows(source_path, sql):
     return rows
 
 
-def _unique_files(context, suffix=None):
-    '''The context's files matching suffix, without the duplicate paths extractions carry
-    for the same file (data_mirror, and /data/data next to /data/user/0), preserving order.
-
-    The dedupe key is the evidence-relative path, not the extracted path: the report's own
-    data folder ends in /data, so a raw-path regex can rewrite the harness boundary instead
-    of the evidence path on archives whose members start with data/.'''
-    seen = set()
-    result = []
-    for file_found in context.get_files_found():
-        file_found = str(file_found)
-        if suffix is not None and not file_found.endswith(suffix):
-            continue
-        relative = str(context.get_relative_path(file_found)).replace('\\', '/')
-        if 'data_mirror' in relative:
-            continue
-        normalized = re.sub(r'(^|/)data/data/', r'\1data/user/0/', relative)
-        if normalized in seen:
-            continue
-        seen.add(normalized)
-        result.append(file_found)
-    return result
+def _files_ending(context, suffix):
+    '''The context's files ending in suffix, one copy per duplicate storage view.'''
+    return unique_files(context, [f for f in context.get_files_found()
+                                  if str(f).endswith(suffix)])
 
 
 def _account_dbs(context):
     '''Every per-account <uid>_im.db, as [(account uid, path)].'''
     account_dbs = []
-    for file_found in _unique_files(context, suffix='_im.db'):
+    for file_found in _files_ending(context, '_im.db'):
         match = _ACCOUNT_DB_RE.search(os.path.basename(file_found))
         if match:
             account_dbs.append((match.group(1), file_found))
@@ -303,7 +286,7 @@ def _contact_sources(context):
     '''Contact stores as [(table, path)], IM_USER_BASE_INFO stores first.'''
     contact_dbs = []
     simple_dbs = []
-    for file_found in _unique_files(context):
+    for file_found in unique_files(context):
         name = os.path.basename(file_found)
         if name == 'db_im_xx':
             simple_dbs.append(('SIMPLE_USER', file_found))
@@ -433,7 +416,7 @@ def get_tikTok_account(context):
     data_list = []
     source_path = ''
 
-    for file_found in _unique_files(context, suffix='aweme_user.xml'):
+    for file_found in _files_ending(context, 'aweme_user.xml'):
         source_path = source_path or file_found
         source_file = context.get_relative_path(file_found)
         try:
@@ -478,7 +461,7 @@ def _tolerant_select(source_path, table, columns, tail=''):
 def get_tikTok_app_open(context):
     data_list = []
     source_path = ''
-    for file_found in _unique_files(context, suffix='TIKTOK.db'):
+    for file_found in _files_ending(context, 'TIKTOK.db'):
         source_path = source_path or file_found
         source_file = context.get_relative_path(file_found)
         for (open_time,) in _rows(file_found,
@@ -492,7 +475,7 @@ def get_tikTok_app_open(context):
 def get_tikTok_downloads(context):
     data_list = []
     source_path = ''
-    for file_found in _unique_files(context, suffix='downloader.db'):
+    for file_found in _files_ending(context, 'downloader.db'):
         source_path = source_path or file_found
         source_file = context.get_relative_path(file_found)
         sql = _tolerant_select(
@@ -515,7 +498,7 @@ def get_tikTok_downloads(context):
 def get_tikTok_app_log_events(context):
     data_list = []
     source_path = ''
-    for file_found in _unique_files(context, suffix='ss_app_log.db'):
+    for file_found in _files_ending(context, 'ss_app_log.db'):
         source_path = source_path or file_found
         source_file = context.get_relative_path(file_found)
         for (timestamp, category, tag, label, ext_json, session_id,


### PR DESCRIPTION
Folds the local storage view dedupe helpers in instagram.py, tikTok.py and chromePaymentsCustomerData.py onto storagePathViews.unique_files() from #1135. Module-specific filtering stays at the call sites: the Web Data basename filter and .magisk mirror skip, and the suffix filters.

A listing check of all 18 registered Android corpora shows the selected file sets are identical to the local helpers' on every image, and focused profile runs against pixel3_a11 and pixel3_a12 reproduce every recorded sample_data count unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)