### PR TITLE
Replace deprecated utcfromtimestamp, and guard two pre-1970 birth dates

### DIFF
--- a/scripts/artifacts/DuckDuckGo.py
+++ b/scripts/artifacts/DuckDuckGo.py
@@ -515,7 +515,7 @@ def duckduckgo_thumbnails(context):
         filename = (media_path.name)
         utctime = int(media_path.stem)
 
-        timestamp = (datetime.datetime.utcfromtimestamp(utctime/1000).strftime('%Y-%m-%d %H:%M:%S'))
+        timestamp = (datetime.datetime.fromtimestamp(utctime/1000, datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S'))
         media_item = check_in_media(file_found, filename)
 
         if media_item:

--- a/scripts/artifacts/Grok.py
+++ b/scripts/artifacts/Grok.py
@@ -173,7 +173,7 @@ def grok_generatedvideos(context):
             ts_raw = parts[2]
             try:
                 ts = int(ts_raw)
-                dt = datetime.datetime.utcfromtimestamp(ts / 1000.0)
+                dt = datetime.datetime.fromtimestamp(ts / 1000.0, datetime.timezone.utc)
                 extracted_ts = dt.strftime('%Y-%m-%d %H:%M:%S')
             except Exception:
                 extracted_ts = ""
@@ -185,7 +185,7 @@ def grok_generatedvideos(context):
 
             try:
                 ts2 = int(last_touch_raw)
-                dt2 = datetime.datetime.utcfromtimestamp(ts2 / 1000.0)
+                dt2 = datetime.datetime.fromtimestamp(ts2 / 1000.0, datetime.timezone.utc)
                 db_last_touch_utc = dt2.strftime('%Y-%m-%d %H:%M:%S')
             except Exception:
                 db_last_touch_utc = ""
@@ -232,7 +232,7 @@ def grok_generatedvideos(context):
             ts_raw = parts[2]
             try:
                 ts = int(ts_raw)
-                dt = datetime.datetime.utcfromtimestamp(ts / 1000.0)
+                dt = datetime.datetime.fromtimestamp(ts / 1000.0, datetime.timezone.utc)
                 extracted_ts = dt.strftime('%Y-%m-%d %H:%M:%S')
             except Exception:
                 extracted_ts = ""
@@ -240,7 +240,7 @@ def grok_generatedvideos(context):
         db_last_touch_utc = ""
         try:
             ts2 = int(last_touch_raw)
-            dt2 = datetime.datetime.utcfromtimestamp(ts2 / 1000.0)
+            dt2 = datetime.datetime.fromtimestamp(ts2 / 1000.0, datetime.timezone.utc)
             db_last_touch_utc = dt2.strftime('%Y-%m-%d %H:%M:%S')
         except Exception:
             db_last_touch_utc = ""

--- a/scripts/artifacts/OrnetBrowser.py
+++ b/scripts/artifacts/OrnetBrowser.py
@@ -485,7 +485,7 @@ def ornetbrowser_thumbnails(context):
         filename = (media_path.name)
         utctime = int(media_path.stem)
 
-        timestamp = (datetime.datetime.utcfromtimestamp(utctime/1000).strftime('%Y-%m-%d %H:%M:%S'))
+        timestamp = (datetime.datetime.fromtimestamp(utctime/1000, datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S'))
         media_item = check_in_media(file_found, filename)
 
         if media_item:
@@ -612,7 +612,7 @@ def ornetbrowser_usageinfo(context):
             if key_name == "last_app_close_time":
                 try:
                     ts = int(value_raw)
-                    dt = datetime.datetime.utcfromtimestamp(ts / 1000.0)
+                    dt = datetime.datetime.fromtimestamp(ts / 1000.0, datetime.timezone.utc)
                     value_out = dt.strftime("%Y-%m-%d %H:%M:%S")
                 except Exception:
                     pass

--- a/scripts/artifacts/PumaUsers.py
+++ b/scripts/artifacts/PumaUsers.py
@@ -17,6 +17,8 @@ __artifacts_v2__ = {
 
 import datetime
 
+_EPOCH_UTC = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
+
 from scripts.html_safe import esc
 from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
 
@@ -42,7 +44,9 @@ def get_puma_users(context):
 
     data_list = []
     for row in all_rows:
-        dob = datetime.datetime.fromtimestamp(int(row[4]) / 1000, datetime.timezone.utc) if row[4] else ''
+        # Added to the epoch rather than passed to fromtimestamp: a date of birth can
+        # predate 1970, where that function raises gmtime() errors on some platforms.
+        dob = _EPOCH_UTC + datetime.timedelta(milliseconds=int(row[4])) if row[4] else ''
         work_time = row[16] / 60 if row[16] else 'N/A'
         # The avatar URL is remote, so an <img> here would make opening the report
         # fetch it and disclose the examination to the service. Report the URL as

--- a/scripts/artifacts/RunkeeperUser.py
+++ b/scripts/artifacts/RunkeeperUser.py
@@ -38,8 +38,14 @@ def _read_xml_with_fixed_first_line(xml_file):
     return "\n".join(lines)
 
 
+_EPOCH_UTC = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
+
+
 def _ms_to_utc(value):
-    return datetime.datetime.fromtimestamp(int(value) / 1000, datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+    # Added to the epoch rather than passed to fromtimestamp: this also converts the
+    # birthday attribute, which can predate 1970, where that function raises gmtime()
+    # errors on some platforms.
+    return (_EPOCH_UTC + datetime.timedelta(milliseconds=int(value))).strftime('%Y-%m-%d %H:%M:%S')
 
 
 def _s_to_utc(value):

--- a/scripts/artifacts/TorBrowser.py
+++ b/scripts/artifacts/TorBrowser.py
@@ -93,7 +93,7 @@ def torbrowser_thumbnails(context):
         location = str(media_path.parent)
 
         modified_ts = os.path.getmtime(file_found)
-        modifiedtime = datetime.datetime.utcfromtimestamp(int(modified_ts)).strftime('%Y-%m-%d %H:%M:%S')
+        modifiedtime = datetime.datetime.fromtimestamp(int(modified_ts), datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
 
         media_item = check_in_media(filename)
 
@@ -179,7 +179,7 @@ def torbrowser_usageinfo(context):
             if key_name == "pref_key_last_browse_activity_time":
                 try:
                     ts = int(value_raw)
-                    dt = datetime.datetime.utcfromtimestamp(ts / 1000.0)
+                    dt = datetime.datetime.fromtimestamp(ts / 1000.0, datetime.timezone.utc)
                     value_out = dt.strftime("%Y-%m-%d %H:%M:%S")
                 except Exception:
                     pass

--- a/scripts/artifacts/gmailEmails.py
+++ b/scripts/artifacts/gmailEmails.py
@@ -75,7 +75,7 @@ __artifacts_v2__ = {
 import zlib
 from scripts.ilapfuncs import decode_protobuf
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 
 from scripts.ilapfuncs import open_sqlite_db_readonly, check_in_media, get_sqlite_db_records, artifact_processor, \
     logfunc
@@ -137,7 +137,7 @@ def gmailEmails(context):
                     decompressed_data = zlib.decompress(arreglo)
                     message, typedef = decode_protobuf(decompressed_data)
                    
-                    timestamp = (datetime.utcfromtimestamp(message['17'] / 1000))              
+                    timestamp = (datetime.fromtimestamp(message['17'] / 1000, timezone.utc))              
                 else:
                     continue
 

--- a/scripts/artifacts/shutdown_checkpoints.py
+++ b/scripts/artifacts/shutdown_checkpoints.py
@@ -44,7 +44,7 @@ def shutdown_checkpoints(context):
                     
                     entry_epoch = line.split("epoch=")
                     epoch = int(entry_epoch[1].replace(')',''))
-                    shutdown_timestamp = datetime.datetime.utcfromtimestamp(epoch/1000).strftime('%Y-%m-%d %H:%M:%S')
+                    shutdown_timestamp = datetime.datetime.fromtimestamp(epoch/1000, datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
                     
                     data_list.append((shutdown_timestamp, request, line, context.get_relative_path(file_found)))
                 else:


### PR DESCRIPTION
Replaces datetime.utcfromtimestamp(), deprecated since Python 3.12 and scheduled for removal, across six artifacts. Eleven call sites now use datetime.fromtimestamp(value, datetime.timezone.utc), which the deprecation notice names as the replacement. The tz argument is required, since without it fromtimestamp() returns local time.

Ten stringify the result on the spot and are unchanged. The eleventh, in gmailEmails, keeps the datetime object, so its Timestamp column now shows an explicit +00:00. Every other datetime column in the tool already renders the offset, and the LAVA value does not move because datetime columns are stored as an integer epoch either way.

PumaUsers and RunkeeperUser convert a date of birth, which can predate 1970 where fromtimestamp() raises gmtime() errors. Both now add a timedelta to the epoch. Neither has data in a registered corpus, so that part is completeness, not an observed failure.
