### PR TITLE
Update modules_to_exclude.py

### DIFF
--- a/scripts/modules_to_exclude.py
+++ b/scripts/modules_to_exclude.py
@@ -2,5 +2,7 @@
 # These modules are deselected by default in the GUI.
 
 modules_to_exclude = [
+    'c2paProvenance',
+    'imagemngCache',
     'walStrings'
 ]


### PR DESCRIPTION
Turn off c2paProvenance and imagengCache by default as they take a long time on larger images