### PR TITLE
Credit the sample provider on the modules built from his samples

### DIFF
--- a/scripts/artifacts/disneyPlus.py
+++ b/scripts/artifacts/disneyPlus.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "disneyplus_resume_points": {
         "name": "Disney+ - Playback Resume Points",
         "description": "Parses the playback resume positions stored by the Disney+ Android app.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -33,7 +33,7 @@ __artifacts_v2__ = {
     "disneyplus_last_played": {
         "name": "Disney+ - Last Played Item",
         "description": "Parses the last played item recorded by the Disney+ Android app.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -56,7 +56,7 @@ __artifacts_v2__ = {
     "disneyplus_recent_searches": {
         "name": "Disney+ - Recent Searches",
         "description": "Parses the recent search terms stored by the Disney+ Android app.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -77,7 +77,7 @@ __artifacts_v2__ = {
     "disneyplus_session": {
         "name": "Disney+ - Session State",
         "description": "Parses the streaming SDK session state of the Disney+ Android app.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -105,7 +105,7 @@ __artifacts_v2__ = {
     "disneyplus_app_settings": {
         "name": "Disney+ - App Settings and State",
         "description": "Parses the app state and playback preferences of the Disney+ Android app.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -133,7 +133,7 @@ __artifacts_v2__ = {
     "disneyplus_playback_requests": {
         "name": "Disney+ - Playback Requests",
         "description": "Summarises the cached streaming requests of the Disney+ Android app.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -157,7 +157,7 @@ __artifacts_v2__ = {
     "disneyplus_trickplay": {
         "name": "Disney+ - Trickplay Preview",
         "description": "Checks in a preview frame from each trickplay index cached by the Disney+ Android app.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -189,7 +189,7 @@ __artifacts_v2__ = {
     "disneyplus_cached_content": {
         "name": "Disney+ - Cached Content Responses",
         "description": "Summarises the content service responses cached by the Disney+ Android app.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -222,7 +222,7 @@ __artifacts_v2__ = {
     "disneyplus_cached_images": {
         "name": "Disney+ - Cached Image Stores",
         "description": "Summarises the image caches of the Disney+ Android app.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -253,7 +253,7 @@ __artifacts_v2__ = {
     "disneyplus_sdk_events": {
         "name": "Disney+ - SDK Events",
         "description": "Parses the streaming SDK telemetry events of the Disney+ Android app.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",

--- a/scripts/artifacts/ebay.py
+++ b/scripts/artifacts/ebay.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "ebay_watch_list": {
         "name": "eBay - Watch List",
         "description": "Parses the watched listings stored by the eBay Android app.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -33,7 +33,7 @@ __artifacts_v2__ = {
     "ebay_recent_searches": {
         "name": "eBay - Recent Searches",
         "description": "Parses the recent search history stored by the eBay Android app.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -58,7 +58,7 @@ __artifacts_v2__ = {
     "ebay_search_suggestions": {
         "name": "eBay - Search Suggestions",
         "description": "Parses the saved search queries stored by the eBay Android app.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -84,7 +84,7 @@ __artifacts_v2__ = {
     "ebay_followed_searches": {
         "name": "eBay - Followed Searches",
         "description": "Parses the followed searches and interests cached by the eBay Android app.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -110,7 +110,7 @@ __artifacts_v2__ = {
     "ebay_followed_sellers": {
         "name": "eBay - Followed Sellers",
         "description": "Parses the followed seller records stored by the eBay Android app.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -130,7 +130,7 @@ __artifacts_v2__ = {
     "ebay_app_sessions": {
         "name": "eBay - App Sessions",
         "description": "Parses the app session records stored by the eBay Android app.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -156,7 +156,7 @@ __artifacts_v2__ = {
     "ebay_cached_images": {
         "name": "eBay - Cached Images",
         "description": "Parses the cached listing images stored by the eBay Android app.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -189,7 +189,7 @@ __artifacts_v2__ = {
     "ebay_accounts": {
         "name": "eBay - Accounts",
         "description": "Parses the user identifiers the eBay Android app stored across its own tables.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -214,7 +214,7 @@ __artifacts_v2__ = {
     "ebay_app_configuration": {
         "name": "eBay - App Configuration",
         "description": "Parses the app and marketplace configuration record of the eBay Android app.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -236,7 +236,7 @@ __artifacts_v2__ = {
     "ebay_app_state": {
         "name": "eBay - App State",
         "description": "Parses the timestamped application state entries of the eBay Android app.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -258,7 +258,7 @@ __artifacts_v2__ = {
     "ebay_share_channels": {
         "name": "eBay - Share Channels",
         "description": "Parses the share channel records stored by the eBay Android app.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",

--- a/scripts/artifacts/roblox.py
+++ b/scripts/artifacts/roblox.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     "roblox_account": {
         "name": "Roblox - Account",
         "description": "Parses the signed in Roblox account recorded by the Roblox Android client.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -39,7 +39,7 @@ __artifacts_v2__ = {
     "roblox_previous_accounts": {
         "name": "Roblox - Previous Accounts",
         "description": "Parses the account picker list kept by the Roblox Android client.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -60,7 +60,7 @@ __artifacts_v2__ = {
     "roblox_app_launches": {
         "name": "Roblox - App Launches",
         "description": "Parses the per launch client log files written by the Roblox Android client.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -86,7 +86,7 @@ __artifacts_v2__ = {
     "roblox_game_activity": {
         "name": "Roblox - Game Activity",
         "description": "Parses experience joins and game server connections from the Roblox Android client logs.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -118,7 +118,7 @@ __artifacts_v2__ = {
     "roblox_push_notifications": {
         "name": "Roblox - Push Notifications Received",
         "description": "Parses the received push notification ids recorded by the Roblox Android client.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -152,7 +152,7 @@ __artifacts_v2__ = {
     "roblox_marketplace_searches": {
         "name": "Roblox - Marketplace Searches",
         "description": "Parses the recent marketplace search terms kept by the Roblox Android client.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -174,7 +174,7 @@ __artifacts_v2__ = {
     "roblox_user_game_settings": {
         "name": "Roblox - User Game Settings",
         "description": "Parses the in experience settings saved by the Roblox Android client.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -200,7 +200,7 @@ __artifacts_v2__ = {
     "roblox_account_policy": {
         "name": "Roblox - Account Policy",
         "description": "Parses the cached account policy response held by the Roblox Android client.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -219,7 +219,7 @@ __artifacts_v2__ = {
     "roblox_app_state": {
         "name": "Roblox - Application State",
         "description": "Parses install, launch count and notification state preferences of the Roblox Android client.",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",

--- a/scripts/artifacts/shazam.py
+++ b/scripts/artifacts/shazam.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Rows of the tag table in the Shazam library database, each holding the "
                        "time of a music recognition with the track it resolved to, the stored "
                        "coordinates and place names, and the recognition request identifier",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -54,7 +54,7 @@ __artifacts_v2__ = {
         "description": "Rows of the track table in the Shazam library database, with the artists, "
                        "genres and moods the app stored against each track, how many times it "
                        "was recognised and when it was last recognised",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -84,7 +84,7 @@ __artifacts_v2__ = {
         "description": "Entries of the app's HTTP response cache, each holding the URL the app "
                        "requested, the times the request was sent and the response received, and "
                        "the track the URL refers to where the library database records it",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -113,7 +113,7 @@ __artifacts_v2__ = {
         "name": "Shazam Offline Request Queue",
         "description": "Rows of the guaranteed_requests table in the Shazam guaranteed requests "
                        "database, holding HTTP requests the app queued for later delivery",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -133,7 +133,7 @@ __artifacts_v2__ = {
         "description": "Entries of the Shazam application preferences file, holding the install "
                        "identifier, the times the app recorded for its last recognition and last "
                        "foreground, and the flags it kept about its own state",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",
@@ -165,7 +165,7 @@ __artifacts_v2__ = {
         "description": "One row per store of content the app downloaded and held, giving what "
                        "each store contains, how much of it is on disk and the period the store "
                        "itself records",
-        "author": "@AlexisBrignoni, Claude",
+        "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",
         "requirements": "none",


### PR DESCRIPTION
Adds @mattiaepi (Mattia Epifani) to the author field of the four Android modules built from samples he provided, matching the form already used on adobeReader, booking, outlook, pinterest, primeVideo, ryanair, truecaller and uber.

Shazam, Disney+, Roblox and eBay, 36 artifacts. No other field changes.