### PR TITLE
Key the eBay and Disney+ cache indexes on the container

### DIFF
--- a/scripts/artifacts/disneyPlus.py
+++ b/scripts/artifacts/disneyPlus.py
@@ -289,7 +289,7 @@ import xml.etree.ElementTree as ET
 from datetime import datetime, timedelta, timezone
 from urllib.parse import unquote, urlparse
 
-from scripts.artifacts.storagePathViews import unique_files
+from scripts.artifacts.storagePathViews import canonical_path, unique_files
 from scripts.ilapfuncs import (
     artifact_processor,
     check_in_embedded_media,
@@ -336,6 +336,26 @@ _IMAGE_MAGIC = (
 )
 
 _BIF_MAGIC = b'\x89BIF\r\n\x1a\n'
+
+
+_PACKAGE = 'com.disney.disneyplus'
+
+
+def _container(context, path):
+    '''A key for the app data directory a matched file belongs to.
+
+    Matched on a path segment equal to the package name rather than on a substring, so a
+    directory that merely contains the name cannot be taken for the container. Every index
+    below is keyed on it together with its own key, because a cache entry name, a media id
+    and a store name all repeat across app data directories, and keying on those alone
+    merged a second Android user's rows into the first user's.
+    '''
+    relative = str(context.get_relative_path(path)).replace('\\', '/')
+    parts = relative.split('/')
+    for position, part in enumerate(parts):
+        if part == _PACKAGE:
+            return canonical_path('/'.join(parts[:position + 1]))[0]
+    return canonical_path(relative)[0]
 
 
 def _relative(context, path):
@@ -837,7 +857,7 @@ def disneyplus_playback_requests(context):
         source_path = source_path or body
         decoded = unquote(parsed.path)
         media_id = _media_id(decoded)
-        record = per_media.setdefault(media_id, {
+        record = per_media.setdefault((_container(context, body), media_id), {
             'expiries': [], 'manifests': 0, 'indexes': 0, 'other': 0, 'hosts': set(),
             'device': '', 'account': '', 'key': '', 'forms': set(),
             'source': _relative(context, body)})
@@ -860,7 +880,7 @@ def disneyplus_playback_requests(context):
         else:
             record['other'] += 1
 
-    for media_id, record in per_media.items():
+    for (_owner, media_id), record in per_media.items():
         expiries = sorted(record['expiries'])
         data_list.append((
             _seconds(expiries[0]) if expiries else '',
@@ -978,7 +998,7 @@ def disneyplus_cached_images(context):
     stores = {}
 
     def record(store, path, data, url, basis):
-        entry = stores.setdefault(store, {
+        entry = stores.setdefault((_container(context, path), store), {
             'files': 0, 'hashes': set(), 'linked': 0, 'basis': set(), 'bytes': 0,
             'kinds': set(), 'gzip': 0, 'dir': ''})
         entry['files'] += 1
@@ -996,11 +1016,12 @@ def disneyplus_cached_images(context):
         if not label:
             continue
         source_path = source_path or body
-        by_hash.setdefault(hashlib.sha256(data).hexdigest(), url)
+        by_hash.setdefault((_container(context, body), hashlib.sha256(data).hexdigest()), url)
+        owner = _container(context, body)
         record('http-cache', body, data, url, 'URL recorded in cache entry')
-        stores['http-cache']['kinds'].add(label)
+        stores[(owner, 'http-cache')]['kinds'].add(label)
         if encoding:
-            stores['http-cache']['gzip'] += 1
+            stores[(owner, 'http-cache')]['gzip'] += 1
 
     for store, fragment in (('offline_images', '/files/offline_images/'),
                             ('glide-cache-v2', '/cache/glide-cache-v2/')):
@@ -1012,14 +1033,16 @@ def disneyplus_cached_images(context):
             if not label:
                 continue
             source_path = source_path or file_found
-            url = by_hash.get(hashlib.sha256(data).hexdigest(), '')
+            url = by_hash.get(
+                (_container(context, file_found), hashlib.sha256(data).hexdigest()), '')
+            owner = _container(context, file_found)
             record(store, file_found, data, url,
                    'Content hash match to a cached response')
-            stores[store]['kinds'].add(label)
+            stores[(owner, store)]['kinds'].add(label)
             if encoding:
-                stores[store]['gzip'] += 1
+                stores[(owner, store)]['gzip'] += 1
 
-    for store, entry in stores.items():
+    for (_owner, store), entry in stores.items():
         data_list.append((
             store, entry['files'], len(entry['hashes']), entry['linked'],
             ', '.join(sorted(entry['basis'])) or 'No link established',

--- a/scripts/artifacts/ebay.py
+++ b/scripts/artifacts/ebay.py
@@ -285,7 +285,7 @@ import re
 import struct
 from datetime import datetime, timedelta, timezone
 
-from scripts.artifacts.storagePathViews import unique_files
+from scripts.artifacts.storagePathViews import canonical_path, unique_files
 from scripts.ilapfuncs import (
     artifact_processor,
     check_in_embedded_media,
@@ -459,8 +459,29 @@ def _url_candidates(url):
             yield base + size + extension
 
 
+_PACKAGE = 'com.ebay.mobile'
+
+
+def _container(context, path):
+    '''A key for the app data directory a matched file belongs to.
+
+    Matched on a path segment equal to the package name rather than on a substring, so a
+    directory that merely contains the name cannot be taken for the container. The cache
+    and listing indexes below are keyed on it together with their own key, because a cache
+    entry name repeats across app data directories: keying on the name alone dropped a
+    second Android user's cache entries and could hand one directory's image to another
+    directory's listing.
+    '''
+    relative = str(context.get_relative_path(path)).replace('\\', '/')
+    parts = relative.split('/')
+    for position, part in enumerate(parts):
+        if part == _PACKAGE:
+            return canonical_path('/'.join(parts[:position + 1]))[0]
+    return canonical_path(relative)[0]
+
+
 def _image_cache_files(context):
-    '''Cache file name to path for every entry of the app's image cache.'''
+    '''(container, cache file name) to path for every entry of the app's image cache.'''
     files = {}
     for path in unique_files(context):
         parts = path.replace('\\', '/').split('/')
@@ -469,7 +490,7 @@ def _image_cache_files(context):
         name = os.path.basename(path)
         if not name.endswith('.dat'):
             continue
-        files.setdefault(name[:-4], path)
+        files.setdefault((_container(context, path), name[:-4]), path)
     return files
 
 
@@ -484,7 +505,7 @@ def _watch_rows(file_found):
 
 
 def _listing_by_cache_key(context):
-    '''Cache file name to (listing id, title) for every watched listing that resolves.
+    '''(container, cache file name) to (listing id, title) for each resolving listing.
 
     The listing's stored image URL and each rendition variant of it are hashed and looked
     up among the cache file names. Equality of a SHA-256 over the whole URL is what makes
@@ -492,12 +513,13 @@ def _listing_by_cache_key(context):
     '''
     resolved = {}
     for file_found in _databases(context, 'nautilus_db'):
+        owner = _container(context, file_found)
         for row in _watch_rows(file_found):
             url = _text(row[5])
             if not url:
                 continue
             for candidate in _url_candidates(url):
-                key = _cache_key(candidate)
+                key = (owner, _cache_key(candidate))
                 if key not in resolved:
                     resolved[key] = (_text(row[2]), _text(row[1]))
     return resolved
@@ -515,12 +537,13 @@ def ebay_watch_list(context):
             continue
         source_path = file_found
         relative = context.get_relative_path(file_found)
+        owner = _container(context, file_found)
         for row in rows:
             url = _text(row[5])
             media = ''
             if url and cache_files:
                 for candidate in _url_candidates(url):
-                    cache_path = cache_files.get(_cache_key(candidate))
+                    cache_path = cache_files.get((owner, _cache_key(candidate)))
                     if not cache_path:
                         continue
                     _, _, payload = _cache_entry(cache_path)
@@ -805,7 +828,7 @@ def ebay_cached_images(context):
     source_path = ''
     listings = _listing_by_cache_key(context)
 
-    for name, file_found in sorted(_image_cache_files(context).items()):
+    for (owner, name), file_found in sorted(_image_cache_files(context).items()):
         header, metadata, payload = _cache_entry(file_found)
         if header is None:
             logfunc(f'eBay cached images: could not read cache framing of {file_found}')
@@ -815,7 +838,7 @@ def ebay_cached_images(context):
             logfunc(f'eBay cached images: cached value is not an image in {file_found}')
             continue
         source_path = file_found
-        listing_id, title = listings.get(name, ('', ''))
+        listing_id, title = listings.get((owner, name), ('', ''))
         media = check_in_embedded_media(
             file_found, payload, f'{name}.{kind[2]}',
             force_type=kind[1], force_extension=kind[2])


### PR DESCRIPTION
Three artifacts dropped a second Android user's rows, because each built a dictionary keyed on something that repeats across app data directories.

- eBay cached images: keyed on the bare cache entry name
- eBay listing index: keyed on the bare cache key
- Disney+ playback requests: keyed on the media id
- Disney+ cached image stores: keyed on the store name

All are now keyed on the container as well. The eBay listing index mattered twice over: the watch list resolves a cached image by hashing the listing's image address, so with a bare key a listing in one app data directory could be given an image from another. That lookup now happens inside the container the listing's database came from.

Measured on a tree with one container under both spellings, a second Android user at /data/user/10, and a decoy package. Of the 42 artifacts across the five modules checked this way, all now report the same rows as before on a single container and exactly twice as many on the multi container tree. Before: eBay cached images 227 against 454, Disney+ image stores 3 against 6, playback requests 2 against 4.