### PR TITLE
Add a pull request template with the artifact checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## What this changes
+
+<!-- One or two sentences. What does this add, fix or change? -->
+
+## For a new or changed artifact
+
+<!-- Delete this section if the PR does not touch scripts/artifacts. -->
+
+- [ ] Ran the tool against a real extraction and confirmed the row counts, not just that it imports.
+- [ ] Ran `python admin/scripts/check_artifact_output.py <report folder>` on that report and **fixed or documented every finding**. An empty or constant column is often a real result (no group chats, coarse location denied); the fix for those is to say so in the artifact's `notes`, which is also what stops the checker reporting them.
+- [ ] Checked it against a second app data directory (a second Android user, or two iOS containers). `--compare <multi-container report>` reads the scaling for you: it should be exactly double.
+- [ ] `notes`, `description` and `sample_data` say only what the data shows, and the numbers were re-derived from the finished run.
+
+## Anything reviewers should know
+
+<!-- Undocumented codes reported as stored, a store that could not be decrypted, a validation gap, etc. -->


### PR DESCRIPTION
The repo had no PR template. This adds a short one. Its artifact section makes the two output-quality checks a visible step instead of something a contributor has to remember: run `check_artifact_output.py` on the report, and check the artifact against a second app data directory (`--compare` reads the scaling).

The checklist frames a finding correctly: an empty or constant column is often a real forensic negative, and the item says the fix is to state that in the `notes` (which is also what clears the finding), not that every finding is a bug. The artifact section is delete-if-not-applicable, so a core or docs PR is not burdened with it.