### PR TITLE
Update the contact and blog links in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Android Logs Events And Protobuf Parser
 
-If you want to contribute hit me up on twitter: https://twitter.com/AlexisBrignoni
+If you want to contribute hit me up here: https://abrignoni.github.io
 
-Details in blog post here: https://abrignoni.blogspot.com/2020/02/aleapp-android-logs-events-and-protobuf.html
+Blog posts here: https://leapps.org/blog
 
 ## Requirements
 


### PR DESCRIPTION
## What this changes

Updates the two links at the top of the README. The contact line now points to https://abrignoni.github.io instead of the old Twitter profile, and the blog line points to https://leapps.org/blog instead of the 2020 blogspot post.

## Anything reviewers should know

The blog link goes to the blog index rather than a single post, so the wording changed from "Details in blog post here" to "Blog posts here".