### PR TITLE
Add the image manifest for Android public images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ instance/
 # Personal Claude Code context, not shared with the team
 CLAUDE.local.md
 .claude/settings.local.json
+
+# Per-machine image locations for make_test_data.py, see admin/docs/testing/guide_adding_images.md
+admin/image_manifest.local.json

--- a/admin/docs/testing/create_module_test_cases.md
+++ b/admin/docs/testing/create_module_test_cases.md
@@ -107,7 +107,7 @@ Multiple test cases (e.g., "case_ios12_basic", "case_ios14_advanced") can be inc
 
 ## Image Manifest
 
-The script uses an `image_manifest.json` file located in the `admin` directory. This manifest contains information about available test images, including their names, descriptions, and local paths.
+The script uses an `image_manifest.json` file located in the `admin` directory. This manifest carries the identity of each publicly available test image: its name, the corpus key artifacts cite in `sample_data`, the published filename and hash, and where to download it. Where the image lives on your own machine goes in the git-ignored `admin/image_manifest.local.json`. See [guide_adding_images.md](guide_adding_images.md).
 
 ## Known Issues and Limitations
 

--- a/admin/docs/testing/guide_adding_images.md
+++ b/admin/docs/testing/guide_adding_images.md
@@ -1,0 +1,114 @@
+# Guide: Adding a New Image to the Manifest
+
+This guide covers adding a test image to `admin/image_manifest.json`. The manifest tracks
+metadata about publicly available test images, which are far too large to keep in the
+repository, and it lets `admin/test/scripts/make_test_data.py` find your local copy so it can
+generate focused test case data. Accurate metadata, `os_version` especially, also helps when
+writing test cases for modules whose logic branches on the Android release.
+
+The manifest has a second job. `admin/scripts/check_pr_test_data.py` runs on artifact pull
+requests, and when a changed module's `sample_data` cites a corpus key the manifest knows, the
+bot tells the contributor a maintainer can generate the fixture from the public image instead
+of asking them to supply test data.
+
+**An entry is a statement that the image can be obtained.** Only publicly available images go
+in. Corpus keys naming images that are not distributed stay out, and are listed instead in
+[public_corpus_images.md](../public_corpus_images.md) so a reader knows not to go looking.
+
+## Steps to Add a New Image
+
+1. **Obtain the Test Image**:
+   - Acquire a publicly available test image containing sample data for Android artifacts.
+   - Note the source, creation date, and any relevant information about the image.
+
+2. **Extract a File Path List** (optional):
+   - Extract a list of file paths from the test image and save it as a CSV in
+     `admin/data/filepath-lists/`, compressed as a zip.
+   - Point the entry's `file_path_list` at it. No entry carries one today, and
+     `make_test_data.py` works without it.
+
+3. **Analyze File Path Patterns** (optional, needs step 2):
+   - Run `admin/scripts/filepath_search_list.py`, which reads `admin/data/filepath-lists/` and
+     writes `admin/data/generated/filepath_results.csv` and
+     `admin/docs/filepath_search_summary.md`.
+
+4. **Update the Image Manifest**:
+   - Open `admin/image_manifest.json`.
+   - Add a new entry to the `"images"` array with the following structure:
+
+```json
+{
+  "image_name": "unique_image_name",
+  "sample_data_key": "corpus_key_used_in_sample_data",
+  "description": "Device and OS, then who published it",
+  "published_file": "Image-Filename-As-Published.zip",
+  "download_url": "https://example.com/download/link/for/image",
+  "author": {
+    "name": "Author Name",
+    "organization": "Organization Name (if applicable)"
+  },
+  "image_info": {
+    "os_name": "Android",
+    "os_version": "14",
+    "device_model": "Device model (if known)"
+  },
+  "file_info": {
+    "md5_hash": "md5_hash_as_published"
+  },
+  "notes": "What the published hash is of, and anything else a reader needs"
+}
+```
+
+   - `sample_data_key` is the corpus key artifacts cite in `sample_data` and in
+     [public_corpus_images.md](../public_corpus_images.md). For new entries make it the same
+     string as `image_name`.
+   - `published_file` is the exact filename the publisher distributes, with no path. The
+     resolver searches for that name, so getting it right is what makes `search_roots` work.
+   - Record `md5_hash` in lowercase, as published. Say in `notes` whether that hash is of the
+     file itself or of a wrapper archive, because a working copy is often the inner image
+     un-nested from the wrapper and cannot match the wrapper's hash.
+   - Fill `image_info` only where a source records the value. Leave a field out rather than
+     guessing it.
+   - Manifest entries carry no machine-specific paths. Older entries in other cores still list
+     `local_image_paths` and those keep working, but do not add that field to new entries.
+
+5. **Record Your Local Path**:
+   - Machine-specific locations live in `admin/image_manifest.local.json`, which is
+     git-ignored. Map the image directly, or name folders to search for `published_file`:
+
+```json
+{
+  "image_paths": {
+    "unique_image_name": "~/phone-images/Image-Filename-As-Published.zip"
+  },
+  "search_roots": [
+    "~/phone-images"
+  ]
+}
+```
+
+   - `image_paths` keys can be either the `image_name` or the `sample_data_key`.
+   - A direct `image_paths` mapping is checked first and is the reliable option when your copy
+     is renamed, or is the un-nested inner image rather than the published wrapper. That is the
+     common case for the Cellebrite CTF images, where the working copy is an
+     `EXTRACTION_FFS.zip` inside the published archive.
+
+6. **Commit Changes**:
+   - Commit the updated `image_manifest.json`.
+   - Include the file path list zip in the same commit if you made one.
+
+## Best Practices
+
+- Use concise and unique names for the `image_name` field.
+- Keep `description` short: the device and OS, then who published it.
+- Put anything a reader needs in order to trust the hash into `notes`.
+
+## Troubleshooting
+
+- If `make_test_data.py` cannot find your image, check your mapping in
+  `admin/image_manifest.local.json` and that the mapped file exists. The script warns when a
+  mapped path is missing rather than failing silently.
+- LEAPP reads zip and tar, not 7z. Where a publisher ships a `.7z`, register the published
+  name in `published_file` and map your un-packed copy in `image_manifest.local.json`.
+- If you set `file_path_list`, make sure it points at a real CSV zip under
+  `admin/data/filepath-lists/`.

--- a/admin/image_manifest.json
+++ b/admin/image_manifest.json
@@ -1,0 +1,267 @@
+{
+  "images": [
+    {
+      "image_name": "galaxys10_a10",
+      "sample_data_key": "galaxys10_a10",
+      "description": "Samsung Galaxy S10 SM-G973F, Android 10. DFRWS 2021 Challenge.",
+      "published_file": "3_Samsung GSM_SM-G973F_DS Galaxy S10.zip",
+      "download_url": "https://theevidencelocker.github.io/",
+      "author": {
+        "name": "DFRWS"
+      },
+      "image_info": {
+        "os_name": "Android",
+        "os_version": "10",
+        "device_model": "Samsung Galaxy S10 SM-G973F"
+      },
+      "file_info": {
+        "md5_hash": "a86049e46d1e19a961a3aecd97b78bd5"
+      },
+      "notes": "Published MD5 is of the published file and matches a held copy byte for byte. See admin/docs/public_corpus_images.md."
+    },
+    {
+      "image_name": "cookbook_a11",
+      "sample_data_key": "cookbook_a11",
+      "description": "Samsung Galaxy S21 SM-G991U, Android 11. Cody Bounds, Digital Forensics Cookbook Datasets.",
+      "published_file": "Android.7z",
+      "download_url": "https://theevidencelocker.github.io/",
+      "author": {
+        "name": "Cody Bounds"
+      },
+      "image_info": {
+        "os_name": "Android",
+        "os_version": "11",
+        "device_model": "Samsung Galaxy S21 SM-G991U"
+      },
+      "file_info": {
+        "md5_hash": "7188177acdc73a5edb8f6b969e9d6881"
+      },
+      "notes": "Published MD5 is of the publisher's wrapper archive; a working copy is usually the un-nested inner image whose hash cannot match it by construction. Correlate by extraction metadata. See admin/docs/public_corpus_images.md. Distributed as Android.7z; LEAPP reads the inner Samsung Galaxy.zip."
+    },
+    {
+      "image_name": "pixel3_a11",
+      "sample_data_key": "pixel3_a11",
+      "description": "Google Pixel 3, Android 11. Josh Hickman, public images.",
+      "published_file": "android_11.zip",
+      "download_url": "https://digitalcorpora.org/corpora/cell-phones/",
+      "author": {
+        "name": "Josh Hickman"
+      },
+      "image_info": {
+        "os_name": "Android",
+        "os_version": "11",
+        "device_model": "Google Pixel 3"
+      },
+      "file_info": {
+        "md5_hash": "9553729d10bc6cae84916a506cb74d98"
+      },
+      "notes": "Published MD5 is of the publisher's wrapper archive; a working copy is usually the un-nested inner image whose hash cannot match it by construction. Correlate by extraction metadata. See admin/docs/public_corpus_images.md."
+    },
+    {
+      "image_name": "pixel3_a12",
+      "sample_data_key": "pixel3_a12",
+      "description": "Google Pixel 3, Android 12. Josh Hickman, public images.",
+      "published_file": "android_12.zip",
+      "download_url": "https://digitalcorpora.org/corpora/cell-phones/",
+      "author": {
+        "name": "Josh Hickman"
+      },
+      "image_info": {
+        "os_name": "Android",
+        "os_version": "12",
+        "device_model": "Google Pixel 3"
+      },
+      "file_info": {
+        "md5_hash": "b9cb5e213b765d5d649a9634e119b3aa"
+      },
+      "notes": "Published MD5 is of the publisher's wrapper archive; a working copy is usually the un-nested inner image whose hash cannot match it by construction. Correlate by extraction metadata. See admin/docs/public_corpus_images.md."
+    },
+    {
+      "image_name": "russell_pixel6a_a13",
+      "sample_data_key": "russell_pixel6a_a13",
+      "description": "Google Pixel 6a, Android 13. Cellebrite CTF 2023 (\"Russell\").",
+      "published_file": "CellebriteCTF23_Russell.zip",
+      "download_url": "https://theevidencelocker.github.io/",
+      "author": {
+        "name": "Cellebrite"
+      },
+      "image_info": {
+        "os_name": "Android",
+        "os_version": "13",
+        "device_model": "Google Pixel 6a"
+      },
+      "file_info": {
+        "md5_hash": "dc5c077dbd2c2df6c644473447de092b"
+      },
+      "notes": "Published MD5 is of the publisher's wrapper archive; a working copy is usually the un-nested inner image whose hash cannot match it by construction. Correlate by extraction metadata. See admin/docs/public_corpus_images.md."
+    },
+    {
+      "image_name": "sharon_a13",
+      "sample_data_key": "sharon_a13",
+      "description": "Samsung Galaxy S21 5G SM-G991B, Android 13. Cellebrite CTF 2023 (\"Sharon\").",
+      "published_file": "CellebriteCTF23_Sharon.zip",
+      "download_url": "https://theevidencelocker.github.io/",
+      "author": {
+        "name": "Cellebrite"
+      },
+      "image_info": {
+        "os_name": "Android",
+        "os_version": "13",
+        "device_model": "Samsung Galaxy S21 5G SM-G991B"
+      },
+      "file_info": {
+        "md5_hash": "c94ab827d5af5ed22a394fd45d676de3"
+      },
+      "notes": "Published MD5 is of the publisher's wrapper archive; a working copy is usually the un-nested inner image whose hash cannot match it by construction. Correlate by extraction metadata. See admin/docs/public_corpus_images.md."
+    },
+    {
+      "image_name": "userb2_a13",
+      "sample_data_key": "userb2_a13",
+      "description": "Android 13, data partition only. Hexordia, Magnet Virtual Summit CTF 2025.",
+      "published_file": "UserB2.7z",
+      "download_url": "https://theevidencelocker.github.io/",
+      "author": {
+        "name": "Hexordia"
+      },
+      "image_info": {
+        "os_name": "Android",
+        "os_version": "13"
+      },
+      "file_info": {
+        "md5_hash": "76077dce06c68d8ec5505173180e0a5f"
+      },
+      "notes": "Published MD5 is of the publisher's wrapper archive; a working copy is usually the un-nested inner image whose hash cannot match it by construction. Correlate by extraction metadata. See admin/docs/public_corpus_images.md. Distributed as UserB2.7z; LEAPP reads the inner UserB2 - Data.tar."
+    },
+    {
+      "image_name": "pixel7a_a14",
+      "sample_data_key": "pixel7a_a14",
+      "description": "Google Pixel 7a, Android 14. Josh Hickman, public images.",
+      "published_file": "Android_14_Public_Image.tar.gz",
+      "download_url": "https://digitalcorpora.org/corpora/cell-phones/",
+      "author": {
+        "name": "Josh Hickman"
+      },
+      "image_info": {
+        "os_name": "Android",
+        "os_version": "14",
+        "device_model": "Google Pixel 7a"
+      },
+      "file_info": {
+        "md5_hash": "2f9578715a315c0897e51ef9c1007f2d"
+      },
+      "notes": "The link between this key and the published file is inferred from extraction metadata and release dates, not established, and the published MD5 has not been matched against a held copy. See admin/docs/public_corpus_images.md."
+    },
+    {
+      "image_name": "russell_a14",
+      "sample_data_key": "russell_a14",
+      "description": "Google Pixel 6a, Android 14. Cellebrite CTF 2024 (\"Russell\").",
+      "published_file": "CellebriteCTF24_Russell.zip",
+      "download_url": "https://theevidencelocker.github.io/",
+      "author": {
+        "name": "Cellebrite"
+      },
+      "image_info": {
+        "os_name": "Android",
+        "os_version": "14",
+        "device_model": "Google Pixel 6a"
+      },
+      "file_info": {
+        "md5_hash": "e182fc05a9b83fcacc9582db92cef6c8"
+      },
+      "notes": "Published MD5 is of the publisher's wrapper archive; a working copy is usually the un-nested inner image whose hash cannot match it by construction. Correlate by extraction metadata. See admin/docs/public_corpus_images.md."
+    },
+    {
+      "image_name": "samsunga53_a14",
+      "sample_data_key": "samsunga53_a14",
+      "description": "Samsung A53 SM-S536DL, Android 14. Hexordia, Magnet Virtual Summit CTF 2026.",
+      "published_file": "SamsungA53.zip",
+      "download_url": "https://theevidencelocker.github.io/",
+      "author": {
+        "name": "Hexordia"
+      },
+      "image_info": {
+        "os_name": "Android",
+        "os_version": "14",
+        "device_model": "Samsung A53 SM-S536DL"
+      },
+      "file_info": {
+        "md5_hash": "bee600ecc8086325211a4ab5cbf5ff47"
+      },
+      "notes": "Published MD5 is of the publisher's wrapper archive; a working copy is usually the un-nested inner image whose hash cannot match it by construction. Correlate by extraction metadata. See admin/docs/public_corpus_images.md."
+    },
+    {
+      "image_name": "sharon_a14",
+      "sample_data_key": "sharon_a14",
+      "description": "Samsung Galaxy S21 SM-G991B, Android 14. Cellebrite CTF 2024 (\"Sharon\").",
+      "published_file": "CellebriteCTF24_Sharon.zip",
+      "download_url": "https://theevidencelocker.github.io/",
+      "author": {
+        "name": "Cellebrite"
+      },
+      "image_info": {
+        "os_name": "Android",
+        "os_version": "14",
+        "device_model": "Samsung Galaxy S21 SM-G991B"
+      },
+      "file_info": {
+        "md5_hash": "514bf12c5862b20937f9f808932b1368"
+      },
+      "notes": "Published MD5 is of the publisher's wrapper archive; a working copy is usually the un-nested inner image whose hash cannot match it by construction. Correlate by extraction metadata. See admin/docs/public_corpus_images.md."
+    },
+    {
+      "image_name": "anne_a15",
+      "sample_data_key": "anne_a15",
+      "description": "Samsung SM-S911U1, Android 15. Cellebrite CTF 2025 (\"Anne Lockwood\").",
+      "published_file": "2025CellebriteCTF_AnneLockwood.zip",
+      "download_url": "https://theevidencelocker.github.io/",
+      "author": {
+        "name": "Cellebrite"
+      },
+      "image_info": {
+        "os_name": "Android",
+        "os_version": "15",
+        "device_model": "Samsung SM-S911U1"
+      },
+      "file_info": {
+        "md5_hash": "d2e42194b1b16e35fbb0f84eef924fb5"
+      },
+      "notes": "Published MD5 is of the publisher's wrapper archive; a working copy is usually the un-nested inner image whose hash cannot match it by construction. Correlate by extraction metadata. See admin/docs/public_corpus_images.md."
+    },
+    {
+      "image_name": "kevin_pocox7_a15",
+      "sample_data_key": "kevin_pocox7_a15",
+      "description": "Xiaomi Poco X7 Pro, Android 15. Cellebrite CTF 2025 (\"Kevin Mallory\").",
+      "published_file": "2025CellebriteCTF_KevinMallory.zip",
+      "download_url": "https://theevidencelocker.github.io/",
+      "author": {
+        "name": "Cellebrite"
+      },
+      "image_info": {
+        "os_name": "Android",
+        "os_version": "15",
+        "device_model": "Xiaomi Poco X7 Pro"
+      },
+      "file_info": {
+        "md5_hash": "3dbe94d72cb6c76f03e0995f1f20e55e"
+      },
+      "notes": "Published MD5 is of the publisher's wrapper archive; a working copy is usually the un-nested inner image whose hash cannot match it by construction. Correlate by extraction metadata. See admin/docs/public_corpus_images.md."
+    },
+    {
+      "image_name": "df020_mavic_pro_android",
+      "sample_data_key": "df020_mavic_pro_android",
+      "description": "Paired phone for a DJI Mavic Pro, Android logical. VTO Labs / NIST CFReDS Drone Forensics Program, ref DF020.",
+      "published_file": "Android_Logical.zip",
+      "download_url": "https://cfreds.nist.gov/all/VTO/DroneForensics",
+      "author": {
+        "name": "VTO Labs"
+      },
+      "image_info": {
+        "os_name": "Android"
+      },
+      "file_info": {
+        "md5_hash": "6bc5cdc147e813f8744c04814a89e18a"
+      },
+      "notes": "Published MD5 is the publisher's own data sheet value for this file. See admin/docs/public_corpus_images.md."
+    }
+  ]
+}

--- a/admin/test/scripts/make_test_data.py
+++ b/admin/test/scripts/make_test_data.py
@@ -102,7 +102,7 @@ def load_image_manifest():
     manifest_path = os.path.join(repo_root, 'admin', 'image_manifest.json')
     if not os.path.exists(manifest_path):
         sys.exit("This repo has no admin/image_manifest.json yet; use --case with --input, "
-                 "or add a manifest (see admin/docs/testing/guide_adding_images.md in iLEAPP).")
+                 "or add a manifest (see admin/docs/testing/guide_adding_images.md).")
     with open(manifest_path, 'r', encoding='utf-8') as f:
         return json.load(f)['images']
 


### PR DESCRIPTION
Gives ALEAPP an `admin/image_manifest.json`, keyed to the corpus keys artifacts cite in `sample_data`.

- Fourteen entries, one per publicly available corpus key: published filename, published MD5, device and OS, and where to download it.
- Values come from the corpus registry and `admin/docs/public_corpus_images.md`. The two were cross-checked against each other and disagree nowhere.
- Entries are identity only. Machine paths go in the git-ignored `admin/image_manifest.local.json`, which `make_test_data.py` already resolves.
- Ports iLEAPP's guide for adding an image, adapted to this repo.

Keys naming images that are not distributed stay out, so an entry means the image can be obtained. Where a publisher ships a wrapper archive, the MD5 is of that wrapper and a working copy is usually the inner image, which the notes say per entry.