### PR TITLE
Read every Gmail store across accounts and Android users

### DIFF
--- a/scripts/artifacts/gmail.py
+++ b/scripts/artifacts/gmail.py
@@ -4,23 +4,34 @@ __artifacts_v2__ = {
         "description": "gmailActive: Get gmail account information",
         "author": "Joshua James {joshua@dfirscience.org}",
         "creation_date": "2021-11-08",
-        "last_update_date": "2021-11-08",
+        "last_update_date": "2026-08-24",
         "requirements": "none",
         "category": "Gmail",
-        "notes": "",
+        "notes": "One row per Gmail.xml, so a device with several Android users reports each "
+                 "user's active account. Duplicate storage spellings of the same file "
+                 "(data/data, data/user/<n>, data_mirror) are collapsed before reading, and "
+                 "files are read in sorted path order so the output does not depend on the "
+                 "host platform's directory listing order.",
         "paths": ('*/com.google.android.gm/shared_prefs/Gmail.xml',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "mail",
         "sample_data": {
             "anne_a15": "Android 15 | com.google.android.gm vc 65346694 | 1 row",
+            "cookbook_a11": "Android 11 | com.google.android.gm vc 64291995 | 1 row",
             "galaxys10_a10": "Android 10 | com.google.android.gm vc 62632206 | 1 row",
             "hc_pixel8pro_a16": "Android 16 | com.google.android.gm vc 65800239 | 1 row",
+            "hc_pixel8pro_a17": "Android 17 | com.google.android.gm vc 65854395 | 1 row",
             "kevin_pocox7_a15": "Android 15 | com.google.android.gm vc 65346694 | 1 row",
+            "pixel3_a11": "Android 11 | com.google.android.gm vc 62324124 | 1 row",
+            "pixel3_a12": "Android 12 | com.google.android.gm vc 62900470 | 1 row",
             "pixel7a_a14": "Android 14 | com.google.android.gm vc 64361093 | 1 row",
+            "s20fe_a13": "Android 13 | com.google.android.gm vc 65854395 | 1 row",
             "samsunga53_a14": "Android 14 | com.google.android.gm vc 65429598 | 1 row",
             "samsungs20_a13": "Android 13 | com.google.android.gm vc 65465122 | 1 row",
+            "sharon_a13": "Android 13 | com.google.android.gm vc 63927777 | 1 row",
             "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 1 row",
-            "russell_pixel6a_a13": "Android 13 | com.google.android.gm vc 63927733 | 1 row",
+            "russell_a14": "Android 14 | com.google.android.gm vc 64738650 | 2 rows across 2 Android users",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gm vc 63927733 | 2 rows across 2 Android users",
             "userb2_a13": "Android 13 | com.google.android.gm vc 64855928 | 1 row",
         },
     }
@@ -29,6 +40,8 @@ __artifacts_v2__ = {
 import re
 import xml.etree.ElementTree as ET
 
+from scripts.artifacts.storagePathViews import unique_files
+from scripts.context import Context
 from scripts.ilapfuncs import artifact_processor, logfunc
 
 
@@ -52,15 +65,20 @@ def _parse_xml(file_found):
 
 @artifact_processor
 def get_gmailActive(context):
-    files_found = context.get_files_found()
-
     data_list = []
-    source_path = str(files_found[0])
-    root = _parse_xml(source_path)
-    for child in root:
-        if child.attrib['name'] == "active-account":
-            logfunc("Active gmail account found: " + child.text)
-            data_list.append((child.text,))
 
-    data_headers = ('Active Gmail Address',)
-    return data_headers, data_list, source_path
+    # Every Android user's Gmail.xml gets read, not just whichever file the
+    # seeker happened to list first; duplicate storage spellings of one file
+    # collapse to a single copy, and sorting keeps the order platform-independent.
+    files_found = sorted(unique_files(context),
+                         key=lambda p: Context.get_relative_path(str(p)).replace('\\', '/'))
+    for file_found in files_found:
+        file_found = str(file_found)
+        root = _parse_xml(file_found)
+        for child in root:
+            if child.attrib.get('name') == "active-account" and child.text:
+                logfunc("Active gmail account found: " + child.text)
+                data_list.append((child.text, Context.get_relative_path(file_found)))
+
+    data_headers = ('Active Gmail Address', 'Source File')
+    return data_headers, data_list, 'See source file(s) below:'

--- a/scripts/artifacts/gmailEmails.py
+++ b/scripts/artifacts/gmailEmails.py
@@ -1,28 +1,34 @@
-# pylint: disable=W0631,W0612,W0622
 __artifacts_v2__ = {
     "gmailEmails": {
         "name": "Gmail - App Emails",
         "description": "Parses emails from Gmail",
         "author": "Alexis Brignoni, Patrick Dalla, @stark4n6",
         "creation_date": "2023-01-04",
-        "last_update_date": "2026-08-01",
+        "last_update_date": "2026-08-24",
         "requirements": "none",
         "category": "Email",
-        "notes": "Recipient, Reply To, Mailed By, Signed by and Subject Line are read from numbered fields of the zipped message protobuf. Protobuf field positions were established through testing; Mailed By and Signed by reflect stored header values and are not verified against Authentication-Results.",
-        "paths": ('*/data/com.google.android.gm/databases/bigTopDataDB.*','*/data/com.google.android.gm/files/downloads/*/attachments/*/*.*'),
+        "notes": "Recipient, Reply To, Mailed By, Signed by and Subject Line are read from numbered fields of the zipped message protobuf. Protobuf field positions were established through testing; Mailed By and Signed by reflect stored header values and are not verified against Authentication-Results. The app keeps one bigTopDataDB.<id> store per signed-in account; every matched store is read, across every Android user of the device, with duplicate storage spellings (data/data, data/user/<n>, data_mirror) collapsed first and stores read in sorted path order. Account ID is the numeric store id as stored. The Account column is filled only when the Java String.hashCode of an address recorded in the same app instance's Gmail.xml equals the store id, which held for every store in the tested images; a store with no matching recorded address keeps a blank Account. A store that cannot be opened or queried is logged and skipped without dropping the other accounts' rows.",
+        "paths": ('*/com.google.android.gm/databases/bigTopDataDB.*','*/com.google.android.gm/files/downloads/*/attachments/*/*.*','*/com.google.android.gm/shared_prefs/Gmail.xml'),
         "output_types": "standard",
         "html_columns": ["Message"],
         "artifact_icon": "inbox",
         "sample_data": {
             "anne_a15": "Android 15 | com.google.android.gm vc 65346694 | 200 rows",
+            "cookbook_a11": "Android 11 | com.google.android.gm vc 64291995 | 201 rows",
             "hc_pixel8pro_a16": "Android 16 | com.google.android.gm vc 65800239 | 201 rows",
+            "hc_pixel8pro_a17": "Android 17 | com.google.android.gm vc 65854395 | 202 rows",
             "kevin_pocox7_a15": "Android 15 | com.google.android.gm vc 65346694 | 206 rows",
+            "pixel3_a11": "Android 11 | com.google.android.gm vc 62324124 | 225 rows",
+            "pixel3_a12": "Android 12 | com.google.android.gm vc 62900470 | 152 rows",
             "pixel7a_a14": "Android 14 | com.google.android.gm vc 64361093 | 206 rows",
-            "samsunga53_a14": "Android 14 | com.google.android.gm vc 65429598 | 112 rows",
+            "s20fe_a13": "Android 13 | com.google.android.gm vc 65854395 | 4 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gm vc 65429598 | 112 rows across 2 account stores",
             "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 207 rows",
             "galaxys10_a10": "Android 10 | com.google.android.gm vc 62632206 | 28 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gm vc 65465122 | 109 rows",
-            "russell_pixel6a_a13": "Android 13 | com.google.android.gm vc 63927733 | 32 rows",
+            "sharon_a13": "Android 13 | com.google.android.gm vc 63927777 | 100 rows",
+            "russell_a14": "Android 14 | com.google.android.gm vc 64738650 | 267 rows across 2 Android users",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gm vc 63927733 | 40 rows across 2 Android users",
             "userb2_a13": "Android 13 | com.google.android.gm vc 64855928 | 186 rows",
         },
     },
@@ -31,23 +37,30 @@ __artifacts_v2__ = {
         "description": "Parses email label metadata from Gmail",
         "author": "@stark4n6",
         "creation_date": "2023-01-04",
-        "last_update_date": "2025-07-31",
+        "last_update_date": "2026-08-24",
         "requirements": "none",
         "category": "Email",
-        "notes": "",
-        "paths": ('*/data/com.google.android.gm/databases/bigTopDataDB.*','*/data/com.google.android.gm/files/downloads/*/attachments/*/*.*'),
+        "notes": "One row per label per account store. Every matched bigTopDataDB.<id> store is read, across every Android user of the device, with duplicate storage spellings collapsed first and stores read in sorted path order. Account ID is the numeric store id as stored; the Account column is resolved from the same app instance's Gmail.xml as described in Gmail - App Emails. Label values are reported as stored.",
+        "paths": ('*/com.google.android.gm/databases/bigTopDataDB.*','*/com.google.android.gm/shared_prefs/Gmail.xml'),
         "output_types": ["html","tsv","lava"],
         "artifact_icon": "mail",
         "sample_data": {
             "anne_a15": "Android 15 | com.google.android.gm vc 65346694 | 32 rows",
+            "cookbook_a11": "Android 11 | com.google.android.gm vc 64291995 | 31 rows",
             "galaxys10_a10": "Android 10 | com.google.android.gm vc 62632206 | 30 rows",
             "hc_pixel8pro_a16": "Android 16 | com.google.android.gm vc 65800239 | 33 rows",
+            "hc_pixel8pro_a17": "Android 17 | com.google.android.gm vc 65854395 | 33 rows",
             "kevin_pocox7_a15": "Android 15 | com.google.android.gm vc 65346694 | 32 rows",
+            "pixel3_a11": "Android 11 | com.google.android.gm vc 62324124 | 30 rows",
+            "pixel3_a12": "Android 12 | com.google.android.gm vc 62900470 | 30 rows",
             "pixel7a_a14": "Android 14 | com.google.android.gm vc 64361093 | 32 rows",
-            "samsunga53_a14": "Android 14 | com.google.android.gm vc 65429598 | 66 rows",
+            "s20fe_a13": "Android 13 | com.google.android.gm vc 65854395 | 33 rows",
+            "samsunga53_a14": "Android 14 | com.google.android.gm vc 65429598 | 66 rows across 2 account stores",
             "samsungs20_a13": "Android 13 | com.google.android.gm vc 65465122 | 33 rows",
+            "sharon_a13": "Android 13 | com.google.android.gm vc 63927777 | 31 rows",
             "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 32 rows",
-            "russell_pixel6a_a13": "Android 13 | com.google.android.gm vc 63927733 | 31 rows",
+            "russell_a14": "Android 14 | com.google.android.gm vc 64738650 | 64 rows across 2 Android users",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gm vc 63927733 | 62 rows across 2 Android users",
             "userb2_a13": "Android 13 | com.google.android.gm vc 64855928 | 32 rows",
         },
     },
@@ -56,193 +69,238 @@ __artifacts_v2__ = {
         "description": "Parses download requests from Gmail",
         "author": "@stark4n6",
         "creation_date": "2023-01-04",
-        "last_update_date": "2026-08-01",
+        "last_update_date": "2026-08-24",
         "requirements": "none",
         "category": "Email",
-        "notes": "",
-        "paths": ('*/data/com.google.android.gm/databases/downloader.db*'),
+        "notes": "Every matched downloader.db is read, across every Android user of the device, with duplicate storage spellings collapsed first and stores read in sorted path order.",
+        "paths": ('*/com.google.android.gm/databases/downloader.db*'),
         "output_types": "standard",
         "artifact_icon": "download",
         "sample_data": {
             "galaxys10_a10": "Android 10 | com.google.android.gm vc 62632206 | 0 rows",
+            "pixel3_a11": "Android 11 | com.google.android.gm vc 62324124 | 0 rows",
+            "pixel3_a12": "Android 12 | com.google.android.gm vc 62900470 | 0 rows",
             "pixel7a_a14": "Android 14 | com.google.android.gm vc 64361093 | 0 rows",
             "samsunga53_a14": "Android 14 | com.google.android.gm vc 65429598 | 0 rows",
+            "sharon_a13": "Android 13 | com.google.android.gm vc 63927777 | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 0 rows",
+            "russell_a14": "Android 14 | com.google.android.gm vc 64738650 | 2 rows",
         },
     }
 }
 
-import zlib
-from scripts.ilapfuncs import decode_protobuf
 import os
+import sqlite3
+import zlib
 from datetime import datetime, timezone
 
-from scripts.ilapfuncs import open_sqlite_db_readonly, check_in_media, get_sqlite_db_records, artifact_processor, \
-    logfunc
+from scripts.artifacts.gmail import _parse_xml
+from scripts.artifacts.storagePathViews import canonical_path, unique_files
+from scripts.context import Context
 from scripts.html_safe import safe_source
+from scripts.ilapfuncs import open_sqlite_db_readonly, check_in_media, get_sqlite_db_records, artifact_processor, \
+    decode_protobuf, logfunc
+
+
+def _sort_key(path):
+    """Evidence-relative path with one separator, so ordering is platform-independent."""
+    return Context.get_relative_path(str(path)).replace('\\', '/')
+
+
+def _container_of(path):
+    """Storage-view aware prefix above the app's own data directory, so files from one
+    Android user (or one storage volume) only pair with files from the same one."""
+    key, _rank = canonical_path(_sort_key(path))
+    return key.split('/com.google.android.gm/', 1)[0]
+
+
+def _java_string_hash(text):
+    """Java String.hashCode, the scheme the store filename suffixes follow on tested images."""
+    value = 0
+    for char in text:
+        value = (31 * value + ord(char)) & 0xFFFFFFFF
+    return value - 0x100000000 if value >= 0x80000000 else value
+
+
+def _accounts_by_store_id(files_found):
+    """{(container, store id): account address} from each container's Gmail.xml.
+
+    Gmail.xml records the signed-in account addresses (the active-account value and
+    the <address>-account-alias keys). A store is attributed to an address only when
+    the Java String.hashCode of a recorded address equals the store's own numeric
+    filename suffix; a store with no matching recorded address stays unresolved.
+    """
+    mapping = {}
+    for file_found in files_found:
+        file_found = str(file_found)
+        if os.path.basename(file_found) != 'Gmail.xml':
+            continue
+        addresses = set()
+        for child in _parse_xml(file_found):
+            name = child.attrib.get('name', '')
+            if name == 'active-account' and child.text:
+                addresses.add(child.text)
+            elif name.endswith('-account-alias') and '@' in name:
+                addresses.add(name[:-len('-account-alias')])
+        container = _container_of(file_found)
+        for address in addresses:
+            mapping[(container, str(_java_string_hash(address)))] = address
+    return mapping
+
+
+def _gmail_stores(files_found, basename_prefix):
+    """The matched database files, one per account store, in sorted path order."""
+    stores = []
+    for file_found in files_found:
+        file_found = str(file_found)
+        base = os.path.basename(file_found)
+        if file_found.endswith(('-wal', '-shm', '-journal')) or base.startswith('.'):
+            continue
+        if file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
+            continue  # Skip mirror, it should be duplicate data
+        if base.startswith(basename_prefix):
+            stores.append(file_found)
+    stores.sort(key=_sort_key)
+    return stores
+
 
 @artifact_processor
 def gmailEmails(context):
-    files_found = context.get_files_found()
-    seeker = context.get_seeker()
-    bigTopDataDB = ''
-    source_bigTop = ''
-    
-    bigTopDataDB_found = []
-    source_bigTop_found = []
+    files_found = unique_files(context)
     data_list = []
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        if file_found.endswith(('-wal','-shm')):
-            continue
-        elif os.path.basename(file_found).startswith('.'):
-            continue
-        if os.path.basename(file_found).startswith('bigTopDataDB'):
-            bigTopDataDB = str(file_found)
-            source_bigTop = file_found.replace(seeker.data_folder, '')
-            bigTopDataDB_found.append(bigTopDataDB)
-            source_bigTop_found.append(source_bigTop)
-        
-    for i in range(len(bigTopDataDB_found)):
-        bigTopDataDB = bigTopDataDB_found[i]
-        source_bigTop = source_bigTop_found[i]
-        db = open_sqlite_db_readonly(bigTopDataDB)
-        cursor = db.cursor()
-        cursor.execute('''
-        select *
-        from item_messages
-        left join item_message_attachments on item_messages.row_id = item_message_attachments.item_messages_row_id
-        ''')
+    accounts = _accounts_by_store_id(files_found)
 
-        all_rows = cursor.fetchall()
-        usageentries = len(all_rows)
-        filename = file_found
+    for bigTopDataDB in _gmail_stores(files_found, 'bigTopDataDB'):
+        store_name = os.path.basename(bigTopDataDB)
+        account_id = store_name.split('bigTopDataDB.', 1)[1] if '.' in store_name else ''
+        account = accounts.get((_container_of(bigTopDataDB), account_id), '')
+        source_file = Context.get_relative_path(bigTopDataDB)
+
+        db = open_sqlite_db_readonly(bigTopDataDB)
+        if db is None:
+            continue
+        try:
+            cursor = db.cursor()
+            cursor.execute('''
+            select *
+            from item_messages
+            left join item_message_attachments on item_messages.row_id = item_message_attachments.item_messages_row_id
+            ''')
+            all_rows = cursor.fetchall()
+
+            cursor.execute('''PRAGMA table_info(item_messages);''')
+            columns_info = cursor.fetchall()
+        except sqlite3.Error as ex:
+            # One unreadable or drifted store must not cost the other accounts their rows
+            logfunc(f'Unable to read Gmail store {source_file}: {ex}')
+            continue
+        finally:
+            db.close()
+
         proto_col = ''
-        
-        cursor.execute('''PRAGMA table_info(item_messages);''')
-        columns_info = cursor.fetchall()
         for col_info in columns_info:
             if col_info[1] == "zipped_message_proto":
                 proto_col = col_info[0]
-        
-        if usageentries > 0:
-            for row in all_rows:
-                id = row[proto_col]
-                if id is not None:
-                    data = id
-                    arreglo = bytearray(data)
-                    arreglo = arreglo[1:]
-                    decompressed_data = zlib.decompress(arreglo)
-                    message, typedef = decode_protobuf(decompressed_data)
-                   
-                    timestamp = (datetime.fromtimestamp(message['17'] / 1000, timezone.utc))              
+
+        for row in all_rows:
+            proto_blob = row[proto_col]
+            if proto_blob is not None:
+                arreglo = bytearray(proto_blob)
+                arreglo = arreglo[1:]
+                decompressed_data = zlib.decompress(arreglo)
+                message, _typedef = decode_protobuf(decompressed_data)
+
+                timestamp = (datetime.fromtimestamp(message['17'] / 1000, timezone.utc))
+            else:
+                continue
+
+            serverid = row[1]
+            attachname = row[15]
+            attachhash = row[16]
+            attachment = ''
+
+            to = (message.get('1', '')).get('2', '') if '1' in message and '2' in message['1'] else '' #receiver
+            if isinstance(to, bytes):
+                to = to.decode()
+
+            toname = (message.get('1', '')).get('3', '') if '1' in message and '3' in message['1'] else '' #receiver name
+            if isinstance(toname, bytes):
+                toname = toname.decode()
+
+            replyto = (message['11'].get('17', '')) if '11' in message and '17' in message['11'] else '' #reply email
+            if isinstance(replyto, bytes):
+                replyto = replyto.decode()
+
+            replytoname = (message['11'].get('15', b'')) #reply name
+            if '11' in message and '15' in message['11'] and isinstance(message['11'].get('15', b''), bytes):
+                replytoname = replytoname.decode()
+            else:
+                replytoname = (message['11'].get('15', ''))
+
+            subjectline = (message.get('5', '')) #Subject line
+            if subjectline != '':
+                if isinstance(subjectline, bytes):
+                    subjectline = subjectline.decode()
                 else:
-                    continue
+                    subjectline = ''
 
-                serverid = row[1]
-                attachname = row[15]
-                attachhash = row[16]
-                attachment = ''
-                
-                to = (message.get('1', '')).get('2', '') if '1' in message and '2' in message['1'] else '' #receiver
-                if isinstance(to, bytes):
-                    to = to.decode()
-
-                toname = (message.get('1', '')).get('3', '') if '1' in message and '3' in message['1'] else '' #receiver name
-                if isinstance(toname, bytes):
-                    toname = toname.decode()
-                        
-                replyto = (message['11'].get('17', '')) if '11' in message and '17' in message['11'] else '' #reply email
-                if isinstance(replyto, bytes):
-                    replyto = replyto.decode()
-                    
-                replytoname = (message['11'].get('15', b'')) #reply name
-                if '11' in message and '15' in message['11'] and isinstance(message['11'].get('15', b''), bytes): 
-                    replytoname = replytoname.decode() 
-                else: 
-                    replytoname = (message['11'].get('15', ''))
-
-                subjectline = (message.get('5', '')) #Subject line
-                if subjectline != '':
-                    if isinstance(subjectline, bytes):
-                        subjectline = subjectline.decode()
-                    else:
-                        subjectline = ''
-                
-                messagehtml = ''
-                messagetest = (message.get('6', '')) #HTML message
+            messagehtml = ''
+            messagetest = (message.get('6', '')) #HTML message
+            if messagetest != '':
+                messagetest = message['6'].get('2','')
                 if messagetest != '':
-                    messagetest = message['6'].get('2','')
-                    if messagetest != '':
-                        try:
-                            if isinstance(message['6']['2'], list):
-                                for x in message['6']['2']:
-                                    messagehtml = messagehtml + (x['3']['2'].decode())
-                            else:
-                                messagehtml = (message['6']['2']['3']['2'].decode())
-                        except (AttributeError, KeyError, TypeError, IndexError):
-                            # The body node nesting varies between app versions
-                            logfunc(f'Unrecognized Gmail message body structure for server id {serverid}; body omitted')
-               
-                mailedby = (message.get('11', {}).get('8', b'')) #mailed by
-                if isinstance(message.get('11', {}).get('8', ''), bytes): 
-                    mailedby = mailedby.decode() 
-                else: 
-                    mailedby = ''
+                    try:
+                        if isinstance(message['6']['2'], list):
+                            for x in message['6']['2']:
+                                messagehtml = messagehtml + (x['3']['2'].decode())
+                        else:
+                            messagehtml = (message['6']['2']['3']['2'].decode())
+                    except (AttributeError, KeyError, TypeError, IndexError):
+                        # The body node nesting varies between app versions
+                        logfunc(f'Unrecognized Gmail message body structure for server id {serverid}; body omitted')
 
-                signedby = (message.get('11', {}).get('9', b'')) #signed by
-                if isinstance(message.get('11', {}).get('9', ''), bytes): 
-                    signedby = signedby.decode() 
-                else: 
-                    signedby = ''
+            mailedby = (message.get('11', {}).get('8', b'')) #mailed by
+            if isinstance(message.get('11', {}).get('8', ''), bytes):
+                mailedby = mailedby.decode()
+            else:
+                mailedby = ''
 
-                if attachname == 'noname':
-                    attachname = ''
-                elif attachname is None:
-                    attachname = ''
-                elif attachhash is None:
-                    attachhash = ''
-                else:
-                    for attachpath in files_found:
-                        if attachhash in attachpath:
-                            if attachpath.endswith(attachname):
-                                attachment = check_in_media(attachpath, name=attachname) or ''
+            signedby = (message.get('11', {}).get('9', b'')) #signed by
+            if isinstance(message.get('11', {}).get('9', ''), bytes):
+                signedby = signedby.decode()
+            else:
+                signedby = ''
 
-                data_list.append((timestamp,serverid,safe_source(messagehtml),attachment,attachname,to,toname,replyto,replytoname,subjectline,mailedby,signedby,bigTopDataDB))
+            if attachname == 'noname':
+                attachname = ''
+            elif attachname is None:
+                attachname = ''
+            elif attachhash is None:
+                attachhash = ''
+            else:
+                for attachpath in files_found:
+                    attachpath = str(attachpath)
+                    if attachhash in attachpath:
+                        if attachpath.endswith(attachname):
+                            attachment = check_in_media(attachpath, name=attachname) or ''
 
-    data_headers = (('Timestamp','datetime'),'Email ID','Message',('Attachment','media'),'Attachment Name','Recipient','Recipient Name','Reply To','Reply To Name','Subject Line','Mailed By','Signed by','Source File')
+            data_list.append((timestamp,account,account_id,serverid,safe_source(messagehtml),attachment,attachname,to,toname,replyto,replytoname,subjectline,mailedby,signedby,source_file))
+
+    data_headers = (('Timestamp','datetime'),'Account','Account ID','Email ID','Message',('Attachment','media'),'Attachment Name','Recipient','Recipient Name','Reply To','Reply To Name','Subject Line','Mailed By','Signed by','Source File')
     return data_headers, data_list, 'See source file(s) below:'
 
-@artifact_processor      
+@artifact_processor
 def gmailLabels(context):
-    files_found = context.get_files_found()
-    seeker = context.get_seeker()
-    bigTopDataDB = ''
-    source_bigTop = ''
-    
-    bigTopDataDB_found = []
-    source_bigTop_found = []
+    files_found = unique_files(context)
     data_list = []
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        if file_found.endswith(('-wal','-shm')):
-            continue
-        elif os.path.basename(file_found).startswith('.'):
-            continue
-        if os.path.basename(file_found).startswith('bigTopDataDB'):
-            bigTopDataDB = str(file_found)
-            source_bigTop = file_found.replace(seeker.data_folder, '')
-            bigTopDataDB_found.append(bigTopDataDB)
-            source_bigTop_found.append(source_bigTop)
-        
-    for i in range(len(bigTopDataDB_found)):
-        bigTopDataDB = bigTopDataDB_found[i]
-        source_bigTop = source_bigTop_found[i]
-        
+    accounts = _accounts_by_store_id(files_found)
+
+    for bigTopDataDB in _gmail_stores(files_found, 'bigTopDataDB'):
+        store_name = os.path.basename(bigTopDataDB)
+        account_id = store_name.split('bigTopDataDB.', 1)[1] if '.' in store_name else ''
+        account = accounts.get((_container_of(bigTopDataDB), account_id), '')
+        source_file = Context.get_relative_path(bigTopDataDB)
+
         query = '''
         select
         label_server_perm_id,
@@ -252,38 +310,26 @@ def gmailLabels(context):
         from label_counts
         order by label_server_perm_id
         '''
-        
+
         db_records = get_sqlite_db_records(bigTopDataDB, query)
-        
+
         for record in db_records:
-            data_list.append((record[0],record[1],record[2],record[3],bigTopDataDB))
-    
-    data_headers = ('Label','Unread Count','Total Count','Unseen Count','Source File')
+            data_list.append((account,account_id,record[0],record[1],record[2],record[3],source_file))
+
+    data_headers = ('Account','Account ID','Label','Unread Count','Total Count','Unseen Count','Source File')
     return data_headers, data_list, 'See source file(s) below:'
-      
-@artifact_processor        
+
+@artifact_processor
 def gmailDownloadRequests(context):
-    files_found = context.get_files_found()
-    seeker = context.get_seeker()
-    downloaderDB = ''
-    source_downloader = ''
+    files_found = unique_files(context)
     data_list = []
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        if file_found.endswith(('-wal','-shm')):
-            continue
-        elif os.path.basename(file_found).startswith('.'):
-            continue
-        if os.path.basename(file_found).startswith('downloader.db'):
-            downloaderDB = str(file_found)
-            source_downloader = file_found.replace(seeker.data_folder, '')
-    
-    if downloaderDB != '':
+
+    for downloaderDB in _gmail_stores(files_found, 'downloader.db'):
+        source_file = Context.get_relative_path(downloaderDB)
+
         #Get Gmail download requests
         query = '''
-        select 
+        select
         datetime(request_time_ms/1000,'unixepoch'),
         account_name,
         type,
@@ -294,11 +340,11 @@ def gmailDownloadRequests(context):
         priority
         from download_requests
         '''
-        
+
         db_records = get_sqlite_db_records(downloaderDB, query)
-        
+
         for record in db_records:
-            data_list.append((record[0],record[1],record[2],record[3],record[4],record[5],record[6],record[7]))
-    
-    data_headers = (('Timestamp Requested','datetime'),'Account Name','Download Type','Caller ID','URL','Target File Path','Target File Size','Priority')
-    return data_headers, data_list, downloaderDB
+            data_list.append((record[0],record[1],record[2],record[3],record[4],record[5],record[6],record[7],source_file))
+
+    data_headers = (('Timestamp Requested','datetime'),'Account Name','Download Type','Caller ID','URL','Target File Path','Target File Size','Priority','Source File')
+    return data_headers, data_list, 'See source file(s) below:'

--- a/scripts/artifacts/gmailIMAPEmails.py
+++ b/scripts/artifacts/gmailIMAPEmails.py
@@ -4,23 +4,30 @@ __artifacts_v2__ = {
         "description": "Parses emails from IMAP mailboxes in the Gmail App",
         "author": "ogmini",
         "creation_date": "2025-08-20",
-        "last_update_date": "2026-08-01",
+        "last_update_date": "2026-08-24",
         "requirements": "none",
         "category": "Email",
-        "notes": "", 
-        "paths": ('*/data/com.google.android.gm/databases/EmailProvider.*','*/data/com.google.android.gm/files/body/0/*/*.*','*/data/com.google.android.gm/databases/*.db_att/*','*/data/com.google.android.gm/cache/*.attachment'), 
+        "notes": "Every matched EmailProvider store is read, across every Android user of the device, with duplicate storage spellings collapsed first and stores read in sorted path order. The Account column is the emailAddress the store's own Account table records for the row. Body and attachment files are only paired with rows from the same app instance they belong to. No tested image held IMAP data (every EmailProvider.db carried empty Account and Message tables), so row-producing behavior is verified against constructed known data, not a real image.",
+        "paths": ('*/com.google.android.gm/databases/EmailProvider.*','*/com.google.android.gm/files/body/0/*/*.*','*/com.google.android.gm/databases/*.db_att/*','*/com.google.android.gm/cache/*.attachment'),
         "output_types": "standard",
         "html_columns": ["Body(HTML)"],
         "artifact_icon": "inbox",
         "sample_data": {
             "anne_a15": "Android 15 | com.google.android.gm vc 65346694 | 0 rows",
+            "cookbook_a11": "Android 11 | com.google.android.gm vc 64291995 | 0 rows",
             "galaxys10_a10": "Android 10 | com.google.android.gm vc 62632206 | 0 rows",
             "hc_pixel8pro_a16": "Android 16 | com.google.android.gm vc 65800239 | 0 rows",
+            "hc_pixel8pro_a17": "Android 17 | com.google.android.gm vc 65854395 | 0 rows",
             "kevin_pocox7_a15": "Android 15 | com.google.android.gm vc 65346694 | 0 rows",
+            "pixel3_a11": "Android 11 | com.google.android.gm vc 62324124 | 0 rows",
+            "pixel3_a12": "Android 12 | com.google.android.gm vc 62900470 | 0 rows",
             "pixel7a_a14": "Android 14 | com.google.android.gm vc 64361093 | 0 rows",
+            "s20fe_a13": "Android 13 | com.google.android.gm vc 65854395 | 0 rows",
             "samsunga53_a14": "Android 14 | com.google.android.gm vc 65429598 | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gm vc 65465122 | 0 rows",
+            "sharon_a13": "Android 13 | com.google.android.gm vc 63927777 | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 0 rows",
+            "russell_a14": "Android 14 | com.google.android.gm vc 64738650 | 0 rows",
             "russell_pixel6a_a13": "Android 13 | com.google.android.gm vc 63927733 | 0 rows",
             "userb2_a13": "Android 13 | com.google.android.gm vc 64855928 | 0 rows",
         },
@@ -29,198 +36,247 @@ __artifacts_v2__ = {
         "name": "Gmail - IMAP Accounts",
         "description": "Parses IMAP Accounts in the Gmail App",
         "author": "ogmini",
-        "creation_date": "2025-10-11", 
-        "last_update_date": "2025-10-11", 
+        "creation_date": "2025-10-11",
+        "last_update_date": "2026-08-24",
         "requirements": "none",
         "category": "Email",
-        "notes": "", 
-        "paths": ('*/data/com.google.android.gm/databases/EmailProvider.*'), 
+        "notes": "Every matched EmailProvider store is read, across every Android user of the device, with duplicate storage spellings collapsed first and stores read in sorted path order. No tested image held IMAP accounts, so row-producing behavior is verified against constructed known data, not a real image.",
+        "paths": ('*/com.google.android.gm/databases/EmailProvider.*'),
         "output_types": "standard",
         "artifact_icon": "user",
         "sample_data": {
             "anne_a15": "Android 15 | com.google.android.gm vc 65346694 | 0 rows",
+            "cookbook_a11": "Android 11 | com.google.android.gm vc 64291995 | 0 rows",
             "galaxys10_a10": "Android 10 | com.google.android.gm vc 62632206 | 0 rows",
             "hc_pixel8pro_a16": "Android 16 | com.google.android.gm vc 65800239 | 0 rows",
+            "hc_pixel8pro_a17": "Android 17 | com.google.android.gm vc 65854395 | 0 rows",
             "kevin_pocox7_a15": "Android 15 | com.google.android.gm vc 65346694 | 0 rows",
+            "pixel3_a11": "Android 11 | com.google.android.gm vc 62324124 | 0 rows",
+            "pixel3_a12": "Android 12 | com.google.android.gm vc 62900470 | 0 rows",
             "pixel7a_a14": "Android 14 | com.google.android.gm vc 64361093 | 0 rows",
+            "s20fe_a13": "Android 13 | com.google.android.gm vc 65854395 | 0 rows",
             "samsunga53_a14": "Android 14 | com.google.android.gm vc 65429598 | 0 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gm vc 65465122 | 0 rows",
+            "sharon_a13": "Android 13 | com.google.android.gm vc 63927777 | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.gm vc 64719072 | 0 rows",
+            "russell_a14": "Android 14 | com.google.android.gm vc 64738650 | 0 rows",
             "russell_pixel6a_a13": "Android 13 | com.google.android.gm vc 63927733 | 0 rows",
             "userb2_a13": "Android 13 | com.google.android.gm vc 64855928 | 0 rows",
-        }, 
+        },
     }
 }
 
 import os
+import sqlite3
 import urllib.parse
 
+from scripts.artifacts.storagePathViews import canonical_path, unique_files
 from scripts.ilapfuncs import open_sqlite_db_readonly, artifact_processor, convert_unix_ts_to_utc, logfunc, check_in_media
 from scripts.context import Context
 from scripts.html_safe import safe_source
 
+
+def _sort_key(path):
+    """Evidence-relative path with one separator, so ordering is platform-independent."""
+    return Context.get_relative_path(str(path)).replace('\\', '/')
+
+
+def _container_of(path):
+    """Storage-view aware prefix above the app's own data directory, so files from one
+    Android user (or one storage volume) only pair with files from the same one."""
+    key, _rank = canonical_path(_sort_key(path))
+    return key.split('/com.google.android.gm/', 1)[0]
+
+
 @artifact_processor
 def gmailIMAPEmails(context):
-    files_found = context.get_files_found()
-    emailProviderDB = ''    
     emailProviderDB_found = []
 
     data_list = []
 
     bodyTxt_list = []
     bodyHtml_list = []
-    
+
     attachRecv_list = []
     attachSent_list = []
-    
-    for file_found in files_found:
+
+    for file_found in unique_files(context):
         file_found = str(file_found)
-        
+
         if file_found.endswith(('-wal','-shm','-journal')):
             continue
         elif os.path.basename(file_found).startswith('.'):
             continue
+        elif file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
+            continue  # Skip mirror, it should be duplicate data
         if os.path.basename(file_found).startswith('EmailProvider'):
-            emailProviderDB = str(file_found) 
-            emailProviderDB_found.append(emailProviderDB)
+            emailProviderDB_found.append(file_found)
         if file_found.endswith(('.txt')):
             bodyTxt_list.append(file_found)
         if file_found.endswith(('.html')):
             bodyHtml_list.append(file_found)
-        if os.path.basename(os.path.dirname(file_found)).endswith(('.db_att')):        
+        if os.path.basename(os.path.dirname(file_found)).endswith(('.db_att')):
             attachRecv_list.append(file_found)
         if file_found.endswith(('.attachment')):
             attachSent_list.append(file_found)
-        
-    for i in range(len(emailProviderDB_found)):
-        emailProviderDB = emailProviderDB_found[i]
-        
+
+    emailProviderDB_found.sort(key=_sort_key)
+
+    for emailProviderDB in emailProviderDB_found:
+        container = _container_of(emailProviderDB)
+
         db = open_sqlite_db_readonly(emailProviderDB)
-        cursor = db.cursor()
-        cursor.execute('''
-        select M.timeStamp, M._id, M.snippet, M.toList, M.replyToList, M.subject, M.fromList, M.displayName, M.flagRead, M.flagAttachment,
-        A._id as AccountID,
-        MB.displayName
-        from Message as M
-        inner join Account as A on A._id = M.AccountKey
-		inner join Mailbox as MB on M.mailboxKey = MB._id
-        ''')
-        
-        all_rows = cursor.fetchall()
-        for row in all_rows:
-            row = list(row)
-            try:
-                row[0] = convert_unix_ts_to_utc(row[0])
-            except (TypeError, ValueError, OverflowError, OSError) as ex:
-                logfunc(f'Error Timestamp conversion: {ex}')
+        if db is None:
+            continue
+        try:
+            cursor = db.cursor()
+            cursor.execute('''
+            select M.timeStamp, M._id, M.snippet, M.toList, M.replyToList, M.subject, M.fromList, M.displayName, M.flagRead, M.flagAttachment,
+            A._id as AccountID,
+            MB.displayName,
+            A.emailAddress
+            from Message as M
+            inner join Account as A on A._id = M.AccountKey
+            inner join Mailbox as MB on M.mailboxKey = MB._id
+            ''')
 
-            # BODY Files - Full message is found elsewhere */data/com.google.android.gm/files/body/[ParentFolder]/[_idFolder]
-            # TXT Body
-            tBody = ''
-            for txtBody in bodyTxt_list:
-                if ((os.path.basename(txtBody)) == (str(row[1]) + '.txt')):
-                    with open(txtBody, "r", encoding="utf-8") as f:
-                        tBody = f.read()
+            all_rows = cursor.fetchall()
+            for row in all_rows:
+                row = list(row)
+                try:
+                    row[0] = convert_unix_ts_to_utc(row[0])
+                except (TypeError, ValueError, OverflowError, OSError) as ex:
+                    logfunc(f'Error Timestamp conversion: {ex}')
 
-            # HTML Body
-            hBody = ''
-            for htmlBody in bodyHtml_list:
-                if ((os.path.basename(htmlBody)) == (str(row[1]) + '.html')):
-                    with open(htmlBody, "r", encoding="utf-8") as f:
-                        hBody = f.read()
-            
-            # ATTACHMENTS - Files can be stored in two different locations depending if they are sent or received.            
-            AttachmentPaths = []
-            if (row[9] == 1):
-                cursor_attach = db.cursor()
-                cursor_attach.execute('''
-                select A.accountKey, A._id, A.fileName, A.mimeType, A.cachedFile
-                from Attachment as A
-                where messageKey = ?
-                ''', (row[1],))
-                
-                attach_rows = cursor_attach.fetchall()
-                for row_a in attach_rows:
-                    row_a = list(row_a)
-                    accountID = row_a[0]
-                    attachmentID = row_a[1]
-                    
-                    if (row_a[4] is None):
-                        # Received Attachment */data/com.google.android.gm/databases/*.db_att/*.*
-                        for rAttach in attachRecv_list:
-                            if (os.path.isfile(rAttach) and ((os.path.basename(rAttach)) == f'{attachmentID}') and ((os.path.basename(os.path.dirname(rAttach))) == f'{accountID}.db_att')):
-                                ref = check_in_media(rAttach, row_a[2])
-                                if ref:
-                                    AttachmentPaths.append(ref)
-                    else:
-                        # Sent Attachment /data/com.google.android.gm/cache/*.attachment
-                        uri = row_a[4]
-                        fileName = ''
-                        parsedUri = urllib.parse.urlparse(uri)
-                        
-                        queryParams = urllib.parse.parse_qs(parsedUri.query)
-                        filePathEncoded = queryParams.get("filePath", [None])[0]
+                # BODY Files - Full message is found elsewhere */data/com.google.android.gm/files/body/[ParentFolder]/[_idFolder]
+                # TXT Body
+                tBody = ''
+                for txtBody in bodyTxt_list:
+                    if _container_of(txtBody) != container:
+                        continue
+                    if ((os.path.basename(txtBody)) == (str(row[1]) + '.txt')):
+                        with open(txtBody, "r", encoding="utf-8") as f:
+                            tBody = f.read()
 
-                        if filePathEncoded:
-                            filePath = urllib.parse.unquote(filePathEncoded)
-                            fileName = os.path.basename(filePath).replace(":", "_")
-                            
-                            for sAttach in attachSent_list:
-                                if (os.path.isfile(sAttach) and ((os.path.basename(sAttach)) == fileName)):
-                                    ref = check_in_media(sAttach, row_a[2])
+                # HTML Body
+                hBody = ''
+                for htmlBody in bodyHtml_list:
+                    if _container_of(htmlBody) != container:
+                        continue
+                    if ((os.path.basename(htmlBody)) == (str(row[1]) + '.html')):
+                        with open(htmlBody, "r", encoding="utf-8") as f:
+                            hBody = f.read()
+
+                # ATTACHMENTS - Files can be stored in two different locations depending if they are sent or received.
+                AttachmentPaths = []
+                if (row[9] == 1):
+                    cursor_attach = db.cursor()
+                    cursor_attach.execute('''
+                    select A.accountKey, A._id, A.fileName, A.mimeType, A.cachedFile
+                    from Attachment as A
+                    where messageKey = ?
+                    ''', (row[1],))
+
+                    attach_rows = cursor_attach.fetchall()
+                    for row_a in attach_rows:
+                        row_a = list(row_a)
+                        accountID = row_a[0]
+                        attachmentID = row_a[1]
+
+                        if (row_a[4] is None):
+                            # Received Attachment */data/com.google.android.gm/databases/*.db_att/*.*
+                            for rAttach in attachRecv_list:
+                                if _container_of(rAttach) != container:
+                                    continue
+                                if (os.path.isfile(rAttach) and ((os.path.basename(rAttach)) == f'{attachmentID}') and ((os.path.basename(os.path.dirname(rAttach))) == f'{accountID}.db_att')):
+                                    ref = check_in_media(rAttach, row_a[2])
                                     if ref:
                                         AttachmentPaths.append(ref)
-                           
-            # Collapse to a bare ref for a single attachment, list for several, and
-            # '' when none resolved -- mirrors the other media artifacts. The None
-            # guards above keep any unresolved ref (which the LAVA viewer chokes on)
-            # out of the list.
-            if len(AttachmentPaths) == 1:
-                attachment_cell = AttachmentPaths[0]
-            elif AttachmentPaths:
-                attachment_cell = AttachmentPaths
-            else:
-                attachment_cell = ''
-            data_list.append((row[0], row[1], row[2], tBody, safe_source(hBody), row[3], row[4], row[5], row[6], row[7], row[8], row[9], attachment_cell, row[11], Context.get_relative_path(emailProviderDB)))
+                        else:
+                            # Sent Attachment /data/com.google.android.gm/cache/*.attachment
+                            uri = row_a[4]
+                            fileName = ''
+                            parsedUri = urllib.parse.urlparse(uri)
 
-    data_headers = (('Timestamp','datetime'),'_id','Snippet', 'Body(TXT)', 'Body(HTML)', 'Recipient','Reply To','Subject Line','From','Display Name', 'Read', 'AttachmentFlag', ('Attachments', 'media'), 'Mailbox Folder', 'Source File')
+                            queryParams = urllib.parse.parse_qs(parsedUri.query)
+                            filePathEncoded = queryParams.get("filePath", [None])[0]
+
+                            if filePathEncoded:
+                                filePath = urllib.parse.unquote(filePathEncoded)
+                                fileName = os.path.basename(filePath).replace(":", "_")
+
+                                for sAttach in attachSent_list:
+                                    if _container_of(sAttach) != container:
+                                        continue
+                                    if (os.path.isfile(sAttach) and ((os.path.basename(sAttach)) == fileName)):
+                                        ref = check_in_media(sAttach, row_a[2])
+                                        if ref:
+                                            AttachmentPaths.append(ref)
+
+                # Collapse to a bare ref for a single attachment, list for several, and
+                # '' when none resolved -- mirrors the other media artifacts. The None
+                # guards above keep any unresolved ref (which the LAVA viewer chokes on)
+                # out of the list.
+                if len(AttachmentPaths) == 1:
+                    attachment_cell = AttachmentPaths[0]
+                elif AttachmentPaths:
+                    attachment_cell = AttachmentPaths
+                else:
+                    attachment_cell = ''
+                data_list.append((row[0], row[12], row[10], row[1], row[2], tBody, safe_source(hBody), row[3], row[4], row[5], row[6], row[7], row[8], row[9], attachment_cell, row[11], Context.get_relative_path(emailProviderDB)))
+        except sqlite3.Error as ex:
+            # One unreadable or drifted store must not cost the other accounts their rows
+            logfunc(f'Unable to read Gmail EmailProvider store {Context.get_relative_path(emailProviderDB)}: {ex}')
+            continue
+        finally:
+            db.close()
+
+    data_headers = (('Timestamp','datetime'),'Account','Account ID','_id','Snippet', 'Body(TXT)', 'Body(HTML)', 'Recipient','Reply To','Subject Line','From','Display Name', 'Read', 'AttachmentFlag', ('Attachments', 'media'), 'Mailbox Folder', 'Source File')
     return data_headers, data_list, 'See source file(s) below:'
-    
+
 @artifact_processor
 def gmailIMAPAccounts(context):
-    files_found = context.get_files_found()
-    emailProviderDB = '' 
     emailProviderDB_found = []
 
     data_list = []
-    
-    for file_found in files_found:
+
+    for file_found in unique_files(context):
         file_found = str(file_found)
-        
+
         if file_found.endswith(('-wal','-shm','-journal')):
             continue
         elif os.path.basename(file_found).startswith('.'):
             continue
+        elif file_found.find('.magisk') >= 0 and file_found.find('mirror') >= 0:
+            continue  # Skip mirror, it should be duplicate data
         if os.path.basename(file_found).startswith('EmailProvider'):
-            emailProviderDB = str(file_found)
-            emailProviderDB_found.append(emailProviderDB)
-        
-    for i in range(len(emailProviderDB_found)):
-        emailProviderDB = emailProviderDB_found[i]
-        
+            emailProviderDB_found.append(file_found)
+
+    emailProviderDB_found.sort(key=_sort_key)
+
+    for emailProviderDB in emailProviderDB_found:
         db = open_sqlite_db_readonly(emailProviderDB)
-        cursor = db.cursor()
-        cursor.execute('''
-        select A._id, A.displayName, A.emailAddress, A.senderName, H.login, H.password, H.address, H.port
-        from Account as A
-        inner join HostAuth as H on (A.hostAuthKeyRecv  = H._id) or (A.hostAuthKeySend = H._id)
-        ''')
+        if db is None:
+            continue
+        try:
+            cursor = db.cursor()
+            cursor.execute('''
+            select A._id, A.displayName, A.emailAddress, A.senderName, H.login, H.password, H.address, H.port
+            from Account as A
+            inner join HostAuth as H on (A.hostAuthKeyRecv  = H._id) or (A.hostAuthKeySend = H._id)
+            ''')
 
-        all_rows = cursor.fetchall()
-        for row in all_rows:
-            row = list(row)
+            all_rows = cursor.fetchall()
+            for row in all_rows:
+                row = list(row)
 
-            data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], Context.get_relative_path(emailProviderDB)))
+                data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], Context.get_relative_path(emailProviderDB)))
+        except sqlite3.Error as ex:
+            # One unreadable or drifted store must not cost the other accounts their rows
+            logfunc(f'Unable to read Gmail EmailProvider store {Context.get_relative_path(emailProviderDB)}: {ex}')
+            continue
+        finally:
+            db.close()
 
     data_headers = ('_id', 'displayName', 'emailAddress', 'senderName', 'login','password','address','port', 'Source File')
     return data_headers, data_list, 'See source file(s) below:'


### PR DESCRIPTION
Fixes multi-account and multi-user store selection in the Gmail modules.

- GmailActive read only the first Gmail.xml found, so a second Android user's active account was dropped. Every matched file is now read.
- App Emails, Label Details, and the IMAP artifacts now read every account store across all Android users, in sorted path order, with duplicate storage spellings collapsed and rows attributed to their account and source file.
- Download Requests read a single downloader.db; it now reads all of them.

Row counts on single-store images are unchanged. New Account and Source File columns carry the attribution.