### PR TITLE
Show Gmail bodies as readable text with a Links column

### DIFF
--- a/scripts/artifacts/gmailEmails.py
+++ b/scripts/artifacts/gmailEmails.py
@@ -5,12 +5,11 @@ __artifacts_v2__ = {
         "author": "Alexis Brignoni, Patrick Dalla, @stark4n6",
         "creation_date": "2023-01-04",
         "last_update_date": "2026-08-24",
-        "requirements": "none",
+        "requirements": "BeautifulSoup",
         "category": "Email",
-        "notes": "Recipient, Reply To, Mailed By, Signed by and Subject Line are read from numbered fields of the zipped message protobuf. Protobuf field positions were established through testing; Mailed By and Signed by reflect stored header values and are not verified against Authentication-Results. The app keeps one bigTopDataDB.<id> store per signed-in account; every matched store is read, across every Android user of the device, with duplicate storage spellings (data/data, data/user/<n>, data_mirror) collapsed first and stores read in sorted path order. Account ID is the numeric store id as stored. The Account column is filled only when the Java String.hashCode of an address recorded in the same app instance's Gmail.xml equals the store id, which held for every store in the tested images; a store with no matching recorded address keeps a blank Account. A store that cannot be opened or queried is logged and skipped without dropping the other accounts' rows.",
+        "notes": "Recipient, Reply To, Mailed By, Signed by and Subject Line are read from numbered fields of the zipped message protobuf. Protobuf field positions were established through testing; Mailed By and Signed by reflect stored header values and are not verified against Authentication-Results. Message is the readable text extracted from the stored HTML body (tags, styling and repeated whitespace removed); Links lists the distinct link targets the same body carries, in document order, as stored. The unmodified body stays in the source database. The app keeps one bigTopDataDB.<id> store per signed-in account; every matched store is read, across every Android user of the device, with duplicate storage spellings (data/data, data/user/<n>, data_mirror) collapsed first and stores read in sorted path order. Account ID is the numeric store id as stored. The Account column is filled only when the Java String.hashCode of an address recorded in the same app instance's Gmail.xml equals the store id, which held for every store in the tested images; a store with no matching recorded address keeps a blank Account. A store that cannot be opened or queried is logged and skipped without dropping the other accounts' rows.",
         "paths": ('*/com.google.android.gm/databases/bigTopDataDB.*','*/com.google.android.gm/files/downloads/*/attachments/*/*.*','*/com.google.android.gm/shared_prefs/Gmail.xml'),
         "output_types": "standard",
-        "html_columns": ["Message"],
         "artifact_icon": "inbox",
         "sample_data": {
             "anne_a15": "Android 15 | com.google.android.gm vc 65346694 | 200 rows",
@@ -90,16 +89,38 @@ __artifacts_v2__ = {
 }
 
 import os
+import re
 import sqlite3
 import zlib
 from datetime import datetime, timezone
 
+from bs4 import BeautifulSoup
+
 from scripts.artifacts.gmail import _parse_xml
 from scripts.artifacts.storagePathViews import canonical_path, unique_files
 from scripts.context import Context
-from scripts.html_safe import safe_source
 from scripts.ilapfuncs import open_sqlite_db_readonly, check_in_media, get_sqlite_db_records, artifact_processor, \
     decode_protobuf, logfunc
+
+# whitespace plus the invisible padding characters observed in marketing preheaders
+_WHITESPACE_RUN = re.compile(r'[\s\u00ad\u034f\u200b\u200c\u200d\ufeff]+')
+
+
+def body_text(html_body):
+    """The readable text of an HTML body: tags dropped, whitespace runs (including the
+    zero-width padding marketing mail hides its preheader behind) collapsed to one space."""
+    if not html_body:
+        return ''
+    text = BeautifulSoup(html_body, 'html.parser').get_text(separator=' ')
+    return _WHITESPACE_RUN.sub(' ', text).strip()
+
+
+def body_links(html_body):
+    """The distinct link targets an HTML body carries, in document order, as stored."""
+    if not html_body:
+        return ''
+    hrefs = (a.get('href') for a in BeautifulSoup(html_body, 'html.parser').find_all('a', href=True))
+    return ' '.join(dict.fromkeys(h for h in hrefs if h))
 
 
 def _sort_key(path):
@@ -284,9 +305,9 @@ def gmailEmails(context):
                         if attachpath.endswith(attachname):
                             attachment = check_in_media(attachpath, name=attachname) or ''
 
-            data_list.append((timestamp,account,account_id,serverid,safe_source(messagehtml),attachment,attachname,to,toname,replyto,replytoname,subjectline,mailedby,signedby,source_file))
+            data_list.append((timestamp,account,account_id,serverid,body_text(messagehtml),body_links(messagehtml),attachment,attachname,to,toname,replyto,replytoname,subjectline,mailedby,signedby,source_file))
 
-    data_headers = (('Timestamp','datetime'),'Account','Account ID','Email ID','Message',('Attachment','media'),'Attachment Name','Recipient','Recipient Name','Reply To','Reply To Name','Subject Line','Mailed By','Signed by','Source File')
+    data_headers = (('Timestamp','datetime'),'Account','Account ID','Email ID','Message','Links',('Attachment','media'),'Attachment Name','Recipient','Recipient Name','Reply To','Reply To Name','Subject Line','Mailed By','Signed by','Source File')
     return data_headers, data_list, 'See source file(s) below:'
 
 @artifact_processor

--- a/scripts/artifacts/gmailIMAPEmails.py
+++ b/scripts/artifacts/gmailIMAPEmails.py
@@ -5,12 +5,11 @@ __artifacts_v2__ = {
         "author": "ogmini",
         "creation_date": "2025-08-20",
         "last_update_date": "2026-08-24",
-        "requirements": "none",
+        "requirements": "BeautifulSoup",
         "category": "Email",
-        "notes": "Every matched EmailProvider store is read, across every Android user of the device, with duplicate storage spellings collapsed first and stores read in sorted path order. The Account column is the emailAddress the store's own Account table records for the row. Body and attachment files are only paired with rows from the same app instance they belong to. No tested image held IMAP data (every EmailProvider.db carried empty Account and Message tables), so row-producing behavior is verified against constructed known data, not a real image.",
+        "notes": "Every matched EmailProvider store is read, across every Android user of the device, with duplicate storage spellings collapsed first and stores read in sorted path order. The Account column is the emailAddress the store's own Account table records for the row. Body and attachment files are only paired with rows from the same app instance they belong to. Body(HTML) is the readable text extracted from the message's stored HTML body file; Links lists the distinct link targets that body carries, in document order, as stored, and the unmodified body file stays in the report's data folder. No tested image held IMAP data (every EmailProvider.db carried empty Account and Message tables), so row-producing behavior is verified against constructed known data, not a real image.",
         "paths": ('*/com.google.android.gm/databases/EmailProvider.*','*/com.google.android.gm/files/body/0/*/*.*','*/com.google.android.gm/databases/*.db_att/*','*/com.google.android.gm/cache/*.attachment'),
         "output_types": "standard",
-        "html_columns": ["Body(HTML)"],
         "artifact_icon": "inbox",
         "sample_data": {
             "anne_a15": "Android 15 | com.google.android.gm vc 65346694 | 0 rows",
@@ -70,10 +69,10 @@ import os
 import sqlite3
 import urllib.parse
 
+from scripts.artifacts.gmailEmails import body_links, body_text
 from scripts.artifacts.storagePathViews import canonical_path, unique_files
 from scripts.ilapfuncs import open_sqlite_db_readonly, artifact_processor, convert_unix_ts_to_utc, logfunc, check_in_media
 from scripts.context import Context
-from scripts.html_safe import safe_source
 
 
 def _sort_key(path):
@@ -223,7 +222,7 @@ def gmailIMAPEmails(context):
                     attachment_cell = AttachmentPaths
                 else:
                     attachment_cell = ''
-                data_list.append((row[0], row[12], row[10], row[1], row[2], tBody, safe_source(hBody), row[3], row[4], row[5], row[6], row[7], row[8], row[9], attachment_cell, row[11], Context.get_relative_path(emailProviderDB)))
+                data_list.append((row[0], row[12], row[10], row[1], row[2], tBody, body_text(hBody), body_links(hBody), row[3], row[4], row[5], row[6], row[7], row[8], row[9], attachment_cell, row[11], Context.get_relative_path(emailProviderDB)))
         except sqlite3.Error as ex:
             # One unreadable or drifted store must not cost the other accounts their rows
             logfunc(f'Unable to read Gmail EmailProvider store {Context.get_relative_path(emailProviderDB)}: {ex}')
@@ -231,7 +230,7 @@ def gmailIMAPEmails(context):
         finally:
             db.close()
 
-    data_headers = (('Timestamp','datetime'),'Account','Account ID','_id','Snippet', 'Body(TXT)', 'Body(HTML)', 'Recipient','Reply To','Subject Line','From','Display Name', 'Read', 'AttachmentFlag', ('Attachments', 'media'), 'Mailbox Folder', 'Source File')
+    data_headers = (('Timestamp','datetime'),'Account','Account ID','_id','Snippet', 'Body(TXT)', 'Body(HTML)', 'Links', 'Recipient','Reply To','Subject Line','From','Display Name', 'Read', 'AttachmentFlag', ('Attachments', 'media'), 'Mailbox Folder', 'Source File')
     return data_headers, data_list, 'See source file(s) below:'
 
 @artifact_processor


### PR DESCRIPTION
Makes the Gmail message content readable in every output surface.

- Message (App Emails) and Body(HTML) (IMAP Mailbox Emails) now hold the text extracted from the stored HTML body instead of the markup itself, which rendered as escaped tag soup in LAVA, the HTML report and the TSV.
- A Links column lists the distinct link targets each body carries, as stored, since text extraction drops them.
- The unmodified bodies stay in the source database and body files. Row counts and all other columns are unchanged.