### PR TITLE
Return real paths as source_path, not prose

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -67,6 +67,14 @@ jobs:
         if: steps.changed-files-py.outputs.any_changed == 'true'
         run: python admin/scripts/check_report_local_paths.py
 
+      # The third element of an artifact's return tuple becomes the report's
+      # "located at" line and the LAVA manifest source_path, so it has to be real
+      # paths. Prose standing in for one points the examiner at a column that often
+      # holds a basename, and the location ends up nowhere in the report.
+      - name: Guard against prose returned as a source path
+        if: steps.changed-files-py.outputs.any_changed == 'true'
+        run: python admin/scripts/check_source_path.py
+
       # Fails only on warnings this pull request introduces. Long-lived modules carry
       # deliberate pre-existing warnings, and failing on those pushed contributors toward
       # unrelated refactors or blanket file-level disables. See the script's docstring.

--- a/admin/scripts/check_source_path.py
+++ b/admin/scripts/check_source_path.py
@@ -1,0 +1,180 @@
+"""Guard the third return element against prose standing in for a path.
+
+An artifact returns `(data_headers, data_list, source_path)`. The third element is
+not decoration. `artifact_processor` splits it on newlines, passes each piece
+through `Context.get_relative_path`, prints it as the report's
+
+    <artifact name> located at: <source_path>
+
+line, and writes it into the LAVA manifest as `source_path`. So it has to be real
+paths, newline joined.
+
+The defect this catches is a string constant standing in for one:
+
+    return data_headers, data_list, 'See source file(s) below'   # WRONG
+    return data_headers, data_list, 'Path column in the report'  # WRONG
+
+It reads as helpful and it is not. It points the examiner at a column that often
+holds a basename rather than a path, so the location of the evidence is nowhere in
+the report, and the LAVA manifest records prose where a consumer expects a path.
+
+The shape to write instead, accumulating after the function's own skip guards so a
+file that was matched but not parsed is not claimed as a source:
+
+    source_paths = set()
+    for file_found in files_found:
+        if <skip guard>:
+            continue
+        source_paths.add(str(file_found))
+        ...
+    return data_headers, data_list, '\\n'.join(sorted(source_paths))
+
+Pass the full staged path. The wrapper reduces it for you; that is the one place
+that reduction is done for the artifact.
+
+Two things this deliberately does NOT fail on:
+
+  * `''` on a branch that also returns an empty `data_list`. The wrapper writes no
+    report at all when there are no rows, so that string never reaches a report.
+    A "not found" message there is pointless but harmless, and `''` is correct.
+  * A variable holding a real path, however it was built. Only string literals are
+    reported, including a literal reached through a variable that is never assigned
+    anything else.
+
+Found by sweeping all five cores in 2026-08: 54 sites. iLEAPP had already been
+swept once (PRs #2022 and #2024, 140 modules) and the class had come back in
+ALEAPP and RLEAPP, which is why it is now a check rather than a sweep.
+
+Usage:
+  check_source_path.py [--root REPO_ROOT]
+
+Exits 1 when anything is found, 0 otherwise.
+"""
+
+import argparse
+import ast
+import os
+import sys
+
+DECORATORS = {'artifact_processor', 'artifact_processor_streaming'}
+
+STANDARD_NOTE = (
+    "Return the paths the function actually parsed, newline joined: "
+    "'\\n'.join(sorted(source_paths)). The wrapper makes them extraction relative."
+)
+
+
+def decorator_names(node):
+    names = []
+    for dec in node.decorator_list:
+        if isinstance(dec, ast.Name):
+            names.append(dec.id)
+        elif isinstance(dec, ast.Attribute):
+            names.append(dec.attr)
+        elif isinstance(dec, ast.Call):
+            func = dec.func
+            names.append(func.id if isinstance(func, ast.Name)
+                         else getattr(func, 'attr', ''))
+    return names
+
+
+def returns_no_rows(node):
+    """Whether this return also hands back an empty data_list literal."""
+    rows = node.value.elts[1]
+    return isinstance(rows, (ast.List, ast.Tuple)) and not rows.elts
+
+
+def scan_function(func):
+    """(line, text) for every literal masquerading as a source path."""
+    triples = [n for n in ast.walk(func)
+               if isinstance(n, ast.Return)
+               and isinstance(n.value, ast.Tuple)
+               and len(n.value.elts) == 3]
+    found = []
+    for ret in triples:
+        tail = ret.value.elts[2]
+
+        # Written straight into the return.
+        if isinstance(tail, ast.Constant) and isinstance(tail.value, str):
+            if tail.value and not returns_no_rows(ret):
+                found.append((ret.lineno, tail.value))
+            continue
+
+        # The quiet spelling: a name that is only ever assigned string literals.
+        if isinstance(tail, ast.Name):
+            assigns = [a for a in ast.walk(func) if isinstance(a, ast.Assign)
+                       and any(isinstance(t, ast.Name) and t.id == tail.id
+                               for t in a.targets)]
+            if not assigns:
+                continue
+            values = [a.value for a in assigns]
+            if not all(isinstance(v, ast.Constant) and isinstance(v.value, str)
+                       for v in values):
+                continue
+            for text in sorted({v.value for v in values}):
+                if text:
+                    found.append((ret.lineno, text))
+    return found
+
+
+def scan_module(path):
+    module = os.path.basename(path)
+    try:
+        with open(path, encoding='utf-8', errors='replace') as handle:
+            tree = ast.parse(handle.read())
+    except SyntaxError as err:
+        return [], f'{module}: could not parse ({err})'
+    violations = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not DECORATORS.intersection(decorator_names(node)):
+            continue
+        for line, text in scan_function(node):
+            violations.append((module, node.name, line, text))
+    return violations, None
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--root', default=None, help='repository root')
+    args = parser.parse_args()
+
+    root = args.root or os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    artifacts = os.path.join(root, 'scripts', 'artifacts')
+    if not os.path.isdir(artifacts):
+        print(f'No scripts/artifacts under {root}', file=sys.stderr)
+        return 2
+
+    violations, unreadable, modules = [], [], 0
+    for name in sorted(os.listdir(artifacts)):
+        if not name.endswith('.py'):
+            continue
+        modules += 1
+        found, problem = scan_module(os.path.join(artifacts, name))
+        violations.extend(found)
+        if problem:
+            unreadable.append(problem)
+
+    if violations:
+        print(f'Artifacts returning prose as source_path ({len(violations)}):')
+        for module, func, line, text in violations:
+            print(f'  {module}:{line}  {func}()  {text!r}')
+        print()
+        print(STANDARD_NOTE)
+        return 1
+
+    summary = (f'Checked {modules} artifact module(s): '
+               'no prose returned as a source path.')
+    if unreadable:
+        summary += f' {len(unreadable)} module(s) NOT checked.'
+    print(summary)
+    for problem in unreadable:
+        print(f'  {problem}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/admin/test/scripts/test_check_source_path.py
+++ b/admin/test/scripts/test_check_source_path.py
@@ -1,0 +1,111 @@
+"""Prove the source_path checker still detects the defects it exists to detect.
+
+check_source_path.py fails when an artifact returns a string constant where the
+report expects real paths. The class had already been swept out of iLEAPP once
+(PRs #2022 and #2024) and had come back in two sibling cores by the time it was
+made a check, so the check is the thing that has to keep working.
+
+The negative cases matter as much as the positive ones. A check wired into CI that
+fails correct code gets switched off, so the shapes that must stay silent are
+pinned here too: an empty string on a branch that returns no rows never reaches a
+report, and a variable holding a real path is not a literal.
+"""
+import importlib.util
+import pathlib
+import sys
+import tempfile
+import textwrap
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_MODULE_PATH = REPO_ROOT / 'admin' / 'scripts' / 'check_source_path.py'
+
+# admin/scripts is not a package, so load the module from its path.
+_spec = importlib.util.spec_from_file_location('check_source_path', _MODULE_PATH)
+csp = importlib.util.module_from_spec(_spec)
+sys.modules['check_source_path'] = csp
+_spec.loader.exec_module(csp)
+
+
+def findings_for(source):
+    with tempfile.TemporaryDirectory() as folder:
+        path = pathlib.Path(folder) / 'sample.py'
+        path.write_text(textwrap.dedent(source), encoding='utf-8')
+        violations, problem = csp.scan_module(str(path))
+    if problem:
+        raise AssertionError(problem)
+    return violations
+
+
+class Prose(unittest.TestCase):
+    def test_flags_prose_in_the_return(self):
+        found = findings_for('''
+            @artifact_processor
+            def demo(context):
+                data_list = [1]
+                return (), data_list, 'See source file(s) below'
+        ''')
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0][3], 'See source file(s) below')
+
+    def test_flags_prose_reached_through_a_variable(self):
+        """appGrouplisting's spelling: assigned once, then returned."""
+        found = findings_for('''
+            @artifact_processor
+            def demo(context):
+                source_path = 'Path column in the report'
+                data_list = [1]
+                return (), data_list, source_path
+        ''')
+        self.assertEqual(len(found), 1)
+
+    def test_accepts_joined_real_paths(self):
+        self.assertEqual(findings_for('''
+            @artifact_processor
+            def demo(context):
+                source_paths = set()
+                data_list = []
+                for file_found in context.get_files_found():
+                    source_paths.add(str(file_found))
+                return (), data_list, '\\n'.join(sorted(source_paths))
+        '''), [])
+
+
+class MustStaySilent(unittest.TestCase):
+    def test_empty_string_on_a_no_rows_branch_is_fine(self):
+        """The wrapper writes no report when data_list is empty."""
+        self.assertEqual(findings_for('''
+            @artifact_processor
+            def demo(context):
+                if not context.get_files_found():
+                    return (), [], ''
+                return (), [1], '\\n'.join(sorted(paths))
+        '''), [])
+
+    def test_an_undecorated_helper_is_not_checked(self):
+        self.assertEqual(findings_for('''
+            def _helper(files_found):
+                return (), [1], 'See source file(s) below'
+        '''), [])
+
+    def test_a_variable_built_from_paths_is_not_a_literal(self):
+        self.assertEqual(findings_for('''
+            @artifact_processor
+            def demo(context):
+                source_path = get_file_path(context.get_files_found(), 'x.db')
+                return (), [1], source_path
+        '''), [])
+
+
+class TheRepoItself(unittest.TestCase):
+    def test_no_artifact_in_this_repo_returns_prose(self):
+        artifacts = REPO_ROOT / 'scripts' / 'artifacts'
+        offenders = []
+        for module in sorted(artifacts.glob('*.py')):
+            violations, _ = csp.scan_module(str(module))
+            offenders.extend(violations)
+        self.assertEqual(offenders, [], f'{len(offenders)} artifact(s) return prose')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/artifacts/DuckDuckGo.py
+++ b/scripts/artifacts/DuckDuckGo.py
@@ -453,7 +453,7 @@ def duckduckgo_downloads(context):
             break
 
     if not source_path:
-        return (), [], "c not found"
+        return (), [], ''
 
     query = '''
         SELECT
@@ -492,12 +492,15 @@ def duckduckgo_thumbnails(context):
     files_found = context.get_files_found()
     data_list = []
 
+    source_paths = set()
+
     for source_path in files_found:
         source_path = str(source_path)
         if source_path.endswith('.db'):
             break
     open_preview_files = set()
     if source_path:
+        source_paths.add(source_path)
         query = '''
             SELECT
                 tabs.tabPreviewFile
@@ -512,6 +515,7 @@ def duckduckgo_thumbnails(context):
         media_path = Path(file_found)
         if media_path.suffix.lower() not in ('.jpg'):
             continue
+        source_paths.add(str(file_found))
         filename = (media_path.name)
         utctime = int(media_path.stem)
 
@@ -529,13 +533,14 @@ def duckduckgo_thumbnails(context):
         'Referenced In Tabs Table', ('Timestamp (UTC)', 'datetime'), ('Thumbnail', 'media'),
         'File Name', 'Location')
 
-    return data_headers, data_list, 'See source path(s) below'
+    return data_headers, data_list, '\n'.join(sorted(source_paths))
 
 
 @artifact_processor
 def duckduckgo_duckai(context):
     files_found = context.get_files_found()
     data_list = []
+    source_paths = set()
 
     duckchats = "_https://duckduckgo.com savedAIChats"
 
@@ -612,6 +617,7 @@ def duckduckgo_duckai(context):
             except ValueError:
                 continue
 
+            source_paths.add(origin)
             chats = parsed.get("chats", [])
             parent_folder = pathlib.Path(origin).parent.name
             origin_filename = pathlib.Path(origin).name
@@ -658,7 +664,7 @@ def duckduckgo_duckai(context):
         "Sequence Number"
     )
 
-    return data_headers, data_list, 'See source path(s) below'
+    return data_headers, data_list, '\n'.join(sorted(source_paths))
 
 
 @artifact_processor

--- a/scripts/artifacts/FilesByGoogle.py
+++ b/scripts/artifacts/FilesByGoogle.py
@@ -41,12 +41,14 @@ from scripts.artifacts.storagePathViews import unique_files
 def fbg_master(context):
     files_found = unique_files(context)
     data_list_master = []
+    source_paths = set()
 
     for file_found in files_found:
         file_found = str(file_found)
-        
+
         # Master list
         if file_found.endswith('files_master_database'):
+            source_paths.add(file_found)
             db = open_sqlite_db_readonly(file_found)
             cursor = db.cursor()
             cursor.execute('''
@@ -91,18 +93,20 @@ def fbg_master(context):
             db.close()
             
     data_headers = (('Date Modified','datetime'),'Root Path','Root Relative Path','File Name','Size','Mime Type','Media Type','URI','Hidden','Title','Parent Folder','Source File') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-    return data_headers, data_list_master, 'See source file(s) below'
+    return data_headers, data_list_master, '\n'.join(sorted(source_paths))
             
 @artifact_processor
 def fbg_searchhistory(context):
     files_found = unique_files(context)
     data_list_search = []
-    
+    source_paths = set()
+
     for file_found in files_found:
         file_found = str(file_found)
 
         # Search History
         if file_found.endswith('search_history_database'):
+            source_paths.add(file_found)
             db = open_sqlite_db_readonly(file_found)
             cursor = db.cursor()
             cursor.execute('''
@@ -131,4 +135,4 @@ def fbg_searchhistory(context):
             continue # Skip all other files
             
     data_headers = (('Timestamp','datetime'),'Search Term','Source File') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-    return data_headers, data_list_search, 'See source file(s) below'
+    return data_headers, data_list_search, '\n'.join(sorted(source_paths))

--- a/scripts/artifacts/OrnetBrowser.py
+++ b/scripts/artifacts/OrnetBrowser.py
@@ -210,7 +210,7 @@ def ornetbrowser_bookmarks(context):
             break
 
     if not source_path:
-        return (), [], "appDatabase not found"
+        return (), [], ''
 
     query = '''
         SELECT
@@ -251,7 +251,7 @@ def ornetbrowser_suggestions(context):
             break
 
     if not source_path:
-        return (), [], "appDatabase not found"
+        return (), [], ''
 
     query = '''
         SELECT
@@ -290,7 +290,7 @@ def ornetbrowser_history(context):
             break
 
     if not source_path:
-        return (), [], "appDatabase not found"
+        return (), [], ''
 
     query = '''
         SELECT
@@ -331,7 +331,7 @@ def ornetbrowser_opentabs(context):
             break
 
     if not source_path:
-        return (), [], "appDatabase not found"
+        return (), [], ''
 
     thumb_lookup = {}
     for file_found in files_found:
@@ -413,7 +413,7 @@ def ornetbrowser_frequents(context):
             break
 
     if not source_path:
-        return (), [], "appDatabase not found"
+        return (), [], ''
 
     query = '''
         SELECT
@@ -477,11 +477,13 @@ def ornetbrowser_downloads(context):
 def ornetbrowser_thumbnails(context):
     files_found = context.get_files_found()
     data_list = []
+    source_paths = set()
 
     for file_found in files_found:
         media_path = Path(file_found)
         if media_path.suffix.lower() not in ('.jpg'):
             continue
+        source_paths.add(str(file_found))
         filename = (media_path.name)
         utctime = int(media_path.stem)
 
@@ -493,7 +495,7 @@ def ornetbrowser_thumbnails(context):
 
     data_headers = (('Timestamp', 'datetime'), ('Thumbnail', 'media'), ' File Name', 'Location')
 
-    return data_headers, data_list, 'See source path(s) below'
+    return data_headers, data_list, '\n'.join(sorted(source_paths))
 
 
 @artifact_processor
@@ -519,7 +521,7 @@ def ornetbrowser_searchhistory(context):
             break
 
     if not source_path:
-        return (), [], "appDatabase not found"
+        return (), [], ''
 
     query = '''
         SELECT

--- a/scripts/artifacts/ProtonDrive.py
+++ b/scripts/artifacts/ProtonDrive.py
@@ -55,7 +55,7 @@ def protondrive_useraccount(context):
             break
 
     if not source_path:
-        return (), [], "db-drive not found"
+        return (), [], ''
 
     query = '''
             SELECT
@@ -100,7 +100,7 @@ def protondrive_fileinfo(context):
             break
 
     if not source_path:
-        return (), [], "db-drive not found"
+        return (), [], ''
 
     query = '''
         SELECT

--- a/scripts/artifacts/RomeoDatingApp.py
+++ b/scripts/artifacts/RomeoDatingApp.py
@@ -65,6 +65,7 @@ def romeo_dating_messages(context):
 
     main_db = ''
     data_list = []
+    source_paths = set()
 
     query = '''
             SELECT me.date [Timestamp],
@@ -89,6 +90,7 @@ def romeo_dating_messages(context):
     for file_found in files_found:
         main_db = str(file_found)
         source_db = context.get_relative_path(main_db)
+        source_paths.add(main_db)
 
         db_records = get_sqlite_db_records(main_db, query)
 
@@ -132,7 +134,7 @@ def romeo_dating_messages(context):
         # On android we only know if an Image was part of the message,
         # content isn't on the phone anymore- so just "image contained?"
 
-    return data_headers, data_list, 'See Table for Source DB'
+    return data_headers, data_list, '\n'.join(sorted(source_paths))
 
 
 @artifact_processor
@@ -144,6 +146,7 @@ def romeo_dating_contacts(context):
 
     main_db = ''
     data_list = []
+    source_paths = set()
 
     query = '''
             SELECT 
@@ -179,6 +182,7 @@ def romeo_dating_contacts(context):
     for file_found in files_found:
         main_db = str(file_found)
         source_db = context.get_relative_path(main_db)
+        source_paths.add(main_db)
 
         db_records = get_sqlite_db_records(main_db, query)
 
@@ -233,7 +237,7 @@ def romeo_dating_contacts(context):
                         'Source Database'
                     )
 
-    return data_headers, data_list, 'See Table for Source DB'
+    return data_headers, data_list, '\n'.join(sorted(source_paths))
 
 
 @artifact_processor

--- a/scripts/artifacts/SamsungTrash.py
+++ b/scripts/artifacts/SamsungTrash.py
@@ -49,7 +49,7 @@ def samsungTrash(context):
     """
 
     data_list = []
-    source_path = "See Source DB column"
+    source_paths = set()
     media_files = [str(path) for path in files_found if "/.Trash/" in str(path)]
 
     for file_found in files_found:
@@ -57,6 +57,7 @@ def samsungTrash(context):
         if not file_found.endswith("trash.db"):
             continue
 
+        source_paths.add(file_found)
         db_records = get_sqlite_db_records(file_found, query)
 
         # Get the media file path to show the media in the results table
@@ -110,4 +111,4 @@ def samsungTrash(context):
         "Source DB",
     )
 
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(sorted(source_paths))

--- a/scripts/artifacts/SimpleStorage_applaunch.py
+++ b/scripts/artifacts/SimpleStorage_applaunch.py
@@ -59,4 +59,4 @@ def SimpleStorage_applaunch(context):
         data_list.append((time_launched,record[1],record[2], Context.get_relative_path(source_path)))
  
     data_headers = (('App Launched Timestamp','datetime'),'App Name','Launched From', 'Source File')
-    return data_headers, data_list, 'See source file(s) below'
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/TorBrowser.py
+++ b/scripts/artifacts/TorBrowser.py
@@ -80,6 +80,7 @@ def _parse_xml(file_found):
 def torbrowser_thumbnails(context):
     files_found = unique_files(context)
     data_list = []
+    source_paths = set()
 
     for file_found in files_found:
         media_path = Path(file_found)
@@ -89,6 +90,7 @@ def torbrowser_thumbnails(context):
         if media_path.suffix.lower() != '.0':
             continue
 
+        source_paths.add(str(file_found))
         filename = media_path.name
         location = context.get_relative_path(str(media_path.parent))
 
@@ -102,7 +104,7 @@ def torbrowser_thumbnails(context):
 
     data_headers = (('ModifiedTime', 'datetime'), ('Thumbnail', 'media'), 'File Name', 'Location')
 
-    return data_headers, data_list, 'See source path(s) below'
+    return data_headers, data_list, '\n'.join(sorted(source_paths))
 
 
 @artifact_processor

--- a/scripts/artifacts/contacts.py
+++ b/scripts/artifacts/contacts.py
@@ -39,7 +39,8 @@ def contacts(context):
 
     source_file = ''
     data_list = []
-    
+    source_paths = set()
+
     for file_found in files_found:
         
         file_name = str(file_found)
@@ -48,6 +49,7 @@ def contacts(context):
             continue
 
         source_file = context.get_relative_path(file_name)
+        source_paths.add(file_name)
 
         db = open_sqlite_db_readonly(file_name)
         cursor = db.cursor()
@@ -90,4 +92,4 @@ def contacts(context):
         db.close()
     
     data_headers = ('Mimetype','Data 1', 'Display Name', 'Phone Number', 'Email Address', 'Source File') # Don't remove the comma, that is required to make this a tuple as there is only 1 element
-    return data_headers, data_list, 'See source file(s) below'
+    return data_headers, data_list, '\n'.join(sorted(source_paths))

--- a/scripts/artifacts/downloads.py
+++ b/scripts/artifacts/downloads.py
@@ -32,11 +32,13 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, conve
 def downloads(context):
     files_found = context.get_files_found()
     data_list = []
-    
+    source_paths = set()
+
     for file_found in files_found:
         file_found = str(file_found)
-        
+
         if file_found.endswith('downloads.db'):
+            source_paths.add(file_found)
             db = open_sqlite_db_readonly(file_found)
             #Get file downloads
             cursor = db.cursor()
@@ -82,4 +84,4 @@ def downloads(context):
             continue
         
     data_headers = (('Last Modified Timestamp','datetime'),'Title','Description','Provider URI','Save Location','Mime Type','App Provider Package','Current Bytes','Total Bytes','Status','Error Message','ETAG','Visible in Downloads UI','Deleted','Source File')    
-    return data_headers, data_list, 'See source file(s) below'
+    return data_headers, data_list, '\n'.join(sorted(source_paths))

--- a/scripts/artifacts/gmail.py
+++ b/scripts/artifacts/gmail.py
@@ -66,6 +66,7 @@ def _parse_xml(file_found):
 @artifact_processor
 def get_gmailActive(context):
     data_list = []
+    source_paths = set()
 
     # Every Android user's Gmail.xml gets read, not just whichever file the
     # seeker happened to list first; duplicate storage spellings of one file
@@ -74,6 +75,7 @@ def get_gmailActive(context):
                          key=lambda p: Context.get_relative_path(str(p)).replace('\\', '/'))
     for file_found in files_found:
         file_found = str(file_found)
+        source_paths.add(file_found)
         root = _parse_xml(file_found)
         for child in root:
             if child.attrib.get('name') == "active-account" and child.text:
@@ -81,4 +83,4 @@ def get_gmailActive(context):
                 data_list.append((child.text, Context.get_relative_path(file_found)))
 
     data_headers = ('Active Gmail Address', 'Source File')
-    return data_headers, data_list, 'See source file(s) below:'
+    return data_headers, data_list, '\n'.join(sorted(source_paths))

--- a/scripts/artifacts/gmailEmails.py
+++ b/scripts/artifacts/gmailEmails.py
@@ -189,6 +189,7 @@ def _gmail_stores(files_found, basename_prefix):
 def gmailEmails(context):
     files_found = unique_files(context)
     data_list = []
+    source_paths = set()
     accounts = _accounts_by_store_id(files_found)
 
     for bigTopDataDB in _gmail_stores(files_found, 'bigTopDataDB'):
@@ -218,6 +219,7 @@ def gmailEmails(context):
         finally:
             db.close()
 
+        source_paths.add(bigTopDataDB)
         proto_col = ''
         for col_info in columns_info:
             if col_info[1] == "zipped_message_proto":
@@ -308,12 +310,13 @@ def gmailEmails(context):
             data_list.append((timestamp,account,account_id,serverid,body_text(messagehtml),body_links(messagehtml),attachment,attachname,to,toname,replyto,replytoname,subjectline,mailedby,signedby,source_file))
 
     data_headers = (('Timestamp','datetime'),'Account','Account ID','Email ID','Message','Links',('Attachment','media'),'Attachment Name','Recipient','Recipient Name','Reply To','Reply To Name','Subject Line','Mailed By','Signed by','Source File')
-    return data_headers, data_list, 'See source file(s) below:'
+    return data_headers, data_list, '\n'.join(sorted(source_paths))
 
 @artifact_processor
 def gmailLabels(context):
     files_found = unique_files(context)
     data_list = []
+    source_paths = set()
     accounts = _accounts_by_store_id(files_found)
 
     for bigTopDataDB in _gmail_stores(files_found, 'bigTopDataDB'):
@@ -321,6 +324,7 @@ def gmailLabels(context):
         account_id = store_name.split('bigTopDataDB.', 1)[1] if '.' in store_name else ''
         account = accounts.get((_container_of(bigTopDataDB), account_id), '')
         source_file = Context.get_relative_path(bigTopDataDB)
+        source_paths.add(bigTopDataDB)
 
         query = '''
         select
@@ -338,15 +342,17 @@ def gmailLabels(context):
             data_list.append((account,account_id,record[0],record[1],record[2],record[3],source_file))
 
     data_headers = ('Account','Account ID','Label','Unread Count','Total Count','Unseen Count','Source File')
-    return data_headers, data_list, 'See source file(s) below:'
+    return data_headers, data_list, '\n'.join(sorted(source_paths))
 
 @artifact_processor
 def gmailDownloadRequests(context):
     files_found = unique_files(context)
     data_list = []
+    source_paths = set()
 
     for downloaderDB in _gmail_stores(files_found, 'downloader.db'):
         source_file = Context.get_relative_path(downloaderDB)
+        source_paths.add(downloaderDB)
 
         #Get Gmail download requests
         query = '''
@@ -368,4 +374,4 @@ def gmailDownloadRequests(context):
             data_list.append((record[0],record[1],record[2],record[3],record[4],record[5],record[6],record[7],source_file))
 
     data_headers = (('Timestamp Requested','datetime'),'Account Name','Download Type','Caller ID','URL','Target File Path','Target File Size','Priority','Source File')
-    return data_headers, data_list, 'See source file(s) below:'
+    return data_headers, data_list, '\n'.join(sorted(source_paths))

--- a/scripts/artifacts/gmailIMAPEmails.py
+++ b/scripts/artifacts/gmailIMAPEmails.py
@@ -92,6 +92,7 @@ def gmailIMAPEmails(context):
     emailProviderDB_found = []
 
     data_list = []
+    source_paths = set()
 
     bodyTxt_list = []
     bodyHtml_list = []
@@ -140,6 +141,7 @@ def gmailIMAPEmails(context):
             ''')
 
             all_rows = cursor.fetchall()
+            source_paths.add(emailProviderDB)
             for row in all_rows:
                 row = list(row)
                 try:
@@ -231,13 +233,14 @@ def gmailIMAPEmails(context):
             db.close()
 
     data_headers = (('Timestamp','datetime'),'Account','Account ID','_id','Snippet', 'Body(TXT)', 'Body(HTML)', 'Links', 'Recipient','Reply To','Subject Line','From','Display Name', 'Read', 'AttachmentFlag', ('Attachments', 'media'), 'Mailbox Folder', 'Source File')
-    return data_headers, data_list, 'See source file(s) below:'
+    return data_headers, data_list, '\n'.join(sorted(source_paths))
 
 @artifact_processor
 def gmailIMAPAccounts(context):
     emailProviderDB_found = []
 
     data_list = []
+    source_paths = set()
 
     for file_found in unique_files(context):
         file_found = str(file_found)
@@ -266,6 +269,7 @@ def gmailIMAPAccounts(context):
             ''')
 
             all_rows = cursor.fetchall()
+            source_paths.add(emailProviderDB)
             for row in all_rows:
                 row = list(row)
 
@@ -278,4 +282,4 @@ def gmailIMAPAccounts(context):
             db.close()
 
     data_headers = ('_id', 'displayName', 'emailAddress', 'senderName', 'login','password','address','port', 'Source File')
-    return data_headers, data_list, 'See source file(s) below:'
+    return data_headers, data_list, '\n'.join(sorted(source_paths))

--- a/scripts/artifacts/googleCast.py
+++ b/scripts/artifacts/googleCast.py
@@ -33,11 +33,13 @@ from scripts.artifacts.storagePathViews import unique_files
 def googleCast(context):
     files_found = unique_files(context)
     data_list = []
-    
+    source_paths = set()
+
     for file_found in files_found:
         file_found = str(file_found)
-        
+
         if file_found.endswith('cast.db'):
+            source_paths.add(file_found)
             db = open_sqlite_db_readonly(file_found)
             cursor = db.cursor()
             cursor.execute('''
@@ -98,4 +100,4 @@ def googleCast(context):
             continue # Skip all other files
     
     data_headers = (('Last Published Timestamp','datetime'),'Device ID (SSDP UDN)','Capabilities','Device Version','Device Friendly Name','Device Model Name','Receiver Metrics ID','Service Instance Name','Device IP Address','Device Port','Supported Criteria','RCN Enabled Status','Hotspot BSSID','Cloud Device ID',('Last Discovered Timestamp','datetime'),('Last Discovered By BLE Timestamp','datetime'),'Source File') 
-    return data_headers, data_list, 'See source file(s) below:'
+    return data_headers, data_list, '\n'.join(sorted(source_paths))

--- a/scripts/artifacts/googleFitGMS.py
+++ b/scripts/artifacts/googleFitGMS.py
@@ -29,11 +29,13 @@ from scripts.artifacts.storagePathViews import unique_files
 def googleFitGMS(context):
     files_found = unique_files(context)
     data_list = []
-    
+    source_paths = set()
+
     for file_found in files_found:
         if str(file_found).endswith(('-wal','-shm')):
             continue
         else:
+            source_paths.add(str(file_found))
             query = '''
             SELECT
             datetime(Sessions.start_time/1000,'unixepoch') AS "Activity Start Time",
@@ -58,4 +60,4 @@ def googleFitGMS(context):
                 data_list.append((record[0],record[1],record[2],record[3],record[4],record[5],context.get_relative_path(file_found)))
 
     data_headers = (('Activity Start Time','datetime'),('Activity End Time','datetime'),'Contributing App','Activity Type','Activity Name','Activity Description','Source File') 
-    return data_headers, data_list, 'See source file(s) below'
+    return data_headers, data_list, '\n'.join(sorted(source_paths))

--- a/scripts/artifacts/intrusion_logging.py
+++ b/scripts/artifacts/intrusion_logging.py
@@ -55,8 +55,10 @@ def ail_dns_events(context):
 
     data_list = []
     source_path = ""
+    source_paths = set()
 
     for source_path in files_found:
+        source_paths.add(str(source_path))
 
         with open(source_path, 'r', encoding='utf-8') as f:
             for line in f:
@@ -81,7 +83,7 @@ def ail_dns_events(context):
                     continue
 
     data_headers = (('Timestamp', 'datetime'), 'Event ID', 'Package Name', 'Hostname', 'Resolved IPs', 'IP Count', 'Source File')
-    return data_headers, data_list, 'See source file below'
+    return data_headers, data_list, '\n'.join(sorted(source_paths))
 
 
 @artifact_processor
@@ -90,8 +92,10 @@ def ail_connect_events(context):
 
     data_list = []
     source_path = ""
+    source_paths = set()
 
     for source_path in files_found:
+        source_paths.add(str(source_path))
         with open(source_path, 'r', encoding='utf-8') as f:
             for line in f:
                 line = line.strip()
@@ -112,7 +116,7 @@ def ail_connect_events(context):
                     continue
 
     data_headers = (('Timestamp', 'datetime'), 'Event ID', 'Package Name', 'Destination IP', 'Port', 'Source File')
-    return data_headers, data_list, 'See source file below'
+    return data_headers, data_list, '\n'.join(sorted(source_paths))
     
 @artifact_processor
 def ail_security_events(context):
@@ -120,9 +124,11 @@ def ail_security_events(context):
 
     data_list = []
     source_path = ""
+    source_paths = set()
     package_actions = ("package_installed", "package_updated", "package_uninstalled")
 
     for source_path in files_found:
+        source_paths.add(str(source_path))
         with open(source_path, 'r', encoding='utf-8') as f:
             for line in f:
                 line = line.strip()
@@ -169,4 +175,4 @@ def ail_security_events(context):
                     continue
 
     data_headers = (('Timestamp', 'datetime'), 'Event ID', 'Action Type', 'Process/Package/UID', 'Details', 'Source File')
-    return data_headers, data_list, 'See source file below'
+    return data_headers, data_list, '\n'.join(sorted(source_paths))

--- a/scripts/artifacts/powerOffReset.py
+++ b/scripts/artifacts/powerOffReset.py
@@ -25,11 +25,13 @@ from scripts.ilapfuncs import artifact_processor
 def powerOffReset(context):
     files_found = context.get_files_found()
     data_list = []
+    source_paths = set()
     pattern = 'REASON:'
-    
+
     for file_found in files_found:
         file_found = str(file_found)
-            
+        source_paths.add(file_found)
+
         with open(file_found, "r", encoding="utf-8") as f:
             data = f.readlines()
             for line in data:
@@ -57,4 +59,4 @@ def powerOffReset(context):
                     continue
 
     data_headers = (('Timestamp (Local)','datetime'),'Timezone Offset','Action','Reason','Source File')
-    return data_headers, data_list, 'See source file(s) below:'
+    return data_headers, data_list, '\n'.join(sorted(source_paths))

--- a/scripts/artifacts/shutdown_checkpoints.py
+++ b/scripts/artifacts/shutdown_checkpoints.py
@@ -28,11 +28,13 @@ from scripts.ilapfuncs import artifact_processor
 def shutdown_checkpoints(context):
     files_found = context.get_files_found()
     data_list = []
+    source_paths = set()
     pattern = 'Shutdown request from '
 
     for file_found in files_found:
         file_found = str(file_found)
-            
+        source_paths.add(file_found)
+
         with open(file_found, "r", encoding="utf-8") as f:
             data = f.readlines()
             for line in data:
@@ -51,4 +53,4 @@ def shutdown_checkpoints(context):
                     continue
 
     data_headers = (('Timestamp','datetime'),'Requestor','Entry','Source File')
-    return data_headers, data_list, 'See source file(s) below:' 
+    return data_headers, data_list, '\n'.join(sorted(source_paths)) 

--- a/scripts/artifacts/thunderbird.py
+++ b/scripts/artifacts/thunderbird.py
@@ -164,6 +164,7 @@ def thunderbird_messages(context):
     ''')
     
     data_list = []
+    source_paths = set()
 
     for file in files_found:
         db_records = get_sqlite_db_records(str(file), query)
@@ -171,7 +172,9 @@ def thunderbird_messages(context):
             account = uuid_mapping[re.search(uuid_regex, file).group(0)]
         except KeyError:
             continue
-    
+
+        source_paths.add(str(file))
+
         for row in db_records:
             sent = convert_unix_ts_to_utc(row[0]/1000) if row[0] is not None else None
             stored = convert_unix_ts_to_utc(row[1]/1000) if row[1] is not None else None
@@ -194,4 +197,4 @@ def thunderbird_messages(context):
 
     data_headers = ( 'Timestamp Sent', 'Timestamp Stored', 'Account', 'Sender', 'Receiver', 'CC', 'BCC', 'Subject', 'Preview', 'Content', 'Attachments', 'Read?', 'Flagged?', 'Answered?', 'Forwarded?', 'Folder Name', 'Source File')
 
-    return data_headers, data_list, 'See source file(s) below:'
+    return data_headers, data_list, '\n'.join(sorted(source_paths))

--- a/scripts/artifacts/walStrings.py
+++ b/scripts/artifacts/walStrings.py
@@ -49,6 +49,7 @@ def get_walStrings(context):
     report_folder = context.get_report_folder()
     x = 1
     data_list = []
+    source_paths = set()
     for file_found in files_found:
         # The seeker can list files it could not extract (e.g. zero-byte
         # archive members), so the path may not exist on disk.
@@ -78,6 +79,7 @@ def get_walStrings(context):
             # safe_local_link() escapes the label and refuses any target that would
             # leave the report folder.
             out = safe_local_link(final, journalName)
+            source_paths.add(str(file_found))
             data_list.append((out, context.get_relative_path(file_found)))
         else:
             try:
@@ -87,4 +89,4 @@ def get_walStrings(context):
         x = x + 1
 
     data_headers = ('Report', 'Location')
-    return data_headers, data_list, ''
+    return data_headers, data_list, '\n'.join(sorted(source_paths))

--- a/scripts/artifacts/wireMessenger.py
+++ b/scripts/artifacts/wireMessenger.py
@@ -350,12 +350,14 @@ _WIRE_ACCOUNT_DIR_RE = re.compile(r'[/\\]wire\.com[/\\]([^/\\]+)[/\\]')
 @artifact_processor
 def get_wire_cached_files(context):
     data_list = []
+    source_paths = set()
 
     for file_found in unique_files(context):
         file_found = str(file_found)
         match = _WIRE_ACCOUNT_DIR_RE.search(file_found)
         if not match or isdir(file_found):
             continue
+        source_paths.add(file_found)
         account_id = match.group(1)
 
         extension = None
@@ -388,7 +390,7 @@ def get_wire_cached_files(context):
         'Account ID',
         'Source Path',
     )
-    return data_headers, data_list, 'See Source Path column'
+    return data_headers, data_list, '\n'.join(sorted(source_paths))
 
 
 _PROTEUS_SESSION_RE = re.compile(
@@ -400,6 +402,7 @@ _OTR_SESSION_RE = re.compile(
 @artifact_processor
 def get_wire_proteus_sessions(context):
     data_list = []
+    source_paths = set()
 
     for file_found in unique_files(context):
         file_found = str(file_found)
@@ -408,6 +411,7 @@ def get_wire_proteus_sessions(context):
         match = _PROTEUS_SESSION_RE.search(file_found) or _OTR_SESSION_RE.search(file_found)
         if not match:
             continue
+        source_paths.add(file_found)
         account_id = match.group(1)
         session_id = match.group(2)
 
@@ -436,4 +440,4 @@ def get_wire_proteus_sessions(context):
         'Session ID (as stored)',
         'Source Path',
     )
-    return data_headers, data_list, 'See Source Path column'
+    return data_headers, data_list, '\n'.join(sorted(source_paths))


### PR DESCRIPTION
The third element of an artifact's return tuple becomes the report's "located at" line and the LAVA manifest source_path. A string constant there points the examiner at a column that often holds only a basename, so the location of the evidence is nowhere in the report.

29 artifacts now report the files they actually parsed, after their own skip guards, newline joined. 9 "not found" guard branches return '' instead of a message; those produce no rows, and no report is written when there are no rows. walStrings returned '' on every branch while producing rows from real files.

Adds admin/scripts/check_source_path.py, wired into the lint job.