### PR TITLE
Give the test harness the data folder, so path columns are comparable

### DIFF
--- a/admin/test/results/galleryVault/galleryVault.galleryvault_vault_files.pixel7a_a14.20260825155139.json
+++ b/admin/test/results/galleryVault/galleryVault.galleryvault_vault_files.pixel7a_a14.20260825155139.json
@@ -6,19 +6,19 @@
     "case_number": "pixel7a_a14",
     "number_of_columns": 11,
     "number_of_rows": 2,
-    "total_data_size_bytes": 560,
+    "total_data_size_bytes": 414,
     "media_checkins": 0,
     "media_embedded_checkins": 2,
     "input_zip_path": "admin/test/cases/data/galleryVault/testdata.galleryVault.galleryvault_vault_files.pixel7a_a14.zip",
-    "start_time": "2026-08-25T04:48:38.629754+00:00",
-    "end_time": "2026-08-25T04:48:38.712875+00:00",
-    "run_time_seconds": 0.036834001541137695,
+    "start_time": "2026-08-25T15:51:39.646549+00:00",
+    "end_time": "2026-08-25T15:51:39.669649+00:00",
+    "run_time_seconds": 0.0030269622802734375,
     "last_commit": {
-      "hash": "9dd6f0ba89c1734104074ca53e08c99302197700",
-      "author_name": "Brigs",
-      "author_email": "abrignoni@gmail.com",
-      "date": "2026-08-07T23:27:07-04:00",
-      "message": "fix: fill in the artifact author field left empty on 27 artifacts"
+      "hash": "f439713616bcfc348b6fb52341b18a8067b3df32",
+      "author_name": "segumarc",
+      "author_email": "segumarc@gmail.com",
+      "date": "2026-08-20T22:23:33-04:00",
+      "message": "Adding multiples artifacts to galleryVault"
     }
   },
   "headers": [
@@ -45,7 +45,7 @@
       58157,
       "",
       "5a58c5e3-55ad-4f4d-b891-d7feb7246339",
-      "admin/test/temp/extract_galleryVault_galleryvault_vault_files_1787633318/Dump/data/media/0/.galleryvault_DoNotDelete_1707411051/files/5a/5a58c5e3-55ad-4f4d-b891-d7feb7246339",
+      "Dump/data/media/0/.galleryvault_DoNotDelete_1707411051/files/5a/5a58c5e3-55ad-4f4d-b891-d7feb7246339",
       "0101"
     ],
     [
@@ -58,7 +58,7 @@
       53669,
       "",
       "42e219d1-79cb-422d-b13b-f2b8e4fb69d4",
-      "admin/test/temp/extract_galleryVault_galleryvault_vault_files_1787633318/Dump/data/media/0/.galleryvault_DoNotDelete_1707411051/files/42/42e219d1-79cb-422d-b13b-f2b8e4fb69d4",
+      "Dump/data/media/0/.galleryvault_DoNotDelete_1707411051/files/42/42e219d1-79cb-422d-b13b-f2b8e4fb69d4",
       "0101"
     ]
   ]

--- a/admin/test/scripts/test_module.py
+++ b/admin/test/scripts/test_module.py
@@ -210,6 +210,11 @@ def process_artifact(zip_path, module_name, artifact_name, _artifact_data, targe
             all_artifacts_info = getattr(module, '__artifacts_v2__', {})
             artifact_info = all_artifacts_info.get(artifact_name, {})
 
+            # The case zip is extracted into temp_dir, so temp_dir is this run's
+            # equivalent of the seeker's data folder. Without it get_relative_path
+            # is a no-op here and a path column records the recorder's own
+            # directory instead of the extraction-relative path.
+            Context.set_data_folder(str(temp_dir))
             Context.set_report_folder(str(mock_report_folder_path))
             Context.set_seeker(mock_seeker)
             Context.set_files_found(all_files)

--- a/scripts/context.py
+++ b/scripts/context.py
@@ -37,6 +37,24 @@ class Context:
         Context._data_folder = getattr(output_params, 'data_folder', None)
 
     @staticmethod
+    def set_data_folder(data_folder):
+        """
+        Sets the folder the seeker stages evidence into, without the rest of the
+        output parameters.
+
+        A normal run gets this from set_output_params. The test harness has no
+        OutputParameters: it extracts a case zip into its own temporary directory
+        and runs artifacts against that. Without this, _data_folder stays None and
+        get_relative_path returns every path unchanged, so an artifact that leaks
+        an absolute path and one that reports a relative path record identical
+        output and no fixture can tell them apart.
+
+        Args:
+            data_folder (str): The folder evidence is staged into.
+        """
+        Context._data_folder = data_folder
+
+    @staticmethod
     def set_report_folder(report_folder):
         """
         Sets the report folder path in the Context.


### PR DESCRIPTION
Context.get_relative_path returns its argument unchanged when _data_folder is unset. The harness set the report folder, the seeker and files_found but never the data folder, so inside it that function did nothing: an artifact leaking an absolute path and one reporting an extraction-relative path recorded identical output, and no fixture could tell them apart.

Adds Context.set_data_folder, since the harness has no OutputParameters to pass.

galleryVault was the one recorded unit carrying the recorder's own temp directory in a data cell; its baseline is re-recorded and differs only by that prefix. The Threema units hold no path column and are unchanged; they cannot be re-verified locally without sqlcipher3, which CI installs from requirements.