### PR TITLE
Stop two timestamps depending on the host timezone

### DIFF
--- a/admin/test/scripts/test_module.py
+++ b/admin/test/scripts/test_module.py
@@ -10,6 +10,11 @@ Design Goals:
   streamlined developer experience.
 - CI/CD Ready: Structured to be eventually integrated into continuous integration
   pipelines for automated regression testing.
+
+Record baselines with TZ=UTC. The committed snapshots are UTC and CI runs UTC, so
+recording on a host in any other zone bakes that offset into every column derived
+from a naive datetime, and the snapshot then only reproduces on a machine set the
+same way. It fails as a wrong value rather than an error.
 """
 
 import sys

--- a/scripts/artifacts/alex_live_data.py
+++ b/scripts/artifacts/alex_live_data.py
@@ -323,6 +323,10 @@ def split_dumpsys_log(dumpsys_file) -> dict:
                 dur_match.group(2).strip(),
                 "%Y-%m-%d %H:%M:%S"
             )
+            # strptime returns a naive datetime and timestamp() reads a naive
+            # value in the host timezone, so this shifted by the offset of
+            # whoever ran the tool. Pinned to match the other converters here.
+            end_time = end_time.replace(tzinfo=datetime.timezone.utc)
             current_start_ts = (
                 end_time - datetime.timedelta(seconds=duration_s)
             ).timestamp()


### PR DESCRIPTION
alex_live_data parsed the dumpsys section end time with strptime, which returns a naive datetime, then subtracted the duration and called timestamp(). A naive value is read in the host timezone, so the same input gave 1710495000 under UTC, 1710513000 under America/Chicago and 1710462600 under Asia/Tokyo. Pinned to UTC, matching the six other converters in this file, so a UTC host sees no change.

That value only reaches a logfunc line, not a report column or LAVA, so the effect was a run log that could not be reproduced on another machine.

test_module.py now says to record baselines with TZ=UTC: the snapshots and CI are UTC, and recording elsewhere bakes the local offset into any column derived from a naive datetime.