### PR TITLE
Note why the BTS video match needs an aware timestamp

### DIFF
--- a/scripts/artifacts/bereal.py
+++ b/scripts/artifacts/bereal.py
@@ -631,6 +631,12 @@ def _own_bts_video_index(files_found):
 def _closest_own_bts_video(bts_index, captured_at, tolerance_ms=120_000):
     if not bts_index or not isinstance(captured_at, datetime):
         return ""
+    # bts_index holds absolute epoch milliseconds read from the filename, so
+    # captured_at has to be timezone aware for the two to be comparable.
+    # _timestamp() guarantees that on both of its datetime branches. If it ever
+    # returns a naive value, timestamp() reads it in the host timezone and every
+    # delta exceeds the tolerance, so this silently matches nothing rather than
+    # matching wrongly.
     target_ms = captured_at.timestamp() * 1000
     best_path, best_delta = "", None
     for ts, path in bts_index:


### PR DESCRIPTION
_closest_own_bts_video compares captured_at.timestamp() against epoch milliseconds read out of a BtsVideo<ms> filename, so the two are only comparable while captured_at is timezone aware. _timestamp() guarantees that on both of its datetime branches, and the match is correct today: the same post resolves to the same target on UTC, America/Chicago, Asia/Tokyo and Pacific/Kiritimati, landing 3 seconds from its clip in each.

Worth stating because breaking it fails quietly. A naive captured_at would push every delta past the 120 second tolerance, so the function would return no video at all rather than the wrong one, and no fixture covers this app.

Comment only, no behaviour change.