### PR TITLE
Build data_headers before the loop, not inside it

### DIFF
--- a/scripts/artifacts/RomeoDatingApp.py
+++ b/scripts/artifacts/RomeoDatingApp.py
@@ -87,6 +87,18 @@ def romeo_dating_messages(context):
             LEFT JOIN ImageAttachmentEntity iae ON me.messageId = iae.parentMessageId
             '''
 
+    data_headers = (    ('Timestamp', 'datetime'),
+                        'Contact ID',
+                        'Contact Username',
+                        'Text', 
+                        'Status',
+                        'Saved?',
+                        'Unread?',
+                        'Message ID',
+                        'Image Contained?',
+                        'Source Database'
+                    )
+
     for file_found in files_found:
         main_db = str(file_found)
         source_db = context.get_relative_path(main_db)
@@ -120,17 +132,6 @@ def romeo_dating_messages(context):
                                 source_db
                             ))
         
-        data_headers = (    ('Timestamp', 'datetime'),
-                            'Contact ID',
-                            'Contact Username',
-                            'Text', 
-                            'Status',
-                            'Saved?',
-                            'Unread?',
-                            'Message ID',
-                            'Image Contained?',
-                            'Source Database'
-                        )
         # On android we only know if an Image was part of the message,
         # content isn't on the phone anymore- so just "image contained?"
 


### PR DESCRIPTION
These artifacts filter wal, shm and journal files out of files_found before looping, so the list they iterate can be empty even though the entry point only calls an artifact when its glob matched. data_headers was assigned inside that loop and read by the return, so an extraction where the glob matched only a sidecar raised UnboundLocalError instead of reporting no rows.

The tuple is a constant with no reference to the loop variable, so hoisting it changes nothing when the loop runs. Verified by comparing the parsed literal before and after: identical in all three functions.

Only these three of the twenty functions that assign inside a loop are reachable. The rest iterate files_found directly, which the entry point guarantees is non-empty, and are left alone.