### PR TITLE
Re-derive stale sample_data row counts for four more corpora

### DIFF
--- a/scripts/artifacts/Cello.py
+++ b/scripts/artifacts/Cello.py
@@ -22,7 +22,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | com.google.android.apps.docs vc 214207580 | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.docs vc 213692448 | 20 rows",
             "russell_pixel6a_a13": "Android 13 | com.google.android.apps.docs vc 213183212 | 1 row",
-            "userb2_a13": "Android 13 | com.google.android.apps.docs vc 213806576 | 8 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.docs vc 213806576 | 4 rows",
         },
     }
 }

--- a/scripts/artifacts/FCMQueuedMessagesDump.py
+++ b/scripts/artifacts/FCMQueuedMessagesDump.py
@@ -22,7 +22,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | com.google.android.gms | 3914 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 36746 rows",
             "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 11408 rows",
-            "userb2_a13": "Android 13 | com.google.android.gms | 2016 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 1008 rows",
         },
     },
     "get_fcm_dump_verizon": {
@@ -72,7 +72,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | com.google.android.gms | 40 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 391 rows",
             "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 86 rows",
-            "userb2_a13": "Android 13 | com.google.android.gms | 142 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 71 rows",
         },
     },
     "get_fcm_dump_instagram": {

--- a/scripts/artifacts/FilesByGoogle.py
+++ b/scripts/artifacts/FilesByGoogle.py
@@ -16,7 +16,7 @@ __artifacts_v2__ = {
             "kevin_pocox7_a15": "Android 15 | com.google.android.apps.nbu.files vc 1508395 | 434 rows",
             "pixel7a_a14": "Android 14 | com.google.android.apps.nbu.files vc 695143 | 228 rows",
             "russell_pixel6a_a13": "Android 13 | com.google.android.apps.nbu.files vc 492527 | 95 rows",
-            "userb2_a13": "Android 13 | com.google.android.apps.nbu.files vc 1107071 | 16 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.nbu.files vc 1107071 | 8 rows",
         }
     },
     "fbg_searchhistory": {

--- a/scripts/artifacts/OperaBrowser.py
+++ b/scripts/artifacts/OperaBrowser.py
@@ -50,7 +50,7 @@ __artifacts_v2__ = {
         "output_types": "standard",
         "artifact_icon": "layout",
         "sample_data": {
-            "pixel7a_a14": "Android 14 |  8 rows",
+            "pixel7a_a14": "Android 14 |  3 rows",
         },
     },
     "opera_tab_navigation": {
@@ -96,7 +96,7 @@ __artifacts_v2__ = {
           "output_types": "standard",
         "artifact_icon": "compass",
         "sample_data": {
-            "pixel7a_a14": "Android 14 | 3 rows",
+            "pixel7a_a14": "Android 14 | 8 rows",
         },
 
     }

--- a/scripts/artifacts/battery_usage_v4.py
+++ b/scripts/artifacts/battery_usage_v4.py
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
             "hc_pixel8pro_a16": "Android 16 | com.google.android.settings.intelligence vc 1000282241 | 0 rows",
             "pixel7a_a14": "Android 14 | com.google.android.settings.intelligence vc 1000230247 | 0 rows",
             "russell_pixel6a_a13": "Android 13 | com.google.android.settings.intelligence vc 1000217934 | 98857 rows",
-            "userb2_a13": "Android 13 | com.google.android.settings.intelligence vc 1000232695 | 216 rows",
+            "userb2_a13": "Android 13 | com.google.android.settings.intelligence vc 1000232695 | 108 rows",
         },
     }
 }

--- a/scripts/artifacts/chrome.py
+++ b/scripts/artifacts/chrome.py
@@ -22,7 +22,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233, com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 65 rows",
             "sharon_a14": "Android 14 | com.android.chrome vc 653310333, com.sec.android.app.sbrowser vc 1260103502 | 137 rows",
             "russell_pixel6a_a13": "Android 13 | com.android.chrome vc 573513033, com.brave.browser vc 415212624 | 118 rows",
-            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 62 rows",
+            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 31 rows",
         },
     },
     "get_chromeWebVisits": {
@@ -52,7 +52,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233, com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 86 rows",
             "sharon_a14": "Android 14 | com.android.chrome vc 653310333, com.sec.android.app.sbrowser vc 1260103502 | 198 rows",
             "russell_pixel6a_a13": "Android 13 | com.android.chrome vc 573513033, com.brave.browser vc 415212624 | 207 rows",
-            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 76 rows",
+            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 38 rows",
         },
     },
     "get_chromeSearchTerms": {
@@ -77,7 +77,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233, com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 18 rows",
             "sharon_a14": "Android 14 | com.android.chrome vc 653310333, com.sec.android.app.sbrowser vc 1260103502 | 18 rows",
             "russell_pixel6a_a13": "Android 13 | com.android.chrome vc 573513033, com.brave.browser vc 415212624 | 37 rows",
-            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 16 rows",
+            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 8 rows",
         },
     },
     "get_chromeDownloads": {
@@ -106,7 +106,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233, com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 2 rows",
             "sharon_a14": "Android 14 | com.android.chrome vc 653310333, com.sec.android.app.sbrowser vc 1260103502 | 108 rows",
             "russell_pixel6a_a13": "Android 13 | com.android.chrome vc 573513033, com.brave.browser vc 415212624 | 1 row",
-            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 2 rows",
+            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 1 row",
         },
     },
     "get_chromeKeywordSearchTerms": {
@@ -131,7 +131,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233, com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 18 rows",
             "sharon_a14": "Android 14 | com.android.chrome vc 653310333, com.sec.android.app.sbrowser vc 1260103502 | 23 rows",
             "russell_pixel6a_a13": "Android 13 | com.android.chrome vc 573513033, com.brave.browser vc 415212624 | 44 rows",
-            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 16 rows",
+            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 8 rows",
         },
     }
 }

--- a/scripts/artifacts/chromeAutofill.py
+++ b/scripts/artifacts/chromeAutofill.py
@@ -22,7 +22,7 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | 6 rows",
             "samsungs20_a13": "Android 13 | 4 rows",
             "russell_pixel6a_a13": "Android 13 | 8 rows",
-            "userb2_a13": "Android 13 | 12 rows",
+            "userb2_a13": "Android 13 | 6 rows",
         },
     },
     "get_chromeAutofillProfiles": {

--- a/scripts/artifacts/chromeCookies.py
+++ b/scripts/artifacts/chromeCookies.py
@@ -21,7 +21,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | 670 rows",
             "sharon_a14": "Android 14 | 1842 rows",
             "russell_pixel6a_a13": "Android 13 | 1420 rows",
-            "userb2_a13": "Android 13 | 632 rows",
+            "userb2_a13": "Android 13 | 316 rows",
         },
     }
 }

--- a/scripts/artifacts/chromeOfflinePages.py
+++ b/scripts/artifacts/chromeOfflinePages.py
@@ -21,7 +21,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233, com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 7 rows",
             "sharon_a14": "Android 14 | com.android.chrome vc 653310333 | 38 rows",
             "russell_pixel6a_a13": "Android 13 | com.android.chrome vc 573513033, com.brave.browser vc 415212624 | 9 rows",
-            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 8 rows",
+            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 4 rows",
         },
     }
 }

--- a/scripts/artifacts/deviceHealthServices_AppUsage.py
+++ b/scripts/artifacts/deviceHealthServices_AppUsage.py
@@ -20,7 +20,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | com.google.android.apps.turbo | 232 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.turbo vc 10261629 | 79 rows",
             "russell_pixel6a_a13": "Android 13 | com.google.android.apps.turbo vc 10261629 | 928 rows",
-            "userb2_a13": "Android 13 | com.google.android.apps.turbo vc 10270697 | 2 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.turbo vc 10270697 | 1 row",
         },
     }
 }

--- a/scripts/artifacts/deviceHealthServices_Battery.py
+++ b/scripts/artifacts/deviceHealthServices_Battery.py
@@ -21,7 +21,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | com.google.android.apps.turbo | 0 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.turbo vc 10261629 | 0 rows",
             "russell_pixel6a_a13": "Android 13 | com.google.android.apps.turbo vc 10261629 | 5604 rows",
-            "userb2_a13": "Android 13 | com.google.android.apps.turbo vc 10270697 | 1144 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.turbo vc 10270697 | 572 rows",
         }
     },
     "Turbo_Bluetooth": {

--- a/scripts/artifacts/gboard.py
+++ b/scripts/artifacts/gboard.py
@@ -17,7 +17,7 @@ __artifacts_v2__ = {
             "kevin_pocox7_a15": "Android 15 | com.google.android.inputmethod.latin vc 175401514 | 4 rows",
             "pixel7a_a14": "Android 14 | com.google.android.inputmethod.latin vc 128278094 | 4 rows",
             "russell_pixel6a_a13": "Android 13 | com.google.android.inputmethod.latin vc 114763994 | 4 rows",
-            "userb2_a13": "Android 13 | com.google.android.inputmethod.latin vc 155404870 | 8 rows",
+            "userb2_a13": "Android 13 | com.google.android.inputmethod.latin vc 155404870 | 4 rows",
         },
     },
     "get_gboardCache_keystrokes": {
@@ -57,7 +57,7 @@ __artifacts_v2__ = {
             "kevin_pocox7_a15": "Android 15 | com.google.android.inputmethod.latin vc 175401514 | 359 rows",
             "pixel7a_a14": "Android 14 | com.google.android.inputmethod.latin vc 128278094 | 230 rows",
             "russell_pixel6a_a13": "Android 13 | com.google.android.inputmethod.latin vc 114763994 | 357 rows",
-            "userb2_a13": "Android 13 | com.google.android.inputmethod.latin vc 155404870 | 140 rows",
+            "userb2_a13": "Android 13 | com.google.android.inputmethod.latin vc 155404870 | 70 rows",
         },
     }
 }

--- a/scripts/artifacts/googleInitiatedNav.py
+++ b/scripts/artifacts/googleInitiatedNav.py
@@ -14,8 +14,8 @@ __artifacts_v2__ = {
         "output_types": "standard",
         "artifact_icon": "map-pin",
         "sample_data": {
-            "kevin_pocox7_a15": "Android 15 | com.google.android.apps.maps vc 1068243484 | 4 rows",
-            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.maps vc 1067057900 | 14 rows",
+            "kevin_pocox7_a15": "Android 15 | com.google.android.apps.maps vc 1068243484 | 2 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.apps.maps vc 1067057900 | 7 rows",
         },
     }
 }

--- a/scripts/artifacts/googleLastTrip.py
+++ b/scripts/artifacts/googleLastTrip.py
@@ -19,7 +19,7 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | com.google.android.apps.maps vc 1067620099 | 2 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.maps vc 1067648704 | 2 rows",
             "russell_pixel6a_a13": "Android 13 | com.google.android.apps.maps vc 1067057900 | 2 rows",
-            "userb2_a13": "Android 13 | com.google.android.apps.maps vc 1067804533 | 4 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.maps vc 1067804533 | 2 rows",
         },
     }
 }

--- a/scripts/artifacts/googleMapsGmm.py
+++ b/scripts/artifacts/googleMapsGmm.py
@@ -22,7 +22,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | com.google.android.apps.maps vc 1068347331 | 1 row",
             "sharon_a14": "Android 14 | com.google.android.apps.maps vc 1067648704 | 0 rows",
             "russell_pixel6a_a13": "Android 13 | com.google.android.apps.maps vc 1067057900 | 6 rows",
-            "userb2_a13": "Android 13 | com.google.android.apps.maps vc 1067804533 | 6 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.maps vc 1067804533 | 3 rows",
         },
     },
     "get_googleMapsGmm_places": {

--- a/scripts/artifacts/googleMessages.py
+++ b/scripts/artifacts/googleMessages.py
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | com.google.android.apps.messaging vc 293261063 | 40 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.messaging vc 161637900 | 0 rows",
             "russell_pixel6a_a13": "Android 13 | com.google.android.apps.messaging vc 186597063 | 36 rows",
-            "userb2_a13": "Android 13 | com.google.android.apps.messaging vc 259818063 | 42 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.messaging vc 259818063 | 21 rows",
         },
         "data_views": {
             "conversation": {

--- a/scripts/artifacts/googlePhotos.py
+++ b/scripts/artifacts/googlePhotos.py
@@ -23,7 +23,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | com.google.android.apps.photos vc 51079548 | 24 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.photos vc 48388495 | 336 rows",
             "russell_pixel6a_a13": "Android 13 | com.google.android.apps.photos vc 48388511 | 204 rows",
-            "userb2_a13": "Android 13 | com.google.android.apps.photos vc 49358716 | 16 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.photos vc 49358716 | 8 rows",
         },
     },
     "get_googlePhotos_remote": {
@@ -52,7 +52,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | com.google.android.apps.photos vc 51079548 | 7 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.photos vc 48388495 | 0 rows",
             "russell_pixel6a_a13": "Android 13 | com.google.android.apps.photos vc 48388511 | 98 rows",
-            "userb2_a13": "Android 13 | com.google.android.apps.photos vc 49358716 | 6 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.photos vc 49358716 | 3 rows",
         },
     },
     "get_googlePhotos_shared": {
@@ -133,7 +133,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | com.google.android.apps.photos vc 51079548 | 43 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.photos vc 48388495 | 68 rows",
             "russell_pixel6a_a13": "Android 13 | com.google.android.apps.photos vc 48388511 | 704 rows",
-            "userb2_a13": "Android 13 | com.google.android.apps.photos vc 49358716 | 10 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.photos vc 49358716 | 5 rows",
         },
     },
     "get_googlePhotos_trash": {

--- a/scripts/artifacts/googlemapaudio.py
+++ b/scripts/artifacts/googlemapaudio.py
@@ -18,7 +18,7 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | com.google.android.apps.maps vc 1067620099 | 301 rows",
             "sharon_a14": "Android 14 | com.google.android.apps.maps vc 1067648704 | 362 rows",
             "russell_pixel6a_a13": "Android 13 | com.google.android.apps.maps vc 1067057900 | 252 rows",
-            "userb2_a13": "Android 13 | com.google.android.apps.maps vc 1067804533 | 26 rows",
+            "userb2_a13": "Android 13 | com.google.android.apps.maps vc 1067804533 | 13 rows",
         },
     }
 }

--- a/scripts/artifacts/imagemngCache.py
+++ b/scripts/artifacts/imagemngCache.py
@@ -15,13 +15,13 @@ __artifacts_v2__ = {
             "anne_a15": "Android 15 | 1895 rows",
             "galaxys10_a10": "Android 10 | 1140 rows",
             "hc_pixel8pro_a16": "Android 16 | 1219 rows",
-            "kevin_pocox7_a15": "Android 15 | 21306 rows",
+            "kevin_pocox7_a15": "Android 15 | 19294 rows",
             "pixel7a_a14": "Android 14 | 6018 rows",
             "samsunga53_a14": "Android 14 | 2348 rows",
             "samsungs20_a13": "Android 13 | 3164 rows",
             "sharon_a14": "Android 14 | 2597 rows",
             "russell_pixel6a_a13": "Android 13 | 7123 rows",
-            "userb2_a13": "Android 13 | 757 rows",
+            "userb2_a13": "Android 13 | 458 rows",
         },
     }
 }

--- a/scripts/artifacts/installedappsGass.py
+++ b/scripts/artifacts/installedappsGass.py
@@ -22,8 +22,8 @@ __artifacts_v2__ = {
             "samsunga53_a14": "Android 14 | com.google.android.gms | 101 rows",
             "samsungs20_a13": "Android 13 | com.google.android.gms | 185 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 1585 rows",
-            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 532 rows",
-            "userb2_a13": "Android 13 | com.google.android.gms | 513 rows",
+            "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 382 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 171 rows",
         },
     }
 }

--- a/scripts/artifacts/installedappsLibrary.py
+++ b/scripts/artifacts/installedappsLibrary.py
@@ -21,7 +21,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | com.android.vending vc 84962330 | 162 rows",
             "sharon_a14": "Android 14 | com.android.vending vc 84222730 | 99 rows",
             "russell_pixel6a_a13": "Android 13 | com.android.vending vc 83631220 | 160 rows",
-            "userb2_a13": "Android 13 | com.android.vending vc 84371930 | 178 rows",
+            "userb2_a13": "Android 13 | com.android.vending vc 84371930 | 89 rows",
         },
     }
 }

--- a/scripts/artifacts/installedappsVending.py
+++ b/scripts/artifacts/installedappsVending.py
@@ -23,7 +23,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | com.android.vending vc 84962330 | 150 rows",
             "sharon_a14": "Android 14 | com.android.vending vc 84222730 | 122 rows",
             "russell_pixel6a_a13": "Android 13 | com.android.vending vc 83631220 | 204 rows",
-            "userb2_a13": "Android 13 | com.android.vending vc 84371930 | 214 rows",
+            "userb2_a13": "Android 13 | com.android.vending vc 84371930 | 107 rows",
         },
     }
 }

--- a/scripts/artifacts/offlinePages.py
+++ b/scripts/artifacts/offlinePages.py
@@ -21,7 +21,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 7 rows",
             "sharon_a14": "Android 14 | com.android.chrome vc 653310333 | 37 rows",
             "russell_pixel6a_a13": "Android 13 | com.android.chrome vc 573513033, com.brave.browser vc 415212624 | 9 rows",
-            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 8 rows",
+            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 4 rows",
         },
     }
 }

--- a/scripts/artifacts/pSettings.py
+++ b/scripts/artifacts/pSettings.py
@@ -18,7 +18,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | com.google.android.gsf | 33 rows",
             "sharon_a14": "Android 14 | com.google.android.gsf | 18 rows",
             "russell_pixel6a_a13": "Android 13 | com.google.android.gsf | 30 rows",
-            "userb2_a13": "Android 13 | com.google.android.gsf | 36 rows",
+            "userb2_a13": "Android 13 | com.google.android.gsf | 18 rows",
         },
     }
 }

--- a/scripts/artifacts/setupWizardinfo.py
+++ b/scripts/artifacts/setupWizardinfo.py
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
             "hc_pixel8pro_a16": "Android 16 | com.google.android.settings.intelligence vc 1000282241 | 1 row",
             "pixel7a_a14": "Android 14 | com.google.android.settings.intelligence vc 1000230247 | 1 row",
             "russell_pixel6a_a13": "Android 13 | com.google.android.settings.intelligence vc 1000217934 | 2 rows",
-            "userb2_a13": "Android 13 | com.google.android.settings.intelligence vc 1000232695 | 2 rows",
+            "userb2_a13": "Android 13 | com.google.android.settings.intelligence vc 1000232695 | 1 row",
         },
     }
 }

--- a/scripts/artifacts/smsmms.py
+++ b/scripts/artifacts/smsmms.py
@@ -21,7 +21,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | com.android.providers.telephony | 35 rows",
             "sharon_a14": "Android 14 | com.android.providers.telephony | 308 rows",
             "russell_pixel6a_a13": "Android 13 | com.android.providers.telephony | 12 rows",
-            "userb2_a13": "Android 13 | com.android.providers.telephony | 38 rows",
+            "userb2_a13": "Android 13 | com.android.providers.telephony | 19 rows",
         },
         "data_views": {
             "conversation": {
@@ -59,7 +59,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | com.android.providers.telephony | 6 rows",
             "sharon_a14": "Android 14 | com.android.providers.telephony | 20 rows",
             "russell_pixel6a_a13": "Android 13 | com.android.providers.telephony | 6 rows",
-            "userb2_a13": "Android 13 | com.android.providers.telephony | 4 rows",
+            "userb2_a13": "Android 13 | com.android.providers.telephony | 2 rows",
         },
         "data_views": {
             "conversation": {

--- a/scripts/artifacts/suggestions.py
+++ b/scripts/artifacts/suggestions.py
@@ -15,7 +15,7 @@ __artifacts_v2__ = {
             "hc_pixel8pro_a16": "Android 16 | com.google.android.settings.intelligence vc 1000282241 | 2 rows",
             "pixel7a_a14": "Android 14 | com.google.android.settings.intelligence vc 1000230247 | 3 rows",
             "russell_pixel6a_a13": "Android 13 | com.google.android.settings.intelligence vc 1000217934 | 5 rows",
-            "userb2_a13": "Android 13 | com.google.android.settings.intelligence vc 1000232695 | 6 rows",
+            "userb2_a13": "Android 13 | com.google.android.settings.intelligence vc 1000232695 | 3 rows",
         },
     }
 }

--- a/scripts/artifacts/ulrUserprefs.py
+++ b/scripts/artifacts/ulrUserprefs.py
@@ -21,7 +21,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | com.google.android.gms | 28 rows",
             "sharon_a14": "Android 14 | com.google.android.gms vc 242835039 | 15 rows",
             "russell_pixel6a_a13": "Android 13 | com.google.android.gms vc 232316044 | 25 rows",
-            "userb2_a13": "Android 13 | com.google.android.gms | 30 rows",
+            "userb2_a13": "Android 13 | com.google.android.gms | 15 rows",
         },
     }
 }

--- a/scripts/artifacts/walStrings.py
+++ b/scripts/artifacts/walStrings.py
@@ -21,7 +21,7 @@ __artifacts_v2__ = {
             "samsungs20_a13": "Android 13 | 792 rows",
             "sharon_a14": "Android 14 | 901 rows",
             "russell_pixel6a_a13": "Android 13 | 456 rows",
-            "userb2_a13": "Android 13 | 527 rows",
+            "userb2_a13": "Android 13 | 265 rows",
         },
         "html_columns": ['Report'],
     }


### PR DESCRIPTION
Stacked on #1223, which corrects the same thing for samsunga53_a14 and samsungs20_a13. Merge that one first.

A sweep of all eighteen registered Android corpora found the same staleness elsewhere. This updates 42 values.

- userb2_a13: 36 values. Two credential encrypted views of every app data directory, so most were exactly twice the real figure.
- kevin_pocox7_a15, russell_pixel6a_a13: googleInitiatedNav, imagemngCache and installedappsGass. No mirrored views on these. aleapp.py searches each pattern in turn and extends files_found with every result, so a file matched by two of an artifact's own patterns is read twice.
- pixel7a_a14: OperaBrowser had its two tab values swapped. session_db holds 3 rows in tab and 8 in navigation_entry.

Counts come from runs that reached "Report generation Completed." with sqlcipher3 present, so the Threema artifacts were exercised rather than disabled.