### PR TITLE
Add return-shape and string-concat lint checks

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -87,6 +87,14 @@ jobs:
         if: steps.changed-files-py.outputs.any_changed == 'true'
         run: python admin/scripts/check_source_path.py
 
+      - name: Guard against artifact functions returning None
+        if: steps.changed-files-py.outputs.any_changed == 'true'
+        run: python admin/scripts/check_artifact_returns.py
+
+      - name: Guard against run-together implicit string concatenation
+        if: steps.changed-files-py.outputs.any_changed == 'true'
+        run: python admin/scripts/check_implicit_concat.py
+
       # Fails only on warnings this pull request introduces. Long-lived modules carry
       # deliberate pre-existing warnings, and failing on those pushed contributors toward
       # unrelated refactors or blanket file-level disables. See the script's docstring.

--- a/admin/scripts/check_artifact_returns.py
+++ b/admin/scripts/check_artifact_returns.py
@@ -1,0 +1,147 @@
+"""Guard artifact functions against returning None instead of the result triple.
+
+An artifact returns `(data_headers, data_list, source_path)`. The wrapper unpacks
+that unconditionally:
+
+    data_headers, data_list, source_path = func(Context)
+
+so a function that ends a branch with `return` or `return None` does not report
+"nothing found". It raises
+
+    TypeError: cannot unpack non-iterable NoneType object
+
+and the artifact fails on every device where the app is installed but that branch
+runs, which for a "no records" branch is the normal state of a fresh install. The
+crash is easy to miss in development because the extraction used to build the
+module has records by construction.
+
+The shape to write instead keeps the headers and the source path and hands back an
+empty list:
+
+    return data_headers, [], source_path
+
+Only returns belonging to the decorated function itself are checked. A nested
+helper may return None freely; that is an ordinary early exit, not a result
+triple.
+
+Usage:
+  check_artifact_returns.py [--root REPO_ROOT]
+
+Exits 1 when anything is found, 0 otherwise.
+"""
+
+import argparse
+import ast
+import os
+import sys
+
+DECORATORS = {'artifact_processor', 'artifact_processor_streaming'}
+
+STANDARD_NOTE = (
+    "Return the triple on every branch: 'return data_headers, [], source_path' "
+    "when nothing was found. The wrapper unpacks three values unconditionally."
+)
+
+
+def decorator_names(node):
+    names = []
+    for dec in node.decorator_list:
+        if isinstance(dec, ast.Name):
+            names.append(dec.id)
+        elif isinstance(dec, ast.Attribute):
+            names.append(dec.attr)
+        elif isinstance(dec, ast.Call):
+            func = dec.func
+            names.append(func.id if isinstance(func, ast.Name)
+                         else getattr(func, 'attr', ''))
+    return names
+
+
+def own_returns(func):
+    """Return nodes belonging to func itself, not to functions nested inside it."""
+    found = []
+
+    def walk(node):
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+                continue
+            if isinstance(child, ast.Return):
+                found.append(child)
+            walk(child)
+
+    walk(func)
+    return found
+
+
+def scan_function(func):
+    """(line, spelling) for every return that hands the wrapper None."""
+    found = []
+    for ret in own_returns(func):
+        if ret.value is None:
+            found.append((ret.lineno, 'return'))
+        elif isinstance(ret.value, ast.Constant) and ret.value.value is None:
+            found.append((ret.lineno, 'return None'))
+    return found
+
+
+def scan_module(path):
+    module = os.path.basename(path)
+    try:
+        with open(path, encoding='utf-8', errors='replace') as handle:
+            tree = ast.parse(handle.read())
+    except SyntaxError as err:
+        return [], f'{module}: could not parse ({err})'
+    violations = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not DECORATORS.intersection(decorator_names(node)):
+            continue
+        for line, spelling in scan_function(node):
+            violations.append((module, node.name, line, spelling))
+    return violations, None
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--root', default=None, help='repository root')
+    args = parser.parse_args()
+
+    root = args.root or os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    artifacts = os.path.join(root, 'scripts', 'artifacts')
+    if not os.path.isdir(artifacts):
+        print(f'No scripts/artifacts under {root}', file=sys.stderr)
+        return 2
+
+    violations, unreadable, modules = [], [], 0
+    for name in sorted(os.listdir(artifacts)):
+        if not name.endswith('.py'):
+            continue
+        modules += 1
+        found, problem = scan_module(os.path.join(artifacts, name))
+        violations.extend(found)
+        if problem:
+            unreadable.append(problem)
+
+    if violations:
+        print(f'Artifact functions returning None ({len(violations)}):')
+        for module, func, line, spelling in violations:
+            print(f'  {module}:{line}  {func}()  {spelling}')
+        print()
+        print(STANDARD_NOTE)
+        return 1
+
+    summary = (f'Checked {modules} artifact module(s): '
+               'no artifact function returns None.')
+    if unreadable:
+        summary += f' {len(unreadable)} module(s) NOT checked.'
+    print(summary)
+    for problem in unreadable:
+        print(f'  {problem}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/admin/scripts/check_implicit_concat.py
+++ b/admin/scripts/check_implicit_concat.py
@@ -1,0 +1,128 @@
+"""Guard against adjacent string literals whose junction runs two words together.
+
+Python joins adjacent string literals silently, so a wrapped metadata string that
+forgets the separating space is valid code with broken prose:
+
+    "description": "Logs information about the app status"
+                   "such as launch, open, close, install.",
+
+renders as "app statussuch as launch" in the report and the LAVA manifest, where
+an examiner reads it. Nothing else catches this: the module imports, lint passes,
+and the value is a perfectly ordinary string.
+
+Only junctions where an alphanumeric character meets an alphanumeric character
+with no whitespace on either side are reported. A junction that ends or begins
+with a space, a newline, or punctuation is a deliberate join and stays silent, so
+a SQL query wrapped as `'select a '  'from b'` is untouched. A long opaque token
+deliberately split across literals would trip this; none exists in the tree
+today, so there is no allowlist until one is needed.
+
+Junctions are found with the tokenizer, not a regex, and only literals that are
+part of one expression are paired: a logical newline between two strings means
+two statements, not a concatenation.
+
+Usage:
+  check_implicit_concat.py [--root REPO_ROOT]
+
+Exits 1 when anything is found, 0 otherwise.
+"""
+
+import argparse
+import ast
+import io
+import os
+import sys
+import tokenize
+
+STANDARD_NOTE = (
+    'End the first literal with a space (or start the second with one) so the '
+    'joined string reads as written.'
+)
+
+
+def scan_source(source):
+    """(line, left tail, right head) for every run-together junction."""
+    try:
+        tokens = list(tokenize.generate_tokens(io.StringIO(source).readline))
+    except tokenize.TokenError:
+        return []
+    found = []
+    prev = None
+    for tok in tokens:
+        if tok.type == tokenize.NEWLINE:
+            # A logical newline ends the expression; strings across it are
+            # separate statements, never an implicit concatenation.
+            prev = None
+            continue
+        if tok.type in (tokenize.NL, tokenize.COMMENT,
+                        tokenize.INDENT, tokenize.DEDENT):
+            continue
+        if tok.type == tokenize.STRING and prev is not None \
+                and prev.type == tokenize.STRING:
+            try:
+                left = ast.literal_eval(prev.string)
+                right = ast.literal_eval(tok.string)
+            except (ValueError, SyntaxError):
+                left = right = None  # f-string or bytes; not checked
+            if isinstance(left, str) and isinstance(right, str) \
+                    and left and right \
+                    and left[-1].isalnum() and right[0].isalnum():
+                found.append((tok.start[0], left[-20:], right[:20]))
+        prev = tok
+    return found
+
+
+def scan_module(path):
+    module = os.path.basename(path)
+    try:
+        with open(path, encoding='utf-8', errors='replace') as handle:
+            source = handle.read()
+    except OSError as err:
+        return [], f'{module}: could not read ({err})'
+    return [(module, line, left, right)
+            for line, left, right in scan_source(source)], None
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--root', default=None, help='repository root')
+    args = parser.parse_args()
+
+    root = args.root or os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    artifacts = os.path.join(root, 'scripts', 'artifacts')
+    if not os.path.isdir(artifacts):
+        print(f'No scripts/artifacts under {root}', file=sys.stderr)
+        return 2
+
+    violations, unreadable, modules = [], [], 0
+    for name in sorted(os.listdir(artifacts)):
+        if not name.endswith('.py'):
+            continue
+        modules += 1
+        found, problem = scan_module(os.path.join(artifacts, name))
+        violations.extend(found)
+        if problem:
+            unreadable.append(problem)
+
+    if violations:
+        print(f'Run-together implicit string concatenations ({len(violations)}):')
+        for module, line, left, right in violations:
+            print(f'  {module}:{line}  ...{left!r} + {right!r}...')
+        print()
+        print(STANDARD_NOTE)
+        return 1
+
+    summary = (f'Checked {modules} artifact module(s): '
+               'no run-together implicit concatenation.')
+    if unreadable:
+        summary += f' {len(unreadable)} module(s) NOT checked.'
+    print(summary)
+    for problem in unreadable:
+        print(f'  {problem}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/admin/test/scripts/test_check_artifact_returns.py
+++ b/admin/test/scripts/test_check_artifact_returns.py
@@ -1,0 +1,97 @@
+"""Prove the return-shape checker still detects the defect it exists to detect.
+
+check_artifact_returns.py fails when an @artifact_processor function returns None
+on any branch, because the wrapper unpacks three values unconditionally and the
+"no records" branch is the normal state of a fresh install.
+
+The negative cases matter as much as the positive ones. A nested helper returning
+None is an ordinary early exit (dropbox.py carries one), and a checker that flags
+it gets switched off.
+"""
+import importlib.util
+import pathlib
+import sys
+import tempfile
+import textwrap
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_MODULE_PATH = REPO_ROOT / 'admin' / 'scripts' / 'check_artifact_returns.py'
+
+# admin/scripts is not a package, so load the module from its path.
+_spec = importlib.util.spec_from_file_location('check_artifact_returns', _MODULE_PATH)
+car = importlib.util.module_from_spec(_spec)
+sys.modules['check_artifact_returns'] = car
+_spec.loader.exec_module(car)
+
+
+def findings_for(source):
+    with tempfile.TemporaryDirectory() as folder:
+        path = pathlib.Path(folder) / 'sample.py'
+        path.write_text(textwrap.dedent(source), encoding='utf-8')
+        violations, problem = car.scan_module(str(path))
+    if problem:
+        raise AssertionError(problem)
+    return violations
+
+
+class ReturnsNone(unittest.TestCase):
+    def test_flags_return_none(self):
+        found = findings_for('''
+            @artifact_processor
+            def demo(context):
+                if not data_list:
+                    return None
+                return data_headers, data_list, source_path
+        ''')
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0][3], 'return None')
+
+    def test_flags_bare_return(self):
+        found = findings_for('''
+            @artifact_processor
+            def demo(context):
+                if not data_list:
+                    return
+                return data_headers, data_list, source_path
+        ''')
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0][3], 'return')
+
+
+class StaysSilent(unittest.TestCase):
+    def test_ignores_nested_helper_returning_none(self):
+        # dropbox.py's shape: an inner accumulator with an early exit.
+        found = findings_for('''
+            @artifact_processor
+            def demo(context):
+                def _record(prop, value):
+                    if not value:
+                        return
+                    matched[prop] = value
+                return data_headers, data_list, source_path
+        ''')
+        self.assertEqual(found, [])
+
+    def test_ignores_undecorated_function(self):
+        found = findings_for('''
+            def helper(x):
+                if not x:
+                    return None
+                return x
+        ''')
+        self.assertEqual(found, [])
+
+    def test_ignores_complete_triples(self):
+        found = findings_for('''
+            @artifact_processor
+            def demo(context):
+                if not data_list:
+                    return data_headers, [], source_path
+                return data_headers, data_list, source_path
+        ''')
+        self.assertEqual(found, [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/admin/test/scripts/test_check_implicit_concat.py
+++ b/admin/test/scripts/test_check_implicit_concat.py
@@ -1,0 +1,73 @@
+"""Prove the implicit-concatenation checker detects run-together junctions only.
+
+check_implicit_concat.py fails when two adjacent string literals join with an
+alphanumeric character on both sides of the junction, because the joined value
+renders run-together words in examiner-facing prose.
+
+The negative cases are the point: deliberate joins with a space at the junction,
+strings that are separate statements, and strings that are separate items in a
+collection must all stay silent, or the check gets switched off.
+"""
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_MODULE_PATH = REPO_ROOT / 'admin' / 'scripts' / 'check_implicit_concat.py'
+
+# admin/scripts is not a package, so load the module from its path.
+_spec = importlib.util.spec_from_file_location('check_implicit_concat', _MODULE_PATH)
+cic = importlib.util.module_from_spec(_spec)
+sys.modules['check_implicit_concat'] = cic
+_spec.loader.exec_module(cic)
+
+
+class RunTogether(unittest.TestCase):
+    def test_flags_alnum_junction(self):
+        found = cic.scan_source(
+            'x = ("Logs information about the app status"\n'
+            '     "such as launch, open, close, install.")\n')
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0][1][-6:], 'status')
+        self.assertEqual(found[0][2][:7], 'such as')
+
+    def test_flags_metadata_dict_value(self):
+        found = cic.scan_source(
+            '__artifacts_v2__ = {\n'
+            '    "demo": {\n'
+            '        "description": "Parses checkin events including user and beer info"\n'
+            '                       "as well as location information",\n'
+            '    }\n'
+            '}\n')
+        self.assertEqual(len(found), 1)
+
+
+class StaysSilent(unittest.TestCase):
+    def test_ignores_space_at_junction(self):
+        self.assertEqual(cic.scan_source(
+            'q = ("select a "\n     "from b")\n'), [])
+        self.assertEqual(cic.scan_source(
+            'q = ("select a"\n     " from b")\n'), [])
+
+    def test_ignores_separate_statements(self):
+        # A docstring followed by a string statement is two statements,
+        # never a concatenation.
+        self.assertEqual(cic.scan_source(
+            '"""Module docstring"""\n"another string"\n'), [])
+
+    def test_ignores_collection_items(self):
+        self.assertEqual(cic.scan_source(
+            'paths = ("a/b", "c/d")\n'), [])
+
+    def test_ignores_punctuation_junction(self):
+        self.assertEqual(cic.scan_source(
+            'x = ("first sentence."\n     " second sentence")\n'), [])
+
+    def test_ignores_fstrings(self):
+        self.assertEqual(cic.scan_source(
+            'x = f"{a}" f"{b}"\n'), [])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds two static checks to the lint gate.

- `check_artifact_returns.py`: an `@artifact_processor` function must not return None on any branch. The wrapper unpacks three values unconditionally, so a bare return crashes the artifact on devices where the app left no records. Nested helpers are exempt.
- `check_implicit_concat.py`: adjacent string literals joining with a letter or digit on both sides of the junction render run-together words in examiner-facing descriptions.

Both report zero findings on current main and are covered by unit tests.