### PR TITLE
Add storage-view checks to the test runner and fix a galleryVault double count

### DIFF
--- a/.github/workflows/test_cases.yml
+++ b/.github/workflows/test_cases.yml
@@ -49,3 +49,6 @@ jobs:
 
       - name: Run test cases against recorded baselines
         run: python admin/test/scripts/run_test_cases.py
+
+      - name: Check storage-view arithmetic on the same cases
+        run: python admin/test/scripts/run_test_cases.py --storage-views

--- a/admin/test/cases/known_failures.json
+++ b/admin/test/cases/known_failures.json
@@ -1,0 +1,13 @@
+{
+  "OperaBrowser.opera_tab_navigation.pixel7a_a14[second-tenant]": "second Android user's copy is staged and then dropped by a single-store accessor; needs per-module triage before the artifact reads every container",
+  "OperaBrowser.opera_tabs.pixel7a_a14[second-tenant]": "second Android user's copy is staged and then dropped by a single-store accessor; needs per-module triage before the artifact reads every container",
+  "PrivatePhotoVault.private_photo_vault_account.pixel7a_a14[second-tenant]": "second Android user's copy is staged and then dropped by a single-store accessor; needs per-module triage before the artifact reads every container",
+  "PrivatePhotoVault.private_photo_vault_albums.pixel7a_a14[second-tenant]": "second Android user's copy is staged and then dropped by a single-store accessor; needs per-module triage before the artifact reads every container",
+  "PrivatePhotoVault.private_photo_vault_media.pixel7a_a14[second-tenant]": "second Android user's copy is staged and then dropped by a single-store accessor; needs per-module triage before the artifact reads every container",
+  "Threema.threema_account.pixel7a_a14[second-tenant]": "second Android user's copy is staged and then dropped by a single-store accessor; needs per-module triage before the artifact reads every container",
+  "Threema.threema_contacts.pixel7a_a14[second-tenant]": "second Android user's copy is staged and then dropped by a single-store accessor; needs per-module triage before the artifact reads every container",
+  "Threema.threema_messages.pixel7a_a14[second-tenant]": "second Android user's copy is staged and then dropped by a single-store accessor; needs per-module triage before the artifact reads every container",
+  "galleryVault.galleryvault_browser_urls.pixel7a_a14[second-tenant]": "second Android user's copy is staged and then dropped by a single-store accessor; needs per-module triage before the artifact reads every container",
+  "galleryVault.galleryvault_folders.pixel7a_a14[second-tenant]": "second Android user's copy is staged and then dropped by a single-store accessor; needs per-module triage before the artifact reads every container",
+  "galleryVault.galleryvault_hidden_files.pixel7a_a14[second-tenant]": "second Android user's copy is staged and then dropped by a single-store accessor; needs per-module triage before the artifact reads every container"
+}

--- a/admin/test/scripts/run_test_cases.py
+++ b/admin/test/scripts/run_test_cases.py
@@ -29,6 +29,28 @@ report but do not gate, so a unit can be excluded deliberately, with a stated
 reason, instead of blocking every PR while it is being repaired. A known
 failure that passes again is flagged so the entry gets removed.
 
+--storage-views runs a different comparison from the same case zips. An Android
+full file system extraction carries the same app data directory under several
+spellings (data/data/<pkg>, data/user/0/<pkg>, ...) and can carry a second
+Android user at data/user/<n>/<pkg>. A single-view fixture cannot detect the
+two defects that follow, so this mode synthesizes them by restaging the zip's
+data/data members and checks the arithmetic per artifact:
+
+- duplicate view (data/user/0): the same file under a second spelling must not
+  change the row count. A doubled count means the storage views are not being
+  collapsed (storagePathViews.unique_files is the shared fix).
+- second tenant (data/user/10): a second Android user's copy must exactly
+  double the row count. An unchanged count means the second user's data is
+  read into files_found and then silently dropped, which is what a
+  first-match-wins accessor does.
+
+Counts are the comparison, not row contents: the two runs extract into
+different temp directories and restage mtimes, so content equality would fail
+on values legitimately derived from the reported file's own path. A unit whose
+base run yields no rows is skipped as uninformative, not passed. Exclusions
+use the same known_failures.json with the leg appended to the unit key, e.g.
+"galleryVault.galleryvault_folders.pixel7a_a14[second-tenant]".
+
 Exit status is 1 if any non-excluded unit failed, errored, or has no
 baseline; 0 otherwise.
 """
@@ -37,6 +59,8 @@ import json
 import os
 import re
 import sys
+import tempfile
+import zipfile
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -99,6 +123,82 @@ def compare(fresh_headers, fresh_rows, baseline):
     return problems
 
 
+def make_view_variant(src_zip, dst_zip, view):
+    """Copy the case zip, restaging each data/data member under a second view.
+
+    Returns the number of members added. Zero means the fixture holds nothing
+    under a data/data spelling, so no variant can be synthesized from it.
+    """
+    added = 0
+    with zipfile.ZipFile(src_zip) as zin, \
+            zipfile.ZipFile(dst_zip, 'w', zipfile.ZIP_DEFLATED) as zout:
+        for info in zin.infolist():
+            payload = zin.read(info.filename)
+            zout.writestr(info, payload)
+            anchored = '/' + info.filename
+            if '/data/data/' in anchored:
+                alt = anchored.replace('/data/data/', view, 1)[1:]
+                zout.writestr(alt, payload)
+                added += 1
+    return added
+
+
+def count_rows(test_module, zip_path, module, artifact, case_data):
+    """Fresh row count for one artifact against one zip."""
+    os_version = case_data.get("image_info", {}).get("os_version")
+    headers, rows, _elapsed, _commit, _media, _embedded = test_module.process_artifact(
+        zip_path, module, artifact, case_data["artifacts"][artifact],
+        target_os_version=os_version)
+    _headers, rows = test_module.process_data(headers, rows)
+    return len(rows)
+
+
+def run_storage_views(test_module, module, artifact, case, case_data):
+    """Runs the two storage-view checks; returns [(unit suffix, status, detail)].
+
+    Base and variants are all fresh runs of the same tool version, so the
+    comparison cannot be skewed by a stale baseline.
+    """
+    zip_path = CASES_DIR / "data" / module / f"testdata.{module}.{artifact}.{case}.zip"
+    if not zip_path.exists():
+        return [("", "BROKEN", f"case declares files but zip is missing: {zip_path}")]
+    try:
+        base = count_rows(test_module, zip_path, module, artifact, case_data)
+    except Exception as ex:  # pylint: disable=broad-except
+        return [("", "ERROR", f"base run: {type(ex).__name__}: {ex}")]
+    if base == 0:
+        return [("", "SKIP", "base run has 0 rows; the arithmetic cannot discriminate")]
+
+    (CASES_DIR.parent / 'temp').mkdir(parents=True, exist_ok=True)
+    results = []
+    legs = (("[duplicate-view]", '/data/user/0/', base,
+             "a duplicate storage view of the same container must not change the count"),
+            ("[second-tenant]", '/data/user/10/', 2 * base,
+             "a second Android user's copy must exactly double the count"))
+    for suffix, view, expected, rule in legs:
+        handle = tempfile.NamedTemporaryFile(
+            suffix='.zip', dir=str(CASES_DIR.parent / 'temp'), delete=False)
+        variant = Path(handle.name)
+        handle.close()
+        try:
+            added = make_view_variant(zip_path, variant, view)
+            if not added:
+                results.append((suffix, "SKIP", "no data/data members to restage"))
+                continue
+            got = count_rows(test_module, variant, module, artifact, case_data)
+        except Exception as ex:  # pylint: disable=broad-except
+            results.append((suffix, "ERROR", f"{type(ex).__name__}: {ex}"))
+            continue
+        finally:
+            variant.unlink(missing_ok=True)
+        if got == expected:
+            results.append((suffix, "PASS", f"{base} rows -> {got} rows"))
+        else:
+            results.append((suffix, "FAIL",
+                            f"{base} rows -> {got} rows, expected {expected}: {rule}"))
+    return results
+
+
 def run_one(test_module, module, artifact, case, case_data):
     """Runs one artifact against one case zip; returns (status, detail)."""
     zip_path = CASES_DIR / "data" / module / f"testdata.{module}.{artifact}.{case}.zip"
@@ -131,6 +231,10 @@ def main(argv=None):
     parser.add_argument("--list", action="store_true", help="list runnable units and exit")
     parser.add_argument("--strict", action="store_true",
                         help="ignore known_failures.json and gate on everything")
+    parser.add_argument("--storage-views", action="store_true",
+                        help="synthesize a duplicate storage view and a second "
+                             "Android user from each case zip and check the "
+                             "row-count arithmetic instead of the baselines")
     args = parser.parse_args(argv)
 
     known = {}
@@ -148,7 +252,7 @@ def main(argv=None):
         cases_file = CASES_DIR / f"testdata.{module}.json"
         if not cases_file.exists():
             print(f"{module}: no case file", flush=True)
-            failures.append((module, "-", "-", "BROKEN", "case file missing"))
+            failures.append((module, "BROKEN", "case file missing"))
             continue
         with open(cases_file, encoding="utf-8") as f:
             cases = json.load(f)
@@ -159,18 +263,25 @@ def main(argv=None):
                 if args.list:
                     print(f"{module} {artifact} {case}")
                     continue
-                status, detail = run_one(test_module, module, artifact, case, case_data)
-                unit = f"{module}.{artifact}.{case}"
-                if unit in known and status != "PASS":
-                    print(f"[KNOWN_FAIL ] {unit}: {status}; excluded: {known[unit]}", flush=True)
-                    counts["KNOWN_FAIL"] = counts.get("KNOWN_FAIL", 0) + 1
-                    continue
-                counts[status] = counts.get(status, 0) + 1
-                if unit in known and status == "PASS":
-                    detail += " (listed in known_failures.json; remove its entry)"
-                print(f"[{status:11s}] {unit}: {detail}", flush=True)
-                if status != "PASS":
-                    failures.append((module, artifact, case, status, detail))
+                if args.storage_views:
+                    results = run_storage_views(test_module, module, artifact,
+                                                case, case_data)
+                else:
+                    results = [("",) + run_one(test_module, module, artifact,
+                                               case, case_data)]
+                for suffix, status, detail in results:
+                    unit = f"{module}.{artifact}.{case}{suffix}"
+                    if unit in known and status not in ("PASS", "SKIP"):
+                        print(f"[KNOWN_FAIL ] {unit}: {status}; excluded: {known[unit]}",
+                              flush=True)
+                        counts["KNOWN_FAIL"] = counts.get("KNOWN_FAIL", 0) + 1
+                        continue
+                    counts[status] = counts.get(status, 0) + 1
+                    if unit in known and status == "PASS":
+                        detail += " (listed in known_failures.json; remove its entry)"
+                    print(f"[{status:11s}] {unit}: {detail}", flush=True)
+                    if status not in ("PASS", "SKIP"):
+                        failures.append((unit, status, detail))
     if args.list:
         return 0
 
@@ -179,8 +290,8 @@ def main(argv=None):
           ", ".join(f"{k}={v}" for k, v in sorted(counts.items())) if counts else "nothing ran")
     if failures:
         print(f"\n{len(failures)} unit(s) need attention:")
-        for module, artifact, case, status, _detail in failures:
-            print(f"  {status:11s} {module}.{artifact}.{case}")
+        for unit, status, _detail in failures:
+            print(f"  {status:11s} {unit}")
         return 1
     return 0
 

--- a/scripts/artifacts/galleryVault.py
+++ b/scripts/artifacts/galleryVault.py
@@ -402,6 +402,8 @@ import xml.etree.ElementTree as ET
 
 from Crypto.Cipher import DES
 
+from scripts.artifacts.storagePathViews import unique_files
+
 from scripts.ilapfuncs import (
     artifact_processor,
     check_in_embedded_media,
@@ -1041,7 +1043,9 @@ def galleryvault_file_actions(context):
 
 @artifact_processor
 def galleryvault_preferences(context):
-    files_found = context.get_files_found()
+    # Kidd.xml can appear under more than one storage view of the same app
+    # directory; read each preference file once, not once per spelling.
+    files_found = unique_files(context)
 
     data_list = []
     source_path = ''


### PR DESCRIPTION
Adds a `--storage-views` mode to `run_test_cases.py` and runs it in CI after the baseline comparison. It restages each case zip's `data/data` members under a second storage view and under a second Android user, then checks the arithmetic per artifact: a duplicate view must not change the row count and a second user's copy must exactly double it. No new fixtures are needed; both variants are synthesized from the zips already committed.

Fixes `galleryvault_preferences` reading each preference file once per storage view, which doubled its rows on extractions carrying more than one spelling. Baselines are unchanged.

The eleven current second-tenant findings are excluded in `known_failures.json` with reasons, so the check gates new artifacts while those get triaged.