### PR TITLE
Read every app container in four modules that dropped a second Android user

### DIFF
--- a/admin/test/cases/known_failures.json
+++ b/admin/test/cases/known_failures.json
@@ -1,13 +1,1 @@
-{
-  "OperaBrowser.opera_tab_navigation.pixel7a_a14[second-tenant]": "second Android user's copy is staged and then dropped by a single-store accessor; needs per-module triage before the artifact reads every container",
-  "OperaBrowser.opera_tabs.pixel7a_a14[second-tenant]": "second Android user's copy is staged and then dropped by a single-store accessor; needs per-module triage before the artifact reads every container",
-  "PrivatePhotoVault.private_photo_vault_account.pixel7a_a14[second-tenant]": "second Android user's copy is staged and then dropped by a single-store accessor; needs per-module triage before the artifact reads every container",
-  "PrivatePhotoVault.private_photo_vault_albums.pixel7a_a14[second-tenant]": "second Android user's copy is staged and then dropped by a single-store accessor; needs per-module triage before the artifact reads every container",
-  "PrivatePhotoVault.private_photo_vault_media.pixel7a_a14[second-tenant]": "second Android user's copy is staged and then dropped by a single-store accessor; needs per-module triage before the artifact reads every container",
-  "Threema.threema_account.pixel7a_a14[second-tenant]": "second Android user's copy is staged and then dropped by a single-store accessor; needs per-module triage before the artifact reads every container",
-  "Threema.threema_contacts.pixel7a_a14[second-tenant]": "second Android user's copy is staged and then dropped by a single-store accessor; needs per-module triage before the artifact reads every container",
-  "Threema.threema_messages.pixel7a_a14[second-tenant]": "second Android user's copy is staged and then dropped by a single-store accessor; needs per-module triage before the artifact reads every container",
-  "galleryVault.galleryvault_browser_urls.pixel7a_a14[second-tenant]": "second Android user's copy is staged and then dropped by a single-store accessor; needs per-module triage before the artifact reads every container",
-  "galleryVault.galleryvault_folders.pixel7a_a14[second-tenant]": "second Android user's copy is staged and then dropped by a single-store accessor; needs per-module triage before the artifact reads every container",
-  "galleryVault.galleryvault_hidden_files.pixel7a_a14[second-tenant]": "second Android user's copy is staged and then dropped by a single-store accessor; needs per-module triage before the artifact reads every container"
-}
+{}

--- a/scripts/artifacts/OperaBrowser.py
+++ b/scripts/artifacts/OperaBrowser.py
@@ -107,6 +107,7 @@ from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs, urlparse
 
 from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, logfunc
+from scripts.artifacts.storagePathViews import unique_files
 
 _WEBKIT_EPOCH = datetime(1601, 1, 1, tzinfo=timezone.utc)
 
@@ -164,12 +165,20 @@ def _search_query(virtual_url):
     return values[0] if values else ""
 
 
-def _find_one(files_found, suffix):
-    for file_found in files_found:
-        file_found = str(file_found)
-        if file_found.endswith(suffix):
-            return file_found
-    return None
+def _stores_by_container(files_found):
+    """[(session_db path, History path or None)] per app container, sorted.
+
+    An extraction can carry a container per Android user, each with its own
+    tabs and history. The History join must stay inside one container: a
+    tab's URL is dated against the same user's History, never another's.
+    Both files sit directly under app_opera/, so the shared parent directory
+    is the container key. The exact-suffix test never matches a sidecar.
+    """
+    normalized = [str(f).replace('\\', '/') for f in files_found]
+    history_by_root = {f[:-len('History')]: f for f in normalized
+                       if f.endswith('History')}
+    return [(f, history_by_root.get(f[:-len('session_db')]))
+            for f in sorted(normalized) if f.endswith('session_db')]
 
 
 @artifact_processor
@@ -180,49 +189,48 @@ def opera_tabs(context):
         "Navigation Entry Count", "Restored", "Internal Tab ID",
     )
 
-    files_found = [str(f) for f in context.get_files_found()]
-    db_path = _find_one(files_found, "session_db")
-    if not db_path:
+    stores = _stores_by_container(unique_files(context))
+    if not stores:
         return data_headers, [], ""
 
-    history_db_path = _find_one(files_found, "History")
-    history_times = _history_last_visit_times(history_db_path)
-
-    tab_order = {}
-    for tab_id, ix in get_sqlite_db_records(db_path, "SELECT tab, ix FROM tab_order"):
-        tab_order[tab_id] = ix
-
-    closed = {}
-    for tab_id, restored in get_sqlite_db_records(
-            db_path, "SELECT tab, restored FROM recently_closed_tab"):
-        closed[tab_id] = bool(restored)
-
-    entry_counts = {}
-    current_page = {}
-    for tab_id, ix, url, title in get_sqlite_db_records(
-            db_path, "SELECT tab, ix, url, title FROM navigation_entry"):
-        entry_counts[tab_id] = entry_counts.get(tab_id, 0) + 1
-        current_page[(tab_id, ix)] = (url, _decode_title(title))
-
     data_list = []
-    for tab_id, current_entry in get_sqlite_db_records(
-            db_path, "SELECT tab, current_entry FROM tab"):
-        is_closed = tab_id in closed
-        url, title = current_page.get((tab_id, current_entry), ("", ""))
-        data_list.append((
-            "Closed" if is_closed else "Open",
-            tab_order.get(tab_id, ""),
-            title,
-            url,
-            history_times.get(url),
-            entry_counts.get(tab_id, 0),
-            "Yes" if closed.get(tab_id) else ("" if is_closed else "N/A"),
-            tab_id,
-        ))
+    for db_path, history_db_path in stores:
+        history_times = _history_last_visit_times(history_db_path)
+
+        tab_order = {}
+        for tab_id, ix in get_sqlite_db_records(db_path, "SELECT tab, ix FROM tab_order"):
+            tab_order[tab_id] = ix
+
+        closed = {}
+        for tab_id, restored in get_sqlite_db_records(
+                db_path, "SELECT tab, restored FROM recently_closed_tab"):
+            closed[tab_id] = bool(restored)
+
+        entry_counts = {}
+        current_page = {}
+        for tab_id, ix, url, title in get_sqlite_db_records(
+                db_path, "SELECT tab, ix, url, title FROM navigation_entry"):
+            entry_counts[tab_id] = entry_counts.get(tab_id, 0) + 1
+            current_page[(tab_id, ix)] = (url, _decode_title(title))
+
+        for tab_id, current_entry in get_sqlite_db_records(
+                db_path, "SELECT tab, current_entry FROM tab"):
+            is_closed = tab_id in closed
+            url, title = current_page.get((tab_id, current_entry), ("", ""))
+            data_list.append((
+                "Closed" if is_closed else "Open",
+                tab_order.get(tab_id, ""),
+                title,
+                url,
+                history_times.get(url),
+                entry_counts.get(tab_id, 0),
+                "Yes" if closed.get(tab_id) else ("" if is_closed else "N/A"),
+                tab_id,
+            ))
 
     data_list.sort(key=lambda row: (row[0] != "Open", row[1] if row[1] != "" else 999))
     logfunc(f"Opera Browser Tabs: {len(data_list)} tab(s) recovered from session_db.")
-    return data_headers, data_list, db_path
+    return data_headers, data_list, '\n'.join(db for db, _ in stores)
 
 
 @artifact_processor
@@ -232,34 +240,33 @@ def opera_tab_navigation(context):
         "Search Query", ("Last Visit Time (History Match)", "datetime"),
     )
 
-    files_found = [str(f) for f in context.get_files_found()]
-    db_path = _find_one(files_found, "session_db")
-    if not db_path:
+    stores = _stores_by_container(unique_files(context))
+    if not stores:
         return data_headers, [], ""
 
-    history_db_path = _find_one(files_found, "History")
-    history_times = _history_last_visit_times(history_db_path)
-
-    current_entry_by_tab = {}
-    for tab_id, current_entry in get_sqlite_db_records(
-            db_path, "SELECT tab, current_entry FROM tab"):
-        current_entry_by_tab[tab_id] = current_entry
-
     data_list = []
-    for tab_id, ix, url, virtual_url, title in get_sqlite_db_records(
-            db_path,
-            "SELECT tab, ix, url, virtual_url, title FROM navigation_entry "
-            "ORDER BY tab, ix"):
-        data_list.append((
-            tab_id,
-            ix,
-            "Yes" if current_entry_by_tab.get(tab_id) == ix else "",
-            _decode_title(title),
-            url,
-            _search_query(virtual_url),
-            history_times.get(url),
-        ))
+    for db_path, history_db_path in stores:
+        history_times = _history_last_visit_times(history_db_path)
+
+        current_entry_by_tab = {}
+        for tab_id, current_entry in get_sqlite_db_records(
+                db_path, "SELECT tab, current_entry FROM tab"):
+            current_entry_by_tab[tab_id] = current_entry
+
+        for tab_id, ix, url, virtual_url, title in get_sqlite_db_records(
+                db_path,
+                "SELECT tab, ix, url, virtual_url, title FROM navigation_entry "
+                "ORDER BY tab, ix"):
+            data_list.append((
+                tab_id,
+                ix,
+                "Yes" if current_entry_by_tab.get(tab_id) == ix else "",
+                _decode_title(title),
+                url,
+                _search_query(virtual_url),
+                history_times.get(url),
+            ))
 
     logfunc(f"Opera Browser Tab Navigation History: {len(data_list)} navigation "
             f"entr{'y' if len(data_list) == 1 else 'ies'} recovered.")
-    return data_headers, data_list, db_path
+    return data_headers, data_list, '\n'.join(db for db, _ in stores)

--- a/scripts/artifacts/PrivatePhotoVault.py
+++ b/scripts/artifacts/PrivatePhotoVault.py
@@ -104,20 +104,16 @@ import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 
 from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, logfunc
+from scripts.artifacts.storagePathViews import unique_files
 
 
-def _find_one(files_found, suffix):
-    for file_found in files_found:
-        file_found = str(file_found)
-        # ppv.db's write-ahead log/shared-memory sidecar files are matched by
-        # the same glob (so ALEAPP extracts them alongside the main file,
-        # which SQLite needs in order to fold their content in), but they are
-        # never the file this function should return itself.
-        if file_found.endswith(('-wal', '-shm', '-journal')):
-            continue
-        if file_found.endswith(suffix):
-            return file_found
-    return None
+def _find_all(files_found, suffix):
+    """Every file ending in suffix, sorted: an extraction can carry a copy per
+    Android user, and each user's vault is separate evidence. ppv.db's
+    write-ahead log/shared-memory sidecars are matched by the same glob (so
+    ALEAPP extracts them alongside the main file, which SQLite needs in order
+    to fold their content in), but the exact-suffix test never returns one."""
+    return sorted(str(f) for f in files_found if str(f).endswith(suffix))
 
 
 def _xml_pref(root, name):
@@ -151,29 +147,33 @@ def private_photo_vault_account(context):
         ("Last Key Event", "datetime"), "Uses Encrypted Preferences",
     )
 
-    files_found = [str(f) for f in context.get_files_found()]
-    prefs_path = _find_one(files_found, 'APP_PREFERENCES.xml')
-    if not prefs_path:
+    files_found = unique_files(context)
+    prefs_paths = _find_all(files_found, 'APP_PREFERENCES.xml')
+    if not prefs_paths:
         return data_headers, [], ""
 
-    try:
-        root = ET.parse(prefs_path).getroot()
-    except ET.ParseError as ex:
-        logfunc(f"Private Photo Vault: could not parse {prefs_path}: {ex}")
-        return data_headers, [], prefs_path
+    data_list = []
+    for prefs_path in prefs_paths:
+        try:
+            root = ET.parse(prefs_path).getroot()
+        except ET.ParseError as ex:
+            logfunc(f"Private Photo Vault: could not parse {prefs_path}: {ex}")
+            continue
 
-    install_date = _epoch_ms_to_utc(_xml_pref(root, 'installDate'))
-    imported_media = _xml_pref(root, 'importedMedia') or ''
-    minutes_spent = _xml_pref(root, 'minutesSpentInApp') or ''
-    key_event_count = _xml_pref(root, 'keyEventCount') or ''
-    last_key_event = _epoch_ms_to_utc(_xml_pref(root, 'lastKeyEventDate'))
-    uses_encrypted_prefs = _xml_pref(root, 'usesEncryptedPreferencesV2') or ''
+        install_date = _epoch_ms_to_utc(_xml_pref(root, 'installDate'))
+        imported_media = _xml_pref(root, 'importedMedia') or ''
+        minutes_spent = _xml_pref(root, 'minutesSpentInApp') or ''
+        key_event_count = _xml_pref(root, 'keyEventCount') or ''
+        last_key_event = _epoch_ms_to_utc(_xml_pref(root, 'lastKeyEventDate'))
+        uses_encrypted_prefs = _xml_pref(root, 'usesEncryptedPreferencesV2') or ''
+
+        data_list.append((
+            install_date, imported_media, minutes_spent, key_event_count,
+            last_key_event, uses_encrypted_prefs,
+        ))
 
     logfunc("Private Photo Vault Account: usage counters recovered.")
-    return data_headers, [(
-        install_date, imported_media, minutes_spent, key_event_count,
-        last_key_event, uses_encrypted_prefs,
-    )], prefs_path
+    return data_headers, data_list, '\n'.join(prefs_paths)
 
 
 @artifact_processor
@@ -183,16 +183,18 @@ def private_photo_vault_albums(context):
         "Deleted",
     )
 
-    files_found = [str(f) for f in context.get_files_found()]
-    source_path = _find_one(files_found, 'ppv.db')
-    if not source_path:
+    files_found = unique_files(context)
+    source_paths = _find_all(files_found, 'ppv.db')
+    if not source_paths:
         return data_headers, [], ""
 
     data_list = []
-    for name, bucket_id, created, order_number, is_deleted in get_sqlite_db_records(
-            source_path,
-            "SELECT name, bucket_id, creation_date, order_number, is_deleted "
-            "FROM Album;"):
+    for name, bucket_id, created, order_number, is_deleted in (
+            record for source_path in source_paths
+            for record in get_sqlite_db_records(
+                source_path,
+                "SELECT name, bucket_id, creation_date, order_number, is_deleted "
+                "FROM Album;")):
         data_list.append((
             name,
             bucket_id,
@@ -202,7 +204,7 @@ def private_photo_vault_albums(context):
         ))
 
     logfunc(f"Private Photo Vault Albums: {len(data_list)} album(s) recovered.")
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)
 
 
 @artifact_processor
@@ -213,20 +215,22 @@ def private_photo_vault_media(context):
         "Favourite", "Deleted", "View Count", "Encryption Key (Wrapped)", "IV",
     )
 
-    files_found = [str(f) for f in context.get_files_found()]
-    source_path = _find_one(files_found, 'ppv.db')
-    if not source_path:
+    files_found = unique_files(context)
+    source_paths = _find_all(files_found, 'ppv.db')
+    if not source_paths:
         return data_headers, [], ""
 
     data_list = []
     for (created, bucket_id, file_path, thumbnail_path, mime_type, width,
          height, is_favourite, is_deleted, view_count, encryption_key,
-         local_iv) in get_sqlite_db_records(
-            source_path,
-            "SELECT creation_date, bucket_id, file_path, thumbnail_path, "
-            "mime_type, image_width, image_height, is_favourite, is_deleted, "
-            "view_count, encryption_key, local_iv FROM MediaFile "
-            "ORDER BY creation_date;"):
+         local_iv) in (
+            record for source_path in source_paths
+            for record in get_sqlite_db_records(
+                source_path,
+                "SELECT creation_date, bucket_id, file_path, thumbnail_path, "
+                "mime_type, image_width, image_height, is_favourite, is_deleted, "
+                "view_count, encryption_key, local_iv FROM MediaFile "
+                "ORDER BY creation_date;")):
         data_list.append((
             _iso_to_utc(created),
             bucket_id,
@@ -244,4 +248,4 @@ def private_photo_vault_media(context):
 
     logfunc(f"Private Photo Vault Media: {len(data_list)} media record(s) "
             f"recovered.")
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/Threema.py
+++ b/scripts/artifacts/Threema.py
@@ -144,6 +144,7 @@ import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 
 from scripts.ilapfuncs import artifact_processor, get_sqlite_db_path, logfunc
+from scripts.artifacts.storagePathViews import unique_files
 
 try:
     from sqlcipher3 import dbapi2 as sqlcipher
@@ -215,18 +216,11 @@ def _xml_value(root, name):
     return node.get('value', node.text)
 
 
-def _find_one(files_found, suffix):
-    for file_found in files_found:
-        file_found = str(file_found)
-        # threema4.db's write-ahead log/shared-memory sidecar files are
-        # matched by the same glob (so ALEAPP extracts them alongside the
-        # main file, which SQLite needs in order to fold their content in),
-        # but they are never the file this function should return itself.
-        if file_found.endswith(('-wal', '-shm', '-journal')):
-            continue
-        if file_found.endswith(suffix):
-            return file_found
-    return None
+def _find_all(files_found, suffix):
+    """Every file ending in suffix, sorted: an extraction can carry a container
+    per Android user, and each user's Threema data is separate evidence. The
+    exact-suffix test never matches a -wal/-shm/-journal sidecar."""
+    return sorted(str(f) for f in files_found if str(f).endswith(suffix))
 
 
 def _epoch_ms_to_utc(value):
@@ -301,17 +295,30 @@ def _open_decrypted_db(db_path, key):
         return None
 
 
-def _decrypted_connection(files_found):
+def _decrypted_connections(files_found):
+    """[(connection or None, db path)] per app container, sorted by db path.
+
+    An extraction can carry a container per Android user, each with its own
+    key.dat and threema4.db. The pairing stays inside one container: a
+    database only opens with the key file next to it, never another user's.
+    A container whose key does not derive still reports its db path, so the
+    report cites the store that could not be opened.
+    """
     if not _SQLCIPHER_AVAILABLE:
-        return None, ""
-    key_dat_path = _find_one(files_found, 'key.dat')
-    db_path = _find_one(files_found, 'threema4.db')
-    if not key_dat_path or not db_path:
-        return None, ""
-    key = _derive_sqlcipher_key(key_dat_path)
-    if key is None:
-        return None, db_path
-    return _open_decrypted_db(db_path, key), db_path
+        return []
+    normalized = [str(f).replace('\\', '/') for f in files_found]
+    keys_by_root = {f[:-len('files/key.dat')]: f for f in normalized
+                    if f.endswith('files/key.dat')}
+    pairs = []
+    for db_path in sorted(f for f in normalized
+                          if f.endswith('databases/threema4.db')):
+        key_dat_path = keys_by_root.get(db_path[:-len('databases/threema4.db')])
+        if not key_dat_path:
+            continue
+        key = _derive_sqlcipher_key(key_dat_path)
+        con = _open_decrypted_db(db_path, key) if key is not None else None
+        pairs.append((con, db_path))
+    return pairs
 
 
 _VERIFICATION_LEVELS = {
@@ -325,21 +332,25 @@ _VERIFICATION_LEVELS = {
 def threema_account(context):
     data_headers = ("Threema ID", "Nickname", "Linked Mobile Number")
 
-    files_found = [str(f) for f in context.get_files_found()]
-    prefs_path = _find_one(files_found, 'ch.threema.app_preferences.xml')
-    if not prefs_path:
+    files_found = unique_files(context)
+    prefs_paths = _find_all(files_found, 'ch.threema.app_preferences.xml')
+    if not prefs_paths:
         return data_headers, [], ""
 
-    root = _parse_xml(prefs_path)
-    identity = _xml_value(root, 'identity') or ''
-    nickname = _xml_value(root, 'nickname') or ''
-    linked_mobile = _xml_value(root, 'linked_mobile') or ''
+    data_list = []
+    for prefs_path in prefs_paths:
+        root = _parse_xml(prefs_path)
+        identity = _xml_value(root, 'identity') or ''
+        nickname = _xml_value(root, 'nickname') or ''
+        linked_mobile = _xml_value(root, 'linked_mobile') or ''
 
-    if not identity:
-        return data_headers, [], prefs_path
+        if not identity:
+            continue
 
-    logfunc(f"Threema Account: ID {identity} recovered.")
-    return data_headers, [(identity, nickname, linked_mobile)], prefs_path
+        logfunc(f"Threema Account: ID {identity} recovered.")
+        data_list.append((identity, nickname, linked_mobile))
+
+    return data_headers, data_list, '\n'.join(prefs_paths)
 
 
 @artifact_processor
@@ -349,36 +360,39 @@ def threema_contacts(context):
         ("Date Added", "datetime"), "Group-Only / Removed", "Archived",
     )
 
-    files_found = [str(f) for f in context.get_files_found()]
-    con, source_path = _decrypted_connection(files_found)
-    if con is None:
-        return data_headers, [], source_path
+    files_found = unique_files(context)
+    pairs = _decrypted_connections(files_found)
+    if not pairs:
+        return data_headers, [], ""
 
     data_list = []
-    try:
-        cur = con.cursor()
-        cur.execute(
-            "SELECT identity, firstName, lastName, publicNickName, "
-            "verificationLevel, dateCreated, acquaintanceLevel, isArchived "
-            "FROM contacts;")
-        for (identity, first, last, nick, level, created,
-             acquaintance_level, archived) in cur.fetchall():
-            display_name = " ".join(p for p in (first, last) if p) or nick or ''
-            data_list.append((
-                identity,
-                display_name,
-                _VERIFICATION_LEVELS.get(level, str(level)),
-                _epoch_ms_to_utc(created),
-                "Yes" if acquaintance_level else "",
-                "Yes" if archived else "",
-            ))
-    finally:
-        con.close()
+    for con, _db_path in pairs:
+        if con is None:
+            continue
+        try:
+            cur = con.cursor()
+            cur.execute(
+                "SELECT identity, firstName, lastName, publicNickName, "
+                "verificationLevel, dateCreated, acquaintanceLevel, isArchived "
+                "FROM contacts;")
+            for (identity, first, last, nick, level, created,
+                 acquaintance_level, archived) in cur.fetchall():
+                display_name = " ".join(p for p in (first, last) if p) or nick or ''
+                data_list.append((
+                    identity,
+                    display_name,
+                    _VERIFICATION_LEVELS.get(level, str(level)),
+                    _epoch_ms_to_utc(created),
+                    "Yes" if acquaintance_level else "",
+                    "Yes" if archived else "",
+                ))
+        finally:
+            con.close()
 
     data_list.sort(key=lambda row: (row[3] is None, row[3]))
     logfunc(f"Threema Contacts: {len(data_list)} contact(s) recovered from "
             f"the decrypted database.")
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(db for _, db in pairs)
 
 
 def _extract_media_info(body_json):
@@ -454,81 +468,84 @@ def threema_messages(context):
         "Quoted Message", ("Delivered", "datetime"), ("Read At", "datetime"),
     )
 
-    files_found = [str(f) for f in context.get_files_found()]
-    con, source_path = _decrypted_connection(files_found)
-    if con is None:
-        return data_headers, [], source_path
+    files_found = unique_files(context)
+    pairs = _decrypted_connections(files_found)
+    if not pairs:
+        return data_headers, [], ""
 
     data_list = []
-    try:
-        cur = con.cursor()
-        contacts = {}
-        for identity, first, last, nick in cur.execute(
-                "SELECT identity, firstName, lastName, publicNickName FROM contacts;"):
-            contacts[identity] = " ".join(p for p in (first, last) if p) or nick or identity
+    for con, _db_path in pairs:
+        if con is None:
+            continue
+        try:
+            cur = con.cursor()
+            contacts = {}
+            for identity, first, last, nick in cur.execute(
+                    "SELECT identity, firstName, lastName, publicNickName FROM contacts;"):
+                contacts[identity] = " ".join(p for p in (first, last) if p) or nick or identity
 
-        cur.execute(
-            "SELECT identity, outbox, type, body, apiMessageId, quotedMessageId, "
-            "state, isRead, createdAtUtc, deliveredAtUtc, readAtUtc "
-            "FROM message ORDER BY createdAtUtc;")
-        rows = cur.fetchall()
+            cur.execute(
+                "SELECT identity, outbox, type, body, apiMessageId, quotedMessageId, "
+                "state, isRead, createdAtUtc, deliveredAtUtc, readAtUtc "
+                "FROM message ORDER BY createdAtUtc;")
+            rows = cur.fetchall()
 
-        api_id_to_text = {}
-        for (identity, outbox, mtype, body, api_id, quoted_id, state,
-             is_read, created, delivered, read_at) in rows:
-            if api_id and mtype == 0 and body:
-                api_id_to_text[api_id] = body
+            api_id_to_text = {}
+            for (identity, outbox, mtype, body, api_id, quoted_id, state,
+                 is_read, created, delivered, read_at) in rows:
+                if api_id and mtype == 0 and body:
+                    api_id_to_text[api_id] = body
 
-        for (identity, outbox, mtype, body, api_id, quoted_id, state,
-             is_read, created, delivered, read_at) in rows:
-            contact_name = contacts.get(identity, identity)
-            direction = "Sent" if outbox else "Received"
-            text = filename = mime_type = ''
-            size = call_status = call_id = duration = None
-            lat = lon = accuracy = None
-            content_type = "Text"
-
-            if mtype == 0:
+            for (identity, outbox, mtype, body, api_id, quoted_id, state,
+                 is_read, created, delivered, read_at) in rows:
+                contact_name = contacts.get(identity, identity)
+                direction = "Sent" if outbox else "Received"
+                text = filename = mime_type = ''
+                size = call_status = call_id = duration = None
+                lat = lon = accuracy = None
                 content_type = "Text"
-                text = body or ''
-            elif mtype == 8:
-                content_type = "Image"
-                filename, mime_type, size = _extract_media_info(body)
-            elif mtype == 4:
-                content_type = "Location"
-                lat, lon, accuracy, text = _extract_location_info(body)
-            elif mtype == 9:
-                content_type = "Call"
-                call_status, call_id, duration = _extract_call_info(body)
-            else:
-                content_type = f"Unrecognized (type={mtype})"
-                text = body or ''
 
-            quoted_text = api_id_to_text.get(quoted_id, '') if quoted_id else ''
+                if mtype == 0:
+                    content_type = "Text"
+                    text = body or ''
+                elif mtype == 8:
+                    content_type = "Image"
+                    filename, mime_type, size = _extract_media_info(body)
+                elif mtype == 4:
+                    content_type = "Location"
+                    lat, lon, accuracy, text = _extract_location_info(body)
+                elif mtype == 9:
+                    content_type = "Call"
+                    call_status, call_id, duration = _extract_call_info(body)
+                else:
+                    content_type = f"Unrecognized (type={mtype})"
+                    text = body or ''
 
-            data_list.append((
-                _epoch_ms_to_utc(created),
-                contact_name,
-                direction,
-                content_type,
-                text or filename,
-                mime_type,
-                size,
-                lat,
-                lon,
-                accuracy,
-                call_status,
-                call_id,
-                duration,
-                state or '',
-                "Yes" if is_read else "",
-                quoted_text,
-                _epoch_ms_to_utc(delivered),
-                _epoch_ms_to_utc(read_at),
-            ))
-    finally:
-        con.close()
+                quoted_text = api_id_to_text.get(quoted_id, '') if quoted_id else ''
+
+                data_list.append((
+                    _epoch_ms_to_utc(created),
+                    contact_name,
+                    direction,
+                    content_type,
+                    text or filename,
+                    mime_type,
+                    size,
+                    lat,
+                    lon,
+                    accuracy,
+                    call_status,
+                    call_id,
+                    duration,
+                    state or '',
+                    "Yes" if is_read else "",
+                    quoted_text,
+                    _epoch_ms_to_utc(delivered),
+                    _epoch_ms_to_utc(read_at),
+                ))
+        finally:
+            con.close()
 
     logfunc(f"Threema Messages: {len(data_list)} message(s) recovered from "
             f"the decrypted database.")
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(db for _, db in pairs)

--- a/scripts/artifacts/galleryVault.py
+++ b/scripts/artifacts/galleryVault.py
@@ -569,8 +569,18 @@ def _ms(value):
     return convert_unix_ts_to_utc(value)
 
 
-def _galleryvault_db(files_found):
-    return get_file_path(files_found, 'galleryvault.db')
+def _galleryvault_dbs(files_found):
+    """Every galleryvault.db in the extraction, sorted: a second Android user
+    has their own vault database, and each one is separate evidence. The
+    exact-suffix test never returns a -wal/-shm/-journal sidecar."""
+    return sorted(str(f) for f in files_found
+                  if str(f).endswith('galleryvault.db'))
+
+
+def _query_all(db_paths, table, query):
+    """Rows of the query from every database, in db path order."""
+    for db_path in db_paths:
+        yield from _query(db_path, table, query)
 
 
 def _cloud_cache_db(files_found):
@@ -716,28 +726,31 @@ def galleryvault_vault_files(context):
 
 @artifact_processor
 def galleryvault_hidden_files(context):
-    source_path = _galleryvault_db(context.get_files_found())
+    source_paths = _galleryvault_dbs(unique_files(context))
     data_list = []
-    columns = _columns(source_path, 'file_v1')
-    delete_state = 'file_v1.delete_state' if 'delete_state' in columns else "''"
+    # The query is built per database: each Android user's copy can carry a
+    # different schema generation, so delete_state is resolved per store.
+    for source_path in source_paths:
+        columns = _columns(source_path, 'file_v1')
+        delete_state = 'file_v1.delete_state' if 'delete_state' in columns else "''"
 
-    query = f'''
-    SELECT file_v1.added_time_utc, file_v1.file_last_modified_time_utc, file_v1.name,
-           folder_v1.name, file_v1.original_path, file_v1.mime_type, file_v1.file_size,
-           file_v1.image_width, file_v1.image_height, file_v1.video_duration,
-           file_v1.file_type, file_v1.encrypt_state, file_v1.storage_type,
-           file_v1.complete_state, {delete_state}, file_v1.uuid, file_v1.source
-    FROM file_v1
-    LEFT JOIN folder_v1 ON file_v1.folder_id = folder_v1._id
-    ORDER BY file_v1.added_time_utc
-    '''
-    for record in _query(source_path, 'file_v1', query):
-        dimensions = f'{record[7]} x {record[8]}' if record[7] or record[8] else ''
-        data_list.append((
-            _ms(record[0]), _ms(record[1]), record[2], record[3], record[4], record[5],
-            record[6], dimensions, record[9], record[10], record[11], record[12],
-            record[13], record[14], record[15], record[16],
-        ))
+        query = f'''
+        SELECT file_v1.added_time_utc, file_v1.file_last_modified_time_utc, file_v1.name,
+               folder_v1.name, file_v1.original_path, file_v1.mime_type, file_v1.file_size,
+               file_v1.image_width, file_v1.image_height, file_v1.video_duration,
+               file_v1.file_type, file_v1.encrypt_state, file_v1.storage_type,
+               file_v1.complete_state, {delete_state}, file_v1.uuid, file_v1.source
+        FROM file_v1
+        LEFT JOIN folder_v1 ON file_v1.folder_id = folder_v1._id
+        ORDER BY file_v1.added_time_utc
+        '''
+        for record in _query(source_path, 'file_v1', query):
+            dimensions = f'{record[7]} x {record[8]}' if record[7] or record[8] else ''
+            data_list.append((
+                _ms(record[0]), _ms(record[1]), record[2], record[3], record[4], record[5],
+                record[6], dimensions, record[9], record[10], record[11], record[12],
+                record[13], record[14], record[15], record[16],
+            ))
 
     data_headers = (
         ('Added Time', 'datetime'),
@@ -757,12 +770,12 @@ def galleryvault_hidden_files(context):
         'UUID',
         'Source',
     )
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)
 
 
 @artifact_processor
 def galleryvault_folders(context):
-    source_path = _galleryvault_db(context.get_files_found())
+    source_paths = _galleryvault_dbs(unique_files(context))
     data_list = []
     query = '''
     SELECT create_time_utc, name, folder_type, child_file_count, child_folder_count,
@@ -770,7 +783,7 @@ def galleryvault_folders(context):
     FROM folder_v1
     ORDER BY create_time_utc
     '''
-    for record in _query(source_path, 'folder_v1', query):
+    for record in _query_all(source_paths, 'folder_v1', query):
         data_list.append((
             _ms(record[0]), record[1], FOLDER_TYPES.get(record[2], record[2]), record[3],
             record[4], record[5], 'Yes' if record[6] else 'No', record[7], record[8],
@@ -787,12 +800,12 @@ def galleryvault_folders(context):
         'UUID',
         'Folder ID',
     )
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)
 
 
 @artifact_processor
 def galleryvault_break_in_reports(context):
-    source_path = _galleryvault_db(context.get_files_found())
+    source_paths = _galleryvault_dbs(unique_files(context))
     data_list = []
     query = '''
     SELECT timestamp, wrongly_attempt_code, locking_type, photo_path, location_latitude,
@@ -800,7 +813,7 @@ def galleryvault_break_in_reports(context):
     FROM break_in_report
     ORDER BY timestamp
     '''
-    for record in _query(source_path, 'break_in_report', query):
+    for record in _query_all(source_paths, 'break_in_report', query):
         media = check_in_media(record[3], os.path.basename(record[3] or '')) or '' if record[3] else ''
         data_list.append((
             _ms(record[0]), record[1], record[2], media, record[3], record[4], record[5],
@@ -818,7 +831,7 @@ def galleryvault_break_in_reports(context):
         'Address',
         'Unread',
     )
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)
 
 
 @artifact_processor
@@ -892,10 +905,10 @@ def galleryvault_applock_break_ins(context):
 
 @artifact_processor
 def galleryvault_browser_history(context):
-    source_path = _galleryvault_db(context.get_files_found())
+    source_paths = _galleryvault_dbs(unique_files(context))
     data_list = []
     query = 'SELECT last_visit_time_utc, title, url, host FROM browser_history ORDER BY last_visit_time_utc'
-    for record in _query(source_path, 'browser_history', query):
+    for record in _query_all(source_paths, 'browser_history', query):
         data_list.append((_ms(record[0]), record[1], record[2], record[3]))
 
     data_headers = (
@@ -904,19 +917,19 @@ def galleryvault_browser_history(context):
         'URL',
         'Host',
     )
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)
 
 
 @artifact_processor
 def galleryvault_browser_urls(context):
-    source_path = _galleryvault_db(context.get_files_found())
+    source_paths = _galleryvault_dbs(unique_files(context))
     data_list = []
     query = '''
     SELECT last_visit_time_utc, create_time_utc, title, url, visit_count, fav_icon_url
     FROM web_url
     ORDER BY _id
     '''
-    for record in _query(source_path, 'web_url', query):
+    for record in _query_all(source_paths, 'web_url', query):
         data_list.append((_ms(record[0]), _ms(record[1]), record[2], record[3], record[4], record[5]))
 
     data_headers = (
@@ -927,12 +940,12 @@ def galleryvault_browser_urls(context):
         'Visit Count',
         'Favicon URL',
     )
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)
 
 
 @artifact_processor
 def galleryvault_downloads(context):
-    source_path = _galleryvault_db(context.get_files_found())
+    source_paths = _galleryvault_dbs(unique_files(context))
     data_list = []
     query = '''
     SELECT begin_time, end_time, name, url, web_url, local_path, mime_type, total_size,
@@ -940,7 +953,7 @@ def galleryvault_downloads(context):
     FROM download_task
     ORDER BY begin_time
     '''
-    for record in _query(source_path, 'download_task', query):
+    for record in _query_all(source_paths, 'download_task', query):
         data_list.append((
             _ms(record[0]), _ms(record[1]), record[2], record[3], record[4], record[5],
             record[6], record[7], record[8], record[9], record[10], record[11], record[12],
@@ -961,12 +974,12 @@ def galleryvault_downloads(context):
         'Error Code',
         'Thumbnail URL',
     )
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)
 
 
 @artifact_processor
 def galleryvault_unhide_history(context):
-    source_path = _galleryvault_db(context.get_files_found())
+    source_paths = _galleryvault_dbs(unique_files(context))
     data_list = []
     query = '''
         SELECT action_time, create_time, name, action_type, file_type, target_path,
@@ -974,7 +987,7 @@ def galleryvault_unhide_history(context):
         FROM export_unhidden_history
         ORDER BY action_time
         '''
-    for record in _query(source_path, 'export_unhidden_history', query):
+    for record in _query_all(source_paths, 'export_unhidden_history', query):
         data_list.append((
             _ms(record[0]), _ms(record[1]), record[2], record[3], record[4], record[5],
             record[6], record[7], record[8], record[9], record[10], record[11],
@@ -994,12 +1007,12 @@ def galleryvault_unhide_history(context):
         'UUID',
         'File ID',
     )
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)
 
 
 @artifact_processor
 def galleryvault_recycle_bin(context):
-    source_path = _galleryvault_db(context.get_files_found())
+    source_paths = _galleryvault_dbs(unique_files(context))
     data_list = []
     query = '''
     SELECT recycle_bin_v1.delete_time, file_v1.name, file_v1.original_path, file_v1.mime_type,
@@ -1008,7 +1021,7 @@ def galleryvault_recycle_bin(context):
     LEFT JOIN file_v1 ON recycle_bin_v1.file_id = file_v1._id
     ORDER BY recycle_bin_v1.delete_time
     '''
-    for record in _query(source_path, 'recycle_bin_v1', query):
+    for record in _query_all(source_paths, 'recycle_bin_v1', query):
         data_list.append((_ms(record[0]), record[1], record[2], record[3], record[4],
                           record[5], record[6]))
 
@@ -1021,7 +1034,7 @@ def galleryvault_recycle_bin(context):
         'UUID',
         'File ID',
     )
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)
 
 
 @artifact_processor


### PR DESCRIPTION
A first-match accessor in OperaBrowser, PrivatePhotoVault, Threema and galleryVault kept the first store the seeker returned, so a second Android user's tabs, vault contents, account and messages were staged and then silently dropped. Each module now iterates every container, with the cross-file pairing kept inside one container: an Opera tab is dated against the same user's History, and a Threema database only opens with the key.dat beside it. galleryVault's schema probe runs per database.

All eleven second-tenant exclusions come out of `known_failures.json`; the storage-view check now passes every unit at exactly double, and the duplicate-view leg is unchanged. Recorded baselines are byte-identical. The per-container History join was additionally proven against a constructed two-user tree with divergent visit times.