### PR TITLE
Check artifact notes for unsupported claim language

### DIFF
--- a/admin/scripts/check_claim_language.py
+++ b/admin/scripts/check_claim_language.py
@@ -95,8 +95,64 @@ CLAIM_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
-# Fields that reach the examiner through the report and the LAVA manifest.
-CHECKED_FIELDS = ('name', 'description')
+# `notes` reaches the examiner too, in the report and in the artifact info modal, so the
+# same standard applies to it. It cannot use the same vocabulary, because notes do a job
+# name and description do not: they state what was tested. "empty on all 18 copies
+# tested" and "NULL for every account tested" are the coverage discipline this project
+# asks for, not claims about a person, and the completeness words would fire on every one
+# of them. Measured on 2026-08-29: the full vocabulary flags 368 of the 1,477 artifacts
+# carrying notes across the five cores, dominated by `every` (190) and `all` (72), almost
+# all of them describing a test set.
+#
+# `read by` comes out for the same reason. In notes it means read by the code, not by a
+# person: "columns are read by position", "not read by this artifact". Nineteen hits in
+# ALEAPP, all benign.
+#
+# What is left is attribution and certainty, which mean the same thing in a note as in a
+# description, and flag 52 artifacts across the five cores.
+NOTES_PATTERN = re.compile(
+    r"\bthe user (searched|typed|viewed|visited|opened|selected|deleted|read|sent|"
+    r"created|hid|chose)\b|"
+    r"\buser[- ](created|entered|typed|searched|selected|initiated)\b|"
+    r"\bsearched by\b|\btyped by\b|\bviewed by\b|\bmanually\b|"
+    r"\bproves?\b|\bdefinitively\b|\balways\b|\breliable|\bvisited\b|\bhabits?\b",
+    re.IGNORECASE,
+)
+
+# A note that *denies* a claim uses the same words as one that makes it: "not terms the
+# user searched for", "does not establish that the user viewed them", "rather than
+# anything the user chose". That denial is the wording this project asks for, so matching
+# it and demanding an allowlist entry would tax the correct behaviour and grow the
+# allowlist without bound. A match in `notes` preceded by a negation inside the same
+# clause is therefore not reported.
+#
+# The window is deliberately short. A negation two sentences back says nothing about this
+# clause, and a long window would swallow real claims. Suppressed matches are counted and
+# printed by --list, because a check that narrows its own scope silently is worse than no
+# check: the count appears under --verbose whether it is zero or not.
+NEGATION_WINDOW = 60
+NEGATION_PATTERN = re.compile(
+    r"\b(not|no|never|nor|neither|without|cannot|rather than|instead of|"
+    r"isn't|doesn't|don't|does not|do not)\b",
+    re.IGNORECASE,
+)
+
+
+def negated(text, start):
+    """True when a negation appears close enough before `start` to govern it."""
+    window = text[max(0, start - NEGATION_WINDOW):start]
+    # A sentence boundary ends the clause, so a negation before it does not govern.
+    window = window.rsplit('. ', 1)[-1]
+    return bool(NEGATION_PATTERN.search(window))
+
+
+# Fields that reach the examiner through the report and the LAVA manifest, and the
+# vocabulary each is matched against.
+CHECKED_FIELDS = {
+    'name': CLAIM_PATTERN,
+    'description': CLAIM_PATTERN,
+    'notes': NOTES_PATTERN,
+}
 
 # Reviewed exceptions, as (filename, artifact_key, field). Each needs a reason.
 ALLOWLIST = {
@@ -106,6 +162,20 @@ ALLOWLIST = {
     # "completedtransfers" is the literal name of the MEGA table being read. The
     # description no longer asserts the transfers themselves completed.
     ('mega_transfers.py', 'get_mega_transfers', 'description'),
+    # "a page visited and then navigated away from ... can be absent here" is the gap the
+    # note is warning about. The sentence states what the artifact misses, not what it proves.
+    ('OperaBrowser.py', 'opera_tab_navigation', 'notes'),
+    # "manually" sits inside the app's own category label, quoted: 272 ('Activity Tracking
+    # started manually'). It is Withings' string, not this parser's claim.
+    ('WithingsHealthMate.py', 'healthmate_trackings', 'notes'),
+    # "listing them beside an account reads as things the user chose when the container does
+    # not establish that" is the reason the titles are deliberately not enumerated. The
+    # denial follows the phrase instead of preceding it, so the negation lookback cannot see it.
+    ('disneyPlus.py', 'disneyplus_cached_content', 'notes'),
+    # "Values are typed by the calling app, not on disk" is about the MMKV value's data type.
+    # Nothing to do with a keyboard.
+    ('justalk.py', 'justalk_app_state', 'notes'),
+    ('justalk.py', 'justalk_kids_app_state', 'notes'),
 }
 
 
@@ -146,21 +216,30 @@ def load_artifacts(path):
 
 
 def scan_file(path):
-    """Return (matches, skip_reason) for one artifact module."""
+    """Return (matches, skip_reason, negated_count) for one artifact module."""
     data, skip_reason = load_artifacts(path)
     if skip_reason is not None:
-        return [], skip_reason
+        return [], skip_reason, 0
 
     filename = os.path.basename(path)
     matches = []
+    negated_counts = []
     for artifact_key, entry in data.items():
         if not isinstance(entry, dict):
             continue
-        for field in CHECKED_FIELDS:
+        for field, pattern in CHECKED_FIELDS.items():
             value = entry.get(field)
             if not isinstance(value, str):
                 continue
-            found = sorted({match.group(0).lower() for match in CLAIM_PATTERN.finditer(value)})
+            hits = list(pattern.finditer(value))
+            suppressed = 0
+            if field == 'notes':
+                kept = [hit for hit in hits if not negated(value, hit.start())]
+                suppressed = len(hits) - len(kept)
+                hits = kept
+            found = sorted({hit.group(0).lower() for hit in hits})
+            if suppressed:
+                negated_counts.append(suppressed)
             if found:
                 allowlisted = (filename, str(artifact_key), field) in ALLOWLIST
                 matches.append({
@@ -171,7 +250,7 @@ def scan_file(path):
                     'terms': found,
                     'allowlisted': allowlisted,
                 })
-    return matches, None
+    return matches, None, sum(negated_counts)
 
 
 def artifact_paths(repo_root):
@@ -198,8 +277,10 @@ def main():
     # allowlisted or not. An ALLOWLIST entry missing from this set matches nothing.
     fired = set()
     checked = 0
+    negated_total = 0
     for path in artifact_paths(repo_root):
-        matches, skip_reason = scan_file(path)
+        matches, skip_reason, negated_here = scan_file(path)
+        negated_total += negated_here
         if skip_reason is not None:
             skipped.append((os.path.basename(path), skip_reason))
             continue
@@ -224,6 +305,7 @@ def main():
               f'{len(skipped)} not checked.')
         allowed_count = sum(1 for match in all_matches if match['allowlisted'])
         print(f'Allowlist holds {len(ALLOWLIST)} entr(ies); {allowed_count} fired this run.')
+        print(f'{negated_total} match(es) in notes were preceded by a negation and not reported.')
         print()
 
     # A stale entry shields nothing except the next claim that lands under that key.

--- a/admin/test/scripts/test_check_claim_language.py
+++ b/admin/test/scripts/test_check_claim_language.py
@@ -1,0 +1,133 @@
+"""Prove the claim checker reads notes, and reads them with the right vocabulary.
+
+Extending the check to `notes` is only worth having if three things hold at once, and
+each fails silently on its own:
+
+* notes are actually matched, or the field is nominally covered and never read;
+* the completeness words do not apply to notes, or the check fires on every artifact
+  that states what it was tested against, which is the wording this project asks for;
+* a denial is not treated as a claim, or the same wording is taxed and the allowlist
+  grows every time somebody writes a limitation down correctly.
+
+The expected values here are spelled out as literals rather than derived from the
+patterns under test. A fixture built from the constant it verifies moves with the bug.
+"""
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_MODULE_PATH = REPO_ROOT / 'admin' / 'scripts' / 'check_claim_language.py'
+
+# admin/scripts is not a package, so load the module from its path.
+_spec = importlib.util.spec_from_file_location('check_claim_language', _MODULE_PATH)
+ccl = importlib.util.module_from_spec(_spec)
+sys.modules['check_claim_language'] = ccl
+_spec.loader.exec_module(ccl)
+
+
+def fires(field, text):
+    """True when the vocabulary for `field` reports a match in `text`, negation applied."""
+    pattern = ccl.CHECKED_FIELDS[field]
+    hits = list(pattern.finditer(text))
+    if field == 'notes':
+        hits = [hit for hit in hits if not ccl.negated(text, hit.start())]
+    return bool(hits)
+
+
+class FieldCoverage(unittest.TestCase):
+    def test_notes_is_checked(self):
+        self.assertIn('notes', ccl.CHECKED_FIELDS)
+
+    def test_name_and_description_keep_the_full_vocabulary(self):
+        self.assertIs(ccl.CHECKED_FIELDS['name'], ccl.CLAIM_PATTERN)
+        self.assertIs(ccl.CHECKED_FIELDS['description'], ccl.CLAIM_PATTERN)
+
+    def test_notes_uses_its_own_vocabulary(self):
+        self.assertIs(ccl.CHECKED_FIELDS['notes'], ccl.NOTES_PATTERN)
+
+
+class NotesVocabulary(unittest.TestCase):
+    # Attribution and certainty mean the same thing in a note as in a description.
+    CLAIMS = (
+        'the term the user typed into the search box',
+        'a page the user visited',
+        'a term the user entered',
+        'this proves the account holder sent it',
+        'the column is always populated',
+        'a reliable record of the conversation',
+    )
+    # Notes state what was tested. These must stay silent or the check punishes the
+    # coverage discipline it exists alongside.
+    COVERAGE = (
+        'empty on all 18 copies tested',
+        'NULL for every account tested',
+        'the complete table list is given above',
+        'present on the entire corpus',
+        'columns are read by position over a select star',
+        'the sidecar is not read by this artifact',
+    )
+
+    def test_claims_fire(self):
+        for text in self.CLAIMS:
+            with self.subTest(text=text):
+                self.assertTrue(fires('notes', text))
+
+    def test_coverage_wording_stays_silent(self):
+        for text in self.COVERAGE:
+            with self.subTest(text=text):
+                self.assertFalse(fires('notes', text))
+
+    def test_notes_drops_exactly_the_two_documented_classes(self):
+        """The two vocabularies differ only where the module says they do.
+
+        Anything else diverging means one of them has been edited alone, which is how
+        the check for one field quietly stops matching the check for another.
+        """
+        removed = ('all', 'every', 'complete', 'entire', 'full list', 'read by')
+        for word in removed:
+            with self.subTest(word=word, vocabulary='description'):
+                self.assertTrue(ccl.CLAIM_PATTERN.search(word))
+            with self.subTest(word=word, vocabulary='notes'):
+                self.assertFalse(ccl.NOTES_PATTERN.search(word))
+        kept = ('the user typed', 'typed by', 'manually', 'proves', 'always',
+                'reliable', 'visited', 'habits', 'user-created')
+        for word in kept:
+            with self.subTest(word=word):
+                self.assertTrue(ccl.CLAIM_PATTERN.search(word))
+                self.assertTrue(ccl.NOTES_PATTERN.search(word))
+
+    def test_description_still_flags_completeness(self):
+        # The narrowing applies to notes only. Regression guard on the original behaviour.
+        self.assertTrue(fires('description', 'every message in the conversation'))
+        self.assertTrue(fires('description', 'all sites the user visited'))
+
+
+class Negation(unittest.TestCase):
+    def test_denial_in_the_same_clause_is_not_a_claim(self):
+        for text in (
+            'this store holds suggestions the app downloaded, not terms the user searched for',
+            'their presence does not establish that the user viewed them',
+            'they evidence the app running rather than anything the user chose',
+            'the app stores no user created images',
+        ):
+            with self.subTest(text=text):
+                self.assertFalse(fires('notes', text))
+
+    def test_a_negation_in_the_previous_sentence_does_not_carry(self):
+        # "not" governs its own clause. A full stop ends it, so the claim after it stands.
+        text = 'The table is not a cache. It records the term the user typed.'
+        self.assertTrue(fires('notes', text))
+
+    def test_a_distant_negation_does_not_carry(self):
+        # Sixty characters is the window; padding past it must leave the claim visible.
+        text = 'not' + ' x' * 45 + ' the term the user typed'
+        self.assertTrue(fires('notes', text))
+
+    def test_the_window_is_bounded_and_short(self):
+        self.assertLessEqual(ccl.NEGATION_WINDOW, 80)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/artifacts/Zapya.py
+++ b/scripts/artifacts/Zapya.py
@@ -4,14 +4,14 @@ __artifacts_v2__ = {
         "description": "Parses Zapya file transfer records (device, name, direction, timestamp, path and title) from the transfer20.db database.",
         "author": "@markmckinnon",
         "creation_date": "2020-03-21",
-        "last_update_date": "2026-08-01",
+        "last_update_date": "2026-08-29",
         "requirements": "none",
         "category": "File Transfer",
         "notes": ("direction is decoded from the transfer table 'direction' column. "
                   "Direction/status value mappings were established through testing; unrecognized "
                   "values are reported as stored.\n"
                   "fromid and toid are populated only when the direction value is recognized; the "
-                  "other device recorded on the row is always present in the Device column."),
+                  "other device recorded on the row is reported in the Device column regardless."),
         "paths": ('*/com.dewmobile.kuaiya.play/databases/transfer20.db*',),
         "output_types": "standard",
         "artifact_icon": "download",

--- a/scripts/artifacts/dhl.py
+++ b/scripts/artifacts/dhl.py
@@ -5,11 +5,11 @@ __artifacts_v2__ = {
                        "airway bill number and the time it was searched.",
         "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-20",
-        "last_update_date": "2026-08-20",
+        "last_update_date": "2026-08-29",
         "requirements": "none",
         "category": "DHL",
-        "notes": "One row per tracking search. Airway Bill is the shipment number the user "
-                 "entered or opened, and Search Date is when the app recorded the search. "
+        "notes": "One row per tracking search. Airway Bill is the shipment number the row "
+                 "records, and Search Date is when the app recorded the search. "
                  "The row carries the account identifier that made the search; a search made "
                  "before sign in carries a zero account, which is why one of the two rows on "
                  "the tested device did. Search Date is stored as local text with no zone, so "

--- a/scripts/artifacts/imo.py
+++ b/scripts/artifacts/imo.py
@@ -21,7 +21,7 @@ __artifacts_v2__ = {
         "description": "Parses IMO messages (timestamp, sender and recipient IDs, message, direction, read status and attachments) from the IMO imofriends.db.",
         "author": "@markmckinnon",
         "creation_date": "2021-03-11",
-        "last_update_date": "2026-08-01",
+        "last_update_date": "2026-08-29",
         "requirements": "none",
         "category": "IMO",
         "notes": ("Direction is decoded from the messages table 'message_type' column. "
@@ -32,7 +32,7 @@ __artifacts_v2__ = {
                   "device owner; a row whose direction value is blank or unrecognized is not "
                   "attributed to the owner.\n"
                   "From ID and To ID are filled only when the direction is recognized; the other "
-                  "party is always present in Chat Partner."),
+                  "party is reported in Chat Partner regardless."),
         "paths": ('*/com.imo.android.imous/databases/imofriends.db*',),
         "output_types": "standard",
         "artifact_icon": "message",

--- a/scripts/artifacts/pinterest.py
+++ b/scripts/artifacts/pinterest.py
@@ -4,7 +4,7 @@ __artifacts_v2__ = {
         "description": "Parses the signed in account record stored by the Pinterest Android app.",
         "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-18",
-        "last_update_date": "2026-08-18",
+        "last_update_date": "2026-08-29",
         "requirements": "none",
         "category": "Pinterest",
         "notes": "Read from the PREF_MY_USER value of the app's own preferences file, which holds "
@@ -12,7 +12,8 @@ __artifacts_v2__ = {
                  "formatted text carrying no time zone, so they are reported as stored rather than "
                  "converted. Birthday is a Unix second value; on the tested sample it landed at "
                  "midday UTC, so only its date part is meaningful. A birth date before 1970 is stored "
-                 "as a negative value, and this column is always seconds, so it is converted in "
+                 "as a negative value, and this column is seconds rather than milliseconds, so "
+                 "it is converted in "
                  "this module rather than inferred from its magnitude. Gender, "
                  "email status and the account type are reported as stored. The counts are the "
                  "values the record carries, not a count of anything parsed from this extraction. "

--- a/scripts/artifacts/smyfilesMetadata.py
+++ b/scripts/artifacts/smyfilesMetadata.py
@@ -87,10 +87,11 @@ __artifacts_v2__ = {
         "description": "File search terms and timestamps from the Samsung My Files FileInfo.db search_history table",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-08-14",
-        "last_update_date": "2026-08-14",
+        "last_update_date": "2026-08-29",
         "requirements": "none",
         "category": "My Files",
-        "notes": "search_history records terms the user typed into the My Files search box. Empty on the "
+        "notes": "search_history holds the search terms the store records for the My Files "
+                 "search box. Empty on the "
                  "registered corpora; the layout was mapped against a private Android 16 sample.",
         "paths": ('*/com.sec.android.app.myfiles/databases/FileInfo.db*',),
         "output_types": "standard",

--- a/scripts/artifacts/yahooMail.py
+++ b/scripts/artifacts/yahooMail.py
@@ -47,7 +47,7 @@ __artifacts_v2__ = {
                        "with the message and unread counts held for each.",
         "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
-        "last_update_date": "2026-08-19",
+        "last_update_date": "2026-08-29",
         "requirements": "none",
         "category": "Yahoo Mail",
         "notes": "One row per folder record. Total Messages and Unread Messages are the "
@@ -59,8 +59,8 @@ __artifacts_v2__ = {
                  "here, because a server side removal, a later re-sync and a local eviction "
                  "all leave the same result. Folder Name is reported as stored. Where the "
                  "stored name decodes from base64 to printable text the decode is offered in "
-                 "its own column, which on the tested device filled for one user created "
-                 "folder and stayed empty for the rest; no source establishes which names the "
+                 "its own column, which on the tested device filled for one folder and "
+                 "stayed empty for the rest; no source establishes which names the "
                  "app encodes, so the stored value is the one to rely on. Folder Types is "
                  "reported as stored. Field mapping was done against a private sample "
                  "provided by Mattia; no sample data is recorded for it.",


### PR DESCRIPTION
Extends the claim-language check to the artifact `notes` field, which reaches the report and the LAVA manifest and was not covered.

- Notes get their own vocabulary. The completeness words are dropped, because a note states what it was tested against ("empty on all 18 copies tested"). `read by` is dropped because in a note it means read by the code.
- A match preceded by a negation in the same clause is not reported, so a note that denies a claim is not flagged for making it. Suppressed matches are counted and printed under `--verbose`.
- Six notes reworded, five reviewed exceptions allowlisted with a reason each.

Measured across the five cores: the existing vocabulary would flag 368 of the 1,477 artifacts carrying notes, this one flags 52. Core change, ALEAPP only for now.
