### PR TITLE
Scope each claim-language allowlist entry to its term

### DIFF
--- a/admin/scripts/check_claim_language.py
+++ b/admin/scripts/check_claim_language.py
@@ -154,29 +154,41 @@ CHECKED_FIELDS = {
     'notes': NOTES_PATTERN,
 }
 
-# Reviewed exceptions, as (filename, artifact_key, field). Each needs a reason.
+# Reviewed exceptions, as (filename, artifact_key, field, term). Each needs a
+# reason. The term is part of the key, so an entry silences the one word it was
+# granted for and never the next claim added to the same text.
 ALLOWLIST = {
     # "completed" names columns the artifact emits (completed time) and the Google Tasks
     # status value, not a claim that the task list is complete.
-    ('googleTasks.py', 'get_googleTasks', 'description'),
+    ('googleTasks.py', 'get_googleTasks', 'description', 'complete'),
     # "completedtransfers" is the literal name of the MEGA table being read. The
     # description no longer asserts the transfers themselves completed.
-    ('mega_transfers.py', 'get_mega_transfers', 'description'),
+    ('mega_transfers.py', 'get_mega_transfers', 'description', 'complete'),
     # "a page visited and then navigated away from ... can be absent here" is the gap the
     # note is warning about. The sentence states what the artifact misses, not what it proves.
-    ('OperaBrowser.py', 'opera_tab_navigation', 'notes'),
+    ('OperaBrowser.py', 'opera_tab_navigation', 'notes', 'visited'),
     # "manually" sits inside the app's own category label, quoted: 272 ('Activity Tracking
     # started manually'). It is Withings' string, not this parser's claim.
-    ('WithingsHealthMate.py', 'healthmate_trackings', 'notes'),
+    ('WithingsHealthMate.py', 'healthmate_trackings', 'notes', 'manually'),
     # "listing them beside an account reads as things the user chose when the container does
     # not establish that" is the reason the titles are deliberately not enumerated. The
     # denial follows the phrase instead of preceding it, so the negation lookback cannot see it.
-    ('disneyPlus.py', 'disneyplus_cached_content', 'notes'),
+    ('disneyPlus.py', 'disneyplus_cached_content', 'notes', 'the user chose'),
     # "Values are typed by the calling app, not on disk" is about the MMKV value's data type.
     # Nothing to do with a keyboard.
-    ('justalk.py', 'justalk_app_state', 'notes'),
-    ('justalk.py', 'justalk_kids_app_state', 'notes'),
+    ('justalk.py', 'justalk_app_state', 'notes', 'typed by'),
+    ('justalk.py', 'justalk_kids_app_state', 'notes', 'typed by'),
 }
+
+
+def unallowlisted(filename, artifact_key, field, terms):
+    """The terms no ALLOWLIST entry covers for this field.
+
+    An entry is keyed on the term it was granted for, so allowlisting one word does
+    not pre-approve the next claim somebody adds to the same text.
+    """
+    return [term for term in terms
+            if (filename, str(artifact_key), field, term) not in ALLOWLIST]
 
 
 def find_artifacts_dict(tree):
@@ -241,13 +253,15 @@ def scan_file(path):
             if suppressed:
                 negated_counts.append(suppressed)
             if found:
-                allowlisted = (filename, str(artifact_key), field) in ALLOWLIST
+                remaining = unallowlisted(filename, artifact_key, field, found)
+                allowlisted = not remaining
                 matches.append({
                     'filename': filename,
                     'artifact_key': str(artifact_key),
                     'field': field,
                     'text': value,
-                    'terms': found,
+                    'terms': remaining or found,
+                    'all_terms': found,
                     'allowlisted': allowlisted,
                 })
     return matches, None, sum(negated_counts)
@@ -286,7 +300,9 @@ def main():
             continue
         checked += 1
         for match in matches:
-            fired.add((match['filename'], match['artifact_key'], match['field']))
+            for term in match['all_terms']:
+                fired.add((match['filename'], match['artifact_key'],
+                           match['field'], term))
         all_matches.extend(matches)
 
     stale = sorted(ALLOWLIST - fired)
@@ -313,7 +329,7 @@ def main():
         print(f'Stale ALLOWLIST entr(ies) ({len(stale)}) -- these no longer match anything '
               f'and should be deleted:')
         for entry in stale:
-            print(f'  {entry[0]}:{entry[1]}:{entry[2]}')
+            print(f'  {entry[0]}:{entry[1]}:{entry[2]}  [{entry[3]}]')
         print()
 
     if args.list_all:

--- a/admin/test/scripts/test_check_claim_language.py
+++ b/admin/test/scripts/test_check_claim_language.py
@@ -175,5 +175,46 @@ class Negation(unittest.TestCase):
         self.assertTrue(fires('notes', text))
 
 
+class AllowlistIsTermScoped(unittest.TestCase):
+    """An exception silences the word it was granted for, not the whole field.
+
+    Keyed on (file, artifact_key, field) an entry pre-approves every future claim
+    anyone adds to that text. The term is part of the key so that it does not.
+    """
+
+    def test_every_entry_is_a_four_tuple_of_strings(self):
+        for entry in ccl.ALLOWLIST:
+            with self.subTest(entry=entry):
+                self.assertEqual(len(entry), 4)
+                self.assertTrue(all(isinstance(part, str) for part in entry))
+
+    def test_every_entry_names_a_term_the_vocabulary_can_produce(self):
+        # A term no pattern can emit is dead on arrival: it silences nothing and the
+        # stale check cannot tell it apart from an entry whose text was reworded.
+        for filename, artifact_key, field, term in ccl.ALLOWLIST:
+            with self.subTest(entry=(filename, artifact_key, field, term)):
+                self.assertEqual(term, term.lower())
+                match = ccl.CHECKED_FIELDS[field].search(term)
+                self.assertIsNotNone(match, f'{term!r} is not in the {field} vocabulary')
+                self.assertEqual(match.group(0).lower(), term)
+
+    def test_an_entry_covers_its_own_term_only(self):
+        # A key no repo can hold, so this behaves the same in all five.
+        probe = ('no_such_module.py', 'no_such_artifact', 'notes')
+        self.assertEqual(
+            ccl.unallowlisted(*probe, ['always', 'the user typed']),
+            ['always', 'the user typed'])
+
+    def test_unallowlisted_returns_only_what_is_uncovered(self):
+        for filename, artifact_key, field, term in sorted(ccl.ALLOWLIST):
+            covered = ccl.unallowlisted(filename, artifact_key, field, [term])
+            self.assertEqual(covered, [], f'{term!r} should be covered by its own entry')
+            # A different term on the same field must still be reported.
+            other = 'proves' if term != 'proves' else 'always'
+            self.assertEqual(
+                ccl.unallowlisted(filename, artifact_key, field, [term, other]), [other])
+            break   # one entry is enough; repos with an empty allowlist skip the loop
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Follow-up to the notes claim-checking work. An `ALLOWLIST` entry was keyed on `(file, artifact_key, field)`, so it silenced the whole field: allowlisting one word pre-approved every future claim added to the same text.

- The key now carries the term, so an entry silences the word it was granted for and nothing else.
- A report names only the terms no entry covers, so a new claim in an already-allowlisted note is reported on its own.
- Stale detection compares on the term too, and the message names it.

Existing entries keep their effect: each term was derived from what it silences today, so nothing new is reported. Across the five cores 27 entries become 29 tuples, two of them having covered two terms each.
