### PR TITLE
Anchor the passive claim forms on a person and complete the verb list

### DIFF
--- a/admin/scripts/check_claim_language.py
+++ b/admin/scripts/check_claim_language.py
@@ -90,7 +90,8 @@ CLAIM_PATTERN = re.compile(
     r"\bthe user (?:searched|typed|viewed|visited|opened|selected|deleted|read|sent|"
     r"created|hid|chose)\b|"
     r"\buser[- ](?:created|entered|typed|searched|selected|initiated)\b|"
-    r"\bsearched by\b|\btyped by\b|\bviewed by\b|\bread by\b|\bmanually\b|"
+    r"\b(?:searched|typed|viewed|read|entered|created|sent|opened|selected|deleted|v"
+    r"isited|chosen|hidden|initiated) by (?:the |a |an )?(?:user|account holder|device owner|subject|owner)\b|\bmanually\b|"
     r"\bproves?\b|\bdefinitively\b|\balways\b|\breliable|\bvisited\b|\bhabits?\b",
     re.IGNORECASE,
 )
@@ -114,7 +115,8 @@ NOTES_PATTERN = re.compile(
     r"\bthe user (?:searched|typed|viewed|visited|opened|selected|deleted|read|sent|"
     r"created|hid|chose)\b|"
     r"\buser[- ](?:created|entered|typed|searched|selected|initiated)\b|"
-    r"\bsearched by\b|\btyped by\b|\bviewed by\b|\bmanually\b|"
+    r"\b(?:searched|typed|viewed|read|entered|created|sent|opened|selected|deleted|v"
+    r"isited|chosen|hidden|initiated) by (?:the |a |an )?(?:user|account holder|device owner|subject|owner)\b|\bmanually\b|"
     r"\bproves?\b|\bdefinitively\b|\balways\b|\breliable|\bvisited\b|\bhabits?\b",
     re.IGNORECASE,
 )
@@ -174,10 +176,6 @@ ALLOWLIST = {
     # not establish that" is the reason the titles are deliberately not enumerated. The
     # denial follows the phrase instead of preceding it, so the negation lookback cannot see it.
     ('disneyPlus.py', 'disneyplus_cached_content', 'notes', 'the user chose'),
-    # "Values are typed by the calling app, not on disk" is about the MMKV value's data type.
-    # Nothing to do with a keyboard.
-    ('justalk.py', 'justalk_app_state', 'notes', 'typed by'),
-    ('justalk.py', 'justalk_kids_app_state', 'notes', 'typed by'),
 }
 
 

--- a/admin/test/scripts/test_check_claim_language.py
+++ b/admin/test/scripts/test_check_claim_language.py
@@ -39,16 +39,20 @@ EXPECTED_CLAIM = (
     r'\ball\b|\bevery\b|\bcomplete|\bfull list\b|\bentire\b|'
     r'\bthe user (?:searched|typed|viewed|visited|opened|selected|deleted|'
     r'read|sent|created|hid|chose)\b|\buser[- ](?:created|entered|typed|'
-    r'searched|selected|initiated)\b|\bsearched by\b|\btyped by\b|'
-    r'\bviewed by\b|\bread by\b|\bmanually\b|\bproves?\b|\bdefinitively\b|'
+    r'searched|selected|initiated)\b|\b(?:searched|typed|viewed|read|'
+    r'entered|created|sent|opened|selected|deleted|visited|chosen|hidden|'
+    r'initiated) by (?:the |a |an )?(?:user|account holder|device owner|'
+    r'subject|owner)\b|\bmanually\b|\bproves?\b|\bdefinitively\b|'
     r'\balways\b|\breliable|\bvisited\b|\bhabits?\b'
 )
 EXPECTED_NOTES = (
     r'\bthe user (?:searched|typed|viewed|visited|opened|selected|deleted|'
     r'read|sent|created|hid|chose)\b|\buser[- ](?:created|entered|typed|'
-    r'searched|selected|initiated)\b|\bsearched by\b|\btyped by\b|'
-    r'\bviewed by\b|\bmanually\b|\bproves?\b|\bdefinitively\b|\balways\b|'
-    r'\breliable|\bvisited\b|\bhabits?\b'
+    r'searched|selected|initiated)\b|\b(?:searched|typed|viewed|read|'
+    r'entered|created|sent|opened|selected|deleted|visited|chosen|hidden|'
+    r'initiated) by (?:the |a |an )?(?:user|account holder|device owner|'
+    r'subject|owner)\b|\bmanually\b|\bproves?\b|\bdefinitively\b|'
+    r'\balways\b|\breliable|\bvisited\b|\bhabits?\b'
 )
 EXPECTED_NEGATION = (
     r'\b(not|no|never|nor|neither|without|cannot|rather than|instead of|'
@@ -119,6 +123,7 @@ class NotesVocabulary(unittest.TestCase):
         'the complete table list is given above',
         'present on the entire corpus',
         'columns are read by position over a select star',
+        'the value entered by the calling app',
         'the sidecar is not read by this artifact',
     )
 
@@ -134,13 +139,13 @@ class NotesVocabulary(unittest.TestCase):
 
     def test_notes_drops_exactly_the_two_documented_classes(self):
         """The two vocabularies differ only where the module says they do."""
-        removed = ('all', 'every', 'complete', 'entire', 'full list', 'read by')
+        removed = ('all', 'every', 'complete', 'entire', 'full list')
         for word in removed:
             with self.subTest(word=word, vocabulary='description'):
                 self.assertTrue(ccl.CLAIM_PATTERN.search(word))
             with self.subTest(word=word, vocabulary='notes'):
                 self.assertFalse(ccl.NOTES_PATTERN.search(word))
-        kept = ('the user typed', 'typed by', 'manually', 'proves', 'always',
+        kept = ('the user typed', 'typed by the user', 'manually', 'proves', 'always',
                 'reliable', 'visited', 'habits', 'user-created')
         for word in kept:
             with self.subTest(word=word):
@@ -214,6 +219,44 @@ class AllowlistIsTermScoped(unittest.TestCase):
             self.assertEqual(
                 ccl.unallowlisted(filename, artifact_key, field, [term, other]), [other])
             break   # one entry is enough; repos with an empty allowlist skip the loop
+
+
+class PassiveFormsAreAnchoredOnAPerson(unittest.TestCase):
+    """The passive family must cover the same verbs as the active one, and fire only
+    when the subject is a person.
+
+    Left short, the check was evadable by voice alone: "the user created" was flagged
+    and "created by the user" was not, with nothing about the claim changed. Left
+    unanchored, "<verb> by" matched a subject that is not a person, which is what put
+    two entries on the allowlist and kept `read by` out of the notes vocabulary.
+    """
+
+    VERBS = ('searched', 'typed', 'viewed', 'read', 'entered', 'created', 'sent',
+             'opened', 'selected', 'deleted', 'visited', 'chosen', 'hidden', 'initiated')
+
+    def test_a_person_as_the_subject_fires_in_both_voices(self):
+        for verb in self.VERBS:
+            for field in ('description', 'notes'):
+                with self.subTest(verb=verb, field=field):
+                    self.assertTrue(fires(field, f'the value {verb} by the user'))
+
+    def test_a_non_person_subject_stays_silent(self):
+        for text in ('columns are read by position',
+                     'values are typed by the calling app',
+                     'rows searched by the indexer',
+                     'a record created by the sync service',
+                     'the file opened by the parser'):
+            for field in ('description', 'notes'):
+                with self.subTest(text=text, field=field):
+                    self.assertFalse(fires(field, text))
+
+    def test_the_two_vocabularies_agree_on_the_passive_family(self):
+        # They diverge only where the module documents a reason, and this is not one.
+        for verb in self.VERBS:
+            probe = f'{verb} by the account holder'
+            with self.subTest(verb=verb):
+                self.assertEqual(bool(ccl.CLAIM_PATTERN.search(probe)),
+                                 bool(ccl.NOTES_PATTERN.search(probe)))
 
 
 if __name__ == '__main__':

--- a/scripts/artifacts/Viber.py
+++ b/scripts/artifacts/Viber.py
@@ -47,13 +47,13 @@ __artifacts_v2__ = {
         "description": "Parses Viber messages (date, sender and recipients, thread, content, direction, unread flag and attachments) from the Viber databases.",
         "author": "@markmckinnon",
         "creation_date": "2020-12-24",
-        "last_update_date": "2026-08-01",
+        "last_update_date": "2026-08-29",
         "requirements": "none",
         "category": "Viber",
         "notes": ("Direction is decoded from the messages table 'send_type' column. Direction/status "
                   "value mappings were established through testing; unrecognized values are reported "
                   "as stored.\n"
-                  "In the conversation view only rows labelled Outgoing are shown as sent by the "
+                  "In the conversation view only rows labelled Outgoing are attributed to the "
                   "device owner; a row whose direction value is blank or unrecognized is not "
                   "attributed to the owner.\n"
                   "Unread carries the messages table 'unread' column as stored; it is not a "

--- a/scripts/artifacts/imo.py
+++ b/scripts/artifacts/imo.py
@@ -28,7 +28,7 @@ __artifacts_v2__ = {
                   "Direction/status value mappings were established through testing; unrecognized "
                   "values are reported as stored, so rows the mapping does not cover are not "
                   "labelled as sent or received.\n"
-                  "In the conversation view only rows labelled Outgoing are shown as sent by the "
+                  "In the conversation view only rows labelled Outgoing are attributed to the "
                   "device owner; a row whose direction value is blank or unrecognized is not "
                   "attributed to the owner.\n"
                   "From ID and To ID are filled only when the direction is recognized; the other "

--- a/scripts/artifacts/kleinanzeigen.de.py
+++ b/scripts/artifacts/kleinanzeigen.de.py
@@ -59,14 +59,14 @@ __artifacts_v2__ = {
         "description": "Extracts individual messages from the message database",
         "author": "@BrunoFischerGermany",
         "creation_date": "2024-04-13",
-        "last_update_date": "2026-08-01",
+        "last_update_date": "2026-08-29",
         "requirements": "none",
         "category": "kleinanzeigen.de App",
         "notes": ("Direction is decoded from each message's 'sender' value: 'ME' identifies a "
                   "message sent from this device. Direction/status value mappings were established "
                   "through testing; any other sender value is reported as stored, and a message "
                   "with no sender value is left blank.\n"
-                  "In the conversation view only rows labelled Outgoing are shown as sent by the "
+                  "In the conversation view only rows labelled Outgoing are attributed to the "
                   "device owner; a row whose direction value is blank or unrecognized is not "
                   "attributed to the owner.\n"
                   "Timestamp is converted from the stored ISO 8601 string; a value that cannot be "

--- a/scripts/artifacts/knuddels.py
+++ b/scripts/artifacts/knuddels.py
@@ -5,7 +5,7 @@ __artifacts_v2__ = {
         "description": "Extracts Knuddels chats (text, images/snaps and GIFs) from database files",
         "author": "@annkirpv",
         "creation_date": "2025-05-04",
-        "last_update_date": "2026-08-01",
+        "last_update_date": "2026-08-29",
         "requirements": "none",
         "category": "Chats",
         "notes": ("From Me is derived from the database file name: the owner's nickname is taken to "
@@ -14,7 +14,7 @@ __artifacts_v2__ = {
                   "the file name does not follow that convention the owner cannot be established "
                   "and the column is left blank for every row of that database rather than "
                   "reporting the messages as received.\n"
-                  "In the conversation view only rows with From Me set to 1 are shown as sent by "
+                  "In the conversation view only rows with From Me set to 1 are attributed to "
                   "the device owner; a blank value is not attributed to the owner.\n"
                   "Message Type is derived from markers found in the message text. A message that "
                   "carries the app's marker prefix but no marker this parser recognises is reported "

--- a/scripts/artifacts/line.py
+++ b/scripts/artifacts/line.py
@@ -24,13 +24,13 @@ __artifacts_v2__ = {
         "description": "Parses LINE messages (time, sender and recipient IDs, direction, thread, message and attachments) from the LINE databases.",
         "author": "@markmckinnon",
         "creation_date": "2021-03-15",
-        "last_update_date": "2026-08-15",
+        "last_update_date": "2026-08-29",
         "requirements": "none",
         "category": "Line",
         "notes": ("Direction is decoded from the chat_history 'status' column. Direction/status "
                   "value mappings were established through testing; unrecognized values are "
                   "reported as stored.\n"
-                  "In the conversation view only rows labelled Outgoing are shown as sent by the "
+                  "In the conversation view only rows labelled Outgoing are attributed to the "
                   "device owner; a row whose direction value is blank or unrecognized is not "
                   "attributed to the owner.\n"
                   "To ID is filled only for rows recognized as outgoing.\n"

--- a/scripts/artifacts/skype.py
+++ b/scripts/artifacts/skype.py
@@ -24,13 +24,13 @@ __artifacts_v2__ = {
         "description": "Parses Skype messages (send time, thread, content, direction, sender and recipient IDs and attachments) from the Skype live database.",
         "author": "@markmckinnon",
         "creation_date": "2021-03-15",
-        "last_update_date": "2026-08-01",
+        "last_update_date": "2026-08-29",
         "requirements": "none",
         "category": "Skype",
         "notes": ("Direction is decoded from the chatitem 'is_sender_me' flag. Direction/status "
                   "value mappings were established through testing; unrecognized values, including "
                   "NULL, are left blank rather than assigned a direction.\n"
-                  "In the conversation view only rows labelled Outgoing are shown as sent by the "
+                  "In the conversation view only rows labelled Outgoing are attributed to the "
                   "device owner; a row whose direction is blank is not attributed to the owner.\n"
                   "To ID is filled only for rows recognized as outgoing."),
         "paths": ('*/com.skype.raider/databases/live*',),


### PR DESCRIPTION
The passive claim forms had two defects pointing opposite ways.

- **Incomplete.** They covered 4 of the 13 verbs the active family covers, so the check was evadable by voice alone: `the user created` was flagged and `created by the user` was not, with nothing about the claim changed.
- **Unanchored.** `<verb> by` matched a subject that is not a person. Across the five cores, 24 of the 26 bare matches had one: `columns are read by position`, `typed by the calling app`. That is why `read by` had been dropped from the notes vocabulary and why two entries sat on the allowlist.

Anchoring on a person fixes both. `read by` returns to the notes vocabulary, where it occurs zero times with a person as the subject, and the two entries it forced are retired.

The shared test pins the new vocabulary and asserts the active and passive voices stay in step.
