### PR TITLE
Add Fossify support for Android

### DIFF
--- a/scripts/artifacts/fossifyCalendar.py
+++ b/scripts/artifacts/fossifyCalendar.py
@@ -39,6 +39,9 @@ __artifacts_v2__ = {
         ),
         "output_types": "standard",
         "artifact_icon": "calendar",
+        "sample_data": {
+            "emu_a15_oss_v2": "Android 15 | org.fossify.calendar vc 20 | 1 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/fossifyCalendar.py
+++ b/scripts/artifacts/fossifyCalendar.py
@@ -1,0 +1,122 @@
+__artifacts_v2__ = {
+    "fossify_calendar_events": {
+        "name": "Fossify Calendar - Events",
+        "description": "Parses calendar events and tasks stored by the Fossify Calendar Android app and its Simple Mobile Tools predecessor.",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-08-30",
+        "last_update_date": "2026-08-30",
+        "requirements": "none",
+        "category": "Fossify Calendar",
+        "notes": "One row per entry in the events table of databases/events.db, joined to event_types for "
+                 "the calendar name. The table holds both calendar events and the app's tasks, told "
+                 "apart by the Type column (0 an event, 1 a task, per TYPE_EVENT and TYPE_TASK in "
+                 "Constants.kt at FossifyOrg/Calendar b269b99bb7152f126677278b486de24f6f1050ff). Title, "
+                 "Location and Description carry the event's own text as stored, and Location and "
+                 "Description were empty on the tested event. Start "
+                 "and End come from start_ts and end_ts, which are Unix seconds; on the tested device a "
+                 "2:00 PM local event stored 1788112800, which is 18:00 UTC and matches the device's "
+                 "America/New_York zone, so they are reported as UTC and the event's own Time Zone is "
+                 "carried in its column. All Day is the FLAG_ALL_DAY bit of the flags column; for an "
+                 "all-day event the time of day is not meaningful and the stored value encodes the date, "
+                 "so its UTC rendering can fall on the previous day, which is not exercised on the tested "
+                 "data. Reminders lists the minutes-before values that are set (a value of -1 means that "
+                 "reminder slot is off, per REMINDER_OFF). Repeats is Yes when the event has a non-zero "
+                 "recurrence interval; the interval, rule and limit are stored but not decoded here. "
+                 "Attendees is the app's stored attendee list as stored. Status is decoded from the "
+                 "Android CalendarContract.Events values 0 tentative, 1 confirmed, 2 cancelled. Last "
+                 "Updated comes from last_updated, which is Unix milliseconds. Source is the app's own "
+                 "origin marker as stored, for example simple-calendar for an event created in the app, "
+                 "imported-ics for an imported file, contact-birthday or contact-anniversary for an event "
+                 "derived from a contact, or a caldav- value for a synced calendar. The tasks table holds "
+                 "task-specific state keyed to these rows and is not parsed separately. The app is the "
+                 "maintained successor to Simple Mobile Tools Calendar and uses the identical schema, so "
+                 "the paths cover both org.fossify.calendar (tested) and "
+                 "com.simplemobiletools.calendar.pro (same schema, from the shared source, not exercised "
+                 "here).",
+        "paths": (
+            '*/org.fossify.calendar/databases/events.db*',
+            '*/com.simplemobiletools.calendar.pro/databases/events.db*',
+        ),
+        "output_types": "standard",
+        "artifact_icon": "calendar",
+    }
+}
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records
+from scripts.artifacts.storagePathViews import unique_files
+
+DB_SUFFIX = 'databases/events.db'
+
+# Constants.kt at FossifyOrg/Calendar b269b99bb7152f126677278b486de24f6f1050ff, and
+# Android CalendarContract.Events for status.
+FLAG_ALL_DAY = 1
+EVENT_TYPES = {0: 'Event', 1: 'Task'}
+STATUSES = {0: 'Tentative', 1: 'Confirmed', 2: 'Cancelled'}
+
+
+def _db_files(context):
+    return [str(f).replace('\\', '/') for f in unique_files(context)
+            if str(f).replace('\\', '/').endswith(DB_SUFFIX)]
+
+
+def _secs(value):
+    if not value:
+        return ''
+    try:
+        return convert_unix_ts_to_utc(int(value))
+    except (TypeError, ValueError):
+        return ''
+
+
+def _ms(value):
+    if not value:
+        return ''
+    try:
+        return convert_unix_ts_to_utc(int(value) // 1000)
+    except (TypeError, ValueError):
+        return ''
+
+
+def _lookup(table, value):
+    if value in table:
+        return table[value]
+    return f'{value} (as stored)'
+
+
+def _reminders(r1, r2, r3):
+    return ', '.join(str(m) for m in (r1, r2, r3) if m is not None and m >= 0)
+
+
+@artifact_processor
+def fossify_calendar_events(context):
+    query = '''SELECT e.start_ts, e.end_ts, e.flags, e.title, e.location, e.description,
+                      e.time_zone, e.reminder_1_minutes, e.reminder_2_minutes,
+                      e.reminder_3_minutes, e.repeat_interval, e.attendees, e.status,
+                      e.type, e.last_updated, e.source, t.title
+               FROM events e
+               LEFT JOIN event_types t ON t.id = e.event_type
+               ORDER BY e.start_ts'''
+    data_list = []
+    sources = []
+    for db_path in _db_files(context):
+        records = get_sqlite_db_records(db_path, query)
+        if not records:
+            continue
+        for r in records:
+            all_day = 'Yes' if (r[2] or 0) & FLAG_ALL_DAY else 'No'
+            repeats = 'Yes' if r[10] else 'No'
+            data_list.append((
+                _secs(r[0]), _secs(r[1]), all_day, r[3] or '', r[4] or '', r[5] or '',
+                r[6] or '', _reminders(r[7], r[8], r[9]), repeats, r[11] or '',
+                _lookup(STATUSES, r[12]), _lookup(EVENT_TYPES, r[13]), r[16] or '',
+                _ms(r[14]), r[15] or '', context.get_relative_path(db_path),
+            ))
+        if db_path not in sources:
+            sources.append(db_path)
+
+    data_headers = (
+        ('Start', 'datetime'), ('End', 'datetime'), 'All Day', 'Title', 'Location',
+        'Description', 'Time Zone', 'Reminders (minutes)', 'Repeats', 'Attendees',
+        'Status', 'Type', 'Calendar', ('Last Updated', 'datetime'), 'Source', 'Source File',
+    )
+    return data_headers, data_list, '\n'.join(sources)

--- a/scripts/artifacts/fossifyGallery.py
+++ b/scripts/artifacts/fossifyGallery.py
@@ -1,0 +1,96 @@
+__artifacts_v2__ = {
+    "fossify_gallery_media": {
+        "name": "Fossify Gallery - Media",
+        "description": "Parses the media index kept by the Fossify Gallery Android app and its Simple Mobile Tools predecessor.",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-08-30",
+        "last_update_date": "2026-08-30",
+        "requirements": "none",
+        "category": "Fossify Gallery",
+        "notes": "One row per entry in the media table of databases/gallery.db. This table is the app's "
+                 "own index of the images and videos it has seen, and it keeps three things a plain "
+                 "media scan does not: whether the user favourited a file, when a file was moved to the "
+                 "app's recycle bin, and the file's recorded date taken. Each row carries the Filename "
+                 "and Full Path as stored, the Type, the Size in bytes, the Video Duration in seconds, "
+                 "the Favorite flag, and three times. Type is decoded from the app's media-type "
+                 "constants, 1 image, 2 video, 4 GIF, 8 raw, 16 SVG, 32 portrait (Constants.kt at "
+                 "FossifyOrg/Gallery b28299dc33821eee8d108a9880ce87876cf31443); on the tested files it "
+                 "was image on every row. Video Duration is 0 for a still image and was 0 on every "
+                 "tested row. Deleted is set from deleted_ts, which is non-zero only when the file is in "
+                 "the app's recycle bin, and records when it was deleted; for a recycled file the Full "
+                 "Path is stored with a recycle_bin/ prefix and the file's bytes are kept under the "
+                 "app's files/.recycle_bin folder, so a non-empty Deleted value marks a file the user "
+                 "removed but that may still be recoverable. Date Taken, Last Modified and Deleted are "
+                 "all Unix milliseconds and are reported as UTC; on the tested device the deletion time "
+                 "18:00 UTC matched the device's 2:00 PM local action. The Favorite flag was confirmed "
+                 "against a favourited file, and the deleted state against a file moved to the recycle "
+                 "bin. Three related tables are not parsed here: favorites duplicates the favourite list "
+                 "the is_favorite flag already carries, date_takens holds corrected date-taken values, "
+                 "and directories is a per-folder cache. The app is the maintained successor to Simple "
+                 "Mobile Tools Gallery and uses the identical schema, so the paths cover both "
+                 "org.fossify.gallery (tested) and com.simplemobiletools.gallery.pro (same schema, from "
+                 "the shared source, not exercised here).",
+        "paths": (
+            '*/org.fossify.gallery/databases/gallery.db*',
+            '*/com.simplemobiletools.gallery.pro/databases/gallery.db*',
+        ),
+        "output_types": "standard",
+        "artifact_icon": "image",
+    }
+}
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records
+from scripts.artifacts.storagePathViews import unique_files
+
+DB_SUFFIX = 'databases/gallery.db'
+
+# Constants.kt at FossifyOrg/Gallery b28299dc33821eee8d108a9880ce87876cf31443.
+MEDIA_TYPES = {1: 'Image', 2: 'Video', 4: 'GIF', 8: 'Raw', 16: 'SVG', 32: 'Portrait'}
+
+
+def _db_files(context):
+    return [str(f).replace('\\', '/') for f in unique_files(context)
+            if str(f).replace('\\', '/').endswith(DB_SUFFIX)]
+
+
+def _ms(value):
+    if not value:
+        return ''
+    try:
+        return convert_unix_ts_to_utc(int(value) // 1000)
+    except (TypeError, ValueError):
+        return ''
+
+
+def _type(value):
+    if value in MEDIA_TYPES:
+        return MEDIA_TYPES[value]
+    return f'{value} (as stored)'
+
+
+@artifact_processor
+def fossify_gallery_media(context):
+    query = '''SELECT filename, full_path, type, size, video_duration, is_favorite,
+                      deleted_ts, date_taken, last_modified
+               FROM media ORDER BY deleted_ts DESC, filename'''
+    data_list = []
+    sources = []
+    for db_path in _db_files(context):
+        records = get_sqlite_db_records(db_path, query)
+        if not records:
+            continue
+        for r in records:
+            favorite = 'Yes' if r[5] else 'No'
+            data_list.append((
+                r[0] or '', r[1] or '', _type(r[2]), r[3], r[4], favorite,
+                _ms(r[6]), _ms(r[7]), _ms(r[8]), context.get_relative_path(db_path),
+            ))
+        if db_path not in sources:
+            sources.append(db_path)
+
+    data_headers = (
+        'Filename', 'Full Path', 'Type', 'Size', 'Video Duration', 'Favorite',
+        ('Deleted', 'datetime'), ('Date Taken', 'datetime'),
+        ('Last Modified', 'datetime'), 'Source File',
+    )
+    return data_headers, data_list, '\n'.join(sources)

--- a/scripts/artifacts/fossifyGallery.py
+++ b/scripts/artifacts/fossifyGallery.py
@@ -36,6 +36,9 @@ __artifacts_v2__ = {
         ),
         "output_types": "standard",
         "artifact_icon": "image",
+        "sample_data": {
+            "emu_a15_oss_v2": "Android 15 | org.fossify.gallery vc 28 | 3 rows; one favourited, one recycle-bin deletion, one ordinary file",
+        },
     }
 }
 

--- a/scripts/artifacts/fossifyNotes.py
+++ b/scripts/artifacts/fossifyNotes.py
@@ -30,6 +30,9 @@ __artifacts_v2__ = {
         ),
         "output_types": "standard",
         "artifact_icon": "file-text",
+        "sample_data": {
+            "emu_a15_oss_v2": "Android 15 | org.fossify.notes vc 13 | 1 rows",
+        },
     }
 }
 

--- a/scripts/artifacts/fossifyNotes.py
+++ b/scripts/artifacts/fossifyNotes.py
@@ -1,0 +1,77 @@
+__artifacts_v2__ = {
+    "fossify_notes": {
+        "name": "Fossify Notes",
+        "description": "Parses notes stored by the Fossify Notes Android app and its Simple Mobile Tools predecessor.",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-08-30",
+        "last_update_date": "2026-08-30",
+        "requirements": "none",
+        "category": "Fossify Notes",
+        "notes": "One row per entry in the notes table of databases/notes.db. Each row is a note the app "
+                 "holds, with its Title, the note content in the Note column as stored, the Type, the "
+                 "Path, and the note-lock state in Protection. Type is decoded from the app's NoteType "
+                 "enum, 0 a plain text note and 1 a checklist; for a checklist the Note column holds the "
+                 "app's serialised list of items rather than plain text (NoteType.kt at FossifyOrg/Notes "
+                 "786fc41f68d1aed8d82144a6de0127ed4dbe8b61). Path is the file the note is backed by when "
+                 "the note is linked to a file on the device, and is empty for a note kept only in the "
+                 "database. Protection is decoded from protection_type using the shared Fossify Commons "
+                 "constants, -1 none, 0 pattern, 1 PIN, 2 fingerprint (Constants.kt at FossifyOrg/Commons "
+                 "92aef4c0ee9d0134f9c44440c96a7b1c733767e0); a value other than none means the note is "
+                 "locked in the app. The note's protection_hash column stores the hash of that lock and "
+                 "is never read or reported here. The notes table carries no created or modified "
+                 "timestamp, so none is reported. The widgets table in the same database holds "
+                 "home-screen widget settings and is not evidential. The app is the maintained successor "
+                 "to Simple Mobile Tools Notes and uses the identical schema, so the paths cover both "
+                 "org.fossify.notes (tested) and com.simplemobiletools.notes.pro (same schema, from the "
+                 "shared source, not exercised here).",
+        "paths": (
+            '*/org.fossify.notes/databases/notes.db*',
+            '*/com.simplemobiletools.notes.pro/databases/notes.db*',
+        ),
+        "output_types": "standard",
+        "artifact_icon": "file-text",
+    }
+}
+
+from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records
+from scripts.artifacts.storagePathViews import unique_files
+
+DB_SUFFIX = 'databases/notes.db'
+
+# NoteType.kt at FossifyOrg/Notes 786fc41f68d1aed8d82144a6de0127ed4dbe8b61.
+NOTE_TYPES = {0: 'Text', 1: 'Checklist'}
+# Constants.kt at FossifyOrg/Commons 92aef4c0ee9d0134f9c44440c96a7b1c733767e0.
+PROTECTION = {-1: 'None', 0: 'Pattern', 1: 'PIN', 2: 'Fingerprint'}
+
+
+def _db_files(context):
+    return [str(f).replace('\\', '/') for f in unique_files(context)
+            if str(f).replace('\\', '/').endswith(DB_SUFFIX)]
+
+
+def _lookup(table, value):
+    if value in table:
+        return table[value]
+    return f'{value} (as stored)'
+
+
+@artifact_processor
+def fossify_notes(context):
+    query = '''SELECT title, value, type, path, protection_type
+               FROM notes ORDER BY id'''
+    data_list = []
+    sources = []
+    for db_path in _db_files(context):
+        records = get_sqlite_db_records(db_path, query)
+        if not records:
+            continue
+        for r in records:
+            data_list.append((
+                r[0] or '', r[1] or '', _lookup(NOTE_TYPES, r[2]), r[3] or '',
+                _lookup(PROTECTION, r[4]), context.get_relative_path(db_path),
+            ))
+        if db_path not in sources:
+            sources.append(db_path)
+
+    data_headers = ('Title', 'Note', 'Type', 'Path', 'Protection', 'Source File')
+    return data_headers, data_list, '\n'.join(sources)


### PR DESCRIPTION
Adds Fossify support for Android, three apps from their own Room stores. Fossify is the maintained successor to Simple Mobile Tools, so the paths also cover the com.simplemobiletools.*.pro packages, which share the schema.

- Notes (notes.db): note title and content, type (text or checklist), file path, and lock state. The per-note lock hash is never read.
- Calendar (events.db): events and tasks with start and end times, time zone, reminders, recurrence, attendees, status, calendar name, and source.
- Gallery (gallery.db): the app's media index, including favourite state and recycle-bin deletions with the deletion time, where the deleted file may still be recoverable under the app's .recycle_bin folder.

Times are Unix milliseconds reported as UTC, except calendar start and end which are Unix seconds. Undocumented values are reported as stored.