### PR TITLE
Name Chromium forks by their package instead of Unknown

### DIFF
--- a/scripts/artifacts/chrome.py
+++ b/scripts/artifacts/chrome.py
@@ -13,6 +13,7 @@ __artifacts_v2__ = {
         "output_types": "standard",
         "artifact_icon": "globe",
         "sample_data": {
+            "emu_a15_oss_v5": "Android 15 | com.android.chrome vc 733915533, com.brave.browser vc 429411704, org.cromite.cromite vc 777816802 | 14 rows",
             "anne_a15": "Android 15 | com.android.chrome vc 733915533, com.sec.android.app.sbrowser vc 1280509502 | 94 rows",
             "galaxys10_a10": "Android 10 | com.android.chrome vc 438910534 | 191 rows",
             "hc_pixel8pro_a16": "Android 16 | com.android.chrome vc 782711433, com.brave.browser vc 429117204, com.sec.android.app.sbrowser vc 1300067502 | 20 rows",
@@ -43,6 +44,7 @@ __artifacts_v2__ = {
         "output_types": "standard",
         "artifact_icon": "globe",
         "sample_data": {
+            "emu_a15_oss_v5": "Android 15 | com.android.chrome vc 733915533, com.brave.browser vc 429411704, org.cromite.cromite vc 777816802 | 17 rows",
             "anne_a15": "Android 15 | com.android.chrome vc 733915533, com.sec.android.app.sbrowser vc 1280509502 | 127 rows",
             "galaxys10_a10": "Android 10 | com.android.chrome vc 438910534 | 291 rows",
             "hc_pixel8pro_a16": "Android 16 | com.android.chrome vc 782711433, com.brave.browser vc 429117204, com.sec.android.app.sbrowser vc 1300067502 | 39 rows",

--- a/scripts/artifacts/chrome.py
+++ b/scripts/artifacts/chrome.py
@@ -145,6 +145,17 @@ from scripts.ilapfuncs import logfunc, open_sqlite_db_readonly, does_column_exis
 from scripts.artifacts.storagePathViews import unique_files
 
 
+def _package_from_path(file_name):
+    """The app package directory an extraction path runs through, or '' if there is none.
+
+    Chromium forks all write to app_chrome, so the layout does not name the browser and
+    the package directory is the only thing in the path that does.
+    """
+    match = re.search(r'/([A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)+)/app_[^/]+/',
+                      str(file_name).replace('\\', '/'))
+    return match.group(1) if match else ''
+
+
 def get_browser_name(file_name):
 
     if 'brave' in file_name.lower():
@@ -162,7 +173,8 @@ def get_browser_name(file_name):
         except Exception:
             return 'Unknown'
     else:
-        return 'Unknown'
+        # Any other Chromium build: name it by its own package rather than 'Unknown'.
+        return _package_from_path(file_name) or 'Unknown'
 
 
 def _webkit_to_utc(value):


### PR DESCRIPTION
The Chromium history globs are anchored on the app_chrome layout, so any Chromium fork is already picked up. get_browser_name only recognised a handful of browsers by substring and returned Unknown for the rest, so a fork's rows reached the report with no way to tell which browser produced them.

Falls back to the package directory in the path, which the extraction records.

Measured on an emulator carrying Brave and Cromite: the same 7 history rows before and after, with Cromite's 4 now labelled org.cromite.cromite instead of Unknown. Brave, Chrome, Edge, Opera and Samsung Browser names are unchanged.