### PR TITLE
Read Chromium tab restore files and report their navigation entries

### DIFF
--- a/admin/scripts/path_anchor_allowlist.json
+++ b/admin/scripts/path_anchor_allowlist.json
@@ -49,6 +49,7 @@
   "*/WhatsApp/Media/*": "shared or system location: no app data container in the path; measured 2026-08-28 on pixel7a_a14, samsunga53_a14, pixel3_a12",
   "*/[Dd][Cc][Ii][Mm]/Kik/*": "shared or system location: DCIM on shared storage; measured 2026-08-28 on pixel7a_a14, samsunga53_a14, pixel3_a12",
   "*/app_Chrome/Default/Network Action Predictor*": "cross-app by design: rows attribute the owning app or browser; matched 0 package(s), measured 2026-08-28 on pixel7a_a14, samsunga53_a14, pixel3_a12",
+  "*/app_chrome/*/Sessions/Tabs_*": "deliberate cross-app sweep whose rows attribute the owning app: every Chromium browser writes the same app_chrome layout, and the Browser column reports the package the file was found under; measured 2026-09-04 across 23 Android corpora, matching com.android.chrome, com.brave.browser and com.microsoft.emmx",
   "*/app_chrome/Default/Bookmarks*": "cross-app by design: rows attribute the owning app or browser; matched 2 package(s), measured 2026-08-28 on pixel7a_a14, samsunga53_a14, pixel3_a12",
   "*/app_chrome/Default/Cookies*": "cross-app by design: rows attribute the owning app or browser; matched 3 package(s), measured 2026-08-28 on pixel7a_a14, samsunga53_a14, pixel3_a12",
   "*/app_chrome/Default/DIPS*": "cross-app by design: rows attribute the owning app or browser; matched 2 package(s), measured 2026-08-28 on pixel7a_a14, samsunga53_a14, pixel3_a12",

--- a/admin/test/scripts/test_snss_parser.py
+++ b/admin/test/scripts/test_snss_parser.py
@@ -1,0 +1,173 @@
+"""Pin the on-disk contract the SNSS reader depends on.
+
+A Chromium tab restore file is "SNSS", an int32 version, then records of a uint16 size followed
+by that many bytes whose first byte is the command id. Command 1 carries a base::Pickle holding
+a tab id and a SerializedNavigationEntry; command 4 is a fixed 16 byte struct, not a pickle, and
+a reader that treats it as one reads nonsense.
+
+The trap this file exists for is alignment. A base::Pickle advances every field to a four byte
+boundary, so a three byte string is followed by one pad byte. A reader that skips exactly the
+string length works on any string whose length happens to be a multiple of four and silently
+walks off the rails on every other one, which looks like a corrupt file rather than a bug.
+
+The expected bytes below are written out as literals rather than produced by the reader, so the
+test cannot inherit the reader's own idea of the layout.
+
+Buffers are built by hand rather than taken from an extraction, so this test carries no sample
+data.
+"""
+import pathlib
+import struct
+import sys
+import tempfile
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.snss_parser import (  # pylint: disable=wrong-import-position
+    SNSSError,
+    decode_navigation_entry,
+    decode_selected_navigation,
+    read_commands,
+    read_navigation_entries,
+    read_selected_navigations,
+)
+
+
+def _pad(payload):
+    return payload + b'\x00' * ((4 - len(payload) % 4) % 4)
+
+
+def _p_int(value):
+    return struct.pack('<i', value)
+
+
+def _p_int64(value):
+    return struct.pack('<q', value)
+
+
+def _p_string(text):
+    raw = text.encode('utf-8')
+    return _p_int(len(raw)) + _pad(raw)
+
+
+def _p_string16(text):
+    raw = text.encode('utf-16-le')
+    return _p_int(len(raw) // 2) + _pad(raw)
+
+
+def _pickle(body):
+    return struct.pack('<I', len(body)) + body
+
+
+def _navigation(tab_id=7, index=2, url='https://example.test/a', title='Example',
+                page_state=b'ps', transition=8, type_mask=0, referrer='https://ref.test/',
+                original='https://orig.test/', overriding_ua=0, timestamp=13300000000000000,
+                http=200, referrer_policy=1, extended=(), tail=True):
+    body = _p_int(tab_id) + _p_int(index) + _p_string(url) + _p_string16(title)
+    body += _p_int(len(page_state)) + _pad(page_state)
+    body += _p_int(transition) + _p_int(type_mask) + _p_string(referrer) + _p_int(0)
+    body += _p_string(original) + _p_int(overriding_ua) + _p_int64(timestamp)
+    body += _p_string16('') + _p_int(http) + _p_int(referrer_policy)
+    body += _p_int(len(extended))
+    for key, value in extended:
+        body += _p_string(key) + _p_string(value)
+    if tail:
+        body += _p_int64(0) + _p_int64(0) + _p_int64(0) + _p_int(0)
+    return _pickle(body)
+
+
+def _file(*commands, version=3, magic=b'SNSS'):
+    out = magic + struct.pack('<i', version)
+    for command_id, payload in commands:
+        body = bytes([command_id]) + payload
+        out += struct.pack('<H', len(body)) + body
+    return out
+
+
+class SNSSParserTest(unittest.TestCase):
+
+    def _write(self, payload):
+        handle = tempfile.NamedTemporaryFile(suffix='.snss', delete=False)
+        handle.write(payload)
+        handle.close()
+        self.addCleanup(lambda: pathlib.Path(handle.name).unlink(missing_ok=True))
+        return handle.name
+
+    def test_header_and_command_framing(self):
+        path = self._write(_file((1, _navigation()), (4, struct.pack('<iiq', 7, 2, 13300000000000001))))
+        ids = [command_id for command_id, _ in read_commands(path)]
+        self.assertEqual(ids, [1, 4])
+
+    def test_rejects_a_file_that_is_not_snss(self):
+        with self.assertRaises(SNSSError):
+            list(read_commands(self._write(b'NOPE' + struct.pack('<i', 3))))
+        with self.assertRaises(SNSSError):
+            list(read_commands(self._write(_file(version=9))))
+
+    def test_navigation_entry_decodes_and_consumes_the_pickle_exactly(self):
+        entry = decode_navigation_entry(_navigation())
+        self.assertEqual(entry['tab_id'], 7)
+        self.assertEqual(entry['index'], 2)
+        self.assertEqual(entry['url'], 'https://example.test/a')
+        self.assertEqual(entry['title'], 'Example')
+        self.assertEqual(entry['transition_type'], 8)
+        self.assertEqual(entry['referrer_url'], 'https://ref.test/')
+        self.assertEqual(entry['original_request_url'], 'https://orig.test/')
+        self.assertEqual(entry['timestamp'], 13300000000000000)
+        self.assertEqual(entry['http_status_code'], 200)
+        self.assertEqual(entry['unread'], 0)
+
+    def test_string_lengths_that_are_not_a_multiple_of_four_still_align(self):
+        """A three byte string is followed by one pad byte; a reader that skips only the length
+        reads the next field from the wrong offset."""
+        for url in ('https://a.test/1', 'https://a.test/12', 'https://a.test/123',
+                    'https://a.test/1234'):
+            entry = decode_navigation_entry(_navigation(url=url, title='t' * (len(url) % 4)))
+            self.assertEqual(entry['url'], url, msg=f'url length {len(url)}')
+            self.assertEqual(entry['http_status_code'], 200, msg=f'url length {len(url)}')
+            self.assertEqual(entry['unread'], 0, msg=f'url length {len(url)}')
+
+    def test_extended_info_pairs_are_read(self):
+        entry = decode_navigation_entry(_navigation(extended=(('k1', 'v1'), ('k2', 'v2'))))
+        self.assertEqual(entry['extended_info'], {'k1': 'v1', 'k2': 'v2'})
+        self.assertEqual(entry['unread'], 0)
+
+    def test_a_payload_that_stops_after_the_type_mask_keeps_what_was_read(self):
+        """Chromium treats every field after the type mask as optional, so a short record is not
+        an error and the fields before it still count."""
+        body = _p_int(9) + _p_int(0) + _p_string('https://short.test/') + _p_string16('Short')
+        body += _p_int(0) + _p_int(8)
+        entry = decode_navigation_entry(_pickle(body))
+        self.assertEqual(entry['url'], 'https://short.test/')
+        self.assertEqual(entry['title'], 'Short')
+        self.assertEqual(entry['transition_type'], 8)
+        self.assertIsNone(entry['http_status_code'])
+
+    def test_selected_navigation_is_a_struct_not_a_pickle(self):
+        record = decode_selected_navigation(struct.pack('<iiq', 1068719225, 6, 13411502943000000))
+        self.assertEqual(record, {'tab_id': 1068719225, 'index': 6,
+                                  'timestamp': 13411502943000000})
+        with self.assertRaises(SNSSError):
+            decode_selected_navigation(b'\x00' * 8)
+
+    def test_reader_helpers_select_the_right_commands(self):
+        path = self._write(_file(
+            (1, _navigation(tab_id=7, index=0, url='https://one.test/')),
+            (11, b'\x00\x00\x00\x00'),
+            (1, _navigation(tab_id=7, index=1, url='https://two.test/')),
+            (4, struct.pack('<iiq', 7, 1, 13300000000000002)),
+        ))
+        self.assertEqual([e['url'] for e in read_navigation_entries(path)],
+                         ['https://one.test/', 'https://two.test/'])
+        self.assertEqual([r['index'] for r in read_selected_navigations(path)], [1])
+
+    def test_a_truncated_trailing_command_is_dropped_rather_than_guessed(self):
+        good = _file((1, _navigation(url='https://kept.test/')))
+        path = self._write(good + struct.pack('<H', 400) + b'\x01\x02\x03')
+        self.assertEqual([e['url'] for e in read_navigation_entries(path)], ['https://kept.test/'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/artifacts/chromeSessionTabs.py
+++ b/scripts/artifacts/chromeSessionTabs.py
@@ -1,0 +1,236 @@
+__artifacts_v2__ = {
+    "chrome_session_tabs": {
+        "name": "Chromium Session Tabs - Navigation Entries",
+        "description": "Pages held in the tab restore file of a Chromium browser, with the "
+                       "address, page title, visit time and HTTP status the browser stored for "
+                       "each entry, and the tab it belongs to.",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-04",
+        "last_update_date": "2026-09-04",
+        "requirements": "none",
+        "category": "Chromium Sessions",
+        "notes": "Read from the Sessions/Tabs_<number> files a Chromium browser writes under its "
+                 "app_chrome folder, with the vendored snss_parser. The path pattern carries no "
+                 "package name because every Chromium browser uses the same layout, so the "
+                 "Browser column reports the package the file was found under and the same glob "
+                 "covers Chrome, Brave and Edge.\n"
+                 "One row per navigation entry the file holds, taken from the command Chromium "
+                 "calls kCommandUpdateTabNavigation. Timestamp is the entry's stored time, "
+                 "microseconds since 1601, and Tab ID and Index identify the tab and the "
+                 "position of the entry in that tab's back and forward list, so several rows "
+                 "with one Tab ID are one tab's history. Transition Type and Referrer Policy are "
+                 "integers Chromium defines and are reported as stored. Reference: Chromium, "
+                 "components/sessions/core/serialized_navigation_entry.cc, which sets the field "
+                 "order, and components/sessions/core/tab_restore_service_impl.cc, which sets "
+                 "the command ids.\n"
+                 "Has Post Data, Overriding User Agent and HTTP Status hold one value across every row of "
+                 "an image whose entries are all ordinary page loads; they are kept because they "
+                 "separate a form submission or a desktop-mode request from a plain visit. "
+                 "Each entry also carries a page state blob holding form and scroll state; it is "
+                 "not decoded and only its size is reported. Every entry decoded on the tested "
+                 "images consumed its record exactly, which is what shows the field order is "
+                 "right.\n"
+                 "This is the browser's own restore file, so a row means the page was in a tab "
+                 "the browser was holding, not that it was open when the device was seized, and "
+                 "the file keeps a limited number of tabs rather than a full history. A page here "
+                 "need not appear in the browser's History database.",
+        "paths": ('*/app_chrome/*/Sessions/Tabs_*',),
+        "output_types": "standard",
+        "artifact_icon": "browser",
+        "sample_data": {
+            "adams_ss134dl_a03s_logical": "0 rows",
+            "adams_ss135dl_a13": "Android 13 | 0 rows",
+            "anne_a15": "Android 15 | 0 rows",
+            "cookbook_a11": "Android 11 | 4 rows",
+            "df020_mavic_pro_android": "0 rows",
+            "emu_a15_oss_v1": "Android 15 | 0 rows",
+            "falken_a326u_a13": "Android 13 | 14 rows",
+            "galaxys10_a10": "Android 10 | 10 rows",
+            "hc_pixel8pro_a16": "Android 16 | 0 rows",
+            "hc_pixel8pro_a17": "Android 17 | 0 rows",
+            "hc_pixel8pro_a17_ail": "Android 17 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | 6 rows",
+            "pixel3_a11": "Android 11 | 0 rows",
+            "pixel3_a12": "Android 12 | 39 rows",
+            "pixel7a_a14": "Android 14 | 11 rows",
+            "russell_a14": "Android 14 | 4 rows",
+            "russell_pixel6a_a13": "Android 13 | 21 rows",
+            "s20fe_a13": "Android 13 | 7 rows",
+            "samsunga53_a14": "Android 14 | 6 rows",
+            "samsungs20_a13": "Android 13 | 3 rows",
+            "sharon_a13": "Android 13 | 9 rows",
+            "sharon_a14": "Android 14 | 3 rows",
+            "userb2_a13": "Android 13 | 0 rows",
+        },
+    },
+    "chrome_session_tab_state": {
+        "name": "Chromium Session Tabs - Tab State",
+        "description": "The entry each tab was sitting on in the tab restore file, with the "
+                       "timestamp the browser stored against it.",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-04",
+        "last_update_date": "2026-09-04",
+        "requirements": "none",
+        "category": "Chromium Sessions",
+        "notes": "Read from the same Tabs_<number> files, from the command Chromium calls "
+                 "kCommandSelectedNavigationInTab. Unlike the navigation entries this record is "
+                 "not a pickle but a fixed structure of a tab id, the selected navigation index "
+                 "and a timestamp, microseconds since 1601. Chromium's tab restore service "
+                 "records that timestamp when the tab is closed. One row per record.\n"
+                 "Selected Index refers to the Index column of the navigation entries artifact "
+                 "for the same Tab ID, so the two join on Tab ID to show which page the tab was "
+                 "on. Browser reports the package the file was found under.",
+        "paths": ('*/app_chrome/*/Sessions/Tabs_*',),
+        "output_types": "standard",
+        "artifact_icon": "browser-check",
+        "sample_data": {
+            "adams_ss134dl_a03s_logical": "0 rows",
+            "adams_ss135dl_a13": "Android 13 | 0 rows",
+            "anne_a15": "Android 15 | 0 rows",
+            "cookbook_a11": "Android 11 | 2 rows",
+            "df020_mavic_pro_android": "0 rows",
+            "emu_a15_oss_v1": "Android 15 | 0 rows",
+            "falken_a326u_a13": "Android 13 | 2 rows",
+            "galaxys10_a10": "Android 10 | 7 rows",
+            "hc_pixel8pro_a16": "Android 16 | 0 rows",
+            "hc_pixel8pro_a17": "Android 17 | 0 rows",
+            "hc_pixel8pro_a17_ail": "Android 17 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | 4 rows",
+            "pixel3_a11": "Android 11 | 0 rows",
+            "pixel3_a12": "Android 12 | 12 rows",
+            "pixel7a_a14": "Android 14 | 4 rows",
+            "russell_a14": "Android 14 | 4 rows",
+            "russell_pixel6a_a13": "Android 13 | 8 rows",
+            "s20fe_a13": "Android 13 | 1 row",
+            "samsunga53_a14": "Android 14 | 3 rows",
+            "samsungs20_a13": "Android 13 | 1 row",
+            "sharon_a13": "Android 13 | 7 rows",
+            "sharon_a14": "Android 14 | 3 rows",
+            "userb2_a13": "Android 13 | 0 rows",
+        },
+    },
+}
+
+import datetime
+import os
+import re
+
+from scripts.ilapfuncs import artifact_processor, logfunc
+from scripts.snss_parser import SNSSError, read_navigation_entries, read_selected_navigations
+
+_CHROMIUM_EPOCH = datetime.datetime(1601, 1, 1, tzinfo=datetime.timezone.utc)
+_PACKAGE = re.compile(r'/([^/]+)/app_chrome/', re.I)
+
+
+def _chromium_time(value):
+    """Microseconds since 1601 as an aware UTC datetime; 0 and empty are reported as blank."""
+    if value in (None, '', 0):
+        return ''
+    try:
+        return _CHROMIUM_EPOCH + datetime.timedelta(microseconds=int(value))
+    except (TypeError, ValueError, OverflowError):
+        return ''
+
+
+def _browser(path):
+    """The package the file sits under, so one cross-browser glob still attributes each row."""
+    match = _PACKAGE.search(path.replace('\\', '/'))
+    return match.group(1) if match else ''
+
+
+def _tab_files(context):
+    for file_found in sorted(context.get_files_found()):
+        file_found = str(file_found)
+        if os.path.isdir(file_found):
+            continue
+        if not os.path.basename(file_found).startswith('Tabs_'):
+            continue
+        yield file_found
+
+
+@artifact_processor
+def chrome_session_tabs(context):
+    data_headers = (
+        ('Timestamp', 'datetime'),
+        'Browser',
+        'Tab ID',
+        'Index',
+        'URL',
+        'Title',
+        'HTTP Status',
+        'Transition Type (as stored)',
+        'Referrer URL',
+        'Original Request URL',
+        'Has Post Data',
+        'Overriding User Agent',
+        'Referrer Policy (as stored)',
+        'Page State Bytes',
+        'Source File',
+    )
+    data_list = []
+    sources = []
+
+    for file_found in _tab_files(context):
+        try:
+            entries = read_navigation_entries(file_found)
+        except (SNSSError, OSError) as error:
+            logfunc(f'Chromium Session Tabs: could not read {os.path.basename(file_found)}: {error}')
+            continue
+        browser = _browser(file_found)
+        relative = context.get_relative_path(file_found)
+        for entry in entries:
+            data_list.append((
+                _chromium_time(entry['timestamp']),
+                browser,
+                entry['tab_id'],
+                entry['index'],
+                entry['url'],
+                entry['title'],
+                entry['http_status_code'] if entry['http_status_code'] is not None else '',
+                entry['transition_type'] if entry['transition_type'] is not None else '',
+                entry['referrer_url'],
+                entry['original_request_url'],
+                entry['has_post_data'] if entry['has_post_data'] is not None else '',
+                entry['is_overriding_user_agent'] if entry['is_overriding_user_agent'] is not None else '',
+                entry['referrer_policy'] if entry['referrer_policy'] is not None else '',
+                entry['page_state_length'],
+                relative,
+            ))
+        if entries:
+            sources.append(file_found)
+
+    return data_headers, data_list, '\n'.join(sources)
+
+
+@artifact_processor
+def chrome_session_tab_state(context):
+    data_headers = (
+        ('Timestamp', 'datetime'),
+        'Browser',
+        'Tab ID',
+        'Selected Index',
+        'Source File',
+    )
+    data_list = []
+    sources = []
+
+    for file_found in _tab_files(context):
+        try:
+            records = read_selected_navigations(file_found)
+        except (SNSSError, OSError) as error:
+            logfunc(f'Chromium Session Tabs: could not read {os.path.basename(file_found)}: {error}')
+            continue
+        browser = _browser(file_found)
+        relative = context.get_relative_path(file_found)
+        for record in records:
+            data_list.append((
+                _chromium_time(record['timestamp']),
+                browser,
+                record['tab_id'],
+                record['index'],
+                relative,
+            ))
+        if records:
+            sources.append(file_found)
+
+    return data_headers, data_list, '\n'.join(sources)

--- a/scripts/snss_parser.py
+++ b/scripts/snss_parser.py
@@ -1,0 +1,210 @@
+"""Reader for Chromium SNSS session files, specifically the tab restore files Chrome and the
+other Chromium browsers write as Sessions/Tabs_<timestamp>.
+
+On-disk shape, derived from the files themselves and confirmed against Chromium's own code:
+
+    "SNSS"            4 bytes of magic
+    version           int32, 1 or 3
+    then records of   uint16 size, then `size` bytes whose first byte is the command id and
+                      whose remainder is that command's payload
+
+The command ids are Chromium's, from components/sessions/core/tab_restore_service_impl.cc:
+kCommandUpdateTabNavigation = 1, kCommandRestoredEntry = 2, kCommandWindowDeprecated = 3,
+kCommandSelectedNavigationInTab = 4, kCommandPinnedState = 5, kCommandSetExtensionAppID = 6,
+kCommandSetWindowAppName = 7, kCommandSetTabUserAgentOverride = 8, kCommandWindow = 9,
+kCommandSetTabGroupData = 10, kCommandSetTabUserAgentOverride2 = 11,
+kCommandSetWindowUserTitle = 12, kCommandCreateGroup = 13, kCommandAddTabExtraData = 14,
+kCommandCreateSplit = 15, kCommandSetTabSplitData = 16. Ids outside that list are returned as
+stored and are not interpreted here.
+
+These ids belong to the tab restore file. Chromium's session files use a different set for the
+same magic, so this reader is for Tabs_ files only.
+
+Two command payloads are decoded:
+
+* Command 1 carries a base::Pickle: an int tab id followed by a SerializedNavigationEntry, whose
+  field order is set by WriteToPickle in components/sessions/core/serialized_navigation_entry.cc:
+  index, virtual url, title, encoded page state, transition type, type mask, referrer url, an
+  obsolete referrer policy int, original request url, is overriding user agent, timestamp,
+  an empty placeholder string16, http status code, referrer policy, an extended info map, and
+  three task ids with a child count. Everything after the type mask is optional in Chromium's
+  reader, so a payload that ends early yields the fields that were present.
+* Command 4 is not a pickle. It is the fixed SelectedNavigationInTabPayload2 struct: an int32 tab
+  id, an int32 selected navigation index, and an int64 timestamp.
+
+Timestamps are Chromium's base::Time internal value, microseconds since 1601-01-01 UTC. They are
+returned as stored; converting them is the caller's job.
+
+A base::Pickle holds a uint32 payload size and then its fields, each advanced to a four byte
+boundary; a string is an int32 length then that many bytes, and a string16 is an int32 length in
+UTF-16 code units then twice that many bytes.
+"""
+import struct
+
+MAGIC = b'SNSS'
+SUPPORTED_VERSIONS = (1, 3)
+
+COMMAND_UPDATE_TAB_NAVIGATION = 1
+COMMAND_SELECTED_NAVIGATION_IN_TAB = 4
+
+
+class SNSSError(Exception):
+    """Raised for a file that is not a readable SNSS session file."""
+
+
+class _Pickle:
+    """Reads a base::Pickle laid out as Chromium writes it."""
+
+    def __init__(self, buffer):
+        if len(buffer) < 4:
+            raise SNSSError('pickle shorter than its header')
+        self._buffer = buffer
+        self._size = struct.unpack_from('<I', buffer, 0)[0]
+        self._offset = 4
+        self._end = 4 + self._size
+        if self._end > len(buffer):
+            raise SNSSError('pickle records more payload than the command carries')
+
+    def _advance(self, count):
+        self._offset += (count + 3) & ~3
+
+    def _need(self, count):
+        if self._offset + count > self._end:
+            raise SNSSError('pickle field runs past the end of the payload')
+
+    def read_int(self):
+        self._need(4)
+        value = struct.unpack_from('<i', self._buffer, self._offset)[0]
+        self._advance(4)
+        return value
+
+    def read_int64(self):
+        self._need(8)
+        value = struct.unpack_from('<q', self._buffer, self._offset)[0]
+        self._advance(8)
+        return value
+
+    def read_string(self):
+        length = self.read_int()
+        if length < 0:
+            raise SNSSError('negative string length')
+        self._need(length)
+        value = self._buffer[self._offset:self._offset + length].decode('utf-8', 'replace')
+        self._advance(length)
+        return value
+
+    def read_string16(self):
+        length = self.read_int()
+        if length < 0:
+            raise SNSSError('negative string16 length')
+        self._need(2 * length)
+        value = self._buffer[self._offset:self._offset + 2 * length].decode('utf-16-le', 'replace')
+        self._advance(2 * length)
+        return value
+
+    @property
+    def remaining(self):
+        """Payload bytes not yet read. Zero after a complete decode."""
+        return self._end - self._offset
+
+
+def read_commands(path):
+    """Yield (command id, payload) for every command in the file, in file order."""
+    with open(path, 'rb') as handle:
+        data = handle.read()
+    if len(data) < 8 or data[:4] != MAGIC:
+        raise SNSSError('file does not start with the SNSS magic')
+    version = struct.unpack_from('<i', data, 4)[0]
+    if version not in SUPPORTED_VERSIONS:
+        raise SNSSError(f'unsupported SNSS version {version}')
+    offset = 8
+    while offset + 2 <= len(data):
+        size = struct.unpack_from('<H', data, offset)[0]
+        offset += 2
+        if size == 0 or offset + size > len(data):
+            return
+        yield data[offset], data[offset + 1:offset + size]
+        offset += size
+
+
+def decode_navigation_entry(payload):
+    """One command 1 payload as a dict. `unread` is 0 when the pickle was consumed exactly."""
+    pickle = _Pickle(payload)
+    entry = {
+        'tab_id': pickle.read_int(),
+        'index': pickle.read_int(),
+        'url': pickle.read_string(),
+        'title': pickle.read_string16(),
+        'page_state_length': 0,
+        'transition_type': None,
+        'has_post_data': None,
+        'referrer_url': '',
+        'original_request_url': '',
+        'is_overriding_user_agent': None,
+        'timestamp': None,
+        'http_status_code': None,
+        'referrer_policy': None,
+        'extended_info': {},
+        'unread': None,
+    }
+    entry['page_state_length'] = len(pickle.read_string())
+    entry['transition_type'] = pickle.read_int()
+    try:
+        type_mask = pickle.read_int()
+        entry['has_post_data'] = bool(type_mask & 1)
+        entry['referrer_url'] = pickle.read_string()
+        pickle.read_int()                       # obsolete referrer policy, written for compatibility
+        entry['original_request_url'] = pickle.read_string()
+        entry['is_overriding_user_agent'] = bool(pickle.read_int())
+        entry['timestamp'] = pickle.read_int64()
+        pickle.read_string16()                  # placeholder where search terms used to be
+        entry['http_status_code'] = pickle.read_int()
+        entry['referrer_policy'] = pickle.read_int()
+        count = pickle.read_int()
+        for _ in range(count):
+            key = pickle.read_string()
+            entry['extended_info'][key] = pickle.read_string()
+        pickle.read_int64()                     # task id
+        pickle.read_int64()                     # parent task id
+        pickle.read_int64()                     # root task id
+        pickle.read_int()                       # child task id count
+    except (SNSSError, struct.error):
+        # Chromium treats every field after the type mask as optional and stops rather than
+        # failing, so a short payload keeps whatever was read.
+        pass
+    entry['unread'] = pickle.remaining
+    return entry
+
+
+def decode_selected_navigation(payload):
+    """One command 4 payload: the tab, its selected navigation index, and the stored timestamp."""
+    if len(payload) < 16:
+        raise SNSSError('selected navigation payload shorter than its struct')
+    tab_id, index, timestamp = struct.unpack_from('<iiq', payload, 0)
+    return {'tab_id': tab_id, 'index': index, 'timestamp': timestamp}
+
+
+def read_navigation_entries(path):
+    """Every decodable command 1 entry in the file."""
+    entries = []
+    for command_id, payload in read_commands(path):
+        if command_id != COMMAND_UPDATE_TAB_NAVIGATION:
+            continue
+        try:
+            entries.append(decode_navigation_entry(payload))
+        except (SNSSError, struct.error, UnicodeDecodeError):
+            continue
+    return entries
+
+
+def read_selected_navigations(path):
+    """Every decodable command 4 record in the file."""
+    records = []
+    for command_id, payload in read_commands(path):
+        if command_id != COMMAND_SELECTED_NAVIGATION_IN_TAB:
+            continue
+        try:
+            records.append(decode_selected_navigation(payload))
+        except (SNSSError, struct.error):
+            continue
+    return records


### PR DESCRIPTION
Adds a reader for the SNSS session files Chromium browsers write as Sessions/Tabs_<number>, which nothing read before, and two artifacts over it.

- Navigation Entries: one row per page a tab was holding, with the address, page title, visit time, HTTP status, referrer and original request URL, and the tab and index so a tab's back and forward list reads in order.
- Tab State: the entry each tab was sitting on, with the timestamp Chromium's tab restore service stores when the tab closes.

The framing was derived from the files themselves and tiles to their exact byte length. The command ids and the navigation entry field order come from Chromium, in tab_restore_service_impl.cc and serialized_navigation_entry.cc. Every entry on the tested images consumed its record exactly, which is what shows the field order is right; a command id Chromium does not define is left as stored.

One pattern covers Chrome, Brave and Edge because they share the app_chrome layout, and a Browser column attributes each row to the package the file sits under. The reader has known-answer tests, including one for the four byte alignment that a length-only reader gets wrong. Measured on 23 Android corpora: 137 navigation entries and 58 tab records across 13 of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
