### PR TITLE
Add the Phone Link linked accounts artifact

### DIFF
--- a/scripts/artifacts/phoneLink.py
+++ b/scripts/artifacts/phoneLink.py
@@ -1,4 +1,60 @@
 __artifacts_v2__ = {
+    "phonelink_accounts": {
+        "name": "Phone Link - Linked Accounts",
+        "description": "The accounts Phone Link stored for the link between this phone and a "
+                       "Windows computer, with the account name and the account type.",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-04",
+        "last_update_date": "2026-09-04",
+        "requirements": "none",
+        "category": "Phone Link",
+        "notes": "Read from the app's ACCOUNT_NAME Preferences DataStore file, a protobuf "
+                 "key and value store. Each key is the account name joined to its type by a "
+                 "colon, and each value is a small JSON object holding the same type and a "
+                 "username, which is reported as Username.\n"
+                 "The DataStore layout is Android's PreferencesProto: field 1 repeats an entry of "
+                 "a key at 1 and a value at 2, and the value's field number gives its type, with "
+                 "5 for a string. Reference: Android Jetpack, "
+                 "datastore/datastore-preferences-core/src/main/proto/preferences.proto.\n"
+                 "A sibling ACCOUNT_DATA_NAME file holds one or more opaque encoded blobs per "
+                 "account, keyed by the account key with an attribute name appended. The values are "
+                 "encoded envelopes rather than plain text, and some are credential material such as "
+                 "a private key or an identity token, so no value from that file is reported. The "
+                 "attribute names are reported as Stored Attributes, with their count, so an examiner "
+                 "knows what the app held for each account.\n"
+                 "Phone Link pairs the phone with a Windows computer signed in to the same "
+                 "account, so a row names an account used for that pairing. It does not "
+                 "establish that a computer is still linked, and the file carries no timestamp.",
+        "paths": ('*/com.microsoft.appmanager/files/datastore/ACCOUNT_NAME.preferences_pb',
+                  '*/com.microsoft.appmanager/files/datastore/ACCOUNT_DATA_NAME.preferences_pb'),
+        "output_types": "standard",
+        "artifact_icon": "user-check",
+        "sample_data": {
+            "adams_ss134dl_a03s_logical": "0 rows",
+            "adams_ss135dl_a13": "Android 13 | 0 rows",
+            "anne_a15": "Android 15 | 0 rows",
+            "cookbook_a11": "Android 11 | 0 rows",
+            "df020_mavic_pro_android": "0 rows",
+            "emu_a15_oss_v1": "Android 15 | 0 rows",
+            "falken_a326u_a13": "Android 13 | 0 rows",
+            "galaxys10_a10": "Android 10 | 0 rows",
+            "hc_pixel8pro_a16": "Android 16 | 0 rows",
+            "hc_pixel8pro_a17": "Android 17 | 0 rows",
+            "hc_pixel8pro_a17_ail": "Android 17 | 0 rows",
+            "kevin_pocox7_a15": "Android 15 | 0 rows",
+            "pixel3_a11": "Android 11 | 0 rows",
+            "pixel3_a12": "Android 12 | 0 rows",
+            "pixel7a_a14": "Android 14 | 0 rows",
+            "russell_a14": "Android 14 | 0 rows",
+            "russell_pixel6a_a13": "Android 13 | 0 rows",
+            "s20fe_a13": "Android 13 | 0 rows",
+            "samsunga53_a14": "Android 14 | 2 rows",
+            "samsungs20_a13": "Android 13 | 2 rows",
+            "sharon_a13": "Android 13 | 0 rows",
+            "sharon_a14": "Android 14 | 0 rows",
+            "userb2_a13": "Android 13 | 0 rows",
+        },
+    },
     "phonelink_content_access": {
         "name": "Phone Link - Content Access Events",
         "description": "Rows from the content_access_event table of the app's eventstore, each "
@@ -77,8 +133,10 @@ __artifacts_v2__ = {
     },
 }
 
+import json
 import os
 
+from scripts import blackboxprotobuf
 from scripts.artifacts.storagePathViews import unique_files
 from scripts.ilapfuncs import (
     artifact_processor,
@@ -197,3 +255,92 @@ def phonelink_phone_apps(context):
         'App ID',
     )
     return data_headers, data_list, '\n'.join(source_paths)
+
+
+# Android Jetpack Preferences DataStore, preferences.proto: field 1 repeats an entry whose key
+# is field 1 and whose value is field 2; the value's own field number carries its type.
+_PREF_ENTRIES = '1'
+_PREF_KEY = '1'
+_PREF_VALUE = '2'
+_PREF_STRING = '5'
+
+
+def _preference_strings(path):
+    """The string entries of a Preferences DataStore file, as {key: value}."""
+    with open(path, 'rb') as handle:
+        raw = handle.read()
+    if not raw:
+        return {}
+    message, _ = blackboxprotobuf.decode_message(raw)
+    entries = message.get(_PREF_ENTRIES)
+    if isinstance(entries, dict):
+        entries = [entries]
+    out = {}
+    for entry in entries or []:
+        if not isinstance(entry, dict):
+            continue
+        key = entry.get(_PREF_KEY)
+        value = entry.get(_PREF_VALUE)
+        if isinstance(key, (bytes, bytearray)):
+            key = key.decode('utf-8', 'replace')
+        if not isinstance(value, dict):
+            continue
+        text = value.get(_PREF_STRING)
+        if isinstance(text, (bytes, bytearray)):
+            out[str(key)] = text.decode('utf-8', 'replace')
+    return out
+
+
+@artifact_processor
+def phonelink_accounts(context):
+    data_headers = (
+        'Account',
+        'Username',
+        'Account Type',
+        'Stored Attributes',
+        'Attribute Count',
+        'Source File',
+    )
+    data_list = []
+    sources = []
+
+    names = {}
+    blobs = {}
+    for file_found in unique_files(context):
+        file_found = str(file_found)
+        if os.path.isdir(file_found):
+            continue
+        base = os.path.basename(file_found)
+        if base not in ('ACCOUNT_NAME.preferences_pb', 'ACCOUNT_DATA_NAME.preferences_pb'):
+            continue
+        try:
+            entries = _preference_strings(file_found)
+        except Exception as error:  # pylint: disable=broad-except
+            logfunc(f'Phone Link: could not read {base}: {error}')
+            continue
+        if base == 'ACCOUNT_NAME.preferences_pb':
+            for key, value in entries.items():
+                names[key] = (value, file_found)
+        else:
+            for key in entries:
+                account_key, _, attribute = key.rpartition(':')
+                blobs.setdefault(account_key, []).append(attribute)
+
+    for key, (value, file_found) in sorted(names.items()):
+        account, _, account_type = key.partition(':')
+        username = ''
+        try:
+            username = str(json.loads(value).get('username', ''))
+        except (ValueError, AttributeError):
+            username = ''
+        data_list.append((
+            account,
+            username,
+            account_type,
+            ', '.join(sorted(blobs.get(key, []))),
+            len(blobs.get(key, [])),
+            context.get_relative_path(file_found),
+        ))
+        sources.append(file_found)
+
+    return data_headers, data_list, '\n'.join(sorted(set(sources)))


### PR DESCRIPTION
Extends the Phone Link module, which read the event store and the linked app list, with a third artifact: the accounts the app stored for the link between this phone and a Windows computer.

The account name, its type and the username come from the ACCOUNT_NAME Preferences DataStore file, a protobuf key and value store. The sibling ACCOUNT_DATA_NAME file holds encoded blobs keyed by the account plus an attribute name, and some are credential material such as a private key or an identity token, so no value from that file is reported. The attribute names are reported with their count so an examiner knows what the app held for each account.

Phone Link pairs the phone with a computer signed in to the same account, so a row names an account used for that pairing. The file carries no timestamp and a row does not establish that a computer is still linked. Measured on 23 Android corpora, with rows on 2 of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
