### PR TITLE
Add ColorNote, MX Player, Nova Launcher, Flipboard and Easy Voice Recorder support

### DIFF
--- a/scripts/artifacts/colorNote.py
+++ b/scripts/artifacts/colorNote.py
@@ -1,0 +1,128 @@
+__artifacts_v2__ = {
+    "colornote_notes": {
+        "name": "ColorNote Notes",
+        "description": "Notes and checklists held by the ColorNote notepad app",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-05",
+        "last_update_date": "2026-09-05",
+        "requirements": "none",
+        "category": "ColorNote",
+        "sample_data": {
+            "emu_a15_oss_v10": "ColorNote 4.8.8 | 6 rows",
+        },
+        "notes": "One row per row of the notes table in "
+                 "com.socialnmobile.dictapps.notepad.color.note/databases/colornote.db. Created, "
+                 "Modified, Minor Modified and Reminder are Unix milliseconds and are reported as "
+                 "UTC. Minor Modified moves when something other than the text changes, such as "
+                 "the colour or the archive state, so a row whose Minor Modified is later than "
+                 "its Modified was touched without its text being edited. A checklist keeps its "
+                 "items inside the same Note column, one per line, with a ticked item written as "
+                 "[V] and an unticked item as [ ]. Note Type, Status, Storage and Reminder Type "
+                 "report the stored integer beside the label. Those labels were read from a "
+                 "decompiled build of the installed version, ColorNote 4.8.8, and are not "
+                 "published source. Four of them are also proven by known data, because the note "
+                 "in question was created that way on the tested device: Note Type 16 Checklist, "
+                 "Status 16 Trash, Storage 16 Archived and Reminder Type 32 Time alarm. Status 32 "
+                 "and 256 and Reminder Type 16 and 128 appear in the app's own queries and were "
+                 "not exercised here. A note pinned to the status bar is written with a "
+                 "reminder_date of -1 rather than a time, so Reminder is reported blank on that "
+                 "row and Reminder Type is what identifies it. Encrypted, Latitude and Longitude "
+                 "held no value on any row "
+                 "of the tested image. Encrypted marks a password-locked note, whose Title stays "
+                 "readable in this table while its Note text does not. Latitude and Longitude are "
+                 "filled by a location reminder rather than by anything the note itself holds. "
+                 "Neither a locked note nor a location reminder was created, so all three are "
+                 "reported as checked absences and not as evidence the features are missing. The "
+                 "folder_id, tags and importance columns are left unparsed: each was constant on "
+                 "the tested image and none carries content the note does not already show. A row "
+                 "is evidence the note was in the store, not that anyone read it.",
+        "paths": ('*/com.socialnmobile.dictapps.notepad.color.note/databases/colornote.db*',),
+        "output_types": "standard",
+        "artifact_icon": "file-text",
+    }
+}
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records
+from scripts.artifacts.storagePathViews import unique_files
+
+DB_SUFFIX = 'databases/colornote.db'
+
+# Read from a decompiled build of ColorNote 4.8.8 with jadx 1.5.6, class
+# com.socialnmobile.colornote.data.i. active_state 0 is the ordinary note list (i.java:297),
+# 16 is what the trash listing selects (i.java:360), and 32 and 256 appear in the app's own
+# sync and template queries (i.java:257, i.java:395).
+NOTE_STATES = {0: 'Active', 16: 'Trash', 32: 'Deleted', 256: 'Template'}
+
+# space 0 is the ordinary list; the archive helper writes 16 (i.java:592).
+NOTE_SPACES = {0: 'Normal', 16: 'Archived'}
+
+# type 0 is a text note and 16 a checklist (i.java:454 selects checklists with type = 16).
+NOTE_TYPES = {0: 'Text', 16: 'Checklist'}
+
+# reminder_type write sites in i.java lines 40 to 100: 0 clears the reminder, 16 stores a
+# date normalised to a day boundary, 32 stores a wall-clock alarm, and 128 pins the note to
+# the status bar.
+REMINDER_TYPES = {0: 'None', 16: 'Date', 32: 'Time alarm', 128: 'Pinned to status bar'}
+
+
+def _db_files(context):
+    return [str(f).replace('\\', '/') for f in unique_files(context)
+            if str(f).replace('\\', '/').endswith(DB_SUFFIX)]
+
+
+def _ms(value):
+    if not value:
+        return ''
+    try:
+        value = int(value)
+        if value < 0:
+            return ''
+        return convert_unix_ts_to_utc(value // 1000)
+    except (TypeError, ValueError, OverflowError, OSError):
+        return ''
+
+
+def _label(value, table):
+    if value is None:
+        return ''
+    if value in table:
+        return f'{table[value]} ({value})'
+    return f'Unknown ({value})'
+
+
+def _coord(value):
+    if value in (None, '', 0):
+        return ''
+    return value
+
+
+@artifact_processor
+def colornote_notes(context):
+    query = '''SELECT created_date, modified_date, minor_modified_date, reminder_date,
+                      title, note, type, active_state, space, reminder_type,
+                      color_index, encrypted, latitude, longitude, uuid
+               FROM notes
+               ORDER BY created_date'''
+    data_list = []
+    sources = []
+    for db_path in _db_files(context):
+        records = get_sqlite_db_records(db_path, query)
+        for r in records:
+            data_list.append((
+                _ms(r[0]), _ms(r[1]), _ms(r[2]), _ms(r[3]),
+                r[4] or '', r[5] or '',
+                _label(r[6], NOTE_TYPES), _label(r[7], NOTE_STATES),
+                _label(r[8], NOTE_SPACES), _label(r[9], REMINDER_TYPES),
+                r[10] if r[10] is not None else '',
+                'Yes' if r[11] else 'No',
+                _coord(r[12]), _coord(r[13]), r[14] or '',
+                context.get_relative_path(db_path)))
+        if records and db_path not in sources:
+            sources.append(db_path)
+
+    data_headers = (
+        ('Created', 'datetime'), ('Modified', 'datetime'),
+        ('Minor Modified', 'datetime'), ('Reminder', 'datetime'),
+        'Title', 'Note', 'Note Type', 'Status', 'Storage', 'Reminder Type',
+        'Colour Index', 'Encrypted', 'Latitude', 'Longitude', 'UUID', 'Source File')
+    return data_headers, data_list, '\n'.join(sources)

--- a/scripts/artifacts/easyVoiceRecorder.py
+++ b/scripts/artifacts/easyVoiceRecorder.py
@@ -1,0 +1,201 @@
+__artifacts_v2__ = {
+    "easyvoicerecorder_library": {
+        "name": "Easy Voice Recorder Library",
+        "description": "Audio files listed in the Easy Voice Recorder library",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-05",
+        "last_update_date": "2026-09-05",
+        "requirements": "none",
+        "category": "Easy Voice Recorder",
+        "sample_data": {
+            "emu_a15_oss_v10": "Easy Voice Recorder 2.10.3 | 4 rows",
+        },
+        "notes": "One row per row of the files table in "
+                 "com.coffeebeanventures.easyvoicerecorder/databases/evr.db, which is the app's "
+                 "own list of the audio in its recordings folder. The path column holds a Storage "
+                 "Access Framework document URI rather than a filesystem path, so Folder and File "
+                 "Name are decoded from that URI: the tree and document parts are percent-encoded "
+                 "and the volume is named before a colon, which is why a URI ending "
+                 "primary%3ARecordings%2Fnote.m4a is reported as the Recordings folder and the "
+                 "file note.m4a. Document URI keeps the value exactly as stored so the decoding "
+                 "can be checked. Duration is the app's own length_in_seconds column. A duration "
+                 "of -1 is reported as blank and is what the app leaves when it could not read the "
+                 "length; one such row was present on the tested device, from a recording the app "
+                 "started and did not finish. There is no timestamp in this table, so a row says "
+                 "the file was in the library and not when it was recorded; the file's own times "
+                 "carry that. The row survives the audio file being deleted, so an entry whose "
+                 "path no longer resolves is a record that the file was once in the folder. "
+                 "Pinned is the should_be_stickied column and was No on every row of the tested "
+                 "image, because nothing was pinned to the top of the app's list there. "
+                 "**Validation limit:** the tested device is an emulator with no working "
+                 "microphone, so no recording was made through the app. The rows were produced by "
+                 "placing known audio in the recordings folder and letting the app index it, plus "
+                 "the app's own incomplete-recording row. The parsing is proven against a real "
+                 "store; the recording flow itself is not exercised here, and a sample from a "
+                 "device that actually recorded would close that gap.",
+        "paths": ('*/com.coffeebeanventures.easyvoicerecorder/databases/evr.db*',),
+        "output_types": "standard",
+        "artifact_icon": "mic",
+    },
+    "easyvoicerecorder_settings": {
+        "name": "Easy Voice Recorder Settings",
+        "description": "Where Easy Voice Recorder saves audio, and how much it has recorded",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-05",
+        "last_update_date": "2026-09-05",
+        "requirements": "none",
+        "category": "Easy Voice Recorder",
+        "sample_data": {
+            "emu_a15_oss_v10": "Easy Voice Recorder 2.10.3 | 8 rows",
+        },
+        "notes": "One row per setting read from "
+                 "com.coffeebeanventures.easyvoicerecorder/shared_prefs/"
+                 "com.coffeebeanventures.easyvoicerecorder_preferences.xml. Only the keys an "
+                 "examiner can act on are reported, and each is named in the Setting column as the "
+                 "app stores it. saved_recordings_folder_key is the folder the app writes "
+                 "recordings to, which matters because the user can point it anywhere and the "
+                 "default is not the only place to look; most_recent_saved_recordings_folder_key "
+                 "is the app's list of folders it has used, so a folder that appears there and is "
+                 "not the current one was a previous destination. total_num_recordings_key and "
+                 "num_recordings_key are the app's own counters and keep counting recordings that "
+                 "have since been deleted, so a count higher than the number of rows in the Easy "
+                 "Voice Recorder Library artifact is the gap worth following. install_info_key is "
+                 "a JSON value holding the app's first install and last update times in Unix "
+                 "milliseconds, and those two are reported as their own rows in UTC. Timestamp is "
+                 "blank on every other row, because the rest of these settings carry no time. The "
+                 "remaining keys in the file are theme, advertising and consent settings and are "
+                 "not reported. Values are shown as stored.",
+        "paths": ('*/com.coffeebeanventures.easyvoicerecorder/shared_prefs/'
+                  'com.coffeebeanventures.easyvoicerecorder_preferences.xml',),
+        "output_types": "standard",
+        "artifact_icon": "settings",
+    },
+}
+
+import json
+import xml.etree.ElementTree as ET
+from urllib.parse import unquote
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records, \
+    logfunc
+from scripts.artifacts.storagePathViews import unique_files
+
+DB_SUFFIX = 'databases/evr.db'
+PREFS_SUFFIX = 'com.coffeebeanventures.easyvoicerecorder_preferences.xml'
+
+REPORTED_KEYS = (
+    'saved_recordings_folder_key',
+    'most_recent_saved_recordings_folder_key',
+    'total_num_recordings_key',
+    'num_recordings_key',
+    '__v2_encoder_preference_key',
+    'wave_sample_rate',
+)
+
+
+def _files(context, suffix):
+    return [str(f).replace('\\', '/') for f in unique_files(context)
+            if str(f).replace('\\', '/').endswith(suffix)]
+
+
+def _ms(value):
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        return ''
+    if value <= 0:
+        return ''
+    try:
+        return convert_unix_ts_to_utc(value // 1000)
+    except (OverflowError, OSError, ValueError):
+        return ''
+
+
+def _saf_parts(uri):
+    """Split a SAF document URI into (folder, file name). Blank when it is not one."""
+    if not uri:
+        return '', ''
+    text = unquote(str(uri))
+    marker = '/document/'
+    if marker not in text:
+        return '', ''
+    document = text.split(marker, 1)[1]
+    if ':' in document:
+        document = document.split(':', 1)[1]
+    document = document.strip('/')
+    if '/' in document:
+        folder, name = document.rsplit('/', 1)
+        return folder, name
+    return '', document
+
+
+@artifact_processor
+def easyvoicerecorder_library(context):
+    query = ('SELECT path, length_in_seconds, should_be_stickied, _id '
+             'FROM files ORDER BY _id')
+    data_list = []
+    sources = []
+    for db_path in _files(context, DB_SUFFIX):
+        records = get_sqlite_db_records(db_path, query)
+        for r in records:
+            folder, name = _saf_parts(r[0])
+            duration = r[1] if r[1] is not None and r[1] >= 0 else ''
+            data_list.append((
+                name, folder, duration,
+                'Yes' if r[2] else 'No', r[0] or '', r[3],
+                context.get_relative_path(db_path)))
+        if records and db_path not in sources:
+            sources.append(db_path)
+
+    data_headers = (
+        'File Name', 'Folder', 'Duration (seconds)', 'Pinned', 'Document URI',
+        'Row ID', 'Source File')
+    return data_headers, data_list, '\n'.join(sources)
+
+
+@artifact_processor
+def easyvoicerecorder_settings(context):
+    data_list = []
+    sources = []
+    for prefs_path in _files(context, PREFS_SUFFIX):
+        try:
+            root = ET.parse(prefs_path).getroot()
+        except (ET.ParseError, OSError) as error:
+            logfunc(f'Could not read Easy Voice Recorder settings from {prefs_path}: {error}')
+            continue
+
+        found = False
+        for element in root:
+            key = element.attrib.get('name', '')
+            if key not in REPORTED_KEYS:
+                continue
+            value = element.attrib.get('value')
+            if value is None:
+                value = (element.text or '').strip()
+            found = True
+            data_list.append((key, value, '', context.get_relative_path(prefs_path)))
+
+        for element in root:
+            if element.attrib.get('name') != 'install_info_key':
+                continue
+            raw = element.attrib.get('value')
+            if raw is None:
+                raw = (element.text or '').strip()
+            try:
+                info = json.loads(raw)
+            except (ValueError, TypeError):
+                continue
+            if not isinstance(info, dict):
+                continue
+            for field, label in (('first_install_time', 'install_info_key first_install_time'),
+                                 ('last_update_time', 'install_info_key last_update_time')):
+                if field in info:
+                    found = True
+                    data_list.append((label, info[field], _ms(info[field]),
+                                      context.get_relative_path(prefs_path)))
+
+        if found and prefs_path not in sources:
+            sources.append(prefs_path)
+
+    data_headers = ('Setting', 'Value', ('Timestamp', 'datetime'), 'Source File')
+    return data_headers, data_list, '\n'.join(sources)

--- a/scripts/artifacts/flipboard.py
+++ b/scripts/artifacts/flipboard.py
@@ -1,0 +1,158 @@
+__artifacts_v2__ = {
+    "flipboard_article_history": {
+        "name": "Flipboard Article History",
+        "description": "Articles opened in Flipboard, with publisher and source URL",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-05",
+        "last_update_date": "2026-09-05",
+        "requirements": "none",
+        "category": "Flipboard",
+        "sample_data": {
+            "emu_a15_oss_v10": "Flipboard 4.3.62 | 2 rows",
+        },
+        "notes": "One row per row of the view_history table in "
+                 "flipboard.app/databases/view_history_database, which the app writes when an "
+                 "article is opened. Viewed is Unix seconds and is reported as UTC. Each row also "
+                 "carries a JSON copy of the item as it stood when it was opened, in the "
+                 "valid_item column, and Source URL, Author, Published and Excerpt are read out "
+                 "of that JSON rather than fetched from anywhere. Published is the item's own "
+                 "dateCreated in Unix seconds, so it is when the article was published and not "
+                 "when it was read; the two are in separate columns for that reason. Excerpt is "
+                 "the app's own strippedExcerptText and is truncated by the app, not by this "
+                 "artifact. Source URL is reported as plain text and is not made clickable. Read "
+                 "and Bookmarked come from the isRead and isBookmarked flags in the same JSON. "
+                 "This table records that the article was opened in the app; it does not record "
+                 "how long it stayed open or whether it was read. Flipboard runs without an "
+                 "account, and the tested device was never signed in, so these rows were produced "
+                 "by an anonymous session.",
+        "paths": ('*/flipboard.app/databases/view_history_database*',),
+        "output_types": "standard",
+        "artifact_icon": "book-open",
+    },
+    "flipboard_sections": {
+        "name": "Flipboard Followed Sections",
+        "description": "Topics and magazines the Flipboard user follows",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-05",
+        "last_update_date": "2026-09-05",
+        "requirements": "none",
+        "category": "Flipboard",
+        "sample_data": {
+            "emu_a15_oss_v10": "Flipboard 4.3.62 | 5 rows",
+        },
+        "notes": "One row per row of the sections table in flipboard.app/databases/users-v6.db. "
+                 "The table's own columns are almost all empty; everything reported here is read "
+                 "from the descriptor column, which holds plain JSON. Title, Feed Type, Remote ID "
+                 "and Private come from that JSON. A Feed Type of topic marks a subject feed "
+                 "rather than a feed the app added by itself, and the Remote ID carries the "
+                 "topic slug after flipboard/topic%2F. Rows with no Feed Type are the feeds the "
+                 "app added, and their Remote ID names what they are: the tested device held "
+                 "auth/flipboard/coverstories and one flipboard/mix row. Position is the sections "
+                 "table's own pos column and is the order the app lists them in. There is no "
+                 "timestamp in this table, so a row says the section is followed and not when it "
+                 "was followed. On the tested device the three topics chosen during first run were "
+                 "all present with Feed Type topic, alongside those two. Service held the single "
+                 "value flipboard on every "
+                 "row and User ID held one value, because the tested device carried one anonymous "
+                 "profile and no other service. Both are kept: User ID is what separates the rows "
+                 "on a device holding more than one profile, and Service is what would separate a "
+                 "section pulled in from a linked account.",
+        "paths": ('*/flipboard.app/databases/users-v6.db*',),
+        "output_types": "standard",
+        "artifact_icon": "hash",
+    },
+}
+
+import json
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records
+from scripts.artifacts.storagePathViews import unique_files
+
+HISTORY_SUFFIX = 'databases/view_history_database'
+USERS_SUFFIX = 'databases/users-v6.db'
+
+
+def _files(context, suffix):
+    return [str(f).replace('\\', '/') for f in unique_files(context)
+            if str(f).replace('\\', '/').endswith(suffix)]
+
+
+def _secs(value):
+    if not value or int(value) <= 0:
+        return ''
+    try:
+        return convert_unix_ts_to_utc(int(value))
+    except (TypeError, ValueError, OverflowError, OSError):
+        return ''
+
+
+def _payload(raw):
+    """Parse the stored JSON copy of the item. Returns {} when it will not parse."""
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _flag(value):
+    if value is True:
+        return 'Yes'
+    if value is False:
+        return 'No'
+    return ''
+
+
+@artifact_processor
+def flipboard_article_history(context):
+    query = ('SELECT time_viewed, title, publisher_name, domain_name, item_type, '
+             'valid_item, id FROM view_history ORDER BY time_viewed DESC')
+    data_list = []
+    sources = []
+    for db_path in _files(context, HISTORY_SUFFIX):
+        records = get_sqlite_db_records(db_path, query)
+        for r in records:
+            item = _payload(r[5])
+            data_list.append((
+                _secs(r[0]), _secs(item.get('dateCreated')), r[1] or item.get('title', ''),
+                r[2] or '', r[3] or item.get('sourceDomain', ''),
+                item.get('sourceURL', ''), item.get('authorDisplayName', ''),
+                item.get('strippedExcerptText', ''), r[4] or '',
+                _flag(item.get('isRead')), _flag(item.get('isBookmarked')),
+                r[6] or '', context.get_relative_path(db_path)))
+        if records and db_path not in sources:
+            sources.append(db_path)
+
+    data_headers = (
+        ('Viewed', 'datetime'), ('Published', 'datetime'), 'Title', 'Publisher',
+        'Domain', 'Source URL', 'Author', 'Excerpt', 'Item Type', 'Read',
+        'Bookmarked', 'Item ID', 'Source File')
+    return data_headers, data_list, '\n'.join(sources)
+
+
+@artifact_processor
+def flipboard_sections(context):
+    query = 'SELECT descriptor, pos, uid, id FROM sections ORDER BY pos'
+    data_list = []
+    sources = []
+    for db_path in _files(context, USERS_SUFFIX):
+        records = get_sqlite_db_records(db_path, query)
+        for r in records:
+            raw = r[0]
+            if isinstance(raw, (bytes, bytearray)):
+                raw = raw.decode('utf-8', 'replace')
+            item = _payload(raw)
+            data_list.append((
+                item.get('title', ''), item.get('feedType', ''),
+                item.get('remoteid', ''), _flag(item.get('private')),
+                item.get('service', ''), r[1], r[2] or '', r[3],
+                context.get_relative_path(db_path)))
+        if records and db_path not in sources:
+            sources.append(db_path)
+
+    data_headers = (
+        'Title', 'Feed Type', 'Remote ID', 'Private', 'Service', 'Position',
+        'User ID', 'Section Row ID', 'Source File')
+    return data_headers, data_list, '\n'.join(sources)

--- a/scripts/artifacts/mxPlayer.py
+++ b/scripts/artifacts/mxPlayer.py
@@ -1,0 +1,178 @@
+__artifacts_v2__ = {
+    "mxplayer_watched": {
+        "name": "MX Player Watched Media",
+        "description": "Media MX Player recorded as played, with resume positions",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-05",
+        "last_update_date": "2026-09-05",
+        "requirements": "none",
+        "category": "MX Player",
+        "sample_data": {
+            "emu_a15_oss_v10": "MX Player 3.1.4 | 2 rows",
+        },
+        "notes": "One row per entry in the VideoFile table of "
+                 "com.mxtech.videoplayer.ad/databases/medias.db that carries a LastWatchTime, so "
+                 "every row here is a file the player recorded as played. Last Watched, Finished "
+                 "and File Modified are Unix milliseconds and are reported as UTC. Finished is "
+                 "written when playback reached the end, so a row with a Last Watched and no "
+                 "Finished was stopped part way, and Resume Position then holds the point in "
+                 "milliseconds where the player would pick the file up again. Both were observed "
+                 "on the tested device: a 30 second clip left part way carried a Resume Position of "
+                 "29758 and no Finished, and a 15 second clip played to the end carried a Finished "
+                 "equal to its Last Watched and a Resume Position of 0, because the player resets "
+                 "the position to the start once a file has run out. A Resume Position of 0 "
+                 "therefore means the start of the file and not the absence of a value; that case "
+                 "is told apart from a file the player never opened by the blank described below. "
+                 "Folder comes from the VideoDirectory "
+                 "row the file points at, so Folder and File Name together give the path as the "
+                 "app stored it. Resume Position is read from the VideoStates table, matched on "
+                 "the file URI that table records rather than on any correlation of size or time; "
+                 "a file with no VideoStates row shows a blank Resume Position. Decode Mode is "
+                 "reported as stored because its values are not documented in anything published. "
+                 "A row is evidence the app played the file, not that a person watched it.",
+        "paths": ('*/com.mxtech.videoplayer.ad/databases/medias.db*',),
+        "output_types": "standard",
+        "artifact_icon": "play-circle",
+    },
+    "mxplayer_media_library": {
+        "name": "MX Player Media Library",
+        "description": "Media files MX Player has indexed, played or not",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-05",
+        "last_update_date": "2026-09-05",
+        "requirements": "none",
+        "category": "MX Player",
+        "sample_data": {
+            "emu_a15_oss_v10": "MX Player 3.1.4 | 4 rows",
+        },
+        "notes": "One row per entry in the VideoFile table of "
+                 "com.mxtech.videoplayer.ad/databases/medias.db, whether or not it was ever "
+                 "played, joined to VideoDirectory for the folder that holds it. File Modified is "
+                 "the file's own modification time in Unix milliseconds, reported as UTC, and is "
+                 "what the app recorded when it indexed the file. Last Watched is blank on a file "
+                 "the app scanned but never played, which is the difference between this artifact "
+                 "and MX Player Watched Media. Size, Duration, Width, Height and the three track "
+                 "counts are the values the app read out of the file itself. The row survives the "
+                 "file being deleted from the device, so an entry here whose path no longer "
+                 "resolves is a record that the file was once present in a folder MX Player "
+                 "scanned. On the tested image two of the four rows were files left by other apps "
+                 "and never opened in MX Player, and both carried a Duration and a resolution but "
+                 "no track counts, because the player fills the track counts when it opens a file "
+                 "for playback. That is also why Video Tracks and Audio Tracks carried the same "
+                 "number on every row of that image: the two played files each held one of each "
+                 "and the two unopened files held none, so the columns matched by coincidence of "
+                 "this sample rather than because one is derived from the other. Subtitle Tracks "
+                 "was 0 throughout, since none of the tested files carried a subtitle track. A row "
+                 "is evidence the app saw the file, not that a person watched it.",
+        "paths": ('*/com.mxtech.videoplayer.ad/databases/medias.db*',),
+        "output_types": "standard",
+        "artifact_icon": "film",
+    },
+}
+
+from urllib.parse import unquote
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records
+from scripts.artifacts.storagePathViews import unique_files
+
+DB_SUFFIX = 'databases/medias.db'
+
+FILE_QUERY = '''SELECT f.LastWatchTime, f.FinishTime, f.LastModified, f.FileName, d.Path,
+                       f.Duration, f.Size, f.Width, f.Height, f.VideoTrackCount,
+                       f.AudioTrackCount, f.SubtitleTrackCount, f.Read, f.Id
+                FROM VideoFile f
+                LEFT JOIN VideoDirectory d ON d.Id = f.Directory
+                ORDER BY f.LastWatchTime DESC, f.Id'''
+
+STATE_QUERY = 'SELECT Uri, Position, DecodeMode, PlaybackSpeed FROM VideoStates'
+
+
+def _db_files(context):
+    return [str(f).replace('\\', '/') for f in unique_files(context)
+            if str(f).replace('\\', '/').endswith(DB_SUFFIX)]
+
+
+def _ms(value):
+    if not value:
+        return ''
+    try:
+        value = int(value)
+        if value < 0:
+            return ''
+        return convert_unix_ts_to_utc(value // 1000)
+    except (TypeError, ValueError, OverflowError, OSError):
+        return ''
+
+
+def _path_key(value):
+    """Normalise a stored file URI or a folder+name pair to one comparable path."""
+    if not value:
+        return ''
+    text = unquote(str(value))
+    if text.startswith('file://'):
+        text = text[len('file://'):]
+    return text.rstrip('/')
+
+
+def _states(db_path):
+    """{normalised path: (position, decode mode, playback speed)} from VideoStates."""
+    result = {}
+    for row in get_sqlite_db_records(db_path, STATE_QUERY):
+        key = _path_key(row[0])
+        if key:
+            result[key] = (row[1], row[2], row[3])
+    return result
+
+
+def _rows(context, watched_only):
+    data_list = []
+    sources = []
+    for db_path in _db_files(context):
+        states = _states(db_path)
+        records = get_sqlite_db_records(db_path, FILE_QUERY)
+        used = False
+        for r in records:
+            if watched_only and not r[0]:
+                continue
+            folder = r[4] or ''
+            key = _path_key(f'{folder}/{r[3]}' if folder else r[3])
+            position, decode_mode, speed = states.get(key, ('', '', ''))
+            used = True
+            if watched_only:
+                data_list.append((
+                    _ms(r[0]), _ms(r[1]), _ms(r[2]), r[3] or '', folder,
+                    position if position not in (None, '') else '',
+                    r[5], decode_mode if decode_mode not in (None, '') else '',
+                    speed if speed not in (None, '') else '',
+                    r[6], r[13], context.get_relative_path(db_path)))
+            else:
+                data_list.append((
+                    _ms(r[2]), _ms(r[0]), r[3] or '', folder, r[6], r[5],
+                    r[7], r[8], r[9], r[10], r[11],
+                    'Yes' if r[12] else 'No', r[13],
+                    context.get_relative_path(db_path)))
+        if used and db_path not in sources:
+            sources.append(db_path)
+    return data_list, '\n'.join(sources)
+
+
+@artifact_processor
+def mxplayer_watched(context):
+    data_list, sources = _rows(context, watched_only=True)
+    data_headers = (
+        ('Last Watched', 'datetime'), ('Finished', 'datetime'),
+        ('File Modified', 'datetime'), 'File Name', 'Folder',
+        'Resume Position (ms)', 'Duration (ms)', 'Decode Mode (as stored)',
+        'Playback Speed', 'Size (bytes)', 'Media ID', 'Source File')
+    return data_headers, data_list, sources
+
+
+@artifact_processor
+def mxplayer_media_library(context):
+    data_list, sources = _rows(context, watched_only=False)
+    data_headers = (
+        ('File Modified', 'datetime'), ('Last Watched', 'datetime'), 'File Name',
+        'Folder', 'Size (bytes)', 'Duration (ms)', 'Width', 'Height',
+        'Video Tracks', 'Audio Tracks', 'Subtitle Tracks', 'Played', 'Media ID',
+        'Source File')
+    return data_headers, data_list, sources

--- a/scripts/artifacts/novaLauncher.py
+++ b/scripts/artifacts/novaLauncher.py
@@ -1,0 +1,173 @@
+__artifacts_v2__ = {
+    "nova_layout": {
+        "name": "Nova Launcher Layout",
+        "description": "Items Nova Launcher places on the home screen, the dock and drawer folders",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-05",
+        "last_update_date": "2026-09-05",
+        "requirements": "none",
+        "category": "Nova Launcher",
+        "sample_data": {
+            "emu_a15_oss_v10": "Nova Launcher 8.9.0 | 19 rows",
+        },
+        "notes": "One row per item in the favorites table of "
+                 "com.teslacoilsw.launcher/databases/nova.db, which holds what the launcher draws "
+                 "on the home screen and in the dock, and also the items sitting inside its "
+                 "drawer folders. Modified is Unix milliseconds and is "
+                 "reported as UTC. It is blank on the items Nova copied out of the previous "
+                 "launcher when it was first set as the default, and carries a time on items "
+                 "written later, so a blank Modified marks an imported item and a filled one marks "
+                 "an item Nova itself wrote. That split was produced on the tested device: nine "
+                 "rows imported at setup carried 0 and the rest carried the setup time. Location "
+                 "resolves the container column, and only the two values seen on the tested device "
+                 "are named. Those two are proven by known data rather than by any published "
+                 "source: the five items with container -101 were the icons sitting in the dock "
+                 "and the items with container -100 were on the home screen itself. Any other "
+                 "container is reported as stored, because Nova is closed source and its remaining "
+                 "values were not exercised here. The tested image also held items under -202, "
+                 "-207 and -208, and those were the members of the Entertainment, Social and "
+                 "Travel drawer folders, whose drawer_groups rows are 2, 7 and 8. Read that "
+                 "relationship off the Nova Launcher Drawer Groups artifact, which resolves folder "
+                 "membership through the join the database records rather than through arithmetic "
+                 "on the container number. Item Type is reported as stored for the same "
+                 "reason; every item on the tested device was 0. Component is taken out of the "
+                 "stored intent and is the package and activity the item launches, which is what "
+                 "identifies the app when the title has been renamed by the user. One internal row "
+                 "with no container and no title is skipped. Span X and Span Y were 1.0 on every "
+                 "row of the tested image because every item there was a single icon; a widget "
+                 "occupies more than one cell and is what makes those two columns vary, so they "
+                 "are kept rather than dropped. A row is evidence the item was in the launcher's "
+                 "layout, not that it was ever tapped.",
+        "paths": ('*/com.teslacoilsw.launcher/databases/nova.db*',),
+        "output_types": "standard",
+        "artifact_icon": "grid",
+    },
+    "nova_drawer_groups": {
+        "name": "Nova Launcher Drawer Groups",
+        "description": "App drawer tabs and folders, and the apps assigned to each",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-05",
+        "last_update_date": "2026-09-05",
+        "requirements": "none",
+        "category": "Nova Launcher",
+        "sample_data": {
+            "emu_a15_oss_v10": "Nova Launcher 8.9.0 | 20 rows",
+        },
+        "notes": "One row per row of the appgroups table in "
+                 "com.teslacoilsw.launcher/databases/nova.db, joined to the drawer_groups row its "
+                 "groupId names. The join is the one the database records: appgroups.groupId is "
+                 "the _id of a drawer_groups row, which was confirmed on the tested device where "
+                 "groups 2, 7 and 8 resolved to the Entertainment, Social and Travel folders that "
+                 "held exactly the apps shown. Assigned is Unix milliseconds, reported as UTC, and "
+                 "is the appgroups row's own modified column. Every component is written twice, "
+                 "once against its group and once against group -100, which is the drawer's whole "
+                 "app list rather than a folder; those rows are reported with a blank Group Name "
+                 "and are what shows an app was present in the drawer at all. Hides Apps From "
+                 "Drawer is the drawer_groups hideApps column and was 1 on every category folder "
+                 "of the tested device, which is the app's own default for a category folder and "
+                 "not a choice made here. Hiding an individual app is a paid Nova Prime feature "
+                 "and was not exercised, so this artifact shows folder membership and the folder's "
+                 "hide setting, not a per-app hidden list. Group Type is reported as stored. A row "
+                 "is evidence the app was assigned to the group, not that it was launched.",
+        "paths": ('*/com.teslacoilsw.launcher/databases/nova.db*',),
+        "output_types": "standard",
+        "artifact_icon": "folder",
+    },
+}
+
+import re
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records
+from scripts.artifacts.storagePathViews import unique_files
+
+DB_SUFFIX = 'databases/nova.db'
+
+# Proven from the layout on the tested device: the items Nova drew in the dock carried
+# container -101 and the items on the home screen carried -100. Nova is closed source and
+# no other container value was produced here, so nothing else is named.
+CONTAINERS = {-100: 'Home screen', -101: 'Dock'}
+
+COMPONENT = re.compile(r'component=([^;]+)')
+
+
+def _db_files(context):
+    return [str(f).replace('\\', '/') for f in unique_files(context)
+            if str(f).replace('\\', '/').endswith(DB_SUFFIX)]
+
+
+def _ms(value):
+    if not value:
+        return ''
+    try:
+        value = int(value)
+        if value < 0:
+            return ''
+        return convert_unix_ts_to_utc(value // 1000)
+    except (TypeError, ValueError, OverflowError, OSError):
+        return ''
+
+
+def _component(intent):
+    if not intent:
+        return ''
+    match = COMPONENT.search(str(intent))
+    return match.group(1) if match else ''
+
+
+def _location(container):
+    if container is None:
+        return ''
+    if container in CONTAINERS:
+        return f'{CONTAINERS[container]} ({container})'
+    return f'As stored ({container})'
+
+
+@artifact_processor
+def nova_layout(context):
+    query = '''SELECT modified, title, container, screen, cellX, cellY, spanX, spanY,
+                      itemType, intent, _id
+               FROM favorites
+               WHERE container IS NOT NULL
+               ORDER BY container, screen, cellY, cellX'''
+    data_list = []
+    sources = []
+    for db_path in _db_files(context):
+        records = get_sqlite_db_records(db_path, query)
+        for r in records:
+            data_list.append((
+                _ms(r[0]), r[1] or '', _location(r[2]), r[3], r[4], r[5], r[6], r[7],
+                r[8], _component(r[9]), r[10], context.get_relative_path(db_path)))
+        if records and db_path not in sources:
+            sources.append(db_path)
+
+    data_headers = (
+        ('Modified', 'datetime'), 'Title', 'Location', 'Screen', 'Cell X', 'Cell Y',
+        'Span X', 'Span Y', 'Item Type (as stored)', 'Component', 'Item ID',
+        'Source File')
+    return data_headers, data_list, '\n'.join(sources)
+
+
+@artifact_processor
+def nova_drawer_groups(context):
+    query = '''SELECT a.modified, g.title, a.groupId, a.component, g.groupType,
+                      g.hideApps, g.tabOrder, a._id
+               FROM appgroups a
+               LEFT JOIN drawer_groups g ON g._id = a.groupId
+               ORDER BY a.groupId, a._id'''
+    data_list = []
+    sources = []
+    for db_path in _db_files(context):
+        records = get_sqlite_db_records(db_path, query)
+        for r in records:
+            data_list.append((
+                _ms(r[0]), r[1] or '', r[2], r[3] or '', r[4] or '',
+                'Yes' if r[5] else ('No' if r[5] is not None else ''),
+                r[6] if r[6] is not None else '', r[7],
+                context.get_relative_path(db_path)))
+        if records and db_path not in sources:
+            sources.append(db_path)
+
+    data_headers = (
+        ('Assigned', 'datetime'), 'Group Name', 'Group ID', 'Component', 'Group Type',
+        'Hides Apps From Drawer', 'Tab Order', 'Assignment ID', 'Source File')
+    return data_headers, data_list, '\n'.join(sources)


### PR DESCRIPTION
Adds support for five closed-source Android apps. Nine artifacts:

- ColorNote Notes (colornote.db): text notes and checklists with created, modified and reminder times, plus the archive and trash states. Checklist ticks are stored inside the note text as [V] and [ ].
- MX Player Watched Media and Media Library (medias.db): watch times, resume positions, and every file the player has indexed with its folder.
- Nova Launcher Layout and Drawer Groups (nova.db)
- Flipboard Article History and Followed Sections
- Easy Voice Recorder Library and Settings

State, reminder and container codes come from a decompiled build of each installed version and say so; anything not sourced is reported as stored. Easy Voice Recorder's notes record that no recording was made on the tested device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
