### PR TITLE
Add Life360 API cache artifacts and cached photos on chat messages

### DIFF
--- a/scripts/artifacts/Life360.py
+++ b/scripts/artifacts/Life360.py
@@ -7,19 +7,26 @@ __artifacts_v2__ = {
         "last_update_date": "2026-09-05",
         "requirements": "none",
         "category": "Life360",
-        "notes": "A message with a photo has a message_media row whose photo_key is the photo's URL. The "
-                 "app's Picasso image cache (cache/picasso-cache) is an OkHttp DiskLruCache whose <hash>.0 "
-                 "file starts with the URL requested and whose <hash>.1 file is the body, so the Photo "
-                 "column renders the cached copy whose stored URL equals photo_key exactly, when the bytes "
-                 "are a JPEG, PNG, GIF or WebP image; Photo URL is photo_key as stored. A photo message "
-                 "whose image was never cached, or was evicted, has the URL and no picture. On the one "
-                 "tested image holding photo messages both photos resolved.",
+        "notes": "A message with a photo has a message_media row whose photo_key is the photo's URL. The app's "
+                 "Picasso image cache (cache/picasso-cache) is an OkHttp DiskLruCache whose <hash>.0 file starts "
+                 "with the URL requested and whose <hash>.1 file is the body, so the Photo column renders the "
+                 "cached copy whose stored URL equals photo_key exactly, when the bytes are a JPEG, PNG, GIF or "
+                 "WebP image; Photo URL is photo_key as stored. A photo message whose image was never cached, or "
+                 "was evicted, has the URL and no picture. pixel7a_a14 was the only tested image with messages: "
+                 "all 20 belong to one Thread ID, both of its photo messages resolved to a cached image, Location "
+                 "Timestamp, Has Location, Latitude, Longitude, Location Name and Message Dismissed were blank on "
+                 "all 20 messages, Message Sent and Message Read were Yes on all 20, and Message Deleted was Yes "
+                 "on 1. Each Android user's messaging.db is read separately and its photos are resolved from that "
+                 "user's own cache.",
         "paths": ('*/com.life360.android.safetymapd/databases/messaging.db*',
                   '*/com.life360.android.safetymapd/cache/picasso-cache/*'),
         "output_types": "all",
         "artifact_icon": "message-circle",
         "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.life360.android.safetymapd vc 2897710 | 0 rows",
+            "hc_pixel8pro_a17": "Android 17 | com.life360.android.safetymapd | 0 rows",
             "pixel7a_a14": "Android 14 | com.life360.android.safetymapd vc 294540 | 20 rows",
+            "sharon_a14": "Android 14 | com.life360.android.safetymapd vc 296030 | 0 rows",
         },
         "data_views": {
             "conversation": {

--- a/scripts/artifacts/Life360.py
+++ b/scripts/artifacts/Life360.py
@@ -4,11 +4,18 @@ __artifacts_v2__ = {
         "description": "Parses Life360 chat messages (messaging.db)",
         "author": "Kevin Pagano (@stark4n6)",
         "creation_date": "2024-01-17",
-        "last_update_date": "2026-07-03",
+        "last_update_date": "2026-09-05",
         "requirements": "none",
         "category": "Life360",
-        "notes": "",
-        "paths": ('*/com.life360.android.safetymapd/databases/messaging.db*',),
+        "notes": "A message with a photo has a message_media row whose photo_key is the photo's URL. The "
+                 "app's Picasso image cache (cache/picasso-cache) is an OkHttp DiskLruCache whose <hash>.0 "
+                 "file starts with the URL requested and whose <hash>.1 file is the body, so the Photo "
+                 "column renders the cached copy whose stored URL equals photo_key exactly, when the bytes "
+                 "are a JPEG, PNG, GIF or WebP image; Photo URL is photo_key as stored. A photo message "
+                 "whose image was never cached, or was evicted, has the URL and no picture. On the one "
+                 "tested image holding photo messages both photos resolved.",
+        "paths": ('*/com.life360.android.safetymapd/databases/messaging.db*',
+                  '*/com.life360.android.safetymapd/cache/picasso-cache/*'),
         "output_types": "all",
         "artifact_icon": "message-circle",
         "sample_data": {
@@ -21,7 +28,8 @@ __artifacts_v2__ = {
                 "directionColumn": "Message Sent",
                 "directionSentValue": "Yes",
                 "timeColumn": "Timestamp",
-                "senderColumn": "Sender Name"
+                "senderColumn": "Sender Name",
+                "mediaColumn": "Photo"
             }
         },
     },
@@ -81,10 +89,12 @@ __artifacts_v2__ = {
 
 import datetime
 import json
+import os
 import sqlite3
 
-from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, check_in_media, open_sqlite_db_readonly
 from scripts.context import Context
+from scripts.artifacts.storagePathViews import canonical_path, unique_files
 
 
 def _sec_to_utc(value):
@@ -105,14 +115,83 @@ def _ms_to_utc(value):
         return ''
 
 
-def _find(files_found, suffix):
-    for file_found in files_found:
+_PACKAGE = 'com.life360.android.safetymapd'
+
+
+def _sources(context, suffix):
+    """Every distinct copy of the store named by suffix, one per app container.
+
+    The duplicate storage views of one file (data/data, data/user/0, data_mirror) collapse to
+    one; a second Android user's copy is its own source.
+    """
+    return [f for f in unique_files(context)
+            if str(f).endswith(suffix) and not str(f).endswith(('-wal', '-shm', '-journal'))
+            and not os.path.isdir(f)]
+
+
+def _container_key(context, file_found):
+    """A key shared by every file of one app container, across its storage-view spellings."""
+    parts = context.get_relative_path(file_found).replace('\\', '/').split('/')
+    if _PACKAGE in parts:
+        parts = parts[:parts.index(_PACKAGE) + 1]
+    return canonical_path('/'.join(parts))[0]
+
+
+_IMAGE_MAGIC = (
+    (b'\xff\xd8\xff', 'image/jpeg', 'jpg'),
+    (b'\x89PNG\r\n\x1a\n', 'image/png', 'png'),
+    (b'GIF87a', 'image/gif', 'gif'),
+    (b'GIF89a', 'image/gif', 'gif'),
+)
+
+
+def _image_type(head):
+    for magic, mime, extension in _IMAGE_MAGIC:
+        if head.startswith(magic):
+            return mime, extension
+    if head[:4] == b'RIFF' and head[8:12] == b'WEBP':
+        return 'image/webp', 'webp'
+    return '', ''
+
+
+def _picasso_bodies(context, container):
+    """{stored URL: path of the <hash>.1 body} for the OkHttp entries of one container's Picasso cache."""
+    bodies = {}
+    urls = {}
+    for file_found in unique_files(context):
         file_found = str(file_found)
-        if file_found.endswith(('-wal', '-shm', '-journal')):
+        if '/picasso-cache/' not in file_found.replace('\\', '/') or os.path.isdir(file_found):
             continue
-        if file_found.endswith(suffix):
-            return file_found
-    return ''
+        if _container_key(context, file_found) != container:
+            continue
+        stem, ext = os.path.splitext(os.path.basename(file_found))
+        if ext == '.0':
+            try:
+                with open(file_found, 'rb') as handle:
+                    first = handle.readline().decode('utf-8', 'replace').rstrip('\n')
+            except OSError:
+                continue
+            if first.startswith(('http://', 'https://')):
+                urls[stem] = first
+        elif ext == '.1':
+            bodies[stem] = file_found
+    return {url: bodies[stem] for stem, url in urls.items() if stem in bodies}
+
+
+def _cached_photo(bodies, photo_key):
+    """Media reference for the cached image whose stored URL equals photo_key, else ''."""
+    path = bodies.get(photo_key or '')
+    if not path:
+        return ''
+    try:
+        with open(path, 'rb') as handle:
+            head = handle.read(16)
+    except OSError:
+        return ''
+    mime, extension = _image_type(head)
+    if not mime:
+        return ''
+    return check_in_media(path, os.path.basename(path), force_type=mime, force_extension=extension) or ''
 
 
 def _q(cursor, sql):
@@ -127,6 +206,8 @@ def _ble_events(file_found):
     """Parse the BLE geolocation/battery events from L360EventStore.db into dicts."""
     rows = []
     db = open_sqlite_db_readonly(file_found)
+    if db is None:
+        return rows
     cursor = db.cursor()
     # Filter to BLE events in Python (json_extract in SQL errors on any malformed-JSON row).
     for data, ev_id in _q(cursor, 'SELECT data, id FROM event WHERE eventVersion = 5'):
@@ -157,13 +238,18 @@ def _ble_events(file_found):
 
 @artifact_processor
 def get_Life360_chat_messages(context):
-    files_found = context.get_files_found()
-    source = _find(files_found, 'messaging.db')
+    sources = _sources(context, 'messaging.db')
     data_list = []
-    if source:
+    for source in sources:
+        bodies = _picasso_bodies(context, _container_key(context, source))
         db = open_sqlite_db_readonly(source)
+        if db is None:
+            continue
         cursor = db.cursor()
-        rows = _q(cursor, '''
+        has_media = bool(_q(cursor, "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'message_media'"))
+        photo_select = 'message_media.photo_key' if has_media else 'NULL AS photo_key'
+        photo_join = 'LEFT JOIN message_media ON message_media._id = message._id' if has_media else ''
+        rows = _q(cursor, f'''
         SELECT
             message.created_at,
             message.thread_id,
@@ -178,9 +264,11 @@ def get_Life360_chat_messages(context):
             message.location_latitude,
             message.location_longitude,
             message.location_name,
-            message.location_timestamp
+            message.location_timestamp,
+            {photo_select}
         FROM message
         LEFT JOIN thread_participant ON message.sender_id = thread_participant.participant_id
+        {photo_join}
         ''')
         for row in rows:
             data_list.append((
@@ -189,6 +277,8 @@ def get_Life360_chat_messages(context):
                 row[5],
                 row[3],
                 row[4],
+                _cached_photo(bodies, row[14]),
+                row[14] or '',
                 row[1],
                 row[2],
                 row[6],
@@ -208,6 +298,8 @@ def get_Life360_chat_messages(context):
         'Message Sent',
         'Sender Name',
         'Message',
+        ('Photo', 'media'),
+        'Photo URL',
         'Thread ID',
         'Sender ID',
         'Message Read',
@@ -219,16 +311,17 @@ def get_Life360_chat_messages(context):
         'Location Name',
         'Source File',
     )
-    return data_headers, data_list, source
+    return data_headers, data_list, '\n'.join(Context.get_relative_path(s) for s in sources)
 
 
 @artifact_processor
 def get_Life360_places(context):
-    files_found = context.get_files_found()
-    source = _find(files_found, 'L360LocalStoreRoomDatabase')
+    sources = _sources(context, 'L360LocalStoreRoomDatabase')
     data_list = []
-    if source:
+    for source in sources:
         db = open_sqlite_db_readonly(source)
+        if db is None:
+            continue
         cursor = db.cursor()
         for row in _q(cursor, '''SELECT name, latitude, longitude, radius, source, source_id, owner_id
                 FROM places'''):
@@ -237,15 +330,14 @@ def get_Life360_places(context):
 
     data_headers = ('Place Name', 'Latitude', 'Longitude', 'Radius (as stored)', 'Places Source', 'Source ID',
                     'Owner ID', 'Source File')
-    return data_headers, data_list, source
+    return data_headers, data_list, '\n'.join(Context.get_relative_path(s) for s in sources)
 
 
 @artifact_processor
 def get_Life360_locations(context):
-    files_found = context.get_files_found()
-    source = _find(files_found, 'L360EventStore.db')
+    sources = _sources(context, 'L360EventStore.db')
     data_list = []
-    if source:
+    for source in sources:
         for e in _ble_events(source):
             data_list.append((e['time'], e['lat'], e['lon'], e['alt'], e['speed'], e['course'],
                               e['bearing'], e['vert'], e['hor'], e['lmode'], e['bssid'], e['ssid'],
@@ -255,17 +347,16 @@ def get_Life360_locations(context):
                     'Course', 'Bearing', 'Vertical Accuracy (as stored)', 'Horizontal Accuracy (as stored)',
                     'Location Mode', 'Connected Access Point BSSID', 'Connected Access Point SSID',
                     'ID', 'Source File')
-    return data_headers, data_list, source
+    return data_headers, data_list, '\n'.join(Context.get_relative_path(s) for s in sources)
 
 
 @artifact_processor
 def get_Life360_device_battery(context):
-    files_found = context.get_files_found()
-    source = _find(files_found, 'L360EventStore.db')
+    sources = _sources(context, 'L360EventStore.db')
     data_list = []
-    if source:
+    for source in sources:
         for e in _ble_events(source):
             data_list.append((e['time'], e['battery'], e['charging'], Context.get_relative_path(source)))
 
     data_headers = (('Timestamp', 'datetime'), 'Device Battery (%)', 'Charging', 'Source File')
-    return data_headers, data_list, source
+    return data_headers, data_list, '\n'.join(Context.get_relative_path(s) for s in sources)

--- a/scripts/artifacts/life360ApiCache.py
+++ b/scripts/artifacts/life360ApiCache.py
@@ -1,0 +1,527 @@
+__artifacts_v2__ = {
+    "life360CacheMemberHistory": {
+        "name": "Life360 - Member Location History (API cache)",
+        "description": "Location history records of circle members, read from the JSON responses to the "
+                       "app's members/<member id>/history API calls that its OkHttp response cache holds. "
+                       "One row per distinct record; a record returned by several cached responses is "
+                       "reported once with the number of copies.",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-05",
+        "last_update_date": "2026-09-05",
+        "requirements": "none",
+        "category": "Life360",
+        "notes": "Read from the app's OkHttp response caches under cache/ (http_cache holds these "
+                 "responses on the tested images). Each cache entry is a pair of files named by the MD5 "
+                 "of the URL: <hash>.0 holds the URL, the status line and the response headers, <hash>.1 "
+                 "the body, gzip-compressed when the Content-Encoding header says so (OkHttp Cache.kt "
+                 "Entry.writeTo at release parent-5.5.0, the same layout since 2.x). The URL names the "
+                 "circle and the member; the body is a locations list whose timestamp, startTimestamp, "
+                 "endTimestamp and since values are Unix seconds and are rendered in UTC. Latitude, "
+                 "longitude, accuracy, speed, battery, and the charge, inTransit, isDriving, wifiState, "
+                 "userActivity, driveSDKStatus and algorithm values are reported as stored; Life360 is "
+                 "closed source and their meanings are not documented. Member Name is resolved from the "
+                 "circles/<id>/members and users/me responses in the same cache and is blank when no cached "
+                 "response names the member. The same record is returned by many cached history responses "
+                 "(the app fetches the history repeatedly with a moving time parameter), so rows are "
+                 "de-duplicated on member, timestamp, coordinates and the start and end timestamps; "
+                 "Cached Copies counts the responses holding the record and First Cached is the earliest "
+                 "OkHttp-Received-Millis among them. The device's own location events are reported by "
+                 "the Life360 Locations artifacts from L360EventStore.db; this artifact adds the history "
+                 "the app fetched for circle members.",
+        "paths": ('*/com.life360.android.safetymapd/cache/*/journal',
+                  '*/com.life360.android.safetymapd/cache/*/[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f].[01]'),
+        "output_types": "all",
+        "artifact_icon": "map-pin",
+    },
+    "life360CacheEmergencyContacts": {
+        "name": "Life360 - Emergency Contacts (API cache)",
+        "description": "Emergency contacts of a circle, read from the JSON responses to the app's "
+                       "circles/<circle id>/emergencyContacts API calls held in its OkHttp response cache.",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-05",
+        "last_update_date": "2026-09-05",
+        "requirements": "none",
+        "category": "Life360",
+        "notes": "Read from the same OkHttp response caches as the Member Location History artifact. One "
+                 "row per distinct contact id per circle; the Cached time is the OkHttp-Received-Millis "
+                 "header of the response that held it. Phone Numbers joins each phone with its type in "
+                 "parentheses where the type is stored. Accepted is reported as stored. No database the "
+                 "other Life360 artifacts read holds these contacts.",
+        "paths": ('*/com.life360.android.safetymapd/cache/*/journal',
+                  '*/com.life360.android.safetymapd/cache/*/[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f].[01]'),
+        "output_types": "standard",
+        "artifact_icon": "phone-call",
+    },
+    "life360CacheEntries": {
+        "name": "Life360 - API Cache Entries",
+        "description": "Index of the exchanges held in the Life360 app's OkHttp response caches: the URL "
+                       "requested, when it was sent and received, the status, the content type and size, "
+                       "and the cached image where the body is one.",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-05",
+        "last_update_date": "2026-09-05",
+        "requirements": "none",
+        "category": "Life360",
+        "notes": "One row per <hash>.0 metadata file in each DiskLruCache directory under the app's cache/ "
+                 "folder whose entries start with a URL (http_cache, l360_http_cache, core_http_cache, "
+                 "picasso-cache, the LaunchDarkly and Statsig SDK caches on the tested images). Sent and "
+                 "Received are the OkHttp-Sent-Millis and OkHttp-Received-Millis headers OkHttp writes into "
+                 "the entry (Unix milliseconds; written since OkHttp 3.4.0, absent from entries of older "
+                 "releases). OkHttp caches GET responses only (Cache.kt put, release parent-5.5.0), so no "
+                 "method column is reported. The URLs themselves carry request parameters the app sent, "
+                 "such as a phone number passed to users/lookup, an invite code passed to code/<code>, and "
+                 "the coordinates passed to nearbyplaces/<lat>/<lon>. Journal State is the last CLEAN, "
+                 "DIRTY or REMOVE line for the entry's key in the directory's journal, blank when the key "
+                 "is not in the journal. Media renders the body when its bytes are a JPEG, PNG, GIF or WebP "
+                 "image and the response is not compressed; other bodies are not decoded here.",
+        "paths": ('*/com.life360.android.safetymapd/cache/*/journal',
+                  '*/com.life360.android.safetymapd/cache/*/[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f].[01]'),
+        "output_types": "standard",
+        "artifact_icon": "list",
+    },
+}
+
+import gzip
+import json
+import os
+import re
+from datetime import datetime, timezone
+
+from scripts.ilapfuncs import artifact_processor, check_in_media, logfunc
+from scripts.artifacts.storagePathViews import canonical_path, unique_files
+
+_PACKAGE = 'com.life360.android.safetymapd'
+_ENTRY = re.compile(r'^([0-9a-f]{32})\.([01])$')
+_HISTORY = re.compile(r'/v3/circles/([0-9a-f-]{36})/members/([0-9a-f-]{36})/history(?:\?|$)')
+_MEMBERS = re.compile(r'/v4/circles/([0-9a-f-]{36})/members$')
+_CONTACTS = re.compile(r'/v3/circles/([0-9a-f-]{36})/emergencyContacts$')
+_ME = re.compile(r'/v3/users/me$')
+# OkHttp writes its two timing pseudo-headers with the platform prefix: "OkHttp" for the
+# library an app bundles (Platform.kt), "X-Android" for the copy inside the Android framework
+# (external/okhttp android/src/main/java/com/squareup/okhttp/internal/Platform.java).
+_SENT = ('okhttp-sent-millis', 'x-android-sent-millis')
+_RECEIVED = ('okhttp-received-millis', 'x-android-received-millis')
+_IMAGE_MAGIC = (
+    (b'\xff\xd8\xff', 'image/jpeg', 'jpg'),
+    (b'\x89PNG\r\n\x1a\n', 'image/png', 'png'),
+    (b'GIF87a', 'image/gif', 'gif'),
+    (b'GIF89a', 'image/gif', 'gif'),
+)
+
+
+def _utc_seconds(value):
+    """UTC datetime from a Unix-seconds value stored as int, float or digit string."""
+    try:
+        return datetime.fromtimestamp(float(value), timezone.utc)
+    except (TypeError, ValueError, OverflowError, OSError):
+        return ''
+
+
+def _utc_millis(value):
+    try:
+        return datetime.fromtimestamp(int(value) / 1000, timezone.utc)
+    except (TypeError, ValueError, OverflowError, OSError):
+        return ''
+
+
+def _first_header(headers, names):
+    for name in names:
+        if name in headers:
+            return headers[name]
+    return ''
+
+
+def _read_entry(path):
+    """(url, status line, headers) from an OkHttp cache <hash>.0 file, or None.
+
+    Layout (Cache.kt Entry.writeTo, parent-5.5.0): URL, request method, vary header count and
+    lines, status line, response header count and lines, then the TLS block for https URLs.
+    """
+    try:
+        with open(path, 'rb') as handle:
+            lines = handle.read().decode('utf-8', 'replace').split('\n')
+    except OSError:
+        return None
+    if len(lines) < 5 or not lines[0].startswith(('http://', 'https://')):
+        return None
+    try:
+        index = 3 + int(lines[2])
+        status = lines[index]
+        count = int(lines[index + 1])
+        header_lines = lines[index + 2:index + 2 + count]
+    except (ValueError, IndexError):
+        return None
+    headers = {}
+    for line in header_lines:
+        name, sep, value = line.partition(':')
+        if sep:
+            headers.setdefault(name.strip().lower(), value.strip())
+    return lines[0], status, headers
+
+
+def _read_journal(path):
+    """{entry key: last CLEAN/DIRTY/REMOVE state} from a libcore DiskLruCache journal, or None."""
+    try:
+        with open(path, 'rb') as handle:
+            lines = handle.read().decode('utf-8', 'replace').split('\n')
+    except OSError:
+        return None
+    if lines[:2] != ['libcore.io.DiskLruCache', '1']:
+        return None
+    states = {}
+    for line in lines[5:]:
+        parts = line.split(' ')
+        if len(parts) >= 2 and parts[0] in ('CLEAN', 'DIRTY', 'REMOVE'):
+            states[parts[1]] = parts[0]
+    return states
+
+
+def _cache_label(context, folder):
+    """The cache folder relative to the package directory, e.g. cache/http_cache."""
+    parts = context.get_relative_path(folder).replace('\\', '/').split('/')
+    if _PACKAGE in parts:
+        return '/'.join(parts[parts.index(_PACKAGE) + 1:])
+    return parts[-1]
+
+
+def _caches(context):
+    """{cache folder: {'journal': path or None, 'entries': {key: {'0': path, '1': path}}}}.
+
+    Folders are keyed by their storage-view canonical path, so a journal and its entries staged
+    from two spellings of one folder (data/data, data/user/0, data_mirror) pair up.
+    """
+    caches = {}
+    by_key = {}
+    for file_found in unique_files(context):
+        file_found = str(file_found)
+        if os.path.isdir(file_found):
+            continue
+        base = os.path.basename(file_found)
+        folder = os.path.dirname(file_found)
+        match = _ENTRY.match(base)
+        if base != 'journal' and not match:
+            continue
+        key = canonical_path(context.get_relative_path(folder))[0]
+        folder = by_key.setdefault(key, folder)
+        cache = caches.setdefault(folder, {'journal': None, 'entries': {}})
+        if base == 'journal':
+            cache['journal'] = file_found
+        else:
+            cache['entries'].setdefault(match.group(1), {})[match.group(2)] = file_found
+    return caches
+
+
+def _exchanges(context):
+    """Every parsed cache entry as a dict, plus the number of <hash>.0 files that did not parse."""
+    exchanges = []
+    skipped = 0
+    for folder, cache in sorted(_caches(context).items()):
+        states = _read_journal(cache['journal']) if cache['journal'] else None
+        label = _cache_label(context, folder)
+        for key, files in sorted(cache['entries'].items()):
+            if '0' not in files:
+                continue
+            parsed = _read_entry(files['0'])
+            if parsed is None:
+                skipped += 1
+                continue
+            url, status, headers = parsed
+            exchanges.append({
+                'cache': label, 'key': key, 'url': url, 'status': status, 'headers': headers,
+                'sent': _utc_millis(_first_header(headers, _SENT)),
+                'received': _utc_millis(_first_header(headers, _RECEIVED)),
+                'received_raw': _first_header(headers, _RECEIVED),
+                'files': files,
+                'state': states.get(key, '') if states is not None else '',
+            })
+    if skipped:
+        logfunc(f'Life360 API cache: {skipped} .0 files did not start with a URL and were skipped')
+    return exchanges
+
+
+def _body(exchange):
+    """The response body bytes, gunzipped when the response says gzip, or None."""
+    path = exchange['files'].get('1')
+    if not path:
+        return None
+    try:
+        with open(path, 'rb') as handle:
+            data = handle.read()
+    except OSError:
+        return None
+    if exchange['headers'].get('content-encoding', '').lower() == 'gzip':
+        try:
+            data = gzip.decompress(data)
+        except (OSError, EOFError, ValueError):
+            return None
+    return data
+
+
+def _json_body(exchange):
+    data = _body(exchange)
+    if data is None:
+        return None
+    try:
+        return json.loads(data)
+    except (ValueError, UnicodeDecodeError):
+        return None
+
+
+def _member_names(exchanges):
+    """{member id: 'First Last'} from the circle members and users/me responses."""
+    names = {}
+    for exchange in exchanges:
+        url = exchange['url'].split('?')[0]
+        if _MEMBERS.search(url):
+            payload = _json_body(exchange)
+            members = payload.get('members', []) if isinstance(payload, dict) else []
+        elif _ME.search(url):
+            payload = _json_body(exchange)
+            members = [payload] if isinstance(payload, dict) else []
+        else:
+            continue
+        for member in members:
+            if isinstance(member, dict) and member.get('id'):
+                name = ' '.join(str(member.get(k) or '') for k in ('firstName', 'lastName')).strip()
+                if name:
+                    names.setdefault(member['id'], name)
+    return names
+
+
+def _text(value):
+    return '' if value is None else str(value)
+
+
+@artifact_processor
+def life360CacheMemberHistory(context):
+    data_headers = (
+        ('Timestamp', 'datetime'),
+        ('Start Timestamp', 'datetime'),
+        ('End Timestamp', 'datetime'),
+        ('Since', 'datetime'),
+        'Member Name',
+        'Member ID',
+        'Circle ID',
+        'Latitude',
+        'Longitude',
+        'Accuracy (as stored)',
+        'Address 1',
+        'Address 2',
+        'Short Address',
+        'Place Name',
+        'Speed (as stored)',
+        'User Activity (as stored)',
+        'In Transit (as stored)',
+        'Is Driving (as stored)',
+        'Battery',
+        'Charge (as stored)',
+        'Wi-Fi State (as stored)',
+        'Drive SDK Status (as stored)',
+        'Algorithm (as stored)',
+        'Trip ID',
+        ('First Cached', 'datetime'),
+        'Cached Copies',
+        'Source File',
+    )
+    exchanges = _exchanges(context)
+    names = _member_names(exchanges)
+    records = {}
+    sources = []
+    responses = 0
+    for exchange in exchanges:
+        match = _HISTORY.search(exchange['url'])
+        if not match:
+            continue
+        payload = _json_body(exchange)
+        if not isinstance(payload, dict):
+            continue
+        responses += 1
+        sources.append(exchange['files']['0'])
+        circle_id, member_id = match.group(1), match.group(2)
+        for loc in payload.get('locations', []):
+            if not isinstance(loc, dict):
+                continue
+            key = (member_id, _text(loc.get('timestamp')), _text(loc.get('latitude')),
+                   _text(loc.get('longitude')), _text(loc.get('startTimestamp')),
+                   _text(loc.get('endTimestamp')))
+            record = records.get(key)
+            received = exchange['received_raw']
+            if record is None:
+                records[key] = {
+                    'loc': loc, 'circle': circle_id, 'member': member_id, 'copies': 1,
+                    'received': received, 'source': exchange['files']['0'],
+                }
+            else:
+                record['copies'] += 1
+                if received and (not record['received'] or int(received) < int(record['received'])):
+                    record['received'] = received
+                    record['source'] = exchange['files']['0']
+    data_list = []
+    for key in sorted(records, key=lambda k: (k[0], k[1])):
+        record = records[key]
+        loc = record['loc']
+        data_list.append((
+            _utc_seconds(loc.get('timestamp')),
+            _utc_seconds(loc.get('startTimestamp')),
+            _utc_seconds(loc.get('endTimestamp')),
+            _utc_seconds(loc.get('since')),
+            names.get(record['member'], ''),
+            record['member'],
+            record['circle'],
+            _text(loc.get('latitude')),
+            _text(loc.get('longitude')),
+            _text(loc.get('accuracy')),
+            _text(loc.get('address1')),
+            _text(loc.get('address2')),
+            _text(loc.get('shortAddress')),
+            _text(loc.get('name')),
+            _text(loc.get('speed')),
+            _text(loc.get('userActivity')),
+            _text(loc.get('inTransit')),
+            _text(loc.get('isDriving')),
+            _text(loc.get('battery')),
+            _text(loc.get('charge')),
+            _text(loc.get('wifiState')),
+            _text(loc.get('driveSDKStatus')),
+            _text(loc.get('algorithm')),
+            _text(loc.get('tripId')),
+            _utc_millis(record['received']),
+            record['copies'],
+            context.get_relative_path(record['source']),
+        ))
+    if responses:
+        logfunc(f'Life360 API cache: {len(data_list)} distinct location records from {responses} history responses')
+    return data_headers, data_list, '\n'.join(context.get_relative_path(p) for p in sources)
+
+
+@artifact_processor
+def life360CacheEmergencyContacts(context):
+    data_headers = (
+        ('Cached', 'datetime'),
+        'First Name',
+        'Last Name',
+        'Phone Numbers',
+        'Emails',
+        'Accepted (as stored)',
+        'Contact ID',
+        'Owner ID',
+        'Circle ID',
+        'Avatar URL',
+        'URL (as stored)',
+        'Source File',
+    )
+    data_list = []
+    sources = []
+    seen = set()
+    for exchange in _exchanges(context):
+        match = _CONTACTS.search(exchange['url'].split('?')[0])
+        if not match:
+            continue
+        payload = _json_body(exchange)
+        if not isinstance(payload, dict):
+            continue
+        sources.append(exchange['files']['0'])
+        for contact in payload.get('emergencyContacts', []):
+            if not isinstance(contact, dict):
+                continue
+            ident = (match.group(1), _text(contact.get('id')))
+            if ident in seen:
+                continue
+            seen.add(ident)
+            phones = []
+            for phone in contact.get('phoneNumbers') or []:
+                if isinstance(phone, dict):
+                    number = _text(phone.get('phone'))
+                    kind = _text(phone.get('type'))
+                    phones.append(f'{number} ({kind})' if kind else number)
+                else:
+                    phones.append(_text(phone))
+            emails = []
+            for email in contact.get('emails') or []:
+                if isinstance(email, dict):
+                    emails.append(_text(email.get('email') or json.dumps(email)))
+                else:
+                    emails.append(_text(email))
+            data_list.append((
+                exchange['received'],
+                _text(contact.get('firstName')),
+                _text(contact.get('lastName')),
+                '; '.join(p for p in phones if p),
+                '; '.join(e for e in emails if e),
+                _text(contact.get('accepted')),
+                _text(contact.get('id')),
+                _text(contact.get('ownerId')),
+                match.group(1),
+                _text(contact.get('avatar')),
+                _text(contact.get('url')),
+                context.get_relative_path(exchange['files']['0']),
+            ))
+    return data_headers, data_list, '\n'.join(context.get_relative_path(p) for p in sources)
+
+
+def _image_type(head):
+    """(mime, extension) for image bytes, or ('', '')."""
+    for magic, mime, extension in _IMAGE_MAGIC:
+        if head.startswith(magic):
+            return mime, extension
+    if head[:4] == b'RIFF' and head[8:12] == b'WEBP':
+        return 'image/webp', 'webp'
+    return '', ''
+
+
+@artifact_processor
+def life360CacheEntries(context):
+    data_headers = (
+        ('Sent', 'datetime'),
+        ('Received', 'datetime'),
+        'Cache',
+        'URL',
+        'Status Line (as stored)',
+        'Content Type',
+        'Content Encoding',
+        'Body Bytes',
+        'Date (as stored)',
+        ('Media', 'media'),
+        'Journal State (as stored)',
+        'Entry Key',
+        'Source File',
+    )
+    data_list = []
+    sources = []
+    for exchange in _exchanges(context):
+        headers = exchange['headers']
+        body_path = exchange['files'].get('1')
+        size = ''
+        media = ''
+        if body_path:
+            try:
+                size = os.path.getsize(body_path)
+            except OSError:
+                size = ''
+            if size and headers.get('content-encoding', '').lower() != 'gzip':
+                try:
+                    with open(body_path, 'rb') as handle:
+                        head = handle.read(16)
+                except OSError:
+                    head = b''
+                mime, extension = _image_type(head)
+                if mime:
+                    media = check_in_media(body_path, f"{exchange['key']}.1",
+                                           force_type=mime, force_extension=extension) or ''
+        sources.append(exchange['files']['0'])
+        data_list.append((
+            exchange['sent'],
+            exchange['received'],
+            exchange['cache'],
+            exchange['url'],
+            exchange['status'],
+            headers.get('content-type', ''),
+            headers.get('content-encoding', ''),
+            size,
+            headers.get('date', ''),
+            media,
+            exchange['state'],
+            exchange['key'],
+            context.get_relative_path(exchange['files']['0']),
+        ))
+    return data_headers, data_list, '\n'.join(context.get_relative_path(p) for p in sources)

--- a/scripts/artifacts/life360ApiCache.py
+++ b/scripts/artifacts/life360ApiCache.py
@@ -10,28 +10,43 @@ __artifacts_v2__ = {
         "last_update_date": "2026-09-05",
         "requirements": "none",
         "category": "Life360",
-        "notes": "Read from the app's OkHttp response caches under cache/ (http_cache holds these "
-                 "responses on the tested images). Each cache entry is a pair of files named by the MD5 "
-                 "of the URL: <hash>.0 holds the URL, the status line and the response headers, <hash>.1 "
-                 "the body, gzip-compressed when the Content-Encoding header says so (OkHttp Cache.kt "
-                 "Entry.writeTo at release parent-5.5.0, the same layout since 2.x). The URL names the "
-                 "circle and the member; the body is a locations list whose timestamp, startTimestamp, "
-                 "endTimestamp and since values are Unix seconds and are rendered in UTC. Latitude, "
-                 "longitude, accuracy, speed, battery, and the charge, inTransit, isDriving, wifiState, "
-                 "userActivity, driveSDKStatus and algorithm values are reported as stored; Life360 is "
-                 "closed source and their meanings are not documented. Member Name is resolved from the "
+        "notes": "Read from the app's OkHttp response caches under cache/; the history responses sat in "
+                 "cache/http_cache on both tested images that held them (hc_pixel8pro_a16 and hc_pixel8pro_a17). "
+                 "Each cache entry is a pair of files named by the MD5 of the URL: <hash>.0 holds the URL, the "
+                 "status line and the response headers, <hash>.1 the body, gzip-compressed when the "
+                 "Content-Encoding header says so (OkHttp Cache.kt Entry.writeTo at release parent-5.5.0, the same "
+                 "layout since 2.x). The URL names the circle and the member; the body is a locations list whose "
+                 "timestamp, startTimestamp and endTimestamp values are Unix seconds and are rendered in UTC (a "
+                 "since value equalled startTimestamp on every record of both images and is not reported "
+                 "separately). Latitude, longitude, accuracy, speed, battery, and the charge, inTransit, "
+                 "isDriving, wifiState, userActivity, driveSDKStatus and algorithm values are reported as stored; "
+                 "Life360 is closed source and their meanings are not documented. On both images Is Driving was 0 "
+                 "and Wi-Fi State was 1 on every record, Address 1, Address 2 and Short Address were empty strings "
+                 "on every record, and every record belonged to one Circle ID. Member Name is resolved from the "
                  "circles/<id>/members and users/me responses in the same cache and is blank when no cached "
-                 "response names the member. The same record is returned by many cached history responses "
-                 "(the app fetches the history repeatedly with a moving time parameter), so rows are "
-                 "de-duplicated on member, timestamp, coordinates and the start and end timestamps; "
-                 "Cached Copies counts the responses holding the record and First Cached is the earliest "
-                 "OkHttp-Received-Millis among them. The device's own location events are reported by "
-                 "the Life360 Locations artifacts from L360EventStore.db; this artifact adds the history "
-                 "the app fetched for circle members.",
+                 "response names the member; every record on both images resolved. The app fetches the history "
+                 "repeatedly with a moving time parameter and the same record comes back in many responses (1,109 "
+                 "of the 1,559 cached history responses held no locations, and the 22,334 location entries in the "
+                 "rest are 2,148 distinct records), so rows are de-duplicated on member, timestamp, coordinates "
+                 "and the start and end timestamps. The values shown are those of the earliest cached response "
+                 "holding the record (First Cached is its OkHttp-Received-Millis); later copies differed in Trip "
+                 "ID on 13 records per image and in speed, battery or another value on one to three records, and "
+                 "Cached Copies counts them (1 to 35 on the tested images). Each image held history responses for "
+                 "4 members and records for 2 of them. The device's own location events are reported by the "
+                 "Life360 Locations artifacts from L360EventStore.db; this artifact adds the history the app "
+                 "fetched for circle members. The cached driverbehavior/trips and drives/<id> responses are not "
+                 "reported: on hc_pixel8pro_a16 all 9 distinct trips they held were already in DriveBladeDB, which "
+                 "the Life360 Drives artifacts read.",
         "paths": ('*/com.life360.android.safetymapd/cache/*/journal',
                   '*/com.life360.android.safetymapd/cache/*/[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f].[01]'),
         "output_types": "all",
         "artifact_icon": "map-pin",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.life360.android.safetymapd vc 2897710 | 562 rows",
+            "hc_pixel8pro_a17": "Android 17 | com.life360.android.safetymapd | 1586 rows",
+            "pixel7a_a14": "Android 14 | com.life360.android.safetymapd vc 294540 | 0 rows",
+            "sharon_a14": "Android 14 | com.life360.android.safetymapd vc 296030 | 0 rows",
+        },
     },
     "life360CacheEmergencyContacts": {
         "name": "Life360 - Emergency Contacts (API cache)",
@@ -42,15 +57,25 @@ __artifacts_v2__ = {
         "last_update_date": "2026-09-05",
         "requirements": "none",
         "category": "Life360",
-        "notes": "Read from the same OkHttp response caches as the Member Location History artifact. One "
-                 "row per distinct contact id per circle; the Cached time is the OkHttp-Received-Millis "
-                 "header of the response that held it. Phone Numbers joins each phone with its type in "
-                 "parentheses where the type is stored. Accepted is reported as stored. No database the "
-                 "other Life360 artifacts read holds these contacts.",
+        "notes": "Read from the same OkHttp response caches as the Member Location History artifact. One row per "
+                 "distinct contact id per circle; the Cached time is the OkHttp-Received-Millis header of the "
+                 "response that held it. Phone Numbers joins each phone with its type in parentheses where the "
+                 "type is stored. Accepted is reported as stored. Two of the four tested images with the app held "
+                 "a contact, one contact on each (the same one, with a name and a phone number and with Emails and "
+                 "Avatar URL blank); pixel7a_a14 held contacts responses whose list was empty and sharon_a14 held "
+                 "no contacts response. The L360LocalStoreRoomDatabase emergency_contacts table has the same "
+                 "fields and is read by no artifact; it held no rows on hc_pixel8pro_a16 while that image's cache "
+                 "held this contact.",
         "paths": ('*/com.life360.android.safetymapd/cache/*/journal',
                   '*/com.life360.android.safetymapd/cache/*/[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f].[01]'),
         "output_types": "standard",
         "artifact_icon": "phone-call",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.life360.android.safetymapd vc 2897710 | 1 row",
+            "hc_pixel8pro_a17": "Android 17 | com.life360.android.safetymapd | 1 row",
+            "pixel7a_a14": "Android 14 | com.life360.android.safetymapd vc 294540 | 0 rows",
+            "sharon_a14": "Android 14 | com.life360.android.safetymapd vc 296030 | 0 rows",
+        },
     },
     "life360CacheEntries": {
         "name": "Life360 - API Cache Entries",
@@ -62,22 +87,33 @@ __artifacts_v2__ = {
         "last_update_date": "2026-09-05",
         "requirements": "none",
         "category": "Life360",
-        "notes": "One row per <hash>.0 metadata file in each DiskLruCache directory under the app's cache/ "
-                 "folder whose entries start with a URL (http_cache, l360_http_cache, core_http_cache, "
-                 "picasso-cache, the LaunchDarkly and Statsig SDK caches on the tested images). Sent and "
-                 "Received are the OkHttp-Sent-Millis and OkHttp-Received-Millis headers OkHttp writes into "
-                 "the entry (Unix milliseconds; written since OkHttp 3.4.0, absent from entries of older "
-                 "releases). OkHttp caches GET responses only (Cache.kt put, release parent-5.5.0), so no "
-                 "method column is reported. The URLs themselves carry request parameters the app sent, "
-                 "such as a phone number passed to users/lookup, an invite code passed to code/<code>, and "
-                 "the coordinates passed to nearbyplaces/<lat>/<lon>. Journal State is the last CLEAN, "
-                 "DIRTY or REMOVE line for the entry's key in the directory's journal, blank when the key "
-                 "is not in the journal. Media renders the body when its bytes are a JPEG, PNG, GIF or WebP "
-                 "image and the response is not compressed; other bodies are not decoded here.",
+        "notes": "One row per <hash>.0 metadata file in each DiskLruCache directory under the app's cache/ folder "
+                 "whose entries start with a URL. Sent and Received are the OkHttp-Sent-Millis and "
+                 "OkHttp-Received-Millis headers OkHttp writes into the entry (Unix milliseconds; written since "
+                 "OkHttp 3.4.0 and absent from entries of older releases, though every entry on the tested images "
+                 "carried both). OkHttp caches GET responses only (Cache.kt put, release parent-5.5.0), so no "
+                 "method column is reported. The URLs themselves carry request parameters the app sent, such as a "
+                 "phone number passed to users/lookup, an invite code passed to code/<code>, and the coordinates "
+                 "passed to nearbyplaces/<lat>/<lon>. Journal State is the last CLEAN, DIRTY or REMOVE line for "
+                 "the entry's key in the directory's journal, blank when the key is not in the journal; it was "
+                 "CLEAN on all 1,960 entries of the tested images. Media renders the body when its bytes are a "
+                 "JPEG, PNG, GIF or WebP image and the response is not compressed (4 entries, the avatars and chat "
+                 "photos in picasso-cache on pixel7a_a14); other bodies are not decoded here. On the 4 of 31 "
+                 "tested images that held the app the entries came from six directories: http_cache 1,884, "
+                 "l360_http_cache 41, statsig_http_cache_com.life360.android.safetymapd 18 (DNS-over-HTTPS "
+                 "exchanges with cloudflare-dns.com, content type application/dns-message), "
+                 "com.launchdarkly.http-cache 8, picasso-cache 6 and core_http_cache 3; 1,936 of the 1,960 bodies "
+                 "are JSON.",
         "paths": ('*/com.life360.android.safetymapd/cache/*/journal',
                   '*/com.life360.android.safetymapd/cache/*/[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f].[01]'),
         "output_types": "standard",
         "artifact_icon": "list",
+        "sample_data": {
+            "hc_pixel8pro_a16": "Android 16 | com.life360.android.safetymapd vc 2897710 | 765 rows",
+            "hc_pixel8pro_a17": "Android 17 | com.life360.android.safetymapd | 1148 rows",
+            "pixel7a_a14": "Android 14 | com.life360.android.safetymapd vc 294540 | 41 rows",
+            "sharon_a14": "Android 14 | com.life360.android.safetymapd vc 296030 | 6 rows",
+        },
     },
 }
 
@@ -298,16 +334,15 @@ def life360CacheMemberHistory(context):
         ('Timestamp', 'datetime'),
         ('Start Timestamp', 'datetime'),
         ('End Timestamp', 'datetime'),
-        ('Since', 'datetime'),
         'Member Name',
         'Member ID',
         'Circle ID',
         'Latitude',
         'Longitude',
         'Accuracy (as stored)',
-        'Address 1',
-        'Address 2',
-        'Short Address',
+        'Address 1 (as stored)',
+        'Address 2 (as stored)',
+        'Short Address (as stored)',
         'Place Name',
         'Speed (as stored)',
         'User Activity (as stored)',
@@ -354,8 +389,7 @@ def life360CacheMemberHistory(context):
             else:
                 record['copies'] += 1
                 if received and (not record['received'] or int(received) < int(record['received'])):
-                    record['received'] = received
-                    record['source'] = exchange['files']['0']
+                    record.update(loc=loc, received=received, source=exchange['files']['0'])
     data_list = []
     for key in sorted(records, key=lambda k: (k[0], k[1])):
         record = records[key]
@@ -364,7 +398,6 @@ def life360CacheMemberHistory(context):
             _utc_seconds(loc.get('timestamp')),
             _utc_seconds(loc.get('startTimestamp')),
             _utc_seconds(loc.get('endTimestamp')),
-            _utc_seconds(loc.get('since')),
             names.get(record['member'], ''),
             record['member'],
             record['circle'],


### PR DESCRIPTION
Adds Life360 API cache artifacts for Android and renders cached photos on Life360 chat messages.

New module life360ApiCache.py, read from the app's OkHttp response caches under cache/:

- Member Location History: the location records in the cached members/<id>/history responses, one row per distinct record with the number of cached copies. KML output.
- Emergency Contacts
- API Cache Entries: URL, sent and received times, status, content type and size for each cached exchange, with the cached image rendered where the body is one.

Life360.py: chat messages join message_media and show the cached photo whose stored URL equals photo_key. Every artifact in the module now reads each container's store rather than the first one found, so a second Android user's copy adds its own rows.

Timestamps in the responses are Unix seconds and are rendered in UTC. Undocumented values are reported as stored. The trips and drives in the cache were all present in DriveBladeDB on the tested image, so they are not reported again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
