### PR TITLE
Add Solid Explorer, HERE WeGo and Moovit support for Android

### DIFF
--- a/scripts/artifacts/hereWeGo.py
+++ b/scripts/artifacts/hereWeGo.py
@@ -1,0 +1,460 @@
+__artifacts_v2__ = {
+    "here_wego_recent_searches": {
+        "name": "HERE WeGo Recent Searches",
+        "description": "Searches made in HERE WeGo, with the time each was made",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-05",
+        "last_update_date": "2026-09-05",
+        "requirements": "none",
+        "category": "HERE WeGo",
+        "sample_data": {
+            "emu_a15_oss_v14": "HERE WeGo 4.21.100 | 2 rows",
+        },
+        "notes": "One row per entry of the recentSearchResults value in "
+                 "com.here.app.maps/shared_prefs/FlutterSharedPreferences.xml. The app is built "
+                 "with Flutter, so that file holds its settings and the value is a Flutter string "
+                 "list: a base64 marker, an exclamation mark, then a JSON array whose members are "
+                 "themselves JSON objects. The field names below are the ones the app itself "
+                 "writes into that JSON. "
+                 "Searched is the entry's own timestamp field. It carries no zone and is not "
+                 "reported as UTC, because it is not UTC: on the tested device the two stored "
+                 "values matched the device's local clock at the moment each search was made, and "
+                 "the device was four hours behind UTC. Read it against the device's own time "
+                 "zone setting. "
+                 "Search Term is the title field, which for a typed search is the text submitted. "
+                 "Type read freeText on both rows of the tested device, where both searches were "
+                 "typed rather than chosen from a suggestion. Place ID, Address, Category, "
+                 "Latitude, Longitude, Place Category ID and Href were null on every row for the "
+                 "same reason: they are the fields the app fills when an entry names a resolved "
+                 "place rather than a free text query, and they are reported because that is the "
+                 "case worth having on a device where it occurs. "
+                 "The list is a recent-searches list, so it is capped and ordered by the app, and "
+                 "an absent term is not evidence it was never searched for.",
+        "paths": ('*/com.here.app.maps/shared_prefs/FlutterSharedPreferences.xml',),
+        "output_types": "standard",
+        "artifact_icon": "search",
+    },
+    "here_wego_saved_places": {
+        "name": "HERE WeGo Saved Places",
+        "description": "Places saved into HERE WeGo collections, with their coordinates",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-05",
+        "last_update_date": "2026-09-05",
+        "requirements": "none",
+        "category": "HERE WeGo",
+        "sample_data": {
+            "emu_a15_oss_v14": "HERE WeGo 4.21.100 | 2 rows",
+        },
+        "notes": "One row per entry in com.here.app.maps/app_flutter/collection.place.box.hive, "
+                 "a Hive box, which is the store the app's Flutter code uses for saved places. "
+                 "The box is a sequence of frames, each ending in its own CRC32 over the rest of "
+                 "the frame; every frame read here is checked against that CRC and a frame that "
+                 "fails it stops the read, so a row is only produced from a frame the format's "
+                 "own checksum accepts. "
+                 "Saved is the entry's timestamp field, Unix milliseconds, reported as UTC. "
+                 "Latitude and Longitude come from the entry's own coordinate object, so a saved "
+                 "place is a coordinate an examiner can map, and KML output is produced. "
+                 "Collection is resolved through collection.box.hive beside it. A collection there "
+                 "carries its places as a list, and each place in that list repeats the entry id "
+                 "the place box files the full record under, so the list is the join and it is "
+                 "one the store itself records. Collection is blank when no collection lists that "
+                 "entry id. A collection holding no places produces no row here, because this "
+                 "artifact reports places. "
+                 "The field names are not in the file. Hive writes a registered class as numbered "
+                 "fields, and the names live in the app's compiled Dart, so each column here is "
+                 "named from what the value was on data created for this purpose: a place saved "
+                 "under a collection named for the test, whose title, address, coordinate, "
+                 "category and category id were all known before the file was read. Fields that "
+                 "held no value on the tested device are not reported. "
+                 "A Hive box is append only, so an entry that was written more than once keeps "
+                 "its earlier frames in the file. The current state is the last frame for a key, "
+                 "which is what is reported, and Earlier Writes counts the superseded frames that "
+                 "remain in the file for that key. "
+                 "Entry Key is the key the box stores the entry under. Rows are box entries, not "
+                 "distinct places: on the tested device one saved place was present under two "
+                 "different entry keys with identical content, so a place can be counted twice.",
+        "paths": ('*/com.here.app.maps/app_flutter/collection.place.box.hive',
+                  '*/com.here.app.maps/app_flutter/collection.box.hive'),
+        "output_types": "all",
+        "artifact_icon": "star",
+    },
+    "here_wego_map_positions": {
+        "name": "HERE WeGo Map Positions",
+        "description": "The last device location and last map view HERE WeGo recorded",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-05",
+        "last_update_date": "2026-09-05",
+        "requirements": "none",
+        "category": "HERE WeGo",
+        "sample_data": {
+            "emu_a15_oss_v14": "HERE WeGo 4.21.100 | 2 rows",
+        },
+        "notes": "Up to two rows, read from the last_location and last_map_view_center values in "
+                 "com.here.app.maps/shared_prefs/FlutterSharedPreferences.xml. "
+                 "Last Location is a bare latitude and longitude pair the app stores for the "
+                 "device's own last known position. Last Map View Center is a JSON object holding "
+                 "the centre of the map the last time it was displayed, together with a distance "
+                 "and a zoom level, which are reported as stored. "
+                 "These are two different things and the notes are worth reading before either is "
+                 "used. The first is where the app last placed the device. The second is where "
+                 "the map was last looking, which a person can pan anywhere without going there. "
+                 "On the tested device they differed, the map centre sitting about 2.7 kilometres "
+                 "from the recorded device position. "
+                 "Neither value carries a timestamp, so neither can be placed in time from this "
+                 "file. KML output is produced for both.",
+        "paths": ('*/com.here.app.maps/shared_prefs/FlutterSharedPreferences.xml',),
+        "output_types": "all",
+        "artifact_icon": "map-pin",
+    },
+    "here_wego_settings": {
+        "name": "HERE WeGo Settings",
+        "description": "HERE WeGo preferences, including whether the terms were accepted",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-05",
+        "last_update_date": "2026-09-05",
+        "requirements": "none",
+        "category": "HERE WeGo",
+        "sample_data": {
+            "emu_a15_oss_v14": "HERE WeGo 4.21.100 | 28 rows",
+        },
+        "notes": "One row per key in "
+                 "com.here.app.maps/shared_prefs/FlutterSharedPreferences.xml, with the flutter. "
+                 "prefix the Flutter plugin adds stripped from the reported name. Type is the XML "
+                 "element the value was stored as. "
+                 "Setting names are the app's own. is_terms_and_privacy_accepted records whether "
+                 "the service terms were accepted, is_ftu_complete whether first time use "
+                 "finished, and first_session_monthly_date carries a timestamp for the first "
+                 "session that does end in Z and so is UTC, unlike the search timestamps in the "
+                 "Recent Searches artifact. prefs_app_version carries the app version the "
+                 "preferences were last written by. "
+                 "recentSearchResults, last_location and last_map_view_center are reported by the "
+                 "other three artifacts in this module and are skipped here, so that a long "
+                 "encoded value does not sit in this table. Every other key is reported as "
+                 "stored, including keys this module does not interpret, because the set of keys "
+                 "changes between releases and an unrecognised one is still evidence of a "
+                 "setting.",
+        "paths": ('*/com.here.app.maps/shared_prefs/FlutterSharedPreferences.xml',),
+        "output_types": "standard",
+        "artifact_icon": "settings",
+    },
+}
+
+import json
+import os
+import struct
+import xml.etree.ElementTree as ET
+import zlib
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, logfunc
+from scripts.artifacts.storagePathViews import unique_files
+
+PREFS_SUFFIX = 'shared_prefs/FlutterSharedPreferences.xml'
+PLACE_BOX = 'app_flutter/collection.place.box.hive'
+COLLECTION_BOX = 'app_flutter/collection.box.hive'
+
+# Flutter's shared_preferences plugin prefixes a string list with this marker.
+LIST_MARKER = 'VGhpcyBpcyB0aGUgcHJlZml4IGZvciBhIGxpc3Qu!'
+
+# Reported by the other artifacts in this module rather than in the settings table.
+SETTINGS_SKIP = ('recentSearchResults', 'last_location', 'last_map_view_center')
+
+# Hive value type ids, from the format's own writer.
+_NULL, _INT, _DOUBLE, _BOOL, _STRING, _BYTELIST = 0, 1, 2, 3, 4, 5
+_INTLIST, _DOUBLELIST, _BOOLLIST, _STRINGLIST, _LIST, _MAP = 6, 7, 8, 9, 10, 11
+_HIVELIST, _DATETIME = 12, 13
+
+# Field numbers of a saved place, named from data created for the purpose. Hive stores a
+# registered class as numbered fields and keeps the names in the app's compiled Dart.
+PLACE_TIME, PLACE_ENTRY_ID, PLACE_TITLE = 1, 3, 4
+PLACE_ADDRESS, PLACE_COORD, PLACE_ID, PLACE_AREA = 5, 6, 7, 8
+PLACE_CATEGORY, PLACE_CATEGORY_ID = 9, 10
+COORD_LAT, COORD_LON = 0, 1
+COLLECTION_NAME, COLLECTION_ID, COLLECTION_PLACES = 3, 4, 5
+
+
+def _prefs_files(context):
+    return [str(f).replace('\\', '/') for f in unique_files(context)
+            if str(f).replace('\\', '/').endswith(PREFS_SUFFIX)]
+
+
+def _box_files(context, suffix):
+    return [str(f).replace('\\', '/') for f in unique_files(context)
+            if str(f).replace('\\', '/').endswith(suffix)]
+
+
+def _prefs(path):
+    """{name without the flutter. prefix: (element tag, value)} from one preferences file."""
+    out = {}
+    try:
+        root = ET.parse(path).getroot()
+    except (ET.ParseError, OSError) as ex:
+        logfunc(f'HERE WeGo: could not read {os.path.basename(path)}: {ex}')
+        return out
+    for entry in root:
+        name = entry.get('name')
+        if not name:
+            continue
+        value = entry.get('value')
+        if value is None:
+            value = (entry.text or '').strip()
+        out[name[8:] if name.startswith('flutter.') else name] = (entry.tag, value)
+    return out
+
+
+def _ms(value):
+    if not value:
+        return ''
+    try:
+        value = int(value)
+        if value <= 0:
+            return ''
+        return convert_unix_ts_to_utc(value // 1000)
+    except (TypeError, ValueError, OverflowError, OSError):
+        return ''
+
+
+def _read_value(buf, index):
+    """One Hive value at `index`, returning it and the index after it."""
+    kind = buf[index]
+    index += 1
+    if kind == _NULL:
+        return None, index
+    if kind in (_INT, _DOUBLE, _DATETIME):
+        number, = struct.unpack('<d', buf[index:index + 8])
+        return (number if kind == _DOUBLE else int(number)), index + 8
+    if kind == _BOOL:
+        return bool(buf[index]), index + 1
+    if kind in (_STRING, _BYTELIST):
+        length, = struct.unpack('<I', buf[index:index + 4])
+        index += 4
+        chunk = buf[index:index + length]
+        return (chunk.decode('utf-8', 'replace') if kind == _STRING else chunk), index + length
+    if kind in (_INTLIST, _DOUBLELIST, _BOOLLIST, _STRINGLIST, _LIST, _MAP, _HIVELIST):
+        count, = struct.unpack('<I', buf[index:index + 4])
+        index += 4
+        items = []
+        for _ in range(count):
+            if kind in (_INTLIST, _DOUBLELIST):
+                number, = struct.unpack('<d', buf[index:index + 8])
+                items.append(int(number) if kind == _INTLIST else number)
+                index += 8
+            elif kind == _BOOLLIST:
+                items.append(bool(buf[index]))
+                index += 1
+            elif kind == _STRINGLIST:
+                length, = struct.unpack('<I', buf[index:index + 4])
+                index += 4
+                items.append(buf[index:index + length].decode('utf-8', 'replace'))
+                index += length
+            else:
+                item, index = _read_value(buf, index)
+                items.append(item)
+        return items, index
+    # A registered class: a field count, then that many (field number, value) pairs.
+    count = buf[index]
+    index += 1
+    obj = {}
+    for _ in range(count):
+        field = buf[index]
+        index += 1
+        obj[field], index = _read_value(buf, index)
+    return obj, index
+
+
+def _hive_entries(path):
+    """The live entries of a Hive box, plus how many superseded frames each key has.
+
+    Every frame carries a CRC32 of itself, so a frame that does not match is not read and
+    the walk stops there rather than guessing at the rest of the file.
+    """
+    try:
+        with open(path, 'rb') as handle:
+            buf = handle.read()
+    except OSError as ex:
+        logfunc(f'HERE WeGo: could not read {os.path.basename(path)}: {ex}')
+        return {}, {}
+    live = {}
+    earlier = {}
+    offset = 0
+    try:
+        while offset + 4 <= len(buf):
+            length, = struct.unpack('<I', buf[offset:offset + 4])
+            if length < 8 or offset + length > len(buf):
+                break
+            frame = buf[offset:offset + length]
+            stored, = struct.unpack('<I', frame[-4:])
+            if (zlib.crc32(frame[:-4]) & 0xffffffff) != stored:
+                logfunc(f'HERE WeGo: frame at offset {offset} of '
+                        f'{os.path.basename(path)} failed its own CRC, stopping there')
+                break
+            index = 4
+            key_kind = frame[index]
+            index += 1
+            if key_kind == 0:
+                key, = struct.unpack('<I', frame[index:index + 4])
+                index += 4
+            else:
+                key_length = frame[index]
+                index += 1
+                key = frame[index:index + key_length].decode('utf-8', 'replace')
+                index += key_length
+            value = None
+            if index < length - 4:
+                value, index = _read_value(frame, index)
+            if key in live:
+                earlier[key] = earlier.get(key, 0) + 1
+            live[key] = value
+            offset += length
+    except (IndexError, struct.error, ValueError) as ex:
+        logfunc(f'HERE WeGo: stopped reading {os.path.basename(path)} at offset {offset}: {ex}')
+    return live, earlier
+
+
+def _collection_names(context):
+    """{place entry id: collection name}, the link the store itself records.
+
+    A collection carries its places as a list of place objects, and each of those repeats
+    the entry id the place box stores the full record under, so the list is the join.
+    """
+    names = {}
+    for path in _box_files(context, COLLECTION_BOX):
+        live, _ = _hive_entries(path)
+        for value in live.values():
+            if not isinstance(value, dict):
+                continue
+            name = value.get(COLLECTION_NAME) or ''
+            for place in (value.get(COLLECTION_PLACES) or []):
+                if isinstance(place, dict) and place.get(PLACE_ENTRY_ID):
+                    names[place[PLACE_ENTRY_ID]] = name
+    return names
+
+
+@artifact_processor
+def here_wego_recent_searches(context):
+    data_list = []
+    sources = []
+    for path in _prefs_files(context):
+        raw = _prefs(path).get('recentSearchResults', ('', ''))[1]
+        if not raw or LIST_MARKER not in raw:
+            continue
+        try:
+            entries = json.loads(raw.split('!', 1)[1])
+        except (ValueError, IndexError) as ex:
+            logfunc(f'HERE WeGo: could not read the recent search list: {ex}')
+            continue
+        found = False
+        for entry in entries:
+            try:
+                item = json.loads(entry) if isinstance(entry, str) else entry
+            except ValueError:
+                continue
+            if not isinstance(item, dict):
+                continue
+            data_list.append((
+                item.get('timestamp') or '', item.get('title') or '',
+                item.get('type') or '', item.get('placeId') or '',
+                item.get('address') or '', item.get('category') or '',
+                item.get('lat') if item.get('lat') is not None else '',
+                item.get('lon') if item.get('lon') is not None else '',
+                item.get('placeCategoryId') or '', item.get('href') or '',
+                context.get_relative_path(path)))
+            found = True
+        if found and path not in sources:
+            sources.append(path)
+
+    data_headers = ('Searched (device local time)', 'Search Term', 'Type', 'Place ID',
+                    'Address', 'Category', 'Latitude', 'Longitude',
+                    'Place Category ID', 'Href', 'Source File')
+    return data_headers, data_list, '\n'.join(sources)
+
+
+@artifact_processor
+def here_wego_saved_places(context):
+    collections = _collection_names(context)
+    data_list = []
+    sources = []
+    for path in _box_files(context, PLACE_BOX):
+        live, earlier = _hive_entries(path)
+        found = False
+        for key, value in live.items():
+            if not isinstance(value, dict):
+                continue
+            coord = value.get(PLACE_COORD)
+            latitude = coord.get(COORD_LAT, '') if isinstance(coord, dict) else ''
+            longitude = coord.get(COORD_LON, '') if isinstance(coord, dict) else ''
+            area = value.get(PLACE_AREA)
+            area_text = ''
+            if isinstance(area, dict):
+                area_text = ', '.join(str(area[k]) for k in sorted(area) if area[k])
+            entry_id = value.get(PLACE_ENTRY_ID) or ''
+            data_list.append((
+                _ms(value.get(PLACE_TIME)), value.get(PLACE_TITLE) or '',
+                value.get(PLACE_ADDRESS) or '', latitude, longitude,
+                value.get(PLACE_CATEGORY) or '', value.get(PLACE_CATEGORY_ID) or '',
+                collections.get(entry_id, ''), entry_id,
+                area_text, value.get(PLACE_ID) or '',
+                earlier.get(key, 0), key,
+                context.get_relative_path(path)))
+            found = True
+        if found and path not in sources:
+            sources.append(path)
+
+    data_headers = (('Saved', 'datetime'), 'Title', 'Address',
+                    'Latitude', 'Longitude',
+                    'Category', 'Category ID', 'Collection', 'Place Entry ID',
+                    'Area', 'Place ID', 'Earlier Writes', 'Entry Key', 'Source File')
+    return data_headers, data_list, '\n'.join(sources)
+
+
+@artifact_processor
+def here_wego_map_positions(context):
+    data_list = []
+    sources = []
+    for path in _prefs_files(context):
+        values = _prefs(path)
+        relative = context.get_relative_path(path)
+        found = False
+        raw = values.get('last_location', ('', ''))[1]
+        if raw and ',' in raw:
+            latitude, _, longitude = raw.partition(',')
+            data_list.append(('Last Location', latitude.strip(), longitude.strip(),
+                              '', '', relative))
+            found = True
+        raw = values.get('last_map_view_center', ('', ''))[1]
+        if raw:
+            try:
+                centre = json.loads(raw)
+            except ValueError:
+                centre = {}
+            position = str(centre.get('pos', ''))
+            latitude, _, longitude = position.partition(',')
+            data_list.append(('Last Map View Center', latitude.strip(), longitude.strip(),
+                              centre.get('distance', ''), centre.get('zoomLevel', ''),
+                              relative))
+            found = True
+        if found and path not in sources:
+            sources.append(path)
+
+    data_headers = ('Position', 'Latitude', 'Longitude',
+                    'Distance (as stored)', 'Zoom Level (as stored)', 'Source File')
+    return data_headers, data_list, '\n'.join(sources)
+
+
+@artifact_processor
+def here_wego_settings(context):
+    data_list = []
+    sources = []
+    for path in _prefs_files(context):
+        values = _prefs(path)
+        found = False
+        for name in sorted(values):
+            if name in SETTINGS_SKIP:
+                continue
+            tag, value = values[name]
+            data_list.append((name, value, tag, context.get_relative_path(path)))
+            found = True
+        if found and path not in sources:
+            sources.append(path)
+
+    data_headers = ('Setting', 'Value', 'Type', 'Source File')
+    return data_headers, data_list, '\n'.join(sources)

--- a/scripts/artifacts/moovit.py
+++ b/scripts/artifacts/moovit.py
@@ -1,0 +1,195 @@
+__artifacts_v2__ = {
+    "moovit_trip_plan_history": {
+        "name": "Moovit Trip Plan History",
+        "description": "Journeys planned in Moovit, with both endpoints and their coordinates",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-05",
+        "last_update_date": "2026-09-05",
+        "requirements": "none",
+        "category": "Moovit",
+        "sample_data": {
+            "emu_a15_oss_v14": "Moovit 5.199.1.1804 | 2 rows",
+        },
+        "notes": "One row per entry of "
+                 "com.tranzmate/app_moovit/data_trip_plan/history_trip_plan.ds, the file the app "
+                 "keeps its planned journeys in. It is not SQLite and not JSON. It is Moovit's "
+                 "own serialisation: a string is a four byte big endian character count followed "
+                 "by that many UTF-16 big endian characters, a time is eight big endian bytes of "
+                 "Unix milliseconds, and a place is a signed four byte latitude and a signed four "
+                 "byte longitude, both big endian and both in millionths of a degree, written "
+                 "immediately before the string that names it. "
+                 "That reading of the coordinates was checked against places whose position was "
+                 "known before the file was read, not inferred from the layout: on the tested "
+                 "device the three endpoints decoded to 4, 14 and 116 metres from the published "
+                 "positions of the building at the origin address and of the two destinations, "
+                 "which a wrong scale or byte order would not do. "
+                 "Planned is the entry's own time and is reported as UTC. Origin and Destination "
+                 "are the addresses the app stored for the two ends of the journey; the origin "
+                 "was the device's own position on the tested device, which the app resolves to a "
+                 "street address, so an origin is not necessarily somewhere a person typed. "
+                 "Latitude and Longitude are the destination's, and KML output plots the "
+                 "destination only. The origin's coordinates are in their own two columns and are "
+                 "not plotted, because a row holds two places and the KML writer takes one pair. "
+                 "Itinerary ID is the entry's own identifier and is also the file name of the "
+                 "saved itinerary under app_moovit/data_trip_plan/itinerary_entities and "
+                 "raw_itinerary_entities beside this file, which is the link the store itself "
+                 "records. Those itinerary files hold the full route, leg by leg, and are not "
+                 "parsed here. "
+                 "Metro Area ID is the app's own identifier for the transit region the journey "
+                 "was planned in. It is reported as stored, and the name that goes with it is in "
+                 "the metro_info table of databases/moovit_v1.db beside this file. "
+                 "A row records that a journey was planned, not that it was travelled. Nothing "
+                 "in this file says the route was followed.",
+        "paths": ('*/com.tranzmate/app_moovit/data_trip_plan/history_trip_plan.ds',),
+        "output_types": "all",
+        "artifact_icon": "map",
+    },
+}
+
+import os
+import struct
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, logfunc
+from scripts.artifacts.storagePathViews import unique_files
+
+HISTORY_SUFFIX = 'app_moovit/data_trip_plan/history_trip_plan.ds'
+
+# A Moovit string is a four byte big endian character count then UTF-16BE characters.
+MAX_STRING = 4096
+# Millionths of a degree, so a real place is inside these bounds.
+MAX_LAT, MAX_LON = 90_000_000, 180_000_000
+# Unix milliseconds, wide enough to hold any plausible entry.
+MIN_MS, MAX_MS = 1_000_000_000_000, 4_000_000_000_000
+# A UUID written as a string is this long.
+UUID_LENGTH = 36
+
+
+def _history_files(context):
+    return [str(f).replace('\\', '/') for f in unique_files(context)
+            if str(f).replace('\\', '/').endswith(HISTORY_SUFFIX)]
+
+
+def _string_at(buf, index):
+    """The Moovit string starting at `index`, or None when one does not start there."""
+    if index + 4 > len(buf):
+        return None
+    count = struct.unpack('>I', buf[index:index + 4])[0]
+    if count == 0 or count > MAX_STRING or index + 4 + 2 * count > len(buf):
+        return None
+    try:
+        text = buf[index + 4:index + 4 + 2 * count].decode('utf-16-be')
+    except UnicodeDecodeError:
+        return None
+    if any(ord(character) < 32 for character in text):
+        return None
+    return text, index + 4 + 2 * count
+
+
+def _place_at(buf, index):
+    """(latitude, longitude, name, next index) when a place starts at `index`."""
+    if index + 8 > len(buf):
+        return None
+    latitude, longitude = struct.unpack('>ii', buf[index:index + 8])
+    if abs(latitude) > MAX_LAT or abs(longitude) > MAX_LON:
+        return None
+    if latitude == 0 and longitude == 0:
+        return None
+    found = _string_at(buf, index + 8)
+    if not found:
+        return None
+    name, after = found
+    return latitude / 1_000_000, longitude / 1_000_000, name, after
+
+
+def _is_uuid(text):
+    return len(text) == UUID_LENGTH and text.count('-') == 4
+
+
+def _entries(buf):
+    """Yield one journey per identifier in the file.
+
+    The entries are laid out in a fixed order, so the walk follows it rather than
+    scanning for whatever looks like a place: an identifier starts a journey, the next
+    eight byte value in the millisecond range is its time, the next string is the metro
+    area, and the next two places are the two ends of the journey. Everything after those
+    is the app's own catalogue of route options, which is skipped by looking only for the
+    next identifier.
+    """
+    index = 0
+    current = None
+    while index < len(buf) - 8:
+        found = _string_at(buf, index)
+        if found and _is_uuid(found[0]):
+            if current:
+                yield current
+            current = {'id': found[0], 'time': None, 'metro': '', 'places': []}
+            index = found[1]
+            continue
+        if current is None or len(current['places']) >= 2:
+            index += 1
+            continue
+        if current['time'] is None:
+            value = struct.unpack('>Q', buf[index:index + 8])[0]
+            if MIN_MS < value < MAX_MS:
+                current['time'] = value
+                index += 8
+                continue
+            index += 1
+            continue
+        if not current['metro']:
+            if found:
+                current['metro'] = found[0]
+                index = found[1]
+            else:
+                index += 1
+            continue
+        place = _place_at(buf, index)
+        if place:
+            current['places'].append(place[:3])
+            index = place[3]
+            continue
+        index += 1
+    if current:
+        yield current
+
+
+def _ms(value):
+    if not value:
+        return ''
+    try:
+        return convert_unix_ts_to_utc(int(value) // 1000)
+    except (TypeError, ValueError, OverflowError, OSError):
+        return ''
+
+
+@artifact_processor
+def moovit_trip_plan_history(context):
+    data_list = []
+    sources = []
+    for path in _history_files(context):
+        try:
+            with open(path, 'rb') as handle:
+                buf = handle.read()
+        except OSError as ex:
+            logfunc(f'Moovit: could not read {os.path.basename(path)}: {ex}')
+            continue
+        found = False
+        for entry in _entries(buf):
+            places = entry['places']
+            if len(places) < 2:
+                logfunc(f'Moovit: journey {entry["id"]} carried '
+                        f'{len(places)} endpoints, so it is not reported')
+                continue
+            (origin_lat, origin_lon, origin), (dest_lat, dest_lon, dest) = places[0], places[1]
+            data_list.append((
+                _ms(entry['time']), origin.rstrip(', '), dest.rstrip(', '),
+                dest_lat, dest_lon, origin_lat, origin_lon,
+                entry['metro'], entry['id'], context.get_relative_path(path)))
+            found = True
+        if found and path not in sources:
+            sources.append(path)
+
+    data_headers = (('Planned', 'datetime'), 'Origin', 'Destination',
+                    'Latitude', 'Longitude', 'Origin Latitude', 'Origin Longitude',
+                    'Metro Area ID', 'Itinerary ID', 'Source File')
+    return data_headers, data_list, '\n'.join(sources)

--- a/scripts/artifacts/solidExplorer.py
+++ b/scripts/artifacts/solidExplorer.py
@@ -1,0 +1,242 @@
+__artifacts_v2__ = {
+    "solid_explorer_recent_files": {
+        "name": "Solid Explorer Recent Files",
+        "description": "Files opened through Solid Explorer, with the time each was opened",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-05",
+        "last_update_date": "2026-09-05",
+        "requirements": "none",
+        "category": "Solid Explorer",
+        "sample_data": {
+            "emu_a15_oss_v14": "Solid Explorer 3.5.20 | 2 rows",
+        },
+        "notes": "One row per row of the recent_files table in "
+                 "pl.solidexplorer2/databases/explorer.db. Opened is Unix milliseconds and is "
+                 "reported as UTC. Path is the full path the app recorded, as stored. "
+                 "On the tested device a row appeared when a file was opened from the app and "
+                 "was handled by one of Solid Explorer's own built-in viewers, the text editor "
+                 "and the image viewer. Whether a file opened into a different application is "
+                 "recorded here was not established, so the absence of a row is not evidence a "
+                 "file was never opened. "
+                 "The path is what the app wrote and is not resolved against the extraction, so "
+                 "a row is evidence the app opened that path, not that the file is still there.",
+        "paths": ('*/pl.solidexplorer2/databases/explorer.db*',),
+        "output_types": "standard",
+        "artifact_icon": "file-text",
+    },
+    "solid_explorer_bookmarks": {
+        "name": "Solid Explorer Bookmarks",
+        "description": "Locations bookmarked in Solid Explorer, with how often each was opened",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-05",
+        "last_update_date": "2026-09-05",
+        "requirements": "none",
+        "category": "Solid Explorer",
+        "sample_data": {
+            "emu_a15_oss_v14": "Solid Explorer 3.5.20 | 2 rows",
+        },
+        "notes": "One row per row of the bookmarks table in "
+                 "pl.solidexplorer2/databases/explorer.db. Name is the label shown in the app's "
+                 "drawer and Path is the location it points at. "
+                 "Times Opened is the hitcount column and counts uses of the bookmark. That was "
+                 "measured rather than assumed: on the tested device a bookmark was added and "
+                 "then opened from the drawer twice, and its hitcount went 0, then 1, then 2, "
+                 "while a second bookmark that was never opened stayed at 0. A bookmark can "
+                 "therefore be present and unused, which the column separates. "
+                 "The app ships with a bookmark already present, so a row is not by itself "
+                 "evidence anyone created it; on the tested device the Download bookmark was "
+                 "there before anything was done and is the one that stayed at 0. "
+                 "File System is the id of the row in the file_systems table the bookmark "
+                 "belongs to, which is the link the database itself records, and is what "
+                 "separates a bookmark on local storage from one on a remote connection. "
+                 "Position is reported as stored.",
+        "paths": ('*/pl.solidexplorer2/databases/explorer.db*',),
+        "output_types": "standard",
+        "artifact_icon": "bookmark",
+    },
+    "solid_explorer_searches": {
+        "name": "Solid Explorer Searches",
+        "description": "Search terms submitted in Solid Explorer",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-05",
+        "last_update_date": "2026-09-05",
+        "requirements": "none",
+        "category": "Solid Explorer",
+        "sample_data": {
+            "emu_a15_oss_v14": "Solid Explorer 3.5.20 | 4 rows",
+        },
+        "notes": "One row per row of the search_suggestions and suggestions tables in "
+                 "pl.solidexplorer2/databases/explorer.db. Table says which of the two a row "
+                 "came from. Neither table carries a timestamp, so these terms cannot be placed "
+                 "in time from this store. "
+                 "Search Term is the literal string submitted. It is worth reading literally: on "
+                 "the tested device the app did not clear the search box between searches, so "
+                 "two of the four stored terms are the previous term with the next one appended. "
+                 "That is what the app recorded and it is reported unchanged rather than split. "
+                 "Counter is reported as stored. It read 0 on every row of the tested device, "
+                 "where four terms were submitted and none of them incremented it past zero. "
+                 "Type belongs to the suggestions table only and is blank for rows "
+                 "from search_suggestions. The suggestions table was empty on the tested device.",
+        "paths": ('*/pl.solidexplorer2/databases/explorer.db*',),
+        "output_types": "standard",
+        "artifact_icon": "search",
+    },
+    "solid_explorer_connections": {
+        "name": "Solid Explorer Connections",
+        "description": "Storage connections configured in Solid Explorer, local and remote",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-05",
+        "last_update_date": "2026-09-05",
+        "requirements": "none",
+        "category": "Solid Explorer",
+        "sample_data": {
+            "emu_a15_oss_v14": "Solid Explorer 3.5.20 | 1 rows",
+        },
+        "notes": "One row per row of the file_systems table in "
+                 "pl.solidexplorer2/databases/explorer.db. This is where a remote connection "
+                 "lives: the app supports FTP, SFTP, SMB, WebDAV and cloud accounts, and each "
+                 "one adds a row carrying its server, port, user name and remote path. "
+                 "Password Stored reports only whether the password column holds a value. The "
+                 "password itself is not printed. "
+                 "Connection Type and Connection Mode are reported as stored, being undocumented "
+                 "in anything published. "
+                 "The tested device had only the built-in local storage entry. On that single row "
+                 "Server, User, Charset and Extra were empty, Password Stored read No, Port and "
+                 "both Connection columns read 0, and Remote Path read a single slash. Those "
+                 "columns are reported because they are the substance of this table "
+                 "on a device that has a remote connection configured, which is the case worth "
+                 "having. Package Name on that row read as a local storage identifier rather "
+                 "than an Android package.",
+        "paths": ('*/pl.solidexplorer2/databases/explorer.db*',),
+        "output_types": "standard",
+        "artifact_icon": "server",
+    },
+    "solid_explorer_folders_viewed": {
+        "name": "Solid Explorer Folders Viewed",
+        "description": "Folders Solid Explorer holds display settings for",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-05",
+        "last_update_date": "2026-09-05",
+        "requirements": "none",
+        "category": "Solid Explorer",
+        "sample_data": {
+            "emu_a15_oss_v14": "Solid Explorer 3.5.20 | 4 rows",
+        },
+        "notes": "One row per row of the dirinfo table in "
+                 "pl.solidexplorer2/databases/explorer.db. The table exists to remember how a "
+                 "folder should be displayed, so a row means the app kept settings for that "
+                 "folder rather than that someone deliberately configured it. "
+                 "A row is not written for every folder opened, which was tested rather than "
+                 "assumed: a folder was opened twice from a bookmark during the session that "
+                 "built the sample and gained no row, while four other folders had rows "
+                 "throughout. So a row shows the app held settings for that folder, and the "
+                 "absence of one is not evidence the folder was never opened. No timestamp is "
+                 "stored either, so nothing here can be placed in time. "
+                 "Sort Mode, View Mode, View Scale and Grouped are the display settings and are "
+                 "reported as stored. Hidden Files Shown reports whether hidden files were "
+                 "displayed in that folder; it read No on every row of the tested device, "
+                 "where the setting was never turned on, and is reported because it "
+                 "separates folders on a device where it was. File System is the id of the "
+                 "file_systems row the folder belongs to, which is the link the database "
+                 "itself records.",
+        "paths": ('*/pl.solidexplorer2/databases/explorer.db*',),
+        "output_types": "standard",
+        "artifact_icon": "folder",
+    },
+}
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, \
+    get_sqlite_db_records, null_absent_columns
+from scripts.artifacts.storagePathViews import unique_files
+
+DB_SUFFIX = 'databases/explorer.db'
+
+
+def _db_files(context):
+    # The pattern also matches the -journal sidecar, which is not opened directly.
+    return [str(f).replace('\\', '/') for f in unique_files(context)
+            if str(f).replace('\\', '/').endswith(DB_SUFFIX)]
+
+
+def _ms(value):
+    """A Unix millisecond value as UTC, blank when absent or zero."""
+    if not value:
+        return ''
+    try:
+        value = int(value)
+        if value <= 0:
+            return ''
+        return convert_unix_ts_to_utc(value // 1000)
+    except (TypeError, ValueError, OverflowError, OSError):
+        return ''
+
+
+def _rows(context, query, build, headers):
+    """Run one query over every explorer.db and build the rows with `build`."""
+    data_list = []
+    sources = []
+    for db_path in _db_files(context):
+        records = get_sqlite_db_records(db_path, null_absent_columns(db_path, query))
+        for record in records:
+            data_list.append(build(record) + (context.get_relative_path(db_path),))
+        if records and db_path not in sources:
+            sources.append(db_path)
+    return headers, data_list, '\n'.join(sources)
+
+
+@artifact_processor
+def solid_explorer_recent_files(context):
+    query = 'SELECT time, path FROM recent_files ORDER BY time DESC'
+    headers = (('Opened', 'datetime'), 'Path', 'Source File')
+    return _rows(context, query, lambda r: (_ms(r[0]), r[1] or ''), headers)
+
+
+@artifact_processor
+def solid_explorer_bookmarks(context):
+    query = '''SELECT name, path, hitcount, file_system, parent_id, position
+               FROM bookmarks ORDER BY hitcount DESC, name'''
+    headers = ('Name', 'Path', 'Times Opened', 'File System', 'Parent Path',
+               'Position', 'Source File')
+    return _rows(context, query,
+                 lambda r: (r[0] or '', r[1] or '', r[2], r[3], r[4] or '', r[5]),
+                 headers)
+
+
+@artifact_processor
+def solid_explorer_searches(context):
+    query = '''SELECT suggestion, counter, '' AS type, 'search_suggestions' AS src
+               FROM search_suggestions
+               UNION ALL
+               SELECT suggestion, counter, type, 'suggestions' AS src
+               FROM suggestions'''
+    headers = ('Search Term', 'Counter (as stored)', 'Type (as stored)', 'Table', 'Source File')
+    return _rows(context, query,
+                 lambda r: (r[0] or '', r[1], r[2] if r[2] is not None else '', r[3]),
+                 headers)
+
+
+@artifact_processor
+def solid_explorer_connections(context):
+    query = '''SELECT name, server, port, user, path, package_name, conn_type, conn_mode,
+                      password, charset, extra
+               FROM file_systems ORDER BY name'''
+    headers = ('Name', 'Server', 'Port', 'User', 'Remote Path', 'Package Name',
+               'Connection Type (as stored)', 'Connection Mode (as stored)',
+               'Password Stored', 'Charset', 'Extra', 'Source File')
+    return _rows(context, query,
+                 lambda r: (r[0] or '', r[1] or '', r[2], r[3] or '', r[4] or '',
+                            r[5] or '', r[6], r[7], 'Yes' if r[8] else 'No',
+                            r[9] or '', r[10] or ''),
+                 headers)
+
+
+@artifact_processor
+def solid_explorer_folders_viewed(context):
+    query = '''SELECT file_id, file_system, sort_mode, view_mode, view_scale, grouped, hidden
+               FROM dirinfo ORDER BY file_id'''
+    headers = ('Folder', 'File System', 'Sort Mode (as stored)', 'View Mode (as stored)',
+               'View Scale (as stored)', 'Grouped', 'Hidden Files Shown', 'Source File')
+    return _rows(context, query,
+                 lambda r: (r[0] or '', r[1], r[2], r[3], r[4],
+                            'Yes' if r[5] else 'No', 'Yes' if r[6] else 'No'),
+                 headers)


### PR DESCRIPTION
Adds Solid Explorer, HERE WeGo and Moovit support for Android. Ten artifacts:

- Solid Explorer (databases/explorer.db): recent files with the time each was opened, bookmarks with a use count, search terms, storage connections, and per folder display settings.
- HERE WeGo: recent searches, saved places with coordinates, the last device location and map centre, and settings. The app is Flutter, so these come from FlutterSharedPreferences.xml and two Hive boxes.
- Moovit: planned journeys with both endpoints and their coordinates.

The HERE WeGo search timestamps carry no zone and are device local time, not UTC. Hive frames are checked against their own CRC before being read. Undocumented values are reported as stored, and no stored password is printed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
