### PR TITLE
Correct five descriptions and one note in the terms-gated app modules

### DIFF
--- a/scripts/artifacts/hereWeGo.py
+++ b/scripts/artifacts/hereWeGo.py
@@ -1,7 +1,7 @@
 __artifacts_v2__ = {
     "here_wego_recent_searches": {
         "name": "HERE WeGo Recent Searches",
-        "description": "Searches made in HERE WeGo, with the time each was made",
+        "description": "Recent searches HERE WeGo kept, with the time of each",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-09-05",
         "last_update_date": "2026-09-05",
@@ -28,15 +28,17 @@ __artifacts_v2__ = {
                  "same reason: they are the fields the app fills when an entry names a resolved "
                  "place rather than a free text query, and they are reported because that is the "
                  "case worth having on a device where it occurs. "
-                 "The list is a recent-searches list, so it is capped and ordered by the app, and "
-                 "an absent term is not evidence it was never searched for.",
+                 "The list is a recent-searches list, so the app orders it and may drop older "
+                 "entries. Whether it is capped, and at what, was not established: the tested "
+                 "device held two entries, which cannot reach a cap. Either way an absent term "
+                 "is not evidence it was never searched for.",
         "paths": ('*/com.here.app.maps/shared_prefs/FlutterSharedPreferences.xml',),
         "output_types": "standard",
         "artifact_icon": "search",
     },
     "here_wego_saved_places": {
         "name": "HERE WeGo Saved Places",
-        "description": "Places saved into HERE WeGo collections, with their coordinates",
+        "description": "Place entries in HERE WeGo collections, with their coordinates",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-09-05",
         "last_update_date": "2026-09-05",

--- a/scripts/artifacts/solidExplorer.py
+++ b/scripts/artifacts/solidExplorer.py
@@ -1,7 +1,7 @@
 __artifacts_v2__ = {
     "solid_explorer_recent_files": {
         "name": "Solid Explorer Recent Files",
-        "description": "Files opened through Solid Explorer, with the time each was opened",
+        "description": "Files Solid Explorer recorded as recently opened, with the time of each",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-09-05",
         "last_update_date": "2026-09-05",
@@ -26,7 +26,7 @@ __artifacts_v2__ = {
     },
     "solid_explorer_bookmarks": {
         "name": "Solid Explorer Bookmarks",
-        "description": "Locations bookmarked in Solid Explorer, with how often each was opened",
+        "description": "Bookmarked locations in Solid Explorer, with how often each was opened",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-09-05",
         "last_update_date": "2026-09-05",
@@ -83,7 +83,7 @@ __artifacts_v2__ = {
     },
     "solid_explorer_connections": {
         "name": "Solid Explorer Connections",
-        "description": "Storage connections configured in Solid Explorer, local and remote",
+        "description": "Storage connections Solid Explorer holds, local and remote",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-09-05",
         "last_update_date": "2026-09-05",


### PR DESCRIPTION
Corrects five artifact descriptions and one note across the Solid Explorer and HERE WeGo modules.

Each description claimed more than the artifact's own notes concede: every file opened through Solid Explorer, that a person created each bookmark, that the single connection row was configured, that the HERE WeGo list holds the searches made, and that a saved place row is one distinct place. The notes already said otherwise in all five cases.

The HERE WeGo note also stated the recent search list is capped. That was never observed, so it now says a cap was not established.

No code changes and no row counts move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
