### PR TITLE
Correct two descriptions in the Nova Launcher and Flipboard modules

### DIFF
--- a/scripts/artifacts/flipboard.py
+++ b/scripts/artifacts/flipboard.py
@@ -31,7 +31,7 @@ __artifacts_v2__ = {
     },
     "flipboard_sections": {
         "name": "Flipboard Followed Sections",
-        "description": "Topics and magazines the Flipboard user follows",
+        "description": "Sections Flipboard lists, the topics followed and the feeds the app adds itself",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-09-05",
         "last_update_date": "2026-09-05",

--- a/scripts/artifacts/novaLauncher.py
+++ b/scripts/artifacts/novaLauncher.py
@@ -44,7 +44,7 @@ __artifacts_v2__ = {
     },
     "nova_drawer_groups": {
         "name": "Nova Launcher Drawer Groups",
-        "description": "App drawer tabs and folders, and the apps assigned to each",
+        "description": "Nova Launcher drawer folders and the drawer's whole app list, with the apps in each",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-09-05",
         "last_update_date": "2026-09-05",


### PR DESCRIPTION
Corrects two artifact descriptions.

- Nova Launcher Drawer Groups said "tabs and folders". No row is a tab, and half the rows are the drawer's whole app list, which the notes already explain.
- Flipboard Followed Sections said "topics and magazines the Flipboard user follows". No row is a magazine, and two of the five are feeds the app adds itself, which the notes already say.

No code changes and no row counts move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
