### PR TITLE
Add a CI gate for artifact descriptions that say nothing

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -104,6 +104,15 @@ jobs:
         if: steps.changed-files-py.outputs.any_changed == 'true'
         run: python admin/scripts/check_implicit_concat.py
 
+      # An artifact's description is the one line the report, the LAVA manifest and
+      # casework quote for it. One that is missing, runs to several lines, only repeats
+      # the name, or duplicates a sibling's in the same module says nothing about the
+      # rows it fronts. Whether a description claims past its own notes is a judgement
+      # the script cannot make; its --review mode lays the pair out for that pass.
+      - name: Guard against an artifact description that says nothing
+        if: steps.changed-files-py.outputs.any_changed == 'true'
+        run: python admin/scripts/check_artifact_descriptions.py
+
       # Fails only on warnings this pull request introduces. Long-lived modules carry
       # deliberate pre-existing warnings, and failing on those pushed contributors toward
       # unrelated refactors or blanket file-level disables. See the script's docstring.

--- a/admin/scripts/check_artifact_descriptions.py
+++ b/admin/scripts/check_artifact_descriptions.py
@@ -1,0 +1,192 @@
+"""Fail CI when an artifact's description is missing, runs to more than one line,
+only repeats the artifact's name, or duplicates another artifact's in the same module.
+
+Every artifact module declares an `__artifacts_v2__` dict whose `description` is the
+one line the HTML report, the LAVA manifest and the module index quote for it. It is
+the sentence somebody reads to decide what the artifact is. Four defects in it are
+purely mechanical and this script fails on them:
+
+* missing, or not a string;
+* empty once stripped;
+* more than one line;
+* the same text as the artifact's `name`, which says nothing the name did not;
+* the same text as another artifact's description in the same module, which cannot be
+  right for both, since two artifacts exist because they report different things.
+  The commonest cause is a block copied for a sibling and not finished.
+
+The other half of a description audit is not mechanical and this script does not try
+to be a gate for it: whether a description claims past a limit the artifact's own notes
+already concede. Seven merged artifacts were found doing exactly that in one day by
+reading each description beside the sentences in its notes that concede a limit. That
+is a judgement pass and it belongs before the pull request. `--review` lays the pair
+out for it: for each artifact in the named modules it prints the description and every
+sentence of the notes that carries limiting vocabulary, and never fails.
+
+Usage:
+  check_artifact_descriptions.py [--root REPO_ROOT]
+  check_artifact_descriptions.py --review MODULE [MODULE ...]
+
+Exit status 0 when every description passes the mechanical rules, 1 when any fails,
+2 when the artifact tree cannot be found.
+"""
+import argparse
+import ast
+import os
+import re
+import sys
+
+# Vocabulary that marks a sentence in `notes` as conceding a limit. This drives the
+# review listing only; nothing here is a claim in itself.
+CONCESSION = re.compile(
+    r"\b(?:not established|not evidence|is not|are not|was not|were not|does not|"
+    r"do not|did not|cannot|could not|never|no row|not reported|not parsed|"
+    r"not decoded|not resolved|ships with|already present|only|absence of|"
+    r"blank|empty|unexercised|as stored)\b", re.IGNORECASE)
+
+STANDARD_NOTE = (
+    'A description is the one line quoted for the artifact. Say what the rows are and '
+    'where they come from; a description that repeats the name or a sibling says '
+    'nothing, and one that claims past its own notes is the defect --review exists '
+    'to surface.')
+
+
+def artifact_blocks(path):
+    """The __artifacts_v2__ dict of one module as {key: info}, or (None, problem)."""
+    try:
+        with open(path, encoding='utf-8', errors='replace') as handle:
+            tree = ast.parse(handle.read())
+    except (OSError, SyntaxError) as err:
+        return None, f'{os.path.basename(path)}: could not parse ({err})'
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+                isinstance(t, ast.Name) and t.id == '__artifacts_v2__' for t in node.targets):
+            try:
+                value = ast.literal_eval(node.value)
+            except ValueError:
+                return None, f'{os.path.basename(path)}: __artifacts_v2__ is not a literal'
+            return (value if isinstance(value, dict) else {}), None
+    return {}, None
+
+
+def _normal(text):
+    return ' '.join(str(text).split()).lower()
+
+
+def check_module(path):
+    """(violations, problem) for one module. Each violation is (module, key, reason)."""
+    blocks, problem = artifact_blocks(path)
+    if blocks is None:
+        return [], problem
+    module = os.path.basename(path)
+    violations = []
+    seen = {}
+    for key, info in blocks.items():
+        if not isinstance(info, dict):
+            continue
+        description = info.get('description')
+        if not isinstance(description, str):
+            violations.append((module, key, 'description is missing or not a string'))
+            continue
+        if not description.strip():
+            violations.append((module, key, 'description is empty'))
+            continue
+        if '\n' in description:
+            violations.append((module, key, 'description runs to more than one line'))
+        name = info.get('name')
+        if isinstance(name, str) and _normal(name) == _normal(description):
+            violations.append((module, key, 'description only repeats the name'))
+        normal = _normal(description)
+        if normal in seen:
+            violations.append((module, key,
+                               f'description duplicates {seen[normal]!r} in the same module'))
+        else:
+            seen[normal] = key
+    return violations, None
+
+
+def concession_sentences(notes):
+    """The sentences of a notes field that concede a limit, for the review listing."""
+    if not isinstance(notes, str):
+        return []
+    sentences = [s.strip() for s in re.split(r'(?<=[.])\s+', notes) if s.strip()]
+    return [s for s in sentences if CONCESSION.search(s)]
+
+
+def review(paths):
+    """Print each description beside the limits its own notes concede. Never fails."""
+    for path in paths:
+        blocks, problem = artifact_blocks(path)
+        print(f'\n{"=" * 78}\n{os.path.basename(path)}')
+        if blocks is None:
+            print(f'  {problem}')
+            continue
+        for key, info in blocks.items():
+            if not isinstance(info, dict):
+                continue
+            print(f'\n  {key}')
+            print(f'     description: {info.get("description")!r}')
+            limits = concession_sentences(info.get('notes'))
+            for sentence in limits[:8]:
+                print(f'     notes limit: {sentence[:160]}')
+            if not limits:
+                print('     notes limit: (none conceded)')
+    print('\nJudge each description against the limits beside it: it must not claim past them.')
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--root', default=None, help='repository root')
+    parser.add_argument('--review', nargs='+', metavar='MODULE',
+                        help='print each description beside its notes\' conceded limits '
+                             'for the named artifact modules, and exit 0')
+    args = parser.parse_args()
+
+    root = args.root or os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    artifacts = os.path.join(root, 'scripts', 'artifacts')
+    if not os.path.isdir(artifacts):
+        print(f'No scripts/artifacts under {root}', file=sys.stderr)
+        return 2
+
+    if args.review:
+        paths = []
+        for name in args.review:
+            base = name if name.endswith('.py') else name + '.py'
+            candidate = base if os.path.isabs(base) else os.path.join(artifacts, os.path.basename(base))
+            if not os.path.isfile(candidate):
+                print(f'No such artifact module: {name}', file=sys.stderr)
+                return 2
+            paths.append(candidate)
+        review(paths)
+        return 0
+
+    violations, unreadable, modules = [], [], 0
+    for name in sorted(os.listdir(artifacts)):
+        if not name.endswith('.py'):
+            continue
+        modules += 1
+        found, problem = check_module(os.path.join(artifacts, name))
+        violations.extend(found)
+        if problem:
+            unreadable.append(problem)
+
+    if violations:
+        print(f'Artifact descriptions that say nothing ({len(violations)}):')
+        for module, key, reason in violations:
+            print(f'  {module}::{key}  {reason}')
+        print()
+        print(STANDARD_NOTE)
+        return 1
+
+    summary = f'Checked {modules} artifact module(s): every description is present, one line, and its own.'
+    if unreadable:
+        summary += f' {len(unreadable)} module(s) NOT checked.'
+    print(summary)
+    for problem in unreadable:
+        print(f'  {problem}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/admin/test/scripts/test_check_artifact_descriptions.py
+++ b/admin/test/scripts/test_check_artifact_descriptions.py
@@ -1,0 +1,141 @@
+"""Prove the description checker fails on each shape it exists to catch and passes
+the shapes it must leave alone.
+
+The mechanical defects are exact: a description that is missing, empty, more than one
+line, identical to the artifact's name, or identical to a sibling's in the same module.
+Each gets a fixture that fails and a neighbouring fixture that passes, because a gate
+that has only ever been seen green has not been shown to gate anything.
+
+Two negative cases matter as much as the positives. Identical descriptions in two
+different modules are not flagged, since the rule is scoped to one module, where a
+duplicate is a copy left unfinished. And the review listing is not a gate: its helper
+returns the conceding sentences and nothing here asserts on them as failures.
+
+Expected values are written out as literals rather than derived from the module under
+test, so a fixture cannot move with a bug in the code it checks.
+"""
+import importlib.util
+import pathlib
+import sys
+import tempfile
+import textwrap
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_MODULE_PATH = REPO_ROOT / 'admin' / 'scripts' / 'check_artifact_descriptions.py'
+
+# admin/scripts is not a package, so load the module from its path.
+_spec = importlib.util.spec_from_file_location('check_artifact_descriptions', _MODULE_PATH)
+cad = importlib.util.module_from_spec(_spec)
+sys.modules['check_artifact_descriptions'] = cad
+_spec.loader.exec_module(cad)
+
+
+def violations_for(source, filename='sample.py'):
+    with tempfile.TemporaryDirectory() as folder:
+        path = pathlib.Path(folder) / filename
+        path.write_text(textwrap.dedent(source), encoding='utf-8')
+        found, problem = cad.check_module(str(path))
+    if problem:
+        raise AssertionError(problem)
+    return [(key, reason) for _module, key, reason in found]
+
+
+def block(entries):
+    """An __artifacts_v2__ module source from {key: {field: value}}."""
+    lines = ['__artifacts_v2__ = {']
+    for key, fields in entries.items():
+        lines.append(f'    {key!r}: {{')
+        for field, value in fields.items():
+            lines.append(f'        {field!r}: {value!r},')
+        lines.append('    },')
+    lines.append('}')
+    return '\n'.join(lines) + '\n'
+
+
+class MechanicalDefects(unittest.TestCase):
+    def test_missing_description_fails(self):
+        found = violations_for(block({'a': {'name': 'Thing'}}))
+        self.assertEqual(found, [('a', 'description is missing or not a string')])
+
+    def test_non_string_description_fails(self):
+        found = violations_for(block({'a': {'name': 'Thing', 'description': 7}}))
+        self.assertEqual(found, [('a', 'description is missing or not a string')])
+
+    def test_empty_description_fails(self):
+        found = violations_for(block({'a': {'name': 'Thing', 'description': '   '}}))
+        self.assertEqual(found, [('a', 'description is empty')])
+
+    def test_multiline_description_fails(self):
+        found = violations_for(block({'a': {'name': 'Thing',
+                                             'description': 'Rows from x.\nMore.'}}))
+        self.assertEqual(found, [('a', 'description runs to more than one line')])
+
+    def test_description_equal_to_name_fails(self):
+        found = violations_for(block({'a': {'name': 'Samsung Notes',
+                                             'description': 'Samsung Notes'}}))
+        self.assertEqual(found, [('a', 'description only repeats the name')])
+
+    def test_name_match_ignores_case_and_spacing(self):
+        found = violations_for(block({'a': {'name': 'Samsung  Notes',
+                                             'description': 'samsung notes '}}))
+        self.assertEqual(found, [('a', 'description only repeats the name')])
+
+    def test_duplicate_within_module_fails_on_the_second(self):
+        found = violations_for(block({
+            'contacts': {'name': 'Romeo Contacts', 'description': 'Parses Romeo contacts'},
+            'accounts': {'name': 'Romeo Accounts', 'description': 'Parses Romeo contacts'},
+        }))
+        self.assertEqual(found, [('accounts',
+                                  "description duplicates 'contacts' in the same module")])
+
+    def test_duplicate_match_ignores_case(self):
+        found = violations_for(block({
+            'a': {'name': 'A', 'description': 'Kik notifications from FCM'},
+            'b': {'name': 'B', 'description': 'kik Notifications from fcm'},
+        }))
+        self.assertEqual([k for k, _ in found], ['b'])
+
+
+class ShapesLeftAlone(unittest.TestCase):
+    def test_distinct_one_line_descriptions_pass(self):
+        found = violations_for(block({
+            'a': {'name': 'JusTalk - Calls', 'description': 'Calls from the JusTalk store'},
+            'b': {'name': 'JusTalk Kids - Calls',
+                  'description': 'Calls from the JusTalk Kids store'},
+        }))
+        self.assertEqual(found, [])
+
+    def test_description_that_extends_the_name_passes(self):
+        found = violations_for(block({'a': {'name': 'Samsung Notes',
+                                             'description': 'Notes from Samsung Notes, with media'}}))
+        self.assertEqual(found, [])
+
+    def test_same_description_in_two_modules_is_not_flagged(self):
+        source = block({'a': {'name': 'A', 'description': 'Chess database'}})
+        self.assertEqual(violations_for(source, 'one.py'), [])
+        self.assertEqual(violations_for(source, 'two.py'), [])
+
+    def test_unparseable_module_is_reported_not_crashed(self):
+        with tempfile.TemporaryDirectory() as folder:
+            path = pathlib.Path(folder) / 'broken.py'
+            path.write_text('__artifacts_v2__ = {\n', encoding='utf-8')
+            found, problem = cad.check_module(str(path))
+        self.assertEqual(found, [])
+        self.assertIn('could not parse', problem)
+
+
+class ReviewListing(unittest.TestCase):
+    def test_conceding_sentences_are_selected(self):
+        notes = ('One row per entry. Whether every file is recorded was not established. '
+                 'Times are UTC. A blank value is not evidence of absence.')
+        limits = cad.concession_sentences(notes)
+        self.assertEqual(limits, ['Whether every file is recorded was not established.',
+                                  'A blank value is not evidence of absence.'])
+
+    def test_non_string_notes_yield_nothing(self):
+        self.assertEqual(cad.concession_sentences(None), [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/artifacts/FCMQueuedMessageKik.py
+++ b/scripts/artifacts/FCMQueuedMessageKik.py
@@ -27,7 +27,7 @@ __artifacts_v2__ = {
     },
     "fcm_kik_blanks": {
         "name": "FCM-KIK Notifications Blanks",
-        "description": "Kik Notifications from FCM",
+        "description": 'Kik records from the FCM queued messages store, reported with only the FCM timestamp and sender id',
         "author": "@jfhyla",
         "creation_date": "2025-07-31",
         "last_update_date": "2025-07-31",

--- a/scripts/artifacts/RomeoDatingApp.py
+++ b/scripts/artifacts/RomeoDatingApp.py
@@ -38,7 +38,7 @@ __artifacts_v2__ = {
     },
     'romeo_dating_accounts': {
         'name': 'Romeo Dating App Accounts',
-        'description': 'Parses Romeo Dating App Contacts',
+        'description': 'Account records from the Romeo dating app accounts database, with location, headline, profile text and dates',
         'author': 'Marco Neumann {kalinko@be-binary.de}',
         'version': '0.0.1',
         'creation_date': '2026-02-25',

--- a/scripts/artifacts/SamsungNotes.py
+++ b/scripts/artifacts/SamsungNotes.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
   
     "snotes": {
         "name": "Samsung Notes",
-        "description": "Samsung Notes",
+        "description": "Notes from Samsung Notes' sdoc.db, with their text, times, deletion state and media",
         "author": "Marco Neumann {kalinko@be-binary.de}",
         "creation_date": "2026-01-17",
         "last_update_date": "2026-01-17",

--- a/scripts/artifacts/appSemloc.py
+++ b/scripts/artifacts/appSemloc.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_appSemloc": {
         "name": "App Semantic Locations",
-        "description": "App Semantic Locations",
+        "description": "Location records from Google Play services' app_semanticlocation_rawsignal LevelDB, with coordinates and accuracy",
         "author": "Alexis 'Brigs' Brignoni",
         "creation_date": "2024/06/21",
         "last_update_date": "2024/06/21",

--- a/scripts/artifacts/battery_usage_v9.py
+++ b/scripts/artifacts/battery_usage_v9.py
@@ -17,7 +17,7 @@ __artifacts_v2__ = {
     },
     "get_app_usage_events": {
         "name": "Settings Services - App Battery Usages v9 - App Battery Usage Events",
-        "description": "Getting Battery Usage data out of the database battery-usage-db-v9. Introduced with Android 14",
+        "description": 'App battery usage events from the Settings battery-usage-db-v9 AppUsageEventEntity table, Android 14',
         "author": "Marco Neumann {kalinko@be-binary.de}",
         "creation_date": "2024-05-12",
         "last_update_date": "2026-08-01",

--- a/scripts/artifacts/justalk.py
+++ b/scripts/artifacts/justalk.py
@@ -263,9 +263,7 @@ __artifacts_v2__ = {
     },
     "justalk_kids_messages": {
         "name": "JusTalk Kids - Messages",
-        "description": "Chat messages from the JusTalk Realm store, with the message body, the "
-                       "direction, the sender, the media type and the cached media file where it "
-                       "is present in the extraction",
+        "description": 'Chat messages from the JusTalk Kids Realm store, with the message body, the direction, the sender, the media type and the cached media file where it is present in the extraction',
         "author": "@AlexisBrignoni, @Newhope81, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
@@ -318,8 +316,7 @@ __artifacts_v2__ = {
     },
     "justalk_kids_calls": {
         "name": "JusTalk Kids - Call Logs",
-        "description": "Audio and video calls from the JusTalk Realm store, with the direction, "
-                       "the duration and the server call identifier",
+        "description": 'Audio and video calls from the JusTalk Kids Realm store, with the direction, the duration and the server call identifier',
         "author": "@AlexisBrignoni, @Newhope81, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
@@ -344,8 +341,7 @@ __artifacts_v2__ = {
     },
     "justalk_kids_media": {
         "name": "JusTalk Kids - Media",
-        "description": "File records from the JusTalk Realm store with the cached copies found in "
-                       "the extraction, plus any cached files the store does not account for",
+        "description": 'File records from the JusTalk Kids Realm store with the cached copies found in the extraction, plus any cached files the store does not account for',
         "author": "@AlexisBrignoni, @Newhope81, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
@@ -379,9 +375,7 @@ __artifacts_v2__ = {
     },
     "justalk_kids_contacts": {
         "name": "JusTalk Kids - Contacts",
-        "description": "Contacts from the JusTalk Realm store, with the JusTalk ID, the display "
-                       "and nickname, the client version reported for that account and the last "
-                       "online time",
+        "description": 'Contacts from the JusTalk Kids Realm store, with the JusTalk ID, the display and nickname, the client version reported for that account and the last online time',
         "author": "@AlexisBrignoni, @Newhope81, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
@@ -402,7 +396,7 @@ __artifacts_v2__ = {
     },
     "justalk_kids_members": {
         "name": "JusTalk Kids - Members",
-        "description": "Server members (contacts/groups) from the JusTalk Realm store",
+        "description": 'Server members (contacts/groups) from the JusTalk Kids Realm store',
         "author": "@AlexisBrignoni, @Newhope81, Claude",
         "creation_date": "2026-08-10",
         "last_update_date": "2026-08-10",
@@ -416,7 +410,7 @@ __artifacts_v2__ = {
     },
     "justalk_kids_moments": {
         "name": "JusTalk Kids - Moments",
-        "description": "Moments (timeline posts) from the JusTalk Realm store",
+        "description": 'Moments (timeline posts) from the JusTalk Kids Realm store',
         "author": "@AlexisBrignoni, @Newhope81, Claude",
         "creation_date": "2026-08-10",
         "last_update_date": "2026-08-10",
@@ -430,8 +424,7 @@ __artifacts_v2__ = {
     },
     "justalk_kids_account": {
         "name": "JusTalk Kids - Account",
-        "description": "The local JusTalk account identifiers taken from the Realm store file "
-                       "name, the app's provisioning file and the Realm schema version",
+        "description": "The local JusTalk Kids account identifiers taken from the Realm store file name, the app's provisioning file and the Realm schema version",
         "author": "@AlexisBrignoni, @Newhope81, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",
@@ -492,9 +485,7 @@ __artifacts_v2__ = {
     },
     "justalk_kids_app_state": {
         "name": "JusTalk Kids - App State",
-        "description": "Key and value pairs from the app's default MMKV store, covering the "
-                       "device identifier, the signed-in account id, the push token and the "
-                       "install channel, including values that later writes superseded",
+        "description": "Key and value pairs from JusTalk Kids' default MMKV store, covering the device identifier, the signed-in account id, the push token and the install channel, including values that later writes superseded",
         "author": "@AlexisBrignoni, @Newhope81, Claude",
         "creation_date": "2026-08-07",
         "last_update_date": "2026-08-07",

--- a/scripts/artifacts/kleinanzeigen.de.py
+++ b/scripts/artifacts/kleinanzeigen.de.py
@@ -30,7 +30,7 @@ __artifacts_v2__ = {
     },
     "get_kleinanzeigennonresettablerecentsearchescache": {
         "name": "kleinanzeigen.de - Non resettable Recent Searches Cache",
-        "description": "Extracts Recent Searches Cache",
+        "description": "Recent search terms from kleinanzeigen.de's NON_RESETTABLE_RECENT_SEARCHES_CACHE file, with category and time",
         "author": "@BrunoFischerGermany",
         "creation_date": "2024-04-08",
         "last_update_date": "2024-04-08",

--- a/scripts/artifacts/mega.py
+++ b/scripts/artifacts/mega.py
@@ -1,7 +1,7 @@
 __artifacts_v2__ = {
     "get_mega": {
         "name": "mega",
-        "description": "MEGA",
+        "description": "Chat messages from MEGA's karere database, with sender, message type and attachment name",
         "author": "Kevin Pagano (@stark4n6)",
         "creation_date": "2021-01-31",
         "last_update_date": "2021-01-31",

--- a/scripts/artifacts/shistorylog.py
+++ b/scripts/artifacts/shistorylog.py
@@ -2,7 +2,7 @@ __artifacts_v2__ = {
     
     "history_log": {
         "name": "Samsung Knox History Log",
-        "description": "Samsung Knox History Log",
+        "description": 'Entries from the Samsung Knox Secure Folder HistoryLog table, with tag and message',
         "author": "Alexis Brignoni {linqapp.com/abrignoni}",
         "creation_date": "2026-02-27",
         "last_update_date": "2025-02-27",

--- a/scripts/artifacts/ulrUserprefs.py
+++ b/scripts/artifacts/ulrUserprefs.py
@@ -1,7 +1,7 @@
 __artifacts_v2__ = {
     "get_urluser": {
         "name": "ULR User Prefs",
-        "description": "ULR User Prefs",
+        "description": "Name and value pairs from Google Play services' ULR_USER_PREFS.xml",
         "author": "Alexis 'Brigs' Brignoni",
         "creation_date": "2024-06-21",
         "last_update_date": "2024-06-21",


### PR DESCRIPTION
Adds a CI gate for artifact descriptions, `admin/scripts/check_artifact_descriptions.py`, wired into `python_lint.yml` beside the other gates.

It fails when a description is missing, runs to more than one line, only repeats the artifact's `name`, or duplicates another artifact's in the same module. Each shape has a unit test that fails on it and passes on its neighbour, and the checker was run red against main before the fixes below and green after.

Landing at zero meant correcting the seventeen descriptions on main that trip it: five that only repeated the name (Samsung Notes, App Semantic Locations, MEGA, Knox History Log, ULR User Prefs), four copied from a sibling and not finished (Kik blanks, Romeo accounts, battery usage events, kleinanzeigen non-resettable cache), and JusTalk's eight Kids twins, which now name JusTalk Kids.

Whether a description claims past its own notes is a judgement the gate cannot make. The script's `--review MODULE` mode prints each description beside the sentences in its notes that concede a limit, for that pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
