### PR TITLE
Report BitTorrent file paths as evidence relative and unwrapped

### DIFF
--- a/scripts/artifacts/bittorrentDlhist.py
+++ b/scripts/artifacts/bittorrentDlhist.py
@@ -16,7 +16,6 @@ __artifacts_v2__ = {
 
 import bencoding
 import datetime
-import textwrap
 
 from scripts.ilapfuncs import artifact_processor
 
@@ -44,7 +43,7 @@ def get_bittorrentDlhist(context):
                     time = timestampcalc(x[b'a'])
                     filename = x[b'n'].decode()
                     filepath = x[b's'].decode()
-                data_list.append((time,filename,filepath,textwrap.fill(context.get_relative_path(file_found).strip(), width=25)))
+                data_list.append((time,filename,filepath,context.get_relative_path(file_found)))
 
     data_headers = (
         ('Record Timestamp', 'datetime'),

--- a/scripts/artifacts/chatgpt2.py
+++ b/scripts/artifacts/chatgpt2.py
@@ -20,7 +20,6 @@ __artifacts_v2__ = {
 }
 
 import sqlite3
-import textwrap
 import json
 from datetime import datetime, timezone
 from collections import defaultdict

--- a/scripts/artifacts/torrentResumeinfo.py
+++ b/scripts/artifacts/torrentResumeinfo.py
@@ -19,7 +19,6 @@ __artifacts_v2__ = {
 import bencoding
 import hashlib
 import datetime
-import textwrap
 
 from scripts.ilapfuncs import artifact_processor
 from scripts.html_safe import esc
@@ -67,7 +66,7 @@ def get_torrentResumeinfo(context):
             else:
                 aggregate = aggregate + f'{esc(key.decode())}: {esc(value)} <br>' #add if value is binary decode
 
-        data_list.append((textwrap.fill(file_found, width=25),infohash,aggregate.strip()))
+        data_list.append((context.get_relative_path(file_found),infohash,aggregate.strip()))
 
     data_headers = ('File', 'InfoHash', 'Data')
     return data_headers, data_list, source_path

--- a/scripts/artifacts/torrentinfo.py
+++ b/scripts/artifacts/torrentinfo.py
@@ -19,7 +19,6 @@ __artifacts_v2__ = {
 import bencoding
 import hashlib
 import datetime
-import textwrap
 
 from scripts.ilapfuncs import artifact_processor, logfunc
 from scripts.html_safe import esc
@@ -75,7 +74,7 @@ def get_torrentinfo(context):
                 else:
                     aggregate = aggregate + f'{esc(key.decode())}: {esc(value.decode())} <br>' #add if value is binary decode
 
-            data_list.append((textwrap.fill(file_found.strip(), width=25),infohash,aggregate))
+            data_list.append((context.get_relative_path(file_found),infohash,aggregate))
         except Exception as e: logfunc(str(e))
 
     data_headers = ('File', 'InfoHash', 'Data')


### PR DESCRIPTION
Reports the BitTorrent file paths as evidence relative and stops wrapping them.

- torrentinfo and torrentResumeinfo put the absolute path from the machine running the tool in the File column. It reached the HTML report, the TSV export and the LAVA database.
- All three BitTorrent artifacts ran the path through textwrap.fill. Those newlines split one TSV row across several physical lines, and the HTML report and LAVA collapse them to spaces, so the path showed spaces inside directory and file names.
- Drops an unused textwrap import from chatgpt2.

Row counts are unchanged.