### PR TITLE
Correct descriptions that claimed past their own notes

### DIFF
--- a/scripts/artifacts/PrivatePhotoVault.py
+++ b/scripts/artifacts/PrivatePhotoVault.py
@@ -1,9 +1,8 @@
 __artifacts_v2__ = {
     "private_photo_vault_account": {
         "name": "Private Photo Vault - Account Usage",
-        "description": "Install date and self-reported usage counters for the "
-                       "Private Photo Vault app, read from its main preferences "
-                       "file.",
+        "description": "Install date and the key event count and last key event date the Private Photo Vault app keeps "
+                       "in its main preferences file, reported as stored.",
         "author": "@Gear-I & Claude",
         "creation_date": "2026-08-17",
         "last_update_date": "2026-08-17",

--- a/scripts/artifacts/Spotify.py
+++ b/scripts/artifacts/Spotify.py
@@ -44,10 +44,9 @@ __artifacts_v2__ = {
     },
     "spotify_playlist_library": {
         "name": "Spotify - Playlist Library Activity",
-        "description": "Playlists Spotify's own local usage-tracking file has a "
-                       "record for, with the time each one was first interacted with "
-                       "and a snapshot of two internal usage counters recorded "
-                       "whenever that snapshot changed.",
+        "description": "Playlists Spotify's own local usage-tracking file has a record for, with the earliest time the "
+                       "tracker recorded for each one and a snapshot of two internal usage counters recorded whenever "
+                       "that snapshot changed.",
         "author": "@Gear-I, Claude",
         "creation_date": "2026-08-16",
         "last_update_date": "2026-08-25",

--- a/scripts/artifacts/Xender.py
+++ b/scripts/artifacts/Xender.py
@@ -2,7 +2,8 @@
 __artifacts_v2__ = {
     "get_Xender": {
         "name": "Xender - Contacts",
-        "description": "Parses Xender contact profiles (device ID and nickname) from the Xender trans-history database.",
+        "description": "Parses the Xender profile rows recorded with connect_times = 0 (device ID and nickname) from the "
+                       "Xender trans-history database.",
         "author": "@markmckinnon",
         "creation_date": "2020-12-24",
         "last_update_date": "2026-08-01",

--- a/scripts/artifacts/androidUsers.py
+++ b/scripts/artifacts/androidUsers.py
@@ -1,9 +1,8 @@
 __artifacts_v2__ = {
     "android_users": {
         "name": "Android Users and Profiles",
-        "description": "The Android users and profiles that exist on the device, with each "
-                       "one's name, type, creation time, the time it was last logged in and the time the "
-                       "device last switched to it.",
+        "description": "The Android users and profiles that exist on the device, with each one's name, type and creation "
+                       "time, and the lastLoggedIn and lastEnteredForeground times the platform stored, as stored.",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-09-03",
         "last_update_date": "2026-09-04",

--- a/scripts/artifacts/appicons.py
+++ b/scripts/artifacts/appicons.py
@@ -8,7 +8,8 @@ __artifacts_v2__ = {
         "last_update_date": "2025-03-08",
         "requirements": "none",
         "category": "Installed Apps",
-        "notes": "Seems to be a google thing, on Nexus/Pixel devices only?",
+        "notes": "Read from app_icons.db of the Pixel Launcher, com.google.android.apps.nexuslauncher; the path "
+                 "pattern is anchored on that package, so icons kept by other launchers are not covered.",
         "paths": ('*/com.google.android.apps.nexuslauncher/databases/app_icons.db*'),
         "output_types": ["html", "lava"],
         "artifact_icon": "package",

--- a/scripts/artifacts/c2paProvenance.py
+++ b/scripts/artifacts/c2paProvenance.py
@@ -1,13 +1,11 @@
 __artifacts_v2__ = {
     "get_c2paProvenance": {
         "name": "C2PA Content Provenance (AI Provenance)",
-        "description": "Extracts content-provenance metadata from media files via two independent "
-                       "paths: (1) C2PA / Content Credentials manifests and (2) IPTC/XMP "
-                       "DigitalSourceType tags. Reports the claim generator, edit actions, digital "
-                       "source type, author/creator, credit/copyright, ingredients (prior assets), "
-                       "the stated signer certificate and signing time, and an AI-generated "
-                       "indicator. Useful for establishing whether an image was AI-generated or "
-                       "edited and by what tool.",
+        "description": "Extracts content-provenance metadata from media files via two independent paths: (1) C2PA / "
+                       "Content Credentials manifests and (2) IPTC/XMP DigitalSourceType tags. Reports the claim "
+                       "generator, edit actions, digital source type, author/creator, credit/copyright, ingredients "
+                       "(prior assets), the stated signer certificate and signing time, and an AI-generated indicator. "
+                       "Values are reported as the file carries them and are not cryptographically verified.",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-07-12",
         "last_update_date": "2026-07-12",

--- a/scripts/artifacts/linkbox.py
+++ b/scripts/artifacts/linkbox.py
@@ -1,9 +1,8 @@
 __artifacts_v2__ = {
     "linkbox_uploads": {
         "name": "Linkbox - Uploads",
-        "description": "Rows from the upload table of the app's per-account upload database, "
-                       "each a file sent from the device to the service, with the path it was "
-                       "read from, its size and its MD5",
+        "description": "Rows from the upload table of the app's per-account upload database, each an upload record for a "
+                       "file on the device, with the path it was read from, its size, its MD5 and its status as stored",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-08-30",
         "last_update_date": "2026-08-30",

--- a/scripts/artifacts/nearbyDevices.py
+++ b/scripts/artifacts/nearbyDevices.py
@@ -1,9 +1,9 @@
 __artifacts_v2__ = {
     "nearby_fast_pair": {
         "name": "Nearby - Fast Pair Devices",
-        "description": "Bluetooth accessories the device holds a Fast Pair record for, with the "
-                       "accessory's address, its model name, the name shown for it and the times "
-                       "it was first and last observed.",
+        "description": "Bluetooth accessories the device holds a Fast Pair record for, with the accessory's address and, "
+                       "where the record carries them, its model name, the name shown for it and the times it was first "
+                       "and last observed.",
         "author": "@AlexisBrignoni, Claude",
         "creation_date": "2026-09-04",
         "last_update_date": "2026-09-04",

--- a/scripts/artifacts/revolut.py
+++ b/scripts/artifacts/revolut.py
@@ -1,8 +1,8 @@
 __artifacts_v2__ = {
     "revolut_payment_recipients": {
         "name": "Revolut - Recent Payment Recipients",
-        "description": "Parses the recipients the Revolut Android app recorded as recently "
-                       "paid, with the type of each recipient and the item it links to.",
+        "description": "Parses the recipients listed in the Revolut Android app's recent payment recipients store, with "
+                       "the type of each recipient and the item it links to.",
         "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",

--- a/scripts/artifacts/shazam.py
+++ b/scripts/artifacts/shazam.py
@@ -1,9 +1,9 @@
 __artifacts_v2__ = {
     "shazam_recognitions": {
         "name": "Shazam Recognitions",
-        "description": "Rows of the tag table in the Shazam library database, each holding the "
-                       "time of a music recognition with the track it resolved to, the stored "
-                       "coordinates and place names, and the recognition request identifier",
+        "description": "Rows of the tag table in the Shazam library database, each holding the time of a music "
+                       "recognition with the track it resolved to, the coordinate and place name columns where the row "
+                       "carries them, and the recognition request identifier",
         "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",

--- a/scripts/artifacts/textnow.py
+++ b/scripts/artifacts/textnow.py
@@ -2,7 +2,8 @@
 __artifacts_v2__ = {
     "get_textnow_call_logs": {
         "name": "Text Now - Call Logs",
-        "description": "Parses TextNow call logs (start and end time, participant IDs and direction) from the TextNow textnow_data.db.",
+        "description": "Parses TextNow call logs (start time, a computed end time, participant IDs and direction) from "
+                       "the TextNow textnow_data.db.",
         "author": "@markmckinnon",
         "creation_date": "2021-03-15",
         "last_update_date": "2026-08-01",

--- a/scripts/artifacts/vinted.py
+++ b/scripts/artifacts/vinted.py
@@ -27,8 +27,8 @@ __artifacts_v2__ = {
     },
     "vinted_favorites": {
         "name": "Vinted - Favourited Listings",
-        "description": "Parses the listings the Vinted Android app recorded as favourited, "
-                       "with the listing title where the app also cached the listing.",
+        "description": "Parses the listings in the Vinted Android app's favourites store, with the favourited flag as "
+                       "stored and the listing title where the app also cached the listing.",
         "author": "@AlexisBrignoni, @mattiaepi (Mattia Epifani), Claude",
         "creation_date": "2026-08-19",
         "last_update_date": "2026-08-19",


### PR DESCRIPTION
Corrects twelve artifact descriptions (and one notes field) that claimed more than their own notes support. Each description was read beside the sentences of its notes that concede a limit, using admin/scripts/check_artifact_descriptions.py --review over every module.

- c2paProvenance no longer says it establishes whether an image was AI generated.
- Revolut recipients, Vinted favourites and TextNow call logs describe what the store records rather than a payment, a favourite or a recorded end time.
- Nearby Fast Pair and Shazam recognitions say their often-blank fields are present where the record carries them.
- androidUsers, Private Photo Vault account, Spotify playlist library and Linkbox uploads name fields by their stored name where the notes call the meaning unestablished.
- Xender profiles states the connect_times = 0 filter its query applies.
- appicons replaces a guessed note with the launcher package its path is anchored on.

No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
