### PR TITLE
Add Poweramp, KMPlayer and Moon+ Reader support for Android

### DIFF
--- a/scripts/artifacts/hereWeGo.py
+++ b/scripts/artifacts/hereWeGo.py
@@ -143,12 +143,11 @@ __artifacts_v2__ = {
 
 import json
 import os
-import struct
 import xml.etree.ElementTree as ET
-import zlib
 
 from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, logfunc
 from scripts.artifacts.storagePathViews import unique_files
+from scripts.artifacts.hiveReader import hive_entries
 
 PREFS_SUFFIX = 'shared_prefs/FlutterSharedPreferences.xml'
 PLACE_BOX = 'app_flutter/collection.place.box.hive'
@@ -160,10 +159,6 @@ LIST_MARKER = 'VGhpcyBpcyB0aGUgcHJlZml4IGZvciBhIGxpc3Qu!'
 # Reported by the other artifacts in this module rather than in the settings table.
 SETTINGS_SKIP = ('recentSearchResults', 'last_location', 'last_map_view_center')
 
-# Hive value type ids, from the format's own writer.
-_NULL, _INT, _DOUBLE, _BOOL, _STRING, _BYTELIST = 0, 1, 2, 3, 4, 5
-_INTLIST, _DOUBLELIST, _BOOLLIST, _STRINGLIST, _LIST, _MAP = 6, 7, 8, 9, 10, 11
-_HIVELIST, _DATETIME = 12, 13
 
 # Field numbers of a saved place, named from data created for the purpose. Hive stores a
 # registered class as numbered fields and keeps the names in the app's compiled Dart.
@@ -215,103 +210,6 @@ def _ms(value):
         return ''
 
 
-def _read_value(buf, index):
-    """One Hive value at `index`, returning it and the index after it."""
-    kind = buf[index]
-    index += 1
-    if kind == _NULL:
-        return None, index
-    if kind in (_INT, _DOUBLE, _DATETIME):
-        number, = struct.unpack('<d', buf[index:index + 8])
-        return (number if kind == _DOUBLE else int(number)), index + 8
-    if kind == _BOOL:
-        return bool(buf[index]), index + 1
-    if kind in (_STRING, _BYTELIST):
-        length, = struct.unpack('<I', buf[index:index + 4])
-        index += 4
-        chunk = buf[index:index + length]
-        return (chunk.decode('utf-8', 'replace') if kind == _STRING else chunk), index + length
-    if kind in (_INTLIST, _DOUBLELIST, _BOOLLIST, _STRINGLIST, _LIST, _MAP, _HIVELIST):
-        count, = struct.unpack('<I', buf[index:index + 4])
-        index += 4
-        items = []
-        for _ in range(count):
-            if kind in (_INTLIST, _DOUBLELIST):
-                number, = struct.unpack('<d', buf[index:index + 8])
-                items.append(int(number) if kind == _INTLIST else number)
-                index += 8
-            elif kind == _BOOLLIST:
-                items.append(bool(buf[index]))
-                index += 1
-            elif kind == _STRINGLIST:
-                length, = struct.unpack('<I', buf[index:index + 4])
-                index += 4
-                items.append(buf[index:index + length].decode('utf-8', 'replace'))
-                index += length
-            else:
-                item, index = _read_value(buf, index)
-                items.append(item)
-        return items, index
-    # A registered class: a field count, then that many (field number, value) pairs.
-    count = buf[index]
-    index += 1
-    obj = {}
-    for _ in range(count):
-        field = buf[index]
-        index += 1
-        obj[field], index = _read_value(buf, index)
-    return obj, index
-
-
-def _hive_entries(path):
-    """The live entries of a Hive box, plus how many superseded frames each key has.
-
-    Every frame carries a CRC32 of itself, so a frame that does not match is not read and
-    the walk stops there rather than guessing at the rest of the file.
-    """
-    try:
-        with open(path, 'rb') as handle:
-            buf = handle.read()
-    except OSError as ex:
-        logfunc(f'HERE WeGo: could not read {os.path.basename(path)}: {ex}')
-        return {}, {}
-    live = {}
-    earlier = {}
-    offset = 0
-    try:
-        while offset + 4 <= len(buf):
-            length, = struct.unpack('<I', buf[offset:offset + 4])
-            if length < 8 or offset + length > len(buf):
-                break
-            frame = buf[offset:offset + length]
-            stored, = struct.unpack('<I', frame[-4:])
-            if (zlib.crc32(frame[:-4]) & 0xffffffff) != stored:
-                logfunc(f'HERE WeGo: frame at offset {offset} of '
-                        f'{os.path.basename(path)} failed its own CRC, stopping there')
-                break
-            index = 4
-            key_kind = frame[index]
-            index += 1
-            if key_kind == 0:
-                key, = struct.unpack('<I', frame[index:index + 4])
-                index += 4
-            else:
-                key_length = frame[index]
-                index += 1
-                key = frame[index:index + key_length].decode('utf-8', 'replace')
-                index += key_length
-            value = None
-            if index < length - 4:
-                value, index = _read_value(frame, index)
-            if key in live:
-                earlier[key] = earlier.get(key, 0) + 1
-            live[key] = value
-            offset += length
-    except (IndexError, struct.error, ValueError) as ex:
-        logfunc(f'HERE WeGo: stopped reading {os.path.basename(path)} at offset {offset}: {ex}')
-    return live, earlier
-
-
 def _collection_names(context):
     """{place entry id: collection name}, the link the store itself records.
 
@@ -320,7 +218,7 @@ def _collection_names(context):
     """
     names = {}
     for path in _box_files(context, COLLECTION_BOX):
-        live, _ = _hive_entries(path)
+        live, _ = hive_entries(path)
         for value in live.values():
             if not isinstance(value, dict):
                 continue
@@ -376,7 +274,7 @@ def here_wego_saved_places(context):
     data_list = []
     sources = []
     for path in _box_files(context, PLACE_BOX):
-        live, earlier = _hive_entries(path)
+        live, earlier = hive_entries(path)
         found = False
         for key, value in live.items():
             if not isinstance(value, dict):

--- a/scripts/artifacts/hiveReader.py
+++ b/scripts/artifacts/hiveReader.py
@@ -1,0 +1,120 @@
+"""Reader for the Hive key-value boxes Flutter apps write.
+
+Shared by more than one artifact module, so it lives on its own rather than being copied.
+A box is a flat log of frames, each `[len u32 LE][key][value][crc32 LE]`, and a later frame
+for the same key supersedes an earlier one. Every frame carries its own CRC32, which is what
+tells a real frame from the tail of a partly overwritten file, so the read stops at the first
+frame whose checksum does not match rather than guessing.
+
+Values are self describing: a type id then the payload. A registered class is written as a
+field count and then numbered fields, and the field NAMES live only in the app's compiled
+Dart, so a caller has to map the numbers itself against data it created deliberately.
+"""
+
+import os
+import struct
+import zlib
+
+from scripts.ilapfuncs import logfunc
+
+# Hive value type ids, from the format's own writer.
+_NULL, _INT, _DOUBLE, _BOOL, _STRING, _BYTELIST = 0, 1, 2, 3, 4, 5
+_INTLIST, _DOUBLELIST, _BOOLLIST, _STRINGLIST, _LIST, _MAP = 6, 7, 8, 9, 10, 11
+_HIVELIST, _DATETIME = 12, 13
+
+
+def read_value(buf, index):
+    """One Hive value at `index`, returning it and the index after it."""
+    kind = buf[index]
+    index += 1
+    if kind == _NULL:
+        return None, index
+    if kind in (_INT, _DOUBLE, _DATETIME):
+        number, = struct.unpack('<d', buf[index:index + 8])
+        return (number if kind == _DOUBLE else int(number)), index + 8
+    if kind == _BOOL:
+        return bool(buf[index]), index + 1
+    if kind in (_STRING, _BYTELIST):
+        length, = struct.unpack('<I', buf[index:index + 4])
+        index += 4
+        chunk = buf[index:index + length]
+        return (chunk.decode('utf-8', 'replace') if kind == _STRING else chunk), index + length
+    if kind in (_INTLIST, _DOUBLELIST, _BOOLLIST, _STRINGLIST, _LIST, _MAP, _HIVELIST):
+        count, = struct.unpack('<I', buf[index:index + 4])
+        index += 4
+        items = []
+        for _ in range(count):
+            if kind in (_INTLIST, _DOUBLELIST):
+                number, = struct.unpack('<d', buf[index:index + 8])
+                items.append(int(number) if kind == _INTLIST else number)
+                index += 8
+            elif kind == _BOOLLIST:
+                items.append(bool(buf[index]))
+                index += 1
+            elif kind == _STRINGLIST:
+                length, = struct.unpack('<I', buf[index:index + 4])
+                index += 4
+                items.append(buf[index:index + length].decode('utf-8', 'replace'))
+                index += length
+            else:
+                item, index = read_value(buf, index)
+                items.append(item)
+        return items, index
+    # A registered class: a field count, then that many (field number, value) pairs.
+    count = buf[index]
+    index += 1
+    obj = {}
+    for _ in range(count):
+        field = buf[index]
+        index += 1
+        obj[field], index = read_value(buf, index)
+    return obj, index
+
+
+def hive_entries(path):
+    """The live entries of a Hive box, plus how many superseded frames each key has.
+
+    Every frame carries a CRC32 of itself, so a frame that does not match is not read and
+    the walk stops there rather than guessing at the rest of the file.
+    """
+    try:
+        with open(path, 'rb') as handle:
+            buf = handle.read()
+    except OSError as ex:
+        logfunc(f'HERE WeGo: could not read {os.path.basename(path)}: {ex}')
+        return {}, {}
+    live = {}
+    earlier = {}
+    offset = 0
+    try:
+        while offset + 4 <= len(buf):
+            length, = struct.unpack('<I', buf[offset:offset + 4])
+            if length < 8 or offset + length > len(buf):
+                break
+            frame = buf[offset:offset + length]
+            stored, = struct.unpack('<I', frame[-4:])
+            if (zlib.crc32(frame[:-4]) & 0xffffffff) != stored:
+                logfunc(f'HERE WeGo: frame at offset {offset} of '
+                        f'{os.path.basename(path)} failed its own CRC, stopping there')
+                break
+            index = 4
+            key_kind = frame[index]
+            index += 1
+            if key_kind == 0:
+                key, = struct.unpack('<I', frame[index:index + 4])
+                index += 4
+            else:
+                key_length = frame[index]
+                index += 1
+                key = frame[index:index + key_length].decode('utf-8', 'replace')
+                index += key_length
+            value = None
+            if index < length - 4:
+                value, index = read_value(frame, index)
+            if key in live:
+                earlier[key] = earlier.get(key, 0) + 1
+            live[key] = value
+            offset += length
+    except (IndexError, struct.error, ValueError) as ex:
+        logfunc(f'HERE WeGo: stopped reading {os.path.basename(path)} at offset {offset}: {ex}')
+    return live, earlier

--- a/scripts/artifacts/kmplayer.py
+++ b/scripts/artifacts/kmplayer.py
@@ -1,0 +1,112 @@
+__artifacts_v2__ = {
+    "kmplayer_playback": {
+        "name": "KMPlayer Playback History",
+        "description": "Media KMPlayer opened, with the local URI or remote address of each and the time it was opened",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-06",
+        "last_update_date": "2026-09-06",
+        "requirements": "none",
+        "category": "KMPlayer",
+        "sample_data": {
+            "emu_a15_oss_v15": "KMPlayer 36.04.235 | 2 rows",
+        },
+        "notes": "One row per live entry of the Hive box "
+                 "com.kmplayer/databases/db/hive_url_meta_box.hive. KMPlayer is written in "
+                 "Flutter and keeps its state in Hive boxes rather than in SQLite. A Hive box is "
+                 "a flat log of frames and a later frame for the same key supersedes an earlier "
+                 "one, so only the surviving entries are reported; each frame carries its own "
+                 "CRC32 and the reader stops at the first frame that fails it. "
+                 "Hive stores a class as numbered fields and keeps the field names only in the "
+                 "app's compiled Dart, so the numbers were mapped against playback created "
+                 "deliberately on the tested device rather than read from any source. Two items "
+                 "were played: a local video opened by content URI and a video fetched from an "
+                 "http address, which is what lets the fields be told apart. "
+                 "Opened is field 10, Unix milliseconds, reported as UTC; both rows matched the "
+                 "wall clock of the play that produced them to the second. Address is field 3, "
+                 "which held the full "
+                 "content:// URI for the local play and the full http URL for the remote one, so "
+                 "on the remote row it records an address the device contacted. Title is field 1, "
+                 "which the app fills with the file name for a remote item and with the "
+                 "MediaStore id for a local one, so it is not always a human title. Source (as "
+                 "stored) is field 0; it read 0 on the local row and 1 on the remote row of the "
+                 "tested image, which is one observation of each and not enough to state what the "
+                 "field means, so it is reported as stored. "
+                 "A row records that the app opened the item, not that anyone watched it, and "
+                 "not how much was played. "
+                 "Other stores in the same app that are not parsed here: hive_media_flag_box "
+                 "holds a per-item playback flag block whose field meanings could not be "
+                 "established from two entries; hive_setting_box, hive_home_group_box and "
+                 "hive_quickbutton_box are app configuration and shipped menu layout; "
+                 "hive_mylist_box, hive_queue_list_box, hive_media_bookmark_box and "
+                 "hive_cloud_info_box were all zero bytes on the tested image and would carry "
+                 "user lists, queues and bookmarks on a device that used those features. The app "
+                 "also ships a VLC medialibrary SQLite at databases/db/database.dat; its Media, "
+                 "File and Folder tables were empty here because the in-app library was never "
+                 "scanned, and no existing module claims that path.",
+        "paths": ('*/com.kmplayer/databases/db/hive_url_meta_box.hive',),
+        "output_types": "standard",
+        "artifact_icon": "film",
+    },
+}
+
+import struct
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, logfunc
+from scripts.artifacts.storagePathViews import unique_files
+from scripts.artifacts.hiveReader import hive_entries
+
+BOX_SUFFIX = 'com.kmplayer/databases/db/hive_url_meta_box.hive'
+
+# Field numbers of an entry, mapped from playback created for the purpose. Hive keeps the
+# names only in the app's compiled Dart, so these are named from observation.
+ENTRY_SOURCE, ENTRY_TITLE, ENTRY_ADDRESS, ENTRY_OPENED = 0, 1, 3, 10
+
+
+def _box_files(context):
+    return [str(f).replace('\\', '/') for f in unique_files(context)
+            if str(f).replace('\\', '/').endswith(BOX_SUFFIX)]
+
+
+def _ms(value):
+    if not value:
+        return ''
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        return ''
+    if value <= 0:
+        return ''
+    try:
+        return convert_unix_ts_to_utc(value // 1000)
+    except (OverflowError, OSError, ValueError):
+        return ''
+
+
+@artifact_processor
+def kmplayer_playback(context):
+    data_list = []
+    sources = []
+    for box_path in _box_files(context):
+        try:
+            entries, _ = hive_entries(box_path)
+        except (OSError, ValueError, struct.error) as error:
+            logfunc(f'KMPlayer: could not read {box_path}: {error}')
+            continue
+        seen = False
+        for value in entries.values():
+            if not isinstance(value, dict):
+                continue
+            seen = True
+            data_list.append((
+                _ms(value.get(ENTRY_OPENED)),
+                value.get(ENTRY_ADDRESS) or '',
+                value.get(ENTRY_TITLE) or '',
+                value.get(ENTRY_SOURCE) if value.get(ENTRY_SOURCE) is not None else '',
+                context.get_relative_path(box_path)))
+        if seen and box_path not in sources:
+            sources.append(box_path)
+
+    data_list.sort(key=lambda row: row[0], reverse=True)
+    data_headers = (
+        ('Opened', 'datetime'), 'Address', 'Title', 'Source (as stored)', 'Source File')
+    return data_headers, data_list, '\n'.join(sources)

--- a/scripts/artifacts/moonReader.py
+++ b/scripts/artifacts/moonReader.py
@@ -1,0 +1,104 @@
+__artifacts_v2__ = {
+    "moonreader_reading_sessions": {
+        "name": "Moon+ Reader Reading Sessions",
+        "description": "Books Moon+ Reader recorded time in, with the reading time, words read and progress it stored",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-06",
+        "last_update_date": "2026-09-06",
+        "requirements": "none",
+        "category": "Moon+ Reader",
+        "sample_data": {
+            "emu_a15_oss_v15": "Moon+ Reader 10.7 | 1 row",
+        },
+        "notes": "One row per row of the statistics table in "
+                 "com.flyersoft.moonreader/databases/mrbooks.db. The app writes a row when it has "
+                 "recorded reading time against a file, and the row carries the file's full path, "
+                 "the accumulated reading time in milliseconds, the number of words it counted as "
+                 "read, and a per-day breakdown. "
+                 "Per-day Detail is the dates column reported as stored, because its encoding was "
+                 "read from one day's data and not from any source: on the tested image it held "
+                 "'20701|16323@1048 #19.64%', where 20701 is a count of days from the Unix "
+                 "epoch in the device's own local zone, 16323 and 1048 repeat that day's "
+                 "milliseconds and words, and 19.64% is how far through the file the reader had "
+                 "reached. The day number being local rather than UTC was measured: the reading "
+                 "was done at 03:04 UTC, which was 23:04 the previous evening in the device's "
+                 "America/New_York zone, and the app filed it under the previous day. Day (first "
+                 "entry) is therefore rendered as a plain date with no zone conversion, since "
+                 "converting a local day count as though it were UTC would move it. "
+                 "day's milliseconds and words, and 19.64% is how far through the file the reader "
+                 "had reached. A file read across several days carries several such groups, which "
+                 "was not exercised here, so the column is passed through rather than split. "
+                 "Reading Time (ms) and Words Read are the whole-file totals. "
+                 "There is no absolute timestamp in this table, so a row dates reading only to "
+                 "the day numbers inside Per-day Detail, and the Day (first entry) column is that "
+                 "first day number converted to a date for convenience. "
+                 "A row is evidence the app had the file open long enough to count time against "
+                 "it, not that a person read it. "
+                 "Other tables in the same database are not parsed here and were all empty on the "
+                 "tested image: books is the library shelf, and the tested book was read without "
+                 "being added to it, which is worth knowing because it means statistics records "
+                 "reading for a file that never appears in books; notes holds highlights and "
+                 "annotations; tmpbooks is a scratch list; covers2 holds cover images. Each would "
+                 "carry data on a device that used those features.",
+        "paths": ('*/com.flyersoft.moonreader/databases/mrbooks.db*',),
+        "output_types": "standard",
+        "artifact_icon": "book-open",
+    },
+}
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records
+from scripts.artifacts.storagePathViews import unique_files
+
+DB_SUFFIX = 'com.flyersoft.moonreader/databases/mrbooks.db'
+SECONDS_PER_DAY = 86400
+
+
+def _db_files(context):
+    return [str(f).replace('\\', '/') for f in unique_files(context)
+            if str(f).replace('\\', '/').endswith(DB_SUFFIX)]
+
+
+def _first_day(dates):
+    """The date of the first day group in the app's dates string, blank when it will not read.
+
+    The string is groups separated by ';', each starting with a day number counted from the
+    Unix epoch in the DEVICE'S LOCAL zone, proven by a read at 03:04 UTC being filed under the
+    previous day. It is a date, not an instant, so it is rendered straight rather than
+    converted. Mapped from one day of data created for the purpose, so anything that does not
+    match that shape is left alone rather than guessed at.
+    """
+    if not dates:
+        return ''
+    head = str(dates).split(';')[0].split('|')[0].strip()
+    if not head.isdigit():
+        return ''
+    try:
+        return convert_unix_ts_to_utc(int(head) * SECONDS_PER_DAY)
+    except (OverflowError, OSError, ValueError):
+        return ''
+
+
+@artifact_processor
+def moonreader_reading_sessions(context):
+    query = '''SELECT filename, usedTime, readWords, dates
+               FROM statistics
+               ORDER BY usedTime DESC'''
+    data_list = []
+    sources = []
+    for db_path in _db_files(context):
+        records = get_sqlite_db_records(db_path, query)
+        for r in records:
+            data_list.append((
+                _first_day(r[3]),
+                r[0] or '',
+                r[1],
+                r[2],
+                (r[3] or '').strip(),
+                context.get_relative_path(db_path)))
+        if records and db_path not in sources:
+            sources.append(db_path)
+
+    data_headers = (
+        ('Day (first entry)', 'date'), 'Book Path', 'Reading Time (ms)',
+        'Words Read', 'Per-day Detail (as stored)', 'Source File')
+    return data_headers, data_list, '\n'.join(sources)

--- a/scripts/artifacts/poweramp.py
+++ b/scripts/artifacts/poweramp.py
@@ -1,0 +1,134 @@
+__artifacts_v2__ = {
+    "poweramp_library": {
+        "name": "Poweramp Library and Play History",
+        "description": "Audio files Poweramp has indexed, with play counts, last played times and resume positions",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-05",
+        "last_update_date": "2026-09-05",
+        "requirements": "none",
+        "category": "Poweramp",
+        "sample_data": {
+            "emu_a15_oss_v15": "Poweramp build-1025-bundle-play | 4 rows",
+        },
+        "notes": "One row per row of folder_files in "
+                 "com.maxmpz.audioplayer/databases/folders.db, which is the player's own index of "
+                 "the audio in the folders it was pointed at. The file name is in folder_files "
+                 "and the directory is in the folders table, so Storage Path is the two joined; "
+                 "the module does not use folder_files.file_path, which was empty on every row of "
+                 "the tested image. "
+                 "The table carries two different time units and they were separated by "
+                 "measurement, not assumption: Last Played and Played Fully At are Unix "
+                 "milliseconds, while Date Indexed and File Created are Unix seconds, and on the "
+                 "tested image a millisecond value and a second value written moments apart both "
+                 "resolved to the same minute. All four are reported as UTC. "
+                 "Last Played, Play Count and Played Fully At mean different things, which was "
+                 "established by driving the app rather than inferred. Last Played is stamped when "
+                 "a track STARTS: two tracks skipped after a few seconds carry it and their Play "
+                 "Count stayed 0. Play Count, Total Play Count and Played Fully At move only when "
+                 "a track reaches its end: one track played to completion took Play Count from 0 "
+                 "to 1 and gained a Played Fully At stamp. So a row with Last Played set and Play "
+                 "Count 0 records a track that was started and not finished, and that distinction "
+                 "is the artifact's main value. "
+                 "Resume Position (ms) is the offset the app would resume from and is reset to 0 "
+                 "by a complete play, so a non-zero value marks a track left part way through. "
+                 "Artist, Album and Rating were empty or 0 on every row of the tested image "
+                 "because the audio it was built from carries no such tags and nothing was rated; "
+                 "the app reads them from the file and they populate on ordinary music. Year read "
+                 "10000 on every row, which is the app's own placeholder for a file with no year "
+                 "tag rather than a date, and it is reported as stored. "
+                 "A row is evidence the app indexed the file, and a non-zero Play Count is "
+                 "evidence it played it to the end; neither is evidence a person was listening. "
+                 "Tables in the same database that are not parsed here: eq_presets (17,730 rows) "
+                 "and milk_presets (263) are visualisation and equaliser presets the app ships, "
+                 "reverb_presets and milk_preset_containers likewise; playlists, playlist_entries, "
+                 "queue, bookmarks, search_history, settings_search_history, cat_stats, "
+                 "known_devices and lrc_files were all empty on the tested image and hold user "
+                 "activity worth parsing on a device that has used those features; albums, "
+                 "artists, genres, composers and years are lookup rows the library builds from the "
+                 "same files this artifact already reports.",
+        "paths": ('*/com.maxmpz.audioplayer/databases/folders.db*',),
+        "output_types": "standard",
+        "artifact_icon": "music",
+    },
+}
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, get_sqlite_db_records
+from scripts.artifacts.storagePathViews import unique_files
+
+DB_SUFFIX = 'com.maxmpz.audioplayer/databases/folders.db'
+
+
+def _db_files(context):
+    """The folders.db files, one per container, sidecars excluded."""
+    out = []
+    for found in unique_files(context):
+        path = str(found).replace('\\', '/')
+        if path.endswith(DB_SUFFIX):
+            out.append(path)
+    return out
+
+
+def _ms(value):
+    """A Unix millisecond stamp as UTC. Blank for the app's 0 default."""
+    return _seconds(value, 1000)
+
+
+def _sec(value):
+    """A Unix second stamp as UTC. Blank for the app's 0 default."""
+    return _seconds(value, 1)
+
+
+def _seconds(value, divisor):
+    if not value:
+        return ''
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        return ''
+    if value <= 0:
+        return ''
+    try:
+        return convert_unix_ts_to_utc(value // divisor)
+    except (OverflowError, OSError, ValueError):
+        return ''
+
+
+def _path(folder, name):
+    """Storage Path from the folder row and the file name, which is where the app keeps it."""
+    folder = (folder or '').replace('\\', '/')
+    name = name or ''
+    if folder and not folder.endswith('/'):
+        folder += '/'
+    return folder + name
+
+
+@artifact_processor
+def poweramp_library(context):
+    query = '''SELECT f.played_at, f.played_fully_at, f.created_at, f.file_created_at,
+                      f.title_tag, f.name, f.artist_tag, f.album_tag, f.duration,
+                      f.played_times, f.total_played_times, f.last_pos, f.rating,
+                      f.year, f.bit_rate, o.path
+               FROM folder_files f
+               LEFT JOIN folders o ON o._id = f.folder_id
+               ORDER BY f.played_at DESC, f.name'''
+    data_list = []
+    sources = []
+    for db_path in _db_files(context):
+        records = get_sqlite_db_records(db_path, query)
+        for r in records:
+            data_list.append((
+                _ms(r[0]), _ms(r[1]), _sec(r[2]), _sec(r[3]),
+                r[4] or r[5] or '', r[6] or '', r[7] or '',
+                r[8], r[9], r[10], r[11], r[12], r[13], r[14],
+                _path(r[15], r[5]),
+                context.get_relative_path(db_path)))
+        if records and db_path not in sources:
+            sources.append(db_path)
+
+    data_headers = (
+        ('Last Played', 'datetime'), ('Played Fully At', 'datetime'),
+        ('Date Indexed', 'datetime'), ('File Created', 'datetime'),
+        'Title', 'Artist', 'Album', 'Duration (ms)', 'Play Count',
+        'Total Play Count', 'Resume Position (ms)', 'Rating', 'Year (as stored)',
+        'Bit Rate', 'Storage Path', 'Source File')
+    return data_headers, data_list, '\n'.join(sources)


### PR DESCRIPTION
Adds Poweramp, KMPlayer and Moon+ Reader support for Android. Three closed-source apps that need no account and no terms tap, built from known data on an emulator and validated against a registered corpus.

- Poweramp Library and Play History (folders.db): the library joined to its folders, with play counts, last played, resume positions. The table separates a track that was started from one played to the end, which was measured by playing one through and skipping two. played_at is milliseconds and created_at is seconds in the same table, so they convert separately.
- KMPlayer Playback History: the Hive box the Flutter app keeps, holding the content URI or http address it opened and when.
- Moon+ Reader Reading Sessions (mrbooks.db): file path, reading time, words counted and the per-day breakdown. Its day number is the device's local date, so it renders as a plain date.

The Hive reader hereWeGo.py already carried moves to hiveReader.py so both share one copy. The two functions are unchanged apart from the rename and hereWeGo's four row counts are identical before and after.

Undocumented values are reported as stored, and every other table and box in the three apps is named in the notes with the reason it was left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
