### PR TITLE
Add six Android app parsers from the terms-gated batch

### DIFF
--- a/scripts/artifacts/accuWeather.py
+++ b/scripts/artifacts/accuWeather.py
@@ -1,0 +1,129 @@
+__artifacts_v2__ = {
+    "accuweather_location": {
+        "name": "AccuWeather Location",
+        "description": "The position AccuWeather stored for the device and the location it was set to use",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-06",
+        "last_update_date": "2026-09-06",
+        "requirements": "none",
+        "category": "AccuWeather",
+        "sample_data": {
+            "emu_a15_oss_v16": "AccuWeather 21.1.16-4-rc | 1 row",
+        },
+        "notes": "One row per location record in the DataStore preferences file "
+                 "com.accuweather.android/files/datastore/SETTINGS_LOCATION_PREFERENCES."
+                 "preferences_pb. The app's own SQLite database holds only home screen widget "
+                 "tables and was empty on the tested image, so this file is where the position "
+                 "lives. "
+                 "Latitude, Longitude and Fix Time are read from the GPS_LOCATION_COORDINATES "
+                 "value, which the app stores as a JSON object with latitude, longitude and "
+                 "lastKnownLocationFix members. Fix Time is Unix milliseconds and is reported as "
+                 "UTC. Location Key is the app's own numeric key for the place it was showing, "
+                 "and Default Location is which source it was set to use, 'gps_location' on the "
+                 "tested image. "
+                 "**The coordinates on the tested image are the Android emulator's default fix**, "
+                 "38.898, -77.037, which is not a place anyone travelled to; they are reported "
+                 "because the field is the artifact, and an examiner reading a real device gets "
+                 "a real position in the same field. "
+                 "A row records the position the app last held, not a track: the file keeps one "
+                 "coordinate pair and overwrites it, so there is no history here and no way to "
+                 "tell how long the device was there. "
+                 "Two neighbouring DataStore files are not parsed. "
+                 "SETTINGS_SHARED_PREFERENCES holds display, unit and notification settings, "
+                 "which say nothing about where the device was. "
+                 "one_app_native_settings_datastore holds the catalogue of national weather "
+                 "alert providers the app downloads, which is server data and would read as "
+                 "device activity if reported.",
+        "paths": ('*/com.accuweather.android/files/datastore/SETTINGS_LOCATION_PREFERENCES.preferences_pb',),
+        "output_types": "standard",
+        "artifact_icon": "map-pin",
+    },
+}
+
+import json
+import os
+
+import scripts.blackboxprotobuf as blackboxprotobuf
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, logfunc
+from scripts.artifacts.storagePathViews import unique_files
+
+STORE_SUFFIX = 'SETTINGS_LOCATION_PREFERENCES.preferences_pb'
+# DataStore preferences wire layout: entries(1){ key(1), value(2){ string(5) } }
+_ENTRIES, _KEY, _VALUE, _STRING = '1', '1', '2', '5'
+
+
+def _store_files(context):
+    return [str(f).replace('\\', '/') for f in unique_files(context)
+            if str(f).replace('\\', '/').endswith(STORE_SUFFIX)]
+
+
+def _as_text(value):
+    return value.decode('utf-8', 'replace') if isinstance(value, bytes) else (value or '')
+
+
+def _preferences(path):
+    """{key: string value} for a DataStore preferences file, or {} when unreadable."""
+    try:
+        with open(path, 'rb') as handle:
+            raw = handle.read()
+    except OSError as error:
+        logfunc(f'AccuWeather: could not read {os.path.basename(path)}: {error}')
+        return {}
+    try:
+        message, _ = blackboxprotobuf.decode_message(raw)
+    except Exception as error:  # pylint: disable=broad-exception-caught
+        logfunc(f'AccuWeather: {os.path.basename(path)} did not decode as protobuf: {error}')
+        return {}
+    entries = message.get(_ENTRIES)
+    if entries is None:
+        return {}
+    if not isinstance(entries, list):
+        entries = [entries]
+    out = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        key = _as_text(entry.get(_KEY))
+        value = entry.get(_VALUE)
+        if key and isinstance(value, dict) and _STRING in value:
+            out[key] = _as_text(value[_STRING])
+    return out
+
+
+@artifact_processor
+def accuweather_location(context):
+    data_list = []
+    sources = []
+    for path in _store_files(context):
+        values = _preferences(path)
+        if not values:
+            continue
+        latitude = longitude = fix = ''
+        try:
+            coordinates = json.loads(values.get('GPS_LOCATION_COORDINATES') or '')
+        except (TypeError, ValueError):
+            coordinates = None
+        if isinstance(coordinates, dict):
+            latitude = coordinates.get('latitude', '')
+            longitude = coordinates.get('longitude', '')
+            stamp = coordinates.get('lastKnownLocationFix')
+            if isinstance(stamp, int) and stamp > 0:
+                try:
+                    fix = convert_unix_ts_to_utc(stamp // 1000)
+                except (OverflowError, OSError, ValueError):
+                    fix = ''
+        if latitude == '' and longitude == '' and not values.get('CURRENT_LOCATION_KEY'):
+            continue
+        data_list.append((
+            fix, latitude, longitude,
+            values.get('CURRENT_LOCATION_KEY', ''),
+            values.get('DEFAULT_LOCATION_KEY_SETTING_SHARED_KEY', ''),
+            values.get('DEFAULT_LOCATION_NAME_SETTING_SHARED_KEY', ''),
+            context.get_relative_path(path)))
+        if path not in sources:
+            sources.append(path)
+
+    data_headers = (
+        ('Fix Time', 'datetime'), 'Latitude', 'Longitude', 'Location Key',
+        'Default Location', 'Default Location Name', 'Source File')
+    return data_headers, data_list, '\n'.join(sources)

--- a/scripts/artifacts/cloudflareWarp.py
+++ b/scripts/artifacts/cloudflareWarp.py
@@ -1,0 +1,122 @@
+__artifacts_v2__ = {
+    "cloudflare_warp_registration": {
+        "name": "Cloudflare 1.1.1.1 WARP Registration and State",
+        "description": "The WARP registration this device holds and the VPN state the app recorded",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-06",
+        "last_update_date": "2026-09-06",
+        "requirements": "none",
+        "category": "Cloudflare WARP",
+        "sample_data": {
+            "emu_a15_oss_v16": "1.1.1.1 WARP 6.38.9 | 12 rows",
+        },
+        "notes": "One row per value read from "
+                 "com.cloudflare.onedotonedotonedotone/shared_prefs/"
+                 "com.cloudflare.onedotonedotonedotone_preferences.xml, which is where the app "
+                 "keeps its state; it writes no database of its own. "
+                 "Registration Id and Account Id identify this installation to Cloudflare, and "
+                 "Account Type read 'free' on the tested image, so together they say the device "
+                 "registered with the service and on what footing. Terms Accepted and "
+                 "Registration Executed are ISO 8601 strings that carry their own UTC offset, so "
+                 "they are reported exactly as stored and need no conversion; on the tested "
+                 "device both ended in -04:00, the device's own zone. "
+                 "VPN Profile Installed, Service Running, Auto Connect and Tunnel Protocol are "
+                 "the app's own flags, reported as stored. Tunnel Protocol read 'masque'. "
+                 "Installed By is the installer package the app recorded, which said which store "
+                 "delivered it. "
+                 "**The private key is deliberately not reported.** The preferences file also "
+                 "holds warp_private_key, and a private key has no place in a forensic artifact; "
+                 "its presence is noted here so an examiner knows it exists in the file, and its "
+                 "value is left there. The public key and the tunnel peer configuration are not "
+                 "reported either, being long key material of no evidential use on their own. "
+                 "What a row supports is bounded: these values show the device registered with "
+                 "WARP and how the tunnel was configured. They do not record connections made, "
+                 "traffic carried, or times the tunnel was up, none of which this app writes to "
+                 "disk.",
+        "paths": ('*/com.cloudflare.onedotonedotonedotone/shared_prefs/'
+                  'com.cloudflare.onedotonedotonedotone_preferences.xml',),
+        "output_types": "standard",
+        "artifact_icon": "shield",
+    },
+}
+
+import json
+import os
+import xml.etree.ElementTree as ET
+
+from scripts.ilapfuncs import artifact_processor, logfunc
+from scripts.artifacts.storagePathViews import unique_files
+
+PREFS_SUFFIX = ('com.cloudflare.onedotonedotonedotone/shared_prefs/'
+                'com.cloudflare.onedotonedotonedotone_preferences.xml')
+# Reported directly. Key material is deliberately absent from this map.
+SIMPLE = {
+    'warp_registration_id': 'Registration Id',
+    'terms_acceptance_date': 'Terms Accepted',
+    'registration_data_exec_timestamp': 'Registration Executed',
+    'selected_tunnel_protocol': 'Tunnel Protocol',
+    'vpn_profile_installed': 'VPN Profile Installed',
+    'is_service_running': 'Service Running',
+    'auto_connect': 'Auto Connect',
+    'installer_package_name': 'Installed By',
+    'onboardingstatus': 'Onboarding Complete',
+}
+
+
+def _prefs_files(context):
+    return [str(f).replace('\\', '/') for f in unique_files(context)
+            if str(f).replace('\\', '/').endswith(PREFS_SUFFIX)]
+
+
+def _values(path):
+    try:
+        root = ET.parse(path).getroot()
+    except (OSError, ET.ParseError) as error:
+        logfunc(f'Cloudflare WARP: could not read {os.path.basename(path)}: {error}')
+        return {}
+    out = {}
+    for node in root:
+        name = node.get('name')
+        if not name:
+            continue
+        out[name] = node.get('value') if node.get('value') is not None else (node.text or '')
+    return out
+
+
+def _account(raw):
+    """(account id, account type) from the warp_account JSON, blanks when it will not read."""
+    try:
+        parsed = json.loads(raw or '')
+    except (TypeError, ValueError):
+        return '', ''
+    if not isinstance(parsed, dict):
+        return '', ''
+    return str(parsed.get('id') or ''), str(parsed.get('account_type') or '')
+
+
+@artifact_processor
+def cloudflare_warp_registration(context):
+    data_list = []
+    sources = []
+    for path in _prefs_files(context):
+        values = _values(path)
+        if not values:
+            continue
+        rows = []
+        for key, label in SIMPLE.items():
+            if values.get(key) not in (None, ''):
+                rows.append((label, values[key].strip('"')))
+        account_id, account_type = _account(values.get('warp_account'))
+        if account_id:
+            rows.append(('Account Id', account_id))
+        if account_type:
+            rows.append(('Account Type', account_type))
+        if values.get('warp_private_key'):
+            rows.append(('Private Key', 'present in the preferences file, not reported here'))
+        for label, value in rows:
+            data_list.append((label, value, context.get_relative_path(path)))
+        if rows and path not in sources:
+            sources.append(path)
+
+    data_headers = ('Item', 'Value (as stored)', 'Source File')
+    return data_headers, data_list, '\n'.join(sources)

--- a/scripts/artifacts/fileManagerPlus.py
+++ b/scripts/artifacts/fileManagerPlus.py
@@ -1,0 +1,210 @@
+__artifacts_v2__ = {
+    "filemanagerplus_thumbnails": {
+        "name": "Cx File Explorer and File Manager+ Cached Thumbnails",
+        "description": "Thumbnail images these file managers rendered while browsing, recovered from their cache",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-06",
+        "last_update_date": "2026-09-06",
+        "requirements": "none",
+        "category": "File Manager",
+        "sample_data": {
+            "emu_a15_oss_v16": "Cx File Explorer 2.7.8 and File Manager+ 3.8.3 | 29 rows",
+        },
+        "notes": "One row per cached thumbnail under "
+                 "Android/data/<package>/cache/thumbnail336x336/ on shared storage. Cx File "
+                 "Explorer and File Manager+ are the same developer's apps and use an identical "
+                 "layout, so both are read here and the App column is taken from the package "
+                 "segment of the path, never from the file name. That matters: the two also ship "
+                 "an identically named database, so a glob keyed on a file name rather than the "
+                 "package would attribute one app's activity to the other. "
+                 "The thumbnail is a JPEG the app rendered while displaying a folder, so it is "
+                 "evidence the app displayed that item, and it survives independently of the "
+                 "file it was made from. A thumbnail whose source has since been deleted is "
+                 "still here and still renders, which is the reason this cache is worth reading. "
+                 "Kind is taken from the containing directory, which the app splits into "
+                 "dir_image, dir_video and dir_audio; on the tested image all rows were "
+                 "dir_image, and the video and audio directories existed and were empty, which "
+                 "is recorded rather than hidden. "
+                 "The cache file name is a set of hashes the app derives from the item, so it "
+                 "does not reverse to a path and no path is claimed here. The thumbnail's own "
+                 "content is what identifies it. File times are not reported: the framework "
+                 "restores only modification time when staging, so a cache file's timestamps "
+                 "describe the extraction rather than the browsing. "
+                 "The app's bookmarks table is not parsed here because every row on the tested "
+                 "image was a shipped default (DCIM, Movies and Music, all written at install "
+                 "time), and its last_visited preference held empty lists throughout, so neither "
+                 "carried user activity on this image.",
+        "paths": ('*/Android/data/com.cxinventor.file.explorer/cache/thumbnail*/*/*',
+                  '*/Android/data/com.alphainventor.filemanager/cache/thumbnail*/*/*'),
+        "output_types": "standard",
+        "artifact_icon": "image",
+    },
+    "filemanagerplus_scanned_folders": {
+        "name": "Cx File Explorer and File Manager+ Scanned Folders",
+        "description": "Folders these file managers recorded scanning, with the time recorded against each",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-06",
+        "last_update_date": "2026-09-06",
+        "requirements": "none",
+        "category": "File Manager",
+        "sample_data": {
+            "emu_a15_oss_v16": "Cx File Explorer 2.7.8 and File Manager+ 3.8.3 | 170 rows",
+        },
+        "notes": "One row per record in Android/data/<package>/files/scanfile.full or "
+                 "scanfile.fast on shared storage. The file opens with a short header line, and each line after it is one "
+                 "record whose fields are separated by NUL bytes rather than by whitespace: a "
+                 "percent-encoded absolute path, a Unix millisecond time, two boolean flags, and "
+                 "and optionally a fifth field describing one file in that folder. "
+                 "The path is decoded here and the time is reported as UTC; the two flags are "
+                 "reported as stored because nothing says what they mean. Flag 2 read false on every "
+                 "one of the 170 records on the tested image while Flag 1 varied, so Flag 2 is a "
+                 "uniform column here rather than an empty one, and it is kept because a device "
+                 "whose scans differ would be the case worth seeing. "
+                 "That fifth field is KIND/COUNT/SIZE/MODIFIED/NAME, and the mapping is proven "
+                 "rather than assumed: files whose size was known appeared with their exact "
+                 "size, a 650 byte document and a 31,204 byte one, and the fourth member "
+                 "converts to that file's modification time. It is split into Content Kind, "
+                 "Item Count, File Name, File Size and File Modified; a name containing a slash "
+                 "is kept whole, and a field not matching the shape is passed through as the "
+                 "kind alone rather than being guessed at. "
+                 "This is the part worth an examiner's attention: the record names a file that "
+                 "was in that folder, with its size and modification time, so it can evidence a "
+                 "file that is no longer present. "
+                 "The format was read from the file itself, not from any published source, so a "
+                 "record that does not match that shape is skipped rather than guessed at, and "
+                 "the Records Skipped figure in the log says how many. "
+                 "What a row means is bounded: the app wrote the folder into its scan index with "
+                 "that time against it. It is not proof a person opened that folder, because the "
+                 "app indexes storage on its own, and the two files differ in depth, with "
+                 "scanfile.fast holding a shorter sweep than scanfile.full. Both are read and the "
+                 "Scan File column says which one a row came from. App is taken from the package "
+                 "segment of the path for the same reason as the thumbnail artifact.",
+        "paths": ('*/Android/data/com.cxinventor.file.explorer/files/scanfile.*',
+                  '*/Android/data/com.alphainventor.filemanager/files/scanfile.*'),
+        "output_types": "standard",
+        "artifact_icon": "folder",
+    },
+}
+
+import os
+import urllib.parse
+
+from scripts.ilapfuncs import artifact_processor, check_in_media, convert_unix_ts_to_utc, logfunc
+from scripts.artifacts.storagePathViews import unique_files
+
+APPS = {
+    'com.cxinventor.file.explorer': 'Cx File Explorer',
+    'com.alphainventor.filemanager': 'File Manager+',
+}
+KINDS = {'dir_image': 'Image', 'dir_video': 'Video', 'dir_audio': 'Audio'}
+
+
+def _app_of(path):
+    """The app name from the package segment of the path, blank when no package matches.
+
+    Keyed on a whole path segment so a package name appearing as a substring elsewhere
+    cannot claim the row; the two apps share a database file name, so the segment is the
+    only safe anchor.
+    """
+    segments = path.split('/')
+    for package, name in APPS.items():
+        if package in segments:
+            return name
+    return ''
+
+
+def _files(context, test):
+    return [str(f).replace('\\', '/') for f in unique_files(context)
+            if test(str(f).replace('\\', '/'))]
+
+
+
+def _summary_row(raw):
+    """(kind, count, file name, size, modified ms) from a scan record's fifth field.
+
+    The field is KIND/COUNT/SIZE/MTIME/NAME, mapped from files whose size was known:
+    a 650 byte document and a 31,204 byte one each appeared with their exact size, and
+    the fourth part converts to that file's modification time. A name may itself contain
+    a slash, so the name is everything from the fifth part on. Anything not matching the
+    shape is returned as a kind alone, so nothing is invented.
+    """
+    if not raw:
+        return '', '', '', '', ''
+    parts = raw.split('/')
+    if len(parts) >= 5 and parts[1].isdigit() and parts[2].isdigit() and parts[3].isdigit():
+        stamp = int(parts[3])
+        modified = ''
+        if stamp > 0:
+            try:
+                modified = convert_unix_ts_to_utc(stamp // 1000)
+            except (OverflowError, OSError, ValueError):
+                modified = ''
+        return parts[0], parts[1], '/'.join(parts[4:]), parts[2], modified
+    return raw, '', '', '', ''
+
+
+@artifact_processor
+def filemanagerplus_thumbnails(context):
+    data_list = []
+    sources = []
+    for path in _files(context, lambda p: '/cache/thumbnail' in p and _app_of(p)):
+        if os.path.isdir(path):
+            continue
+        name = os.path.basename(path)
+        kind = KINDS.get(os.path.basename(os.path.dirname(path)), '')
+        media = check_in_media(path, name)
+        data_list.append((
+            _app_of(path), kind, name, media or '', context.get_relative_path(path)))
+        if path not in sources:
+            sources.append(path)
+
+    data_headers = ('App', 'Kind', 'Cache Name', ('Thumbnail', 'media'), 'Source File')
+    return data_headers, data_list, '\n'.join(sources)
+
+
+@artifact_processor
+def filemanagerplus_scanned_folders(context):
+    data_list = []
+    sources = []
+    skipped = 0
+    for path in _files(context, lambda p: '/files/scanfile.' in p and _app_of(p)):
+        if os.path.isdir(path):
+            continue
+        try:
+            with open(path, 'rb') as handle:
+                raw = handle.read()
+        except OSError as error:
+            logfunc(f'File Manager: could not read {os.path.basename(path)}: {error}')
+            continue
+        seen = False
+        # The first line is a short header; each line after it is one record whose
+        # fields are separated by NUL, not by whitespace.
+        for record in raw.split(b'\n')[1:]:
+            if not record.strip(b'\x00'):
+                continue
+            parts = record.split(b'\x00')
+            if len(parts) < 4 or not parts[1].isdigit():
+                skipped += 1
+                continue
+            seen = True
+            stamp = int(parts[1])
+            data_list.append((
+                convert_unix_ts_to_utc(stamp // 1000) if stamp > 0 else '',
+                _app_of(path),
+                urllib.parse.unquote(parts[0].decode('utf-8', 'replace')),
+                *_summary_row(parts[4].decode('utf-8', 'replace') if len(parts) > 4 else ''),
+                parts[2].decode('utf-8', 'replace'),
+                parts[3].decode('utf-8', 'replace'),
+                os.path.basename(path),
+                context.get_relative_path(path)))
+        if seen and path not in sources:
+            sources.append(path)
+
+    if skipped:
+        logfunc(f'File Manager: {skipped} scan record(s) did not match the expected shape')
+    data_list.sort(key=lambda row: row[0], reverse=True)
+    data_headers = (
+        ('Recorded', 'datetime'), 'App', 'Folder', 'Content Kind', 'Item Count',
+        'File Name', 'File Size (bytes)', ('File Modified', 'datetime'),
+        'Flag 1 (as stored)', 'Flag 2 (as stored)', 'Scan File', 'Source File')
+    return data_headers, data_list, '\n'.join(sources)

--- a/scripts/artifacts/fing.py
+++ b/scripts/artifacts/fing.py
@@ -1,0 +1,141 @@
+__artifacts_v2__ = {
+    "fing_app_state": {
+        "name": "Fing App State and Last Network",
+        "description": "What the Fing app recorded about itself and the network it last scanned",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-06",
+        "last_update_date": "2026-09-06",
+        "requirements": "none",
+        "category": "Fing",
+        "sample_data": {
+            "emu_a15_oss_v16": "Fing 12.13.3 | 10 rows",
+        },
+        "notes": "One row per value read from the app's own preference files and from "
+                 "files/network.last. This artifact is deliberately narrow, and the reason is "
+                 "worth stating plainly: **Fing does not write the list of discovered devices to "
+                 "disk when no account is signed in**. On the tested device a scan found four "
+                 "devices and displayed them, and nothing about those devices exists in the "
+                 "container afterwards. The app's databases directory holds only Firebase "
+                 "stores, and the two large files in its cache, AndroidDeviceDB and EthVendorDB, "
+                 "are vendor and device catalogues the app downloads, which are server data and "
+                 "are not reported here as anything the device did. "
+                 "What does survive is this: Last Scan is uiprefs last_scan_date and Discovery "
+                 "Count is its discovery_count, both written by the app itself. First Used, Last "
+                 "Used and App Version come from marketprefs. Privacy Agreed is that file's "
+                 "privacy.agreed key, which records when the policy was accepted on this device. "
+                 "All four times are Unix milliseconds and are reported as UTC. "
+                 "BSSID and Network Id come from files/network.last, a Java properties file the "
+                 "app writes for the network it last worked with; the BSSID identifies that "
+                 "wireless network, and Current Wifi is the flag stored beside it. The colons in "
+                 "the stored BSSID are backslash escaped by the properties writer and are "
+                 "unescaped here. "
+                 "Values are reported as stored, one per row, so nothing is inferred from them. "
+                 "A row dates app activity, not a person's presence on that network.",
+        "paths": ('*/com.overlook.android.fing/shared_prefs/uiprefs.xml',
+                  '*/com.overlook.android.fing/shared_prefs/marketprefs.xml',
+                  '*/com.overlook.android.fing/files/network.last'),
+        "output_types": "standard",
+        "artifact_icon": "wifi",
+    },
+}
+
+import os
+import xml.etree.ElementTree as ET
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, logfunc
+from scripts.artifacts.storagePathViews import unique_files
+
+# key in the app's file -> (label, is it a Unix millisecond time)
+UI_KEYS = {'last_scan_date': ('Last Scan', True), 'discovery_count': ('Discovery Count', False)}
+MARKET_KEYS = {
+    'app.firstused': ('First Used', True),
+    'app.lastused': ('Last Used', True),
+    'app.versionlastused': ('App Version', False),
+    'rate.numberofruns': ('Number Of Runs', False),
+}
+NETWORK_KEYS = {'bssid': 'BSSID', 'networkid': 'Network Id', 'currentwifi': 'Current Wifi'}
+
+
+def _files(context, tail):
+    return [str(f).replace('\\', '/') for f in unique_files(context)
+            if str(f).replace('\\', '/').endswith(tail)]
+
+
+def _ms(value):
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        return ''
+    if value <= 0:
+        return ''
+    try:
+        return convert_unix_ts_to_utc(value // 1000)
+    except (OverflowError, OSError, ValueError):
+        return ''
+
+
+def _pref_values(path):
+    """{name: text} for every simple value in an Android preferences XML."""
+    try:
+        root = ET.parse(path).getroot()
+    except (OSError, ET.ParseError) as error:
+        logfunc(f'Fing: could not read {os.path.basename(path)}: {error}')
+        return {}
+    out = {}
+    for node in root:
+        name = node.get('name')
+        if not name:
+            continue
+        out[name] = node.get('value') if node.get('value') is not None else (node.text or '')
+    return out
+
+
+def _properties(path):
+    """{key: value} for a Java properties file, with the writer's escaping undone."""
+    out = {}
+    try:
+        with open(path, 'r', encoding='utf-8', errors='replace') as handle:
+            for line in handle:
+                line = line.strip()
+                if not line or line.startswith('#') or '=' not in line:
+                    continue
+                key, _, value = line.partition('=')
+                out[key.strip()] = value.strip().replace('\\:', ':').replace('\\=', '=')
+    except OSError as error:
+        logfunc(f'Fing: could not read {os.path.basename(path)}: {error}')
+    return out
+
+
+@artifact_processor
+def fing_app_state(context):
+    data_list = []
+    sources = []
+
+    def add(label, value, path, when=''):
+        if value in (None, ''):
+            return
+        data_list.append((label, value, when, context.get_relative_path(path)))
+        if path not in sources:
+            sources.append(path)
+
+    for path in _files(context, 'shared_prefs/uiprefs.xml'):
+        values = _pref_values(path)
+        for key, (label, is_time) in UI_KEYS.items():
+            if key in values:
+                add(label, values[key], path, _ms(values[key]) if is_time else '')
+    for path in _files(context, 'shared_prefs/marketprefs.xml'):
+        values = _pref_values(path)
+        for key, (label, is_time) in MARKET_KEYS.items():
+            if key in values:
+                add(label, values[key], path, _ms(values[key]) if is_time else '')
+        for key, value in values.items():
+            if key.startswith('privacy.agreed'):
+                add('Privacy Agreed', value, path, _ms(value))
+    for path in _files(context, 'files/network.last'):
+        values = _properties(path)
+        for key, label in NETWORK_KEYS.items():
+            if key in values:
+                add(label, values[key], path)
+
+    data_headers = ('Item', 'Value (as stored)', ('Time', 'datetime'), 'Source File')
+    return data_headers, data_list, '\n'.join(sources)

--- a/scripts/artifacts/smsBackupRestore.py
+++ b/scripts/artifacts/smsBackupRestore.py
@@ -1,0 +1,171 @@
+__artifacts_v2__ = {
+    "smsbackuprestore_backup_sets": {
+        "name": "SMS Backup and Restore Backup Sets",
+        "description": "Backup files SMS Backup and Restore wrote, with the time of each and the number of items it recorded",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-06",
+        "last_update_date": "2026-09-06",
+        "requirements": "none",
+        "category": "SMS Backup and Restore",
+        "sample_data": {
+            "emu_a15_oss_v16": "SMS Backup & Restore 10.26.010 | 1 row",
+        },
+        "notes": "One row per backup file the app wrote, read from the file's own <smses> or "
+                 "<calls> element. Backup Time is that element's backup_date attribute, Unix "
+                 "milliseconds, reported as UTC; on the tested image it matched the run to the "
+                 "second. Item Count is the count attribute the app wrote, and Items Parsed is "
+                 "how many child elements this module actually read, so the two disagreeing "
+                 "marks a truncated or partly written file rather than being hidden. Backup Set "
+                 "is the app's own UUID for the run and is what ties a backup file to its "
+                 "siblings. Backup Type is the type attribute, 'full' on the tested image. "
+                 "The app can write to a cloud service or to local storage; only local files are "
+                 "visible in an extraction. On the tested device it was configured to keep "
+                 "backups in the app's own files directory, which is why the path is inside the "
+                 "app container; a device configured to write to shared storage puts them under "
+                 "Download or a chosen folder instead, and the same glob will not reach those. "
+                 "A backup file is a copy of the messages as they were at that moment, so it can "
+                 "hold messages that have since been deleted from the device, which is the reason "
+                 "the file is worth reading even when the live message store is also available.",
+        "paths": ('*/com.riteshsahu.SMSBackupRestore/files/sms-*.xml',
+                  '*/com.riteshsahu.SMSBackupRestore/files/calls-*.xml'),
+        "output_types": "standard",
+        "artifact_icon": "archive",
+    },
+    "smsbackuprestore_messages": {
+        "name": "SMS Backup and Restore Messages",
+        "description": "Text messages recorded inside the backup files SMS Backup and Restore wrote",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-06",
+        "last_update_date": "2026-09-06",
+        "requirements": "none",
+        "category": "SMS Backup and Restore",
+        "sample_data": {
+            "emu_a15_oss_v16": "SMS Backup & Restore 10.26.010 | 3 rows",
+        },
+        "notes": "One row per <sms> element inside a backup file the app wrote. These are "
+                 "messages as they stood when the backup ran, so a row can describe a message "
+                 "that is no longer on the device. "
+                 "Timestamp is the element's date attribute, Unix milliseconds, reported as UTC. "
+                 "The file also carries the app's own readable_date, which is a local time string "
+                 "with no zone, and it is reported as stored beside the converted value so the "
+                 "two can be compared; on the tested image 1788675512995 and 'Sep 6, 2026 2:18:32 "
+                 "AM' are the same moment in the device's America/New_York zone. "
+                 "Direction is decoded from the type attribute, where 1 is a received message and "
+                 "2 is a sent one, taken from the values present rather than from any published "
+                 "source, so anything else is reported as stored. Read is the app's read flag as "
+                 "stored. Contact Name is what the app resolved from the address book at backup "
+                 "time and read '(Unknown)' on every row of the tested image, because the numbers "
+                 "were not in contacts. "
+                 "Only <sms> elements are read here. The app writes MMS and their attachments "
+                 "into the same file as <mms> elements with base64 parts, and call logs into a "
+                 "separate calls-*.xml; neither was present on the tested image, so neither is "
+                 "parsed and both are named here so the gap is visible rather than silent.",
+        "paths": ('*/com.riteshsahu.SMSBackupRestore/files/sms-*.xml',),
+        "output_types": "standard",
+        "artifact_icon": "message-square",
+    },
+}
+
+import os
+import xml.etree.ElementTree as ET
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, logfunc
+from scripts.artifacts.storagePathViews import unique_files
+
+BACKUP_DIR = 'com.riteshsahu.SMSBackupRestore/files/'
+# Observed on the tested image; anything else is reported as stored.
+DIRECTIONS = {'1': 'Received', '2': 'Sent'}
+
+
+def _backup_files(context, prefix):
+    out = []
+    for found in unique_files(context):
+        path = str(found).replace('\\', '/')
+        if BACKUP_DIR in path and os.path.basename(path).startswith(prefix) and path.endswith('.xml'):
+            out.append(path)
+    return out
+
+
+def _root(path):
+    """The parsed root element, or None when the file will not parse."""
+    try:
+        return ET.parse(path).getroot()
+    except (OSError, ET.ParseError) as error:
+        logfunc(f'SMS Backup and Restore: could not read {os.path.basename(path)}: {error}')
+        return None
+
+
+def _ms(value):
+    if not value:
+        return ''
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        return ''
+    if value <= 0:
+        return ''
+    try:
+        return convert_unix_ts_to_utc(value // 1000)
+    except (OverflowError, OSError, ValueError):
+        return ''
+
+
+@artifact_processor
+def smsbackuprestore_backup_sets(context):
+    data_list = []
+    sources = []
+    for path in _backup_files(context, 'sms-') + _backup_files(context, 'calls-'):
+        root = _root(path)
+        if root is None:
+            continue
+        parsed = len(list(root))
+        data_list.append((
+            _ms(root.get('backup_date')),
+            os.path.basename(path),
+            root.get('count') or '',
+            parsed,
+            root.get('type') or '',
+            root.get('backup_set') or '',
+            context.get_relative_path(path)))
+        if path not in sources:
+            sources.append(path)
+
+    data_list.sort(key=lambda row: row[0], reverse=True)
+    data_headers = (
+        ('Backup Time', 'datetime'), 'Backup File', 'Item Count (as stored)',
+        'Items Parsed', 'Backup Type', 'Backup Set', 'Source File')
+    return data_headers, data_list, '\n'.join(sources)
+
+
+@artifact_processor
+def smsbackuprestore_messages(context):
+    data_list = []
+    sources = []
+    for path in _backup_files(context, 'sms-'):
+        root = _root(path)
+        if root is None:
+            continue
+        seen = False
+        for sms in root.findall('sms'):
+            seen = True
+            kind = sms.get('type') or ''
+            data_list.append((
+                _ms(sms.get('date')),
+                DIRECTIONS.get(kind, f'{kind} (as stored)' if kind else ''),
+                sms.get('address') or '',
+                sms.get('body') or '',
+                sms.get('contact_name') or '',
+                sms.get('readable_date') or '',
+                sms.get('read') or '',
+                _ms(sms.get('date_sent')),
+                os.path.basename(path),
+                context.get_relative_path(path)))
+        if seen and path not in sources:
+            sources.append(path)
+
+    data_list.sort(key=lambda row: row[0], reverse=True)
+    data_headers = (
+        ('Timestamp', 'datetime'), 'Direction', 'Number', 'Message',
+        'Contact Name (as stored)', 'Readable Date (as stored)', 'Read (as stored)',
+        ('Date Sent', 'datetime'), 'Backup File', 'Source File')
+    return data_headers, data_list, '\n'.join(sources)

--- a/scripts/artifacts/xodo.py
+++ b/scripts/artifacts/xodo.py
@@ -1,0 +1,99 @@
+__artifacts_v2__ = {
+    "xodo_recent_documents": {
+        "name": "Xodo PDF Recent Documents",
+        "description": "Documents Xodo recorded having open, with the page it was left on",
+        "author": "@AlexisBrignoni, Claude",
+        "creation_date": "2026-09-06",
+        "last_update_date": "2026-09-06",
+        "requirements": "none",
+        "category": "Xodo PDF",
+        "sample_data": {
+            "emu_a15_oss_v16": "Xodo PDF 11.0.1 | 1 row",
+        },
+        "notes": "One row per entry of the prefs_pdfviewctrl_tab_manager value in "
+                 "com.xodo.pdf.reader/shared_prefs/com.xodo.pdf.reader_preferences.xml, which "
+                 "the app writes as a JSON object keyed by the document's full path. The app's "
+                 "four SQLite databases were all empty on the tested image, so the preferences "
+                 "file is where this lives. "
+                 "Last Viewed is the entry's tabLastViewedTimestamp and is stored as a local "
+                 "time string with no zone, so it is reported exactly as stored rather than "
+                 "converted; on the tested device 02:25:17.144 was 06:25 UTC, four hours ahead, "
+                 "and treating it as UTC would move the reading by that offset. "
+                 "Last Page is the page the document was left on and is the app's own value, "
+                 "which was 1 on the tested image for a one page document. Zoom and Page "
+                 "Presentation Mode are reported as stored. Document Path is the key of the "
+                 "entry, so it is the path as the app recorded it rather than a path resolved in "
+                 "the extraction; the file may no longer be present. "
+                 "A row is evidence the app had the document open, not that anyone read it, and "
+                 "the app keeps no count of openings, so it dates the last view only. "
+                 "The same preferences file also holds prefs_recent_files_N entries, one JSON "
+                 "object per recent file, and prefs_favorite_files_refs; those repeat the path "
+                 "this artifact already reports without adding a time, so they are not parsed. "
+                 "files/recently_used_cache/record.trn holds the same paths in a flattened form "
+                 "and is likewise not parsed.",
+        "paths": ('*/com.xodo.pdf.reader/shared_prefs/com.xodo.pdf.reader_preferences.xml',),
+        "output_types": "standard",
+        "artifact_icon": "file-text",
+    },
+}
+
+import json
+import xml.etree.ElementTree as ET
+
+from scripts.ilapfuncs import artifact_processor, logfunc
+from scripts.artifacts.storagePathViews import unique_files
+
+PREFS_SUFFIX = 'com.xodo.pdf.reader/shared_prefs/com.xodo.pdf.reader_preferences.xml'
+TAB_MANAGER_KEY = 'prefs_pdfviewctrl_tab_manager'
+
+
+def _prefs_files(context):
+    return [str(f).replace('\\', '/') for f in unique_files(context)
+            if str(f).replace('\\', '/').endswith(PREFS_SUFFIX)]
+
+
+def _tab_manager(path):
+    """The tab manager JSON object, or {} when the file or the value will not read."""
+    try:
+        root = ET.parse(path).getroot()
+    except (OSError, ET.ParseError) as error:
+        logfunc(f'Xodo: could not read {path}: {error}')
+        return {}
+    for node in root.findall('string'):
+        if node.get('name') != TAB_MANAGER_KEY:
+            continue
+        try:
+            parsed = json.loads(node.text or '')
+        except (TypeError, ValueError) as error:
+            logfunc(f'Xodo: {TAB_MANAGER_KEY} did not parse as JSON: {error}')
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+@artifact_processor
+def xodo_recent_documents(context):
+    data_list = []
+    sources = []
+    for path in _prefs_files(context):
+        entries = _tab_manager(path)
+        for document, entry in entries.items():
+            if not isinstance(entry, dict):
+                continue
+            data_list.append((
+                entry.get('tabLastViewedTimestamp') or '',
+                entry.get('tabTitle') or '',
+                document,
+                entry.get('fileExtension') or '',
+                entry.get('lastPage'),
+                entry.get('zoom'),
+                entry.get('pagePresentationMode'),
+                context.get_relative_path(path)))
+        if entries and path not in sources:
+            sources.append(path)
+
+    data_list.sort(key=lambda row: row[0], reverse=True)
+    data_headers = (
+        'Last Viewed (device local, as stored)', 'Title', 'Document Path', 'Extension',
+        'Last Page', 'Zoom', 'Page Presentation Mode (as stored)', 'Source File')
+    return data_headers, data_list, '\n'.join(sources)


### PR DESCRIPTION
Adds six Android app parsers, eight artifacts, from apps whose first run is gated behind a terms or licence acceptance. Built from known data on an emulator and validated against a registered corpus.

- SMS Backup and Restore: the backup runs, and the messages inside them. A backup holds the messages as they stood, so it can carry messages no longer on the device.
- Cx File Explorer and File Manager+ together: their thumbnail cache, which holds a render of every media file they displayed and survives the file itself, and their folder scan index, which names a file in each scanned folder with its size and modification time.
- Xodo: recent documents and the page each was left on.
- Fing: last network BSSID, scan counters and app usage times.
- Cloudflare WARP: registration and tunnel state.
- AccuWeather: the stored position, read from its protobuf DataStore.

The two file managers are the same developer's apps and share both a cache layout and a database file name, so rows are attributed by the package path segment and never by a file name. The scan index field layout was proven against files of known size rather than assumed.

Fing keeps no device list without an account and WARP's private key is deliberately not reported; both are stated in the notes. Undocumented values are reported as stored, and every other table, box and file in the six apps is named with the reason it was left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
