### PR TITLE
Report all Xender profile rows instead of only connect_times = 0

### DIFF
--- a/scripts/artifacts/Xender.py
+++ b/scripts/artifacts/Xender.py
@@ -1,16 +1,41 @@
 # pylint: disable=W0718
 __artifacts_v2__ = {
     "get_Xender": {
-        "name": "Xender - Contacts",
-        "description": "Parses the Xender profile rows recorded with connect_times = 0 (device ID and nickname) from the "
-                       "Xender trans-history database.",
+        "name": "Xender - Connected Devices",
+        "description": "Devices recorded in the Xender profile table, with how many times each connected and when it last did",
         "author": "@markmckinnon",
         "creation_date": "2020-12-24",
         "last_update_date": "2026-08-01",
         "requirements": "none",
         "category": "File Transfer",
-        "notes": ("The query returns only profile rows where connect_times = 0, so profiles with a "
-                  "recorded connection count are not listed here."),
+        "notes": ("One row per row of the profile table in cn.xender/databases/trans-history-db. "
+                  "The table is the app's record of the remote devices it has connected to: "
+                  "device_id, the nickname that device advertised, its device type, how many "
+                  "times it has connected, and when it last did. "
+                  "**This artifact previously filtered on connect_times = 0 and could therefore "
+                  "never return a row.** The filter was removed. In the app's own code there is "
+                  "exactly one place that builds a profile row, saveRemoteDeviceInfo in "
+                  "cn/xender/core/provider/a.java, and it sets connect_times to 1 the first time "
+                  "a device is seen and to the previous value plus one afterwards, alongside "
+                  "last_connect_date from System.currentTimeMillis(). The column is declared "
+                  "INTEGER NOT NULL with no default and the data access object's only insert "
+                  "binds that value, so a row written by that path carries at least 1 and "
+                  "the old query matched nothing. That mapping was read from a **decompiled "
+                  "build** of version 18.8.0.prime, not from published source, and is cited as "
+                  "such; 332 of 14,054 classes did not decompile, so it is a thorough reading "
+                  "rather than an exhaustive one. "
+                  "Last Connected is last_connect_date, Unix milliseconds, reported as UTC. "
+                  "Connect Times is the count as stored. Device Type and Deleted are reported as "
+                  "stored because no source for their code lists was found. "
+                  "What a row supports is bounded: it records that the app holds a profile for "
+                  "that device, with the count and time the app itself wrote. It does not say "
+                  "what was transferred, which is the separate Messages artifact. "
+                  "No registered corpus carries Xender, so this could not be re-derived from "
+                  "case data. On an emulator with the app installed and opened, the profile "
+                  "table was present and empty, which also shows the device does not write its "
+                  "own profile there. A populated table needs a second device to connect to, "
+                  "which was not available, so the columns are code-present and unexercised "
+                  "against real rows."),
         "paths": ('*/cn.xender/databases/trans-history-db*',),
         "output_types": ['html', 'tsv', 'lava'],
         "artifact_icon": "users",
@@ -37,7 +62,7 @@ __artifacts_v2__ = {
 
 import datetime
 
-from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
+from scripts.ilapfuncs import convert_unix_ts_to_utc, artifact_processor, logfunc, open_sqlite_db_readonly
 
 
 def _xender_db(files_found):
@@ -46,6 +71,22 @@ def _xender_db(files_found):
         if file_found.endswith('-db'):
             return file_found
     return ''
+
+
+def _ms(value):
+    """A Unix millisecond stamp as UTC, blank for the app's 0 default."""
+    if not value:
+        return ''
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        return ''
+    if value <= 0:
+        return ''
+    try:
+        return convert_unix_ts_to_utc(value // 1000)
+    except (OverflowError, OSError, ValueError):
+        return ''
 
 
 @artifact_processor
@@ -57,16 +98,22 @@ def get_Xender(context):
         db = open_sqlite_db_readonly(source_path)
         cursor = db.cursor()
         try:
-            cursor.execute('SELECT device_id, nick_name FROM profile WHERE connect_times = 0')
+            cursor.execute('''SELECT last_connect_date, nick_name, device_id, device_type,
+                                     connect_times, mac, _u_id, deleted
+                              FROM profile
+                              ORDER BY last_connect_date DESC''')
             all_rows = cursor.fetchall()
         except Exception as e:
             logfunc(str(e))
             all_rows = []
         db.close()
         for row in all_rows:
-            data_list.append((row[0], row[1]))
+            data_list.append((_ms(row[0]), row[1] or '', row[2] or '', row[3],
+                              row[4], row[5] or '', row[6] or '', row[7]))
 
-    data_headers = ('device_id', 'nick_name')
+    data_headers = (('Last Connected', 'datetime'), 'Nickname', 'Device Id',
+                    'Device Type (as stored)', 'Connect Times', 'MAC', 'User Id',
+                    'Deleted (as stored)')
     return data_headers, data_list, source_path
 
 


### PR DESCRIPTION
The Xender Contacts artifact selected profile rows where `connect_times = 0`. Reading a decompiled build of 18.8.0.prime, that filter could never match a row.

Inside `cn/xender` exactly one place builds a profile row, `saveRemoteDeviceInfo` in `cn/xender/core/provider/a.java`. It sets `connect_times` to 1 the first time a device is seen and to the previous value plus one after that, alongside `last_connect_date` from `currentTimeMillis`. The column is `INTEGER NOT NULL` with no default and the DAO's only insert binds that value, so a row written by that path carries at least 1.

The filter is removed and the artifact reports the table: when each device last connected, nickname, device id, type, connect count, MAC and user id. Renamed to Connected Devices, since the rows are remote devices rather than contacts.

No registered corpus carries Xender. On an emulator with the app installed and opened the profile table was present and empty, which also shows the device does not write its own profile there. A populated table needs a second device, which was not available, so the columns are stated as code-present and unexercised rather than validated. The mapping is cited as coming from a decompiled build, not published source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
