### PR TITLE
Reduce the staged path where it enters a row in torThumbs and xiaohongshu

### DIFF
--- a/scripts/artifacts/torThumbs.py
+++ b/scripts/artifacts/torThumbs.py
@@ -55,7 +55,8 @@ def get_torThumbs(context):
             continue
 
         media = check_in_embedded_media(file_found, buf.getvalue(), f'{filename}.png')
-        data_list.append((_sec_to_utc(os.path.getmtime(file_found)), media, filename, location))
+        data_list.append((_sec_to_utc(os.path.getmtime(file_found)), media, filename,
+                          context.get_relative_path(location)))
 
     data_headers = (('Modified Time', 'datetime'), ('Thumbnail', 'media'), 'Filename', 'Location')
     return data_headers, data_list, source_path

--- a/scripts/artifacts/xiaohongshu.py
+++ b/scripts/artifacts/xiaohongshu.py
@@ -272,7 +272,7 @@ def xiaohongshu_account(context):
             _text(profile.get('liked')),
             _text(profile.get('collected')),
             _text(login.get('isRealLogin')),
-            source,
+            context.get_relative_path(source),
         ))
     return data_headers, data_list, source
 
@@ -307,7 +307,7 @@ def xiaohongshu_recent_chats(context):
                     _text(entry.get('is_group_chat')),
                     _text(entry.get('source')),
                     _text(entry.get('type')),
-                    file_found,
+                    context.get_relative_path(file_found),
                 ))
                 rows += 1
         if rows:
@@ -339,7 +339,8 @@ def xiaohongshu_app_launches(context):
                 continue
             value = decode_value(raw)
             if isinstance(value, int):
-                data_list.append((convert_unix_ts_to_utc(value), index, file_found))
+                data_list.append((convert_unix_ts_to_utc(value), index,
+                                  context.get_relative_path(file_found)))
                 rows += 1
         if rows:
             source = file_found


### PR DESCRIPTION
Three row values carried the tool's absolute staging path into the report, the TSV export and the LAVA database: the TOR Thumbnails Location column, and the Source File column of the Xiaohongshu Account, Recent Chats and App Launches artifacts. Each now passes through `context.get_relative_path` at the append.

Found by scanning real report output; `check_report_local_paths` does not see these shapes because the path comes from `unique_files()` or through an `or` expression, neither of which it tracks. Row counts are unchanged on the tested images (173 artifacts on one, the four Xiaohongshu artifacts on another).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
