### PR TITLE
Widen check_report_local_paths to the shapes a real-output scan found it missing

### DIFF
--- a/admin/scripts/check_report_local_paths.py
+++ b/admin/scripts/check_report_local_paths.py
@@ -51,6 +51,23 @@ clean while publishing the absolute path. And `strip` sat among the methods trea
 reducing a path, though it hands back the whole string, so `file_found.strip()` cleared
 the taint too. ALEAPP's torrentinfo carried both at once.
 
+A third audit, 2026-09-06, scanned real report output instead of source and found 122
+leaking cells in four ALEAPP modules that this check had passed. Three gaps, all now
+closed and pinned in the test file:
+
+  * `unique_files(context)`, the storage-view dedupe helper artifacts are told to use,
+    was not a taint source, so `for file_found in unique_files(context)` was untainted
+    despite the name. torThumbs and three xiaohongshu artifacts leaked through it.
+  * `or`, `and` and `x if c else y` were not propagated, so `source = source or
+    file_found` cleared the taint. xiaohongshu's account artifact leaked through it.
+  * Taint stopped at a function boundary. A module-level helper that returns a staged
+    path, or records carrying one, is now a taint source for the functions that call it,
+    tracked by tuple position so the other fields of a record stay untainted. Tuple
+    unpacking in `for` and assignment, `+=`, `:=` and subscript stores propagate too.
+
+The framework helper that leaked the accounts artifacts lives in ilapfuncs.py and is
+outside this check's scope; that one is pinned by its own unit test.
+
 Usage:
   check_report_local_paths.py [--root REPO_ROOT] [--verbose]
 
@@ -80,7 +97,7 @@ TAINT_PARAM_NAMES = {'files_found', 'file_found'}
 # Calls returning a full staged path. Attribute calls are only taint sources when the
 # receiver is the framework object, so `re.search(...)` and `message.walk()` are not
 # mistaken for `seeker.search(...)` and `os.walk(...)`.
-TAINT_PLAIN_CALLS = {'get_file_path'}
+TAINT_PLAIN_CALLS = {'get_file_path', 'unique_files'}
 TAINT_ATTR_CALLS = {
     'search': {'seeker', 'self'},
     'walk': {'os'},
@@ -144,22 +161,60 @@ def receiver_name(node):
     return ''
 
 
-class FunctionScan:
-    """Taint over one artifact function."""
+WHOLE = 'whole'   # a helper whose whole return value is a staged path or a list of them
 
-    def __init__(self, func):
+
+def _names_in_target(target):
+    """Every plain name bound by an assignment or loop target, with its tuple position.
+
+    `a` binds position 0 and `(a, b)` binds a at 0 and b at 1. A nested tuple flattens
+    to its outer position, which is the conservative reading."""
+    if isinstance(target, ast.Name):
+        return [(target.id, 0)]
+    if isinstance(target, (ast.Tuple, ast.List)):
+        out = []
+        for index, element in enumerate(target.elts):
+            if isinstance(element, ast.Starred):
+                element = element.value
+            for name, _pos in _names_in_target(element):
+                out.append((name, index))
+        return out
+    return []
+
+
+class FunctionScan:
+    """Taint over one artifact function.
+
+    `tainted` is the set of names holding a staged path or a container of them.
+    `positions` maps a name holding records (tuples) to the tuple indexes that carry a
+    path, so unpacking `for path, rows in records` taints `path` and not `rows`.
+    `helpers` maps a module-level function name to WHOLE or a frozenset of positions,
+    for helpers whose return value carries a staged path."""
+
+    def __init__(self, func, helpers=None):
         self.func = func
+        self.helpers = helpers or {}
+        self.positions = {}
+        # Names unpacked from a tainted record whose path position is unknown. They are
+        # tracked so nothing downstream is mistaken for clean, but they are never
+        # reported: a database row read from a store path is not itself a path.
+        self.possible = set()
         self.tainted = self._collect()
 
     def is_tainted(self, node):
         if node is None:
             return False
         if isinstance(node, ast.Name):
-            return node.id in self.tainted
+            return node.id in self.tainted and node.id not in self.positions
         if isinstance(node, ast.Subscript):
             # x[0] of a tainted container is still a path; a component of .parts is not.
             if isinstance(node.value, ast.Attribute) and node.value.attr in SAFE_ATTRS:
                 return False
+            if isinstance(node.slice, ast.Slice):
+                return False
+            positions = self._positions_of(node.value)
+            if positions is not None:
+                return isinstance(node.slice, ast.Constant) and node.slice.value in positions
             return self.is_tainted(node.value)
         if isinstance(node, ast.Attribute):
             if node.attr in SANITIZERS or node.attr in SAFE_ATTRS:
@@ -172,9 +227,78 @@ class FunctionScan:
                        if isinstance(part, ast.FormattedValue))
         if isinstance(node, ast.BinOp):
             return self.is_tainted(node.left) or self.is_tainted(node.right)
+        if isinstance(node, ast.BoolOp):
+            # `a or b` and `a and b` evaluate to one of their operands.
+            return any(self.is_tainted(value) for value in node.values)
+        if isinstance(node, ast.IfExp):
+            return self.is_tainted(node.body) or self.is_tainted(node.orelse)
+        if isinstance(node, ast.NamedExpr):
+            return self.is_tainted(node.value)
         if isinstance(node, (ast.ListComp, ast.SetComp, ast.GeneratorExp)):
-            return any(self.is_tainted(gen.iter) for gen in node.generators)
+            return self._comprehension_tainted(node)
+        if isinstance(node, (ast.Tuple, ast.List)):
+            return any(self.is_tainted(element) for element in node.elts)
         return False
+
+    def _comprehension_tainted(self, node):
+        """A comprehension is tainted when its ELEMENT is, with the loop names it binds
+        from a tainted iterable counted as tainted. `[basename(p) for p in files_found]`
+        is a list of names, not of paths, and must not taint what it feeds."""
+        bound = set()
+        for gen in node.generators:
+            if self.is_tainted(gen.iter) or self._positions_of(gen.iter) is not None \
+                    or (isinstance(gen.iter, ast.Name) and gen.iter.id in TAINT_PARAM_NAMES):
+                positions = self._positions_of(gen.iter)
+                for name, index in _names_in_target(gen.target):
+                    if positions is None or index in positions \
+                            or isinstance(gen.target, ast.Name):
+                        bound.add(name)
+        if not bound:
+            return False
+        saved = self.tainted
+        self.tainted = saved | bound
+        try:
+            return self.is_tainted(node.elt)
+        finally:
+            self.tainted = saved
+
+    def _possible(self, node):
+        """Whether `node` could carry a path, counting `possible` names as tainted."""
+        saved = self.tainted
+        self.tainted = saved | self.possible
+        try:
+            return self.is_tainted(node)
+        finally:
+            self.tainted = saved
+
+    def _positions_of(self, node):
+        """The tuple positions carrying a path when `node` yields records, else None."""
+        if isinstance(node, ast.Name):
+            return self.positions.get(node.id)
+        if isinstance(node, (ast.Tuple, ast.List)):
+            hit = frozenset(i for i, e in enumerate(node.elts) if self.is_tainted(e))
+            return hit or None
+        if isinstance(node, (ast.ListComp, ast.GeneratorExp)) \
+                and isinstance(node.elt, (ast.Tuple, ast.List)):
+            bound = set()
+            for gen in node.generators:
+                if self.is_tainted(gen.iter) or (isinstance(gen.iter, ast.Name)
+                                                and gen.iter.id in TAINT_PARAM_NAMES):
+                    bound |= {n for n, _i in _names_in_target(gen.target)}
+            if not bound:
+                return None
+            saved = self.tainted
+            self.tainted = saved | bound
+            try:
+                hit = frozenset(i for i, e in enumerate(node.elt.elts) if self.is_tainted(e))
+            finally:
+                self.tainted = saved
+            return hit or None
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            spec = self.helpers.get(node.func.id)
+            if isinstance(spec, frozenset):
+                return spec
+        return None
 
     @staticmethod
     def _sanitizes(node):
@@ -187,10 +311,23 @@ class FunctionScan:
             return node.attr in SAFE_ATTRS
         return False
 
+    @staticmethod
+    def _strips_data_folder(node):
+        """`x.replace(seeker.data_folder, '')` is get_relative_path written by hand."""
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                and node.func.attr == 'replace' and node.args):
+            return False
+        first = node.args[0]
+        return ((isinstance(first, ast.Attribute) and first.attr == 'data_folder')
+                or (isinstance(first, ast.Call) and isinstance(first.func, ast.Attribute)
+                    and first.func.attr == 'get_data_folder'))
+
     def _call_tainted(self, node):
         func = node.func
         name = func.attr if isinstance(func, ast.Attribute) else getattr(func, 'id', '')
         if name in SANITIZERS or name in PATH_REDUCING_METHODS:
+            return False
+        if self._strips_data_folder(node):
             return False
         # Wrappers and formatters that hand back whatever they were given. Reached as a
         # bare name (`Path(x)`) or through a module (`pathlib.Path(x)`,
@@ -207,54 +344,229 @@ class FunctionScan:
             # Any other method called ON a path returns something derived from that path,
             # so the taint survives. Only PATH_REDUCING_METHODS above cuts it down.
             return self.is_tainted(func.value)
-        return name in TAINT_PLAIN_CALLS
+        if name in TAINT_PLAIN_CALLS:
+            return True
+        # A module-level helper whose whole return value is a path or a list of paths.
+        # One returning records is tracked by position instead, see _positions_of.
+        return self.helpers.get(name) == WHOLE
+
+    def _bind(self, target, value, tainted):
+        """Taint the names a target binds from `value`, by position where known."""
+        names = _names_in_target(target)
+        if not names:
+            return
+        if isinstance(target, ast.Name):
+            positions = self._positions_of(value)
+            if isinstance(value, (ast.Tuple, ast.List)) and positions is not None:
+                # `record = (name, path)` holds a path at one position, not everywhere.
+                tainted.add(target.id)
+                self.positions[target.id] = positions
+                return
+            if self.is_tainted(value):
+                tainted.add(target.id)
+                if positions is not None:
+                    self.positions[target.id] = positions
+            elif self._positions_of(value) is not None:
+                self.positions[target.id] = self._positions_of(value)
+            elif self._possible(value):
+                self.possible.add(target.id)
+            return
+        # Tuple target. A tuple literal of the same length binds position by position;
+        # a record source binds only its path positions; anything else tainted binds all.
+        if isinstance(value, (ast.Tuple, ast.List)) and len(value.elts) == len(target.elts):
+            for element, source in zip(target.elts, value.elts):
+                self._bind(element, source, tainted)
+            return
+        positions = self._positions_of(value)
+        if positions is not None:
+            for name, index in names:
+                if index in positions:
+                    tainted.add(name)
+            return
+        if self.is_tainted(value) or self._possible(value):
+            for name, _index in names:
+                self.possible.add(name)
 
     def _collect(self):
         tainted = {a.arg for a in self.func.args.args if a.arg in TAINT_PARAM_NAMES}
         for _ in range(8):
-            before = len(tainted)
+            before = (len(tainted), len(self.possible),
+                      sum(len(v) for v in self.positions.values()))
             self.tainted = tainted
             for node in ast.walk(self.func):
-                if isinstance(node, ast.For):
-                    if self.is_tainted(node.iter) or (
-                            isinstance(node.iter, ast.Name)
-                            and node.iter.id in TAINT_PARAM_NAMES):
-                        if isinstance(node.target, ast.Name):
+                if isinstance(node, (ast.For, ast.comprehension)):
+                    iterable = node.iter
+                    is_source = (isinstance(iterable, ast.Name)
+                                 and iterable.id in TAINT_PARAM_NAMES)
+                    certain = is_source or self.is_tainted(iterable)
+                    if certain or self._positions_of(iterable) is not None \
+                            or self._possible(iterable):
+                        # Each item of a record source is a record; bind its positions.
+                        positions = self._positions_of(iterable)
+                        if positions is not None and not isinstance(node.target, ast.Name):
+                            for name, index in _names_in_target(node.target):
+                                if index in positions:
+                                    tainted.add(name)
+                        elif positions is not None:
                             tainted.add(node.target.id)
+                            self.positions[node.target.id] = positions
+                        elif isinstance(node.target, ast.Name) and certain:
+                            # An item of a list of paths is a path.
+                            tainted.add(node.target.id)
+                        else:
+                            # A record with no known path position, or an item of a
+                            # possibly tainted iterable: track, do not report.
+                            for name, _index in _names_in_target(node.target):
+                                self.possible.add(name)
                 elif isinstance(node, ast.Assign):
+                    for target in node.targets:
+                        if isinstance(target, ast.Subscript) \
+                                and isinstance(target.value, ast.Name):
+                            # store['k'] = path taints the container.
+                            if self.is_tainted(node.value):
+                                tainted.add(target.value.id)
+                            continue
+                        if self.is_tainted(node.value) \
+                                or self._positions_of(node.value) is not None \
+                                or self._possible(node.value):
+                            self._bind(target, node.value, tainted)
+                        elif self._sanitizes(node.value):
+                            # Only an explicit reduction clears taint. A bare
+                            # `db_files = []` must not, or it races the later
+                            # `db_files.append(file_found)` on every pass of the
+                            # fixed point and the loop over that list is never seen
+                            # as tainted.
+                            for name, _index in _names_in_target(target):
+                                tainted.discard(name)
+                elif isinstance(node, ast.AugAssign):
+                    if isinstance(node.target, ast.Name):
+                        if self.is_tainted(node.value):
+                            tainted.add(node.target.id)
+                        elif self._possible(node.value):
+                            self.possible.add(node.target.id)
+                elif isinstance(node, ast.NamedExpr):
                     if self.is_tainted(node.value):
-                        for target in node.targets:
-                            if isinstance(target, ast.Name):
-                                tainted.add(target.id)
-                    elif self._sanitizes(node.value):
-                        # Only an explicit reduction clears taint. A bare
-                        # `db_files = []` must not, or it races the later
-                        # `db_files.append(file_found)` on every pass and the
-                        # loop over that list is never seen as tainted.
-                        for target in node.targets:
-                            if isinstance(target, ast.Name):
-                                tainted.discard(target.id)
+                        tainted.add(node.target.id)
+                    elif self._possible(node.value):
+                        self.possible.add(node.target.id)
                 elif isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
                     call = node.value
                     # A list built by appending a tainted value is itself tainted, so
-                    # iterating it later yields tainted names.
+                    # iterating it later yields tainted names. Appending a record
+                    # remembers which positions carry the path.
                     if (isinstance(call.func, ast.Attribute)
                             and call.func.attr in ('append', 'add', 'extend')
                             and isinstance(call.func.value, ast.Name)
-                            and call.args and self.is_tainted(call.args[0])):
-                        tainted.add(call.func.value.id)
-            if len(tainted) == before:
+                            and call.args):
+                        container = call.func.value.id
+                        arg = call.args[0]
+                        if isinstance(arg, (ast.Tuple, ast.List)) \
+                                and call.func.attr != 'extend':
+                            hit = {i for i, e in enumerate(arg.elts) if self.is_tainted(e)}
+                            if hit:
+                                tainted.add(container)
+                                self.positions[container] = \
+                                    frozenset(self.positions.get(container, frozenset()) | hit)
+                        elif self._positions_of(arg) is not None and call.func.attr != 'extend':
+                            tainted.add(container)
+                            self.positions[container] = frozenset(
+                                self.positions.get(container, frozenset()) | self._positions_of(arg))
+                        elif call.func.attr == 'extend' and self._positions_of(arg) is not None:
+                            tainted.add(container)
+                            self.positions[container] = frozenset(
+                                self.positions.get(container, frozenset()) | self._positions_of(arg))
+                        elif self.is_tainted(arg):
+                            tainted.add(container)
+                            self.positions.pop(container, None)
+            after = (len(tainted), len(self.possible),
+                     sum(len(v) for v in self.positions.values()))
+            if after == before:
                 break
         self.tainted = tainted
         return tainted
 
+    def return_spec(self):
+        """WHOLE, a frozenset of record positions, or None, for what this function returns.
 
-def scan_function(func, module, streaming):
+        Used to decide whether a module-level helper is a taint source for its callers."""
+        spec = set()
+        for node in ast.walk(self.func):
+            if isinstance(node, (ast.Return, ast.Yield)) and node.value is not None:
+                value = node.value
+                positions = self._positions_of(value)
+                if isinstance(value, (ast.Tuple, ast.List)):
+                    hit = {i for i, e in enumerate(value.elts) if self.is_tainted(e)}
+                    if hit:
+                        spec |= hit
+                elif positions is not None:
+                    spec |= set(positions)
+                elif self.is_tainted(value):
+                    return WHOLE
+        return frozenset(spec) if spec else None
+
+
+def helper_sources(tree):
+    """Module-level undecorated functions whose return carries a staged path.
+
+    Their bodies are not scanned for rows (a helper handing a full path between
+    functions is normal); what matters is that a caller receiving that path treats it
+    as one. Helpers calling helpers are resolved by iterating to a fixed point."""
+    helpers = {}
+    candidates = [node for node in tree.body
+                  if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                  and not DECORATORS.intersection(decorator_names(node))]
+    for _ in range(4):
+        before = dict(helpers)
+        for func in candidates:
+            spec = FunctionScan(func, helpers).return_spec()
+            if spec is not None:
+                helpers[func.name] = spec
+        if helpers == before:
+            break
+    return helpers
+
+
+def row_containers(func, streaming):
+    """Names whose contents reach the report: the second element of a returned tuple,
+    the second argument of write_artifact_data_table, a yielded name, and anything
+    extended into one of those. Empty when the function gives no such signal, in
+    which case the name hints alone decide."""
+    roots = set()
+    for node in ast.walk(func):
+        if isinstance(node, ast.Return) and isinstance(node.value, (ast.Tuple, ast.List)) \
+                and len(node.value.elts) >= 2 and isinstance(node.value.elts[1], ast.Name):
+            roots.add(node.value.elts[1].id)
+        if (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                and node.func.attr == 'write_artifact_data_table' and len(node.args) >= 2
+                and isinstance(node.args[1], ast.Name)):
+            roots.add(node.args[1].id)
+        if streaming and isinstance(node, ast.Yield) and isinstance(node.value, ast.Name):
+            roots.add(node.value.id)
+    if not roots:
+        return None
+    for _ in range(4):
+        before = len(roots)
+        for node in ast.walk(func):
+            if (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == 'extend' and isinstance(node.func.value, ast.Name)
+                    and node.func.value.id in roots and node.args
+                    and isinstance(node.args[0], ast.Name)):
+                roots.add(node.args[0].id)
+            if isinstance(node, ast.Assign) and isinstance(node.value, ast.Name) \
+                    and node.value.id in roots:
+                roots |= {n for n, _i in _names_in_target(node.targets[0])}
+        if len(roots) == before:
+            break
+    return roots
+
+
+def scan_function(func, module, streaming, helpers=None):
     """Violations for one decorated artifact function."""
-    scan = FunctionScan(func)
+    scan = FunctionScan(func, helpers)
     if not scan.tainted:
         return []
     found = []
+    reaching = row_containers(func, streaming)
 
     def record(line, kind, expr, column):
         key = f'{module}:{func.name}:{expr}'
@@ -267,16 +579,27 @@ def scan_function(func, module, streaming):
                 and node.func.attr == 'write_artifact_data_table' and len(node.args) >= 3):
             if scan.is_tainted(node.args[2]):
                 record(node.lineno, 'located-at', ast.unparse(node.args[2]), None)
-
         if (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
                 and node.func.attr in ('append', 'extend') and node.args):
             target = node.func.value
             name = target.id if isinstance(target, ast.Name) else ''
             if not any(hint in name.lower() for hint in ROW_VARS):
                 continue
+            if reaching is not None and name not in reaching:
+                # A working list that never reaches the report, however it is named.
+                continue
             arg = node.args[0]
-            elements = arg.elts if isinstance(arg, (ast.Tuple, ast.List)) else [arg]
-            for index, element in enumerate(elements):
+            if isinstance(arg, (ast.Tuple, ast.List)):
+                elements = list(enumerate(arg.elts))
+            elif scan._positions_of(arg) is not None:  # pylint: disable=protected-access
+                # A whole record appended by name: its path positions are the columns.
+                elements = [(i, arg) for i in sorted(scan._positions_of(arg))]  # pylint: disable=protected-access
+                for index, _ in elements:
+                    record(node.lineno, 'row-value', f'{ast.unparse(arg)}[{index}]', index)
+                continue
+            else:
+                elements = [(0, arg)]
+            for index, element in elements:
                 if scan.is_tainted(element):
                     record(node.lineno, 'row-value', ast.unparse(element), index)
 
@@ -296,6 +619,7 @@ def scan_module(path):
             tree = ast.parse(handle.read())
     except SyntaxError as err:
         return [], f'{module}: could not parse ({err})'
+    helpers = helper_sources(tree)
     violations = []
     for node in ast.walk(tree):
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -304,7 +628,7 @@ def scan_module(path):
         if not DECORATORS.intersection(decorators):
             continue
         streaming = STREAMING_DECORATOR in decorators
-        for line, kind, expr, column in scan_function(node, module, streaming):
+        for line, kind, expr, column in scan_function(node, module, streaming, helpers):
             violations.append((module, node.name, line, kind, expr, column))
     return violations, None
 

--- a/admin/test/scripts/test_check_report_local_paths.py
+++ b/admin/test/scripts/test_check_report_local_paths.py
@@ -15,6 +15,11 @@ caught either:
 Both shapes are pinned below, so an edit that reintroduces either fails here instead of
 shipping a checker that quietly passes everything.
 
+A third audit (2026-09-06) scanned real report output and found 122 leaking cells the
+checker had passed, through `unique_files()`, `or`, and paths handed back by module
+helpers. Those shapes, and the correct forms that must stay silent, are pinned in
+ThirdAuditShapes.
+
 The false-negative cases matter as much as the positives: a checker wired into CI that
 flags correct code gets disabled, so the shapes that must stay silent are pinned too.
 """
@@ -259,6 +264,213 @@ class Allowlist(unittest.TestCase):
             self.assertEqual(findings_for(source), [])
         finally:
             del crlp.ALLOWLIST['sample.py:demo:file_found']
+
+
+class ThirdAuditShapes(unittest.TestCase):
+    """Shapes a 2026-09-06 scan of real report output found leaking while this check
+    reported clean: 122 cells in four ALEAPP modules. Each positive here is one of those
+    shapes or a sibling of it, and each negative is the correct form that must stay
+    silent, because a checker that flags correct code gets disabled."""
+
+    def _cols(self, source):
+        return sorted((f, col) for _m, f, _l, _k, _e, col in findings_for(source))
+
+    def test_unique_files_is_a_taint_source(self):
+        """torThumbs and xiaohongshu leaked through the repo's own dedupe helper."""
+        self.assertEqual(self._cols('''
+            @artifact_processor
+            def leak(context):
+                data_list = []
+                for file_found in unique_files(context):
+                    data_list.append(('a', file_found))
+                return (), data_list, ''
+        '''), [('leak', 1)])
+
+    def test_unique_files_reduced_is_accepted(self):
+        self.assertEqual(findings_for('''
+            @artifact_processor
+            def fine(context):
+                data_list = []
+                for file_found in unique_files(context):
+                    data_list.append(('a', context.get_relative_path(file_found)))
+                return (), data_list, ''
+        '''), [])
+
+    def test_or_and_and_pass_the_path_through(self):
+        """xiaohongshu's account artifact leaked through `source = source or file_found`."""
+        self.assertEqual(self._cols('''
+            @artifact_processor
+            def leak(files_found, seeker, report_folder):
+                data_list = []
+                source = ''
+                for file_found in files_found:
+                    source = source or file_found
+                    both = file_found and file_found
+                    data_list.append((source, both))
+                return (), data_list, source
+        '''), [('leak', 0), ('leak', 1)])
+
+    def test_a_conditional_expression_passes_the_path_through(self):
+        self.assertEqual(self._cols('''
+            @artifact_processor
+            def leak(files_found, seeker, report_folder):
+                data_list = []
+                for file_found in files_found:
+                    data_list.append(('a', file_found if file_found else ''))
+                return (), data_list, ''
+        '''), [('leak', 1)])
+
+    def test_tuple_unpacking_binds_only_the_path_position(self):
+        """`a, b = file_found, 1` taints a and not b, in the loop and in the assignment."""
+        self.assertEqual(self._cols('''
+            @artifact_processor
+            def leak(files_found, seeker, report_folder):
+                data_list = []
+                pairs = [(f, 1) for f in files_found]
+                for path, num in pairs:
+                    a, b = path, num
+                    data_list.append((num, b, a, path))
+                return (), data_list, ''
+        '''), [('leak', 2), ('leak', 3)])
+
+    def test_dict_store_walrus_and_augmented_assignment_propagate(self):
+        self.assertEqual(self._cols('''
+            @artifact_processor
+            def leak(files_found, seeker, report_folder):
+                data_list = []
+                store = {}
+                acc = ''
+                for file_found in files_found:
+                    store['p'] = file_found
+                    acc += file_found
+                    if (p := file_found):
+                        data_list.append((store['p'], acc, p))
+                return (), data_list, ''
+        '''), [('leak', 0), ('leak', 1), ('leak', 2)])
+
+    def test_a_helper_returning_paths_is_a_source(self):
+        self.assertEqual(self._cols('''
+            def _paths(context):
+                return [str(p) for p in unique_files(context)]
+
+            @artifact_processor
+            def leak(context):
+                data_list = []
+                for p in _paths(context):
+                    data_list.append(('a', p))
+                return (), data_list, ''
+        '''), [('leak', 1)])
+
+    def test_a_helper_returning_records_is_tracked_by_position(self):
+        """The path field of a record is tainted; its other fields are not."""
+        self.assertEqual(self._cols('''
+            def _stores(context):
+                out = []
+                for file_found in unique_files(context):
+                    out.append((file_found, 'parsed', 3))
+                return out
+
+            @artifact_processor
+            def leak(context):
+                data_list = []
+                for path, parsed, count in _stores(context):
+                    data_list.append((parsed, count, path))
+                return (), data_list, ''
+
+            @artifact_processor
+            def fine(context):
+                data_list = []
+                for path, parsed, count in _stores(context):
+                    data_list.append((parsed, count, context.get_relative_path(path)))
+                return (), data_list, ''
+        '''), [('leak', 2)])
+
+    def test_a_helper_returning_reduced_paths_is_not_a_source(self):
+        """A comprehension is judged by its element, not by what it iterates."""
+        self.assertEqual(findings_for('''
+            def _reduced(context):
+                return [context.get_relative_path(p) for p in unique_files(context)]
+
+            @artifact_processor
+            def fine(context):
+                data_list = []
+                for p in _reduced(context):
+                    data_list.append(('a', p))
+                return (), data_list, ''
+        '''), [])
+
+    def test_a_database_row_read_from_a_store_is_not_a_path(self):
+        """Fields unpacked from a record whose path position is unknown stay silent.
+        weChat, hldPrivacySafe and keychain rows would otherwise all be reported."""
+        self.assertEqual(findings_for('''
+            def _rows(context):
+                out = []
+                for file_found in unique_files(context):
+                    for row in query(file_found):
+                        out.append((row, file_found))
+                return out
+
+            @artifact_processor
+            def fine(context):
+                data_list = []
+                for row, path in _rows(context):
+                    name, value, count = row
+                    data_list.append((name or '', value if value else '', count,
+                                      context.get_relative_path(path)))
+                return (), data_list, ''
+        '''), [])
+
+    def test_replacing_the_data_folder_out_of_a_path_reduces_it(self):
+        """get_relative_path written by hand, as FacebookMessenger once did."""
+        self.assertEqual(findings_for('''
+            @artifact_processor
+            def fine(files_found, seeker, report_folder):
+                data_list = []
+                for file_found in files_found:
+                    data_list.append(('a', file_found.replace(seeker.data_folder, '')))
+                return (), data_list, ''
+        '''), [])
+
+    def test_a_slice_of_a_path_is_a_piece_of_it(self):
+        self.assertEqual(findings_for('''
+            def _user(file_found):
+                start = file_found.find('/user/') + 6
+                return file_found[start:start + 3]
+
+            @artifact_processor
+            def fine(files_found, seeker, report_folder):
+                data_list = []
+                for file_found in files_found:
+                    data_list.append((_user(file_found), 'a'))
+                return (), data_list, ''
+        '''), [])
+
+    def test_a_working_list_that_never_reaches_the_report_is_not_a_row_list(self):
+        """dmss collects (name, name, path) records under a *_data_list name, then
+        builds the real rows from them with the path reduced."""
+        self.assertEqual(findings_for('''
+            @artifact_processor
+            def fine(files_found, seeker, report_folder, context):
+                media_data_list = []
+                for file_found in files_found:
+                    record = ('n', 'n', file_found)
+                    media_data_list.append(record)
+                data_list = []
+                for item in media_data_list:
+                    data_list.append((item[0], context.get_relative_path(item[2])))
+                return (), data_list, ''
+        '''), [])
+
+    def test_a_record_appended_by_name_reports_its_path_position(self):
+        self.assertEqual(self._cols('''
+            @artifact_processor
+            def leak(files_found, seeker, report_folder):
+                data_list = []
+                for file_found in files_found:
+                    record = ('n', file_found)
+                    data_list.append(record)
+                return (), data_list, ''
+        '''), [('leak', 1)])
 
 
 class TheRepoItself(unittest.TestCase):

--- a/scripts/artifacts/FacebookMessenger.py
+++ b/scripts/artifacts/FacebookMessenger.py
@@ -150,6 +150,7 @@ __artifacts_v2__ = {
 import datetime
 import sqlite3
 
+from scripts.context import Context
 from scripts.ilapfuncs import artifact_processor, null_absent_columns, open_sqlite_db_readonly
 
 
@@ -169,11 +170,10 @@ def _candidate(file_found):
     return 'mirror' not in file_found and '/user/0/' not in file_found
 
 
-def _src(file_found, seeker):
-    try:
-        return file_found.replace(seeker.data_folder, '')
-    except AttributeError:
-        return file_found
+def _src(file_found, _seeker):
+    # The evidence relative path for a row. The framework's reducer, not a hand-rolled
+    # replace with a fallback that would publish the staged path.
+    return Context.get_relative_path(file_found)
 
 
 def _q(cursor, sql):


### PR DESCRIPTION
Widens `check_report_local_paths.py` to the shapes a scan of real report output found it missing: 122 cells across four ALEAPP modules were publishing the tool's staging path while the check reported clean.

- `unique_files(context)` is now a taint source.
- `or`, `and`, conditional expressions, tuple unpacking, `+=`, `:=` and subscript stores propagate the taint.
- A module-level helper that returns a staged path, or records carrying one, is a source for its callers, tracked by tuple position so the other fields of a record stay untainted.

Precision is kept in step so correct code stays silent: a database row unpacked from a record is not a path, a comprehension is judged by its element, `replace(x.data_folder, ...)` is a reduction, a slice is a piece, and a name-hinted list that never reaches the report is not a row list. Zero findings on this core's merged tree; every previously caught shape still caught; fourteen new pinned tests, nine of which fail on the previous checker. Byte identical with the other four cores.

Also replaces FacebookMessenger's hand-rolled reducer, whose `AttributeError` fallback returned the staging path, with `Context.get_relative_path`. Its output changes only by the leading slash the framework strips, matching every other artifact's Source File; rows and every other cell are identical on the tested image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)