### PR TITLE
Drop the Source File column from the battery usage v9 artifacts

### DIFF
--- a/scripts/artifacts/battery_usage_v9.py
+++ b/scripts/artifacts/battery_usage_v9.py
@@ -41,7 +41,6 @@ import sqlite3
 from scripts.ilapfuncs import decode_protobuf
 
 from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
-from scripts.context import Context
 
 _STATUS = {1: 'Unknown', 2: 'Charging', 3: 'Discharging', 4: 'Not Charging', 5: 'Fully charged'}
 _HEALTH = {1: 'Unknown', 2: 'Good', 3: 'Overheat', 4: 'Dead', 5: 'Over Voltage',
@@ -150,14 +149,13 @@ def get_battery_usage_v9(context):
             info.get('1', ''),                                 # Battery Level
             _status(info.get('2')),                            # Battery Status
             _HEALTH.get(_as_int(info.get('3')), 'None'),       # Battery Health
-            _txt(proto.get('13')),                             # Drain Type
-            Context.get_relative_path(source_path)))
+            _txt(proto.get('13'))))                            # Drain Type
 
     data_headers = (('Timestamp', 'datetime'), 'Application', 'Package Name', 'Hidden',
                     'Boot Timestamp', 'Timezone', 'Total Power', 'Consumed Power',
                     'Foreground Usage (Seconds)', 'Foreground Service Usage (seconds)',
                     'Background Usage (Seconds)', 'Battery Level (%)', 'Battery Status',
-                    'Battery Health', 'Drain Type', 'Source File')
+                    'Battery Health', 'Drain Type')
     return data_headers, data_list, source_path
 
 
@@ -173,7 +171,7 @@ def get_app_usage_events(context):
         packageName, taskRootPackageName, instanceId
         FROM AppUsageEventEntity
     ''')
-    data_list = [(r[0], r[1], _ms_to_utc(r[2]), r[3], r[4], r[5], r[6], Context.get_relative_path(source_path)) for r in rows]
+    data_list = [(r[0], r[1], _ms_to_utc(r[2]), r[3], r[4], r[5], r[6]) for r in rows]
     data_headers = ('uid', 'userId', ('Timestamp', 'datetime'), 'App Usage Event Type',
-                    'Package Name', 'Root Package Name', 'Instance Id', 'Source File')
+                    'Package Name', 'Root Package Name', 'Instance Id')
     return data_headers, data_list, source_path


### PR DESCRIPTION
Drops the Source File column from both battery usage v9 artifacts.

Each one picks a single database with `_db(files_found)` and then repeats that same path on every row: 26,561 and 3,196 rows on one tested image, 26,306 and 386 on another. The report's located at line already names that file, so nothing is lost.

Row counts are unchanged on both images and the output checker reports the same findings before and after. The now unused Context import goes with it.

This came out of a survey of every artifact in both repos that declares a source column. Of the 220 that produced rows on six images, 98 vary and are doing work, and 100 more hold one value only because one file had data on those images. This module was the one where the column repeats a single path the artifact chose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
