### PR TITLE
Run crunch_artifacts on a worker thread so the GUI stays responsive

### DIFF
--- a/aleappGUI.py
+++ b/aleappGUI.py
@@ -3,6 +3,9 @@
 import tkinter as tk
 import typing
 import json
+import queue
+import threading
+import traceback
 import aleapp
 import webbrowser
 import base64
@@ -28,6 +31,11 @@ from scripts.context import Context
 from scripts.lavafuncs import lava_json_name
 
 check_runtime_dependencies()
+
+
+# How often the main thread drains the worker's queue. Short enough that the log still
+# scrolls smoothly, long enough that polling is not itself the load.
+CRUNCH_POLL_MS = 50
 
 
 def allow_output_folder_name_chars(proposed):
@@ -502,68 +510,131 @@ def process(casedata):
         logtext_frame.pack(padx=8, pady=4, expand=True, fill='both')
         progress_bar_frame.pack(padx=2, pady=2, ipady=2, fill='x')
 
-        initialize_lava(input_path, out_params.output_folder_base, extracttype, profile_filename)
-
         # Record history if enabled
         history.record_input_path(input_path)
         history.record_output_path(output_folder)
 
+        # crunch_artifacts blocks for the length of the run. Called here it blocks the Tk
+        # event loop too, and the only thing pumping that loop was log_text.update() inside
+        # logfunc, so Windows paints "(Not Responding)" over a run that is perfectly healthy.
+        # Run it on a worker thread and poll for its output instead.
+        GuiWindow.message_queue = queue.Queue()
+        worker = threading.Thread(
+            target=run_crunch,
+            args=(GuiWindow.message_queue, selected_modules, extracttype, input_path,
+                  out_params, wrap_text, casedata),
+            daemon=True)
+        worker.start()
+        main_window.after(CRUNCH_POLL_MS, poll_crunch, GuiWindow.message_queue, out_params)
+
+
+def run_crunch(message_queue, selected_modules, extracttype, input_path, out_params, wrap_text,
+               case_info):
+    '''Do the processing off the main thread. Touches no widget; reports on the queue.'''
+    try:
+        # LAVA's SQLite connection is opened here rather than in process(): a sqlite3
+        # object may only be used by the thread that created it, so a connection opened
+        # on the main thread is unusable by the artifacts running on this one.
+        initialize_lava(input_path, out_params.output_folder_base, extracttype, profile_filename)
         crunch_successful = aleapp.crunch_artifacts(
             selected_modules, extracttype, input_path, out_params, wrap_text, loader, 
-            casedata, profile_filename)
-        
+            case_info, profile_filename)
         lava_finalize_output(out_params.output_folder_base)
+    except Exception:  # pylint: disable=broad-exception-caught
+        # Without this the GUI would poll an empty queue forever and look hung for real.
+        message_queue.put(('failed', traceback.format_exc()))
+    else:
+        message_queue.put(('done', crunch_successful))
 
-        if crunch_successful:
-            # Record the run in history
-            report_path = os.path.join(out_params.output_folder_base, 'index.html')
-            lava_project_path = os.path.join(out_params.output_folder_base, lava_json_name)
-            history.record_recent_run(leapp_name.lower(), leapp_version, lava_project_path)
 
-            output_folder_path = out_params.output_folder_base
-            if report_path.startswith('\\\\?\\'):  # windows
-                report_path = report_path[4:]
-                lava_project_path = lava_project_path[4:]
-                output_folder_path = output_folder_path[4:]
-            if report_path.startswith('\\\\'):  # UNC path
-                report_path = report_path[2:]
-                lava_project_path = lava_project_path[2:]
-                output_folder_path = output_folder_path[2:]
-            progress_bar.pack_forget()
-            completion_button_frame = ttk.Frame(progress_bar_frame)
-            completion_button_frame.place(relx=0.5, rely=0.5, anchor='center')
-            open_report_button = ttk.Button(
-                completion_button_frame,
-                text='Open HTML in Browser & Close',
-                command=lambda: open_report(report_path))
-            open_report_button.pack(side='left', padx=5)
-
-            lava_launcher = find_lava_launcher(lava_project_path)
-            if lava_launcher:
-                lava_button = ttk.Button(
-                    completion_button_frame,
-                    text='Open Project in LAVA & Close',
-                    command=lambda: open_lava(lava_project_path, lava_launcher))
-            else:
-                lava_button = ttk.Button(
-                    completion_button_frame,
-                    text='Explore LAVA',
-                    command=explore_lava)
-            lava_button.pack(side='left', padx=5)
-
-            open_folder_button = ttk.Button(
-                completion_button_frame,
-                text='Open Output Folder',
-                command=lambda: open_folder(output_folder_path))
-            open_folder_button.pack(side='left', padx=5)
+def poll_crunch(message_queue, out_params):
+    '''Drain the worker's messages onto the widgets. The only place Tk is touched.'''
+    pending_logs = []
+    finished = None
+    while finished is None:
+        try:
+            kind, payload = message_queue.get_nowait()
+        except queue.Empty:
+            break
+        if kind == 'log':
+            pending_logs.append(payload)
+        elif kind == 'progress':
+            progress_bar.config(value=payload)
         else:
-            log_path = out_params.screen_output_file_path
-            if log_path.startswith('\\\\?\\'):  # windows
-                log_path = log_path[4:]
-            tk_msgbox.showerror(
-                title='Error',
-                message=f'Processing failed  :( \nSee log for error details..\nLog file located at {log_path}',
-                parent=main_window)
+            finished = (kind, payload)
+
+    if pending_logs:
+        # One insert per poll, not one per line: a chatty artifact queues thousands, and
+        # inserting each separately costs more than the run it is reporting on.
+        log_text.insert('end', ''.join(pending_logs))
+        log_text.see('end')
+
+    if finished is None:
+        main_window.after(CRUNCH_POLL_MS, poll_crunch, message_queue, out_params)
+        return
+
+    GuiWindow.message_queue = None  # logfunc goes back to writing straight to the widget
+    kind, payload = finished
+    if kind == 'failed':
+        logfunc('Processing failed with an unhandled error:')
+        logfunc(payload)
+        finish_crunch(False, out_params)
+    else:
+        finish_crunch(payload, out_params)
+
+
+def finish_crunch(crunch_successful, out_params):
+    '''Report the outcome. Runs on the main thread once the worker is done.'''
+    if crunch_successful:
+        # Record the run in history
+        report_path = os.path.join(out_params.output_folder_base, 'index.html')
+        lava_project_path = os.path.join(out_params.output_folder_base, lava_json_name)
+        history.record_recent_run(leapp_name.lower(), leapp_version, lava_project_path)
+
+        output_folder_path = out_params.output_folder_base
+        if report_path.startswith('\\\\?\\'):  # windows
+            report_path = report_path[4:]
+            lava_project_path = lava_project_path[4:]
+            output_folder_path = output_folder_path[4:]
+        if report_path.startswith('\\\\'):  # UNC path
+            report_path = report_path[2:]
+            lava_project_path = lava_project_path[2:]
+            output_folder_path = output_folder_path[2:]
+        progress_bar.pack_forget()
+        completion_button_frame = ttk.Frame(progress_bar_frame)
+        completion_button_frame.place(relx=0.5, rely=0.5, anchor='center')
+        open_report_button = ttk.Button(
+            completion_button_frame,
+            text='Open HTML in Browser & Close',
+            command=lambda: open_report(report_path))
+        open_report_button.pack(side='left', padx=5)
+
+        lava_launcher = find_lava_launcher(lava_project_path)
+        if lava_launcher:
+            lava_button = ttk.Button(
+                completion_button_frame,
+                text='Open Project in LAVA & Close',
+                command=lambda: open_lava(lava_project_path, lava_launcher))
+        else:
+            lava_button = ttk.Button(
+                completion_button_frame,
+                text='Explore LAVA',
+                command=explore_lava)
+        lava_button.pack(side='left', padx=5)
+
+        open_folder_button = ttk.Button(
+            completion_button_frame,
+            text='Open Output Folder',
+            command=lambda: open_folder(output_folder_path))
+        open_folder_button.pack(side='left', padx=5)
+    else:
+        log_path = out_params.screen_output_file_path
+        if log_path.startswith('\\\\?\\'):  # windows
+            log_path = log_path[4:]
+        tk_msgbox.showerror(
+            title='Error',
+            message=f'Processing failed  :( \nSee log for error details..\nLog file located at {log_path}',
+            parent=main_window)
 
 
 def select_input(button_type):

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -77,10 +77,16 @@ class OutputParameters:
 class GuiWindow:
     '''This only exists to hold window handle if script is run from GUI'''
     window_handle = None  # static variable
+    # Set to a queue.Queue by the GUI while a run is on a worker thread, and back to None
+    # when it finishes. Tk is not thread-safe: while this is set, nothing below may touch a
+    # widget, so progress and log lines are handed to the GUI's poller instead.
+    message_queue = None
 
     @staticmethod
     def SetProgressBar(n, total):  # pylint: disable=unused-argument
-        if GuiWindow.window_handle:
+        if GuiWindow.message_queue is not None:
+            GuiWindow.message_queue.put(('progress', n))
+        elif GuiWindow.window_handle:
             progress_bar = GuiWindow.window_handle.nametowidget('progress_bar_frame.progress_bar')
             progress_bar.config(value=n)
 
@@ -128,7 +134,15 @@ def logfunc(message=""):
         log_text.see('end')
         log_text.update()
 
-    if GuiWindow.window_handle:
+    def queue_logs(string):
+        _console_write(string)
+        GuiWindow.message_queue.put(('log', string))
+
+    if GuiWindow.message_queue is not None:
+        # On a worker thread. The poller on the main thread does the insert, so the run no
+        # longer depends on log_text.update() to keep the event loop alive.
+        sys.stdout.write = queue_logs
+    elif GuiWindow.window_handle:
         log_text = GuiWindow.window_handle.nametowidget('logs_frame.log_text')
         sys.stdout.write = redirect_logs
 


### PR DESCRIPTION
## The problem

The GUI called `crunch_artifacts()` directly on the Tk main thread from the Process button handler, so for the whole length of a run the only thing pumping the event loop was `log_text.update()` inside `logfunc` (`scripts/ilapfuncs.py`). Between log lines the window stops answering Windows, which paints "(Not Responding)" over a run that is perfectly healthy. A single slow artifact is enough to trigger it, and an examiner watching a report that looks hung has no way to tell it apart from one that is.

## The change

`crunch_artifacts` runs on a daemon worker thread and reports back over a `queue.Queue` that an `after()` poller drains on the main thread.

- `GuiWindow.message_queue` is set while a run is in flight. `logfunc` and `SetProgressBar` check it and enqueue instead of touching a widget, so the worker never calls into Tk.
- The poller drains the queue every 50 ms and does one `log_text.insert()` per poll rather than one per line, which is also less work than the old path.
- The completion UI moved into `finish_crunch()`, called by the poller on the main thread.
- `initialize_lava()` moved out of `process()` and into the worker. A `sqlite3` connection may only be used by the thread that created it, so LAVA's connection has to be opened on the same thread the artifacts run on. Opening it on the main thread raises `SQLite objects created in a thread can only be used in that same thread` on the first artifact that writes.

The `scripts/ilapfuncs.py` half is identical in all five LEAPP cores. The GUI half keeps each core's own `crunch_artifacts` signature.

## Measured

`logfunc` and `SetProgressBar` are the real ones, driven through the real `message_queue` gate; only the workload is simulated (12 artifacts, one of them working 2.5 s without logging). Worst event-loop stall, and how many times the loop was serviced:

| | before | after |
|---|---|---|
| worst stall | 2.55 s | 0.01 s |
| loop serviced | ~300x | ~3300x |

Windows paints "(Not Responding)" at roughly 5 s, so 2.55 s is the visible symptom's floor rather than its ceiling — a genuinely slow artifact stalls for longer.

## Verified on a real run

Full GUI run against a 37 GB Samsung extraction: 1,063 of 1,064 artifacts, 111 s wall, event loop serviced 3,659 times, worst stall 0.19 s, no errors.

The other four LEAPP cores carry the same change on a branch of this name; each was verified against its own real data, since each keeps its own `crunch_artifacts` signature and passing one does not clear the others.
