### PR TITLE
Raise the packaging pin so PyInstaller resolves to a current release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ beautifulsoup4==4.8.2
 bencoding
 fitdecode==0.10.0
 folium==0.14.0
-packaging==20.1
+packaging==24.1
 pillow==12.3.0
 polyline==2.0.0
 # Do NOT pip install the PyPI 'blackboxprotobuf' into this environment: it


### PR DESCRIPTION
## The problem

`requirements.txt` pins `packaging==20.1`. PyInstaller 6.x requires `packaging>=22.0`, so pip cannot take it, backtracks, and lands on the newest release that carries no `packaging` constraint at all — **4.5.1, from 2021**:

```
pip install -r requirements.txt pyinstaller
  packaging    20.1
  pyinstaller  4.5.1      <- no error, no warning
```

4.5.1 predates Python 3.14 and does not support the `hide_console` option `scripts/pyinstaller/aleappGUI.spec` uses, so a build from a clean environment fails in ways that point nowhere near this pin. You only notice if you happen to check which PyInstaller you actually got.

## The change

`packaging` is imported only by `admin/test/scripts/test_dependency_compatibility.py`, which uses it to assert the dependency imports cleanly. `24.1` satisfies that.

`24.1` is the value iLEAPP already carries, so this matches an existing core rather than inventing a version. From the same clean resolution:

```
  packaging    24.1
  pyinstaller  6.22.2
```

## Verified

pip dry-run resolution against this repo's own `requirements.txt`, both ways, changing nothing but this line: `20.1` → PyInstaller 4.5.1, `24.1` → PyInstaller 6.22.2.

The same one-line change is going to the other affected cores; it was found while building DLEAPP, where it is [#124](https://github.com/abrignoni/DLEAPP/pull/124). iLEAPP is already on `24.1` and is unaffected.
