### PR TITLE
Chromium: read one storage view per file in DIPS, Media History and Network Action Predictor

### DIFF
--- a/scripts/artifacts/chromeDIPS.py
+++ b/scripts/artifacts/chromeDIPS.py
@@ -1,7 +1,7 @@
 __artifacts_v2__ = {
     "get_chromeDIPS": {
         "name": "ChromeDIPS",
-        "description": "Module Description: Parses Chromium DIPS (Detect Incidental Party State)",
+        "description": "Parses Chromium DIPS (Detect Incidental Party State)",
         "author": "Kevin Pagano (@stark4n6)",
         "creation_date": "2023-04-07",
         "last_update_date": "2026-07-10",

--- a/scripts/artifacts/chromeDIPS.py
+++ b/scripts/artifacts/chromeDIPS.py
@@ -31,6 +31,7 @@ import datetime
 
 from scripts.ilapfuncs import logfunc, artifact_processor, open_sqlite_db_readonly
 from scripts.artifacts.chrome import get_browser_name
+from scripts.artifacts.storagePathViews import unique_files
 
 
 def _webkit_to_utc(value):
@@ -47,7 +48,7 @@ def _first_column(columns, candidates):
 
 @artifact_processor
 def get_chromeDIPS(context):
-    files_found = context.get_files_found()
+    files_found = unique_files(context)
     # all_data is a consolidated list of all browsers with an extra column to discriminate the browser
     all_data = []
 

--- a/scripts/artifacts/chromeDIPS.py
+++ b/scripts/artifacts/chromeDIPS.py
@@ -17,10 +17,10 @@ __artifacts_v2__ = {
             "pixel7a_a14": "Android 14 | com.android.chrome vc 616710133, com.microsoft.emmx vc 259210005 | 36 rows",
             "sharon_a14": "Android 14 | com.android.chrome vc 653310333 | 19 rows",
             "hc_pixel8pro_a16": "Android 16 | com.android.chrome vc 782711433, com.brave.browser vc 429117204, com.sec.android.app.sbrowser vc 1300067502 | 3 rows",
-            "samsunga53_a14": "Android 14 | com.android.chrome vc 744417133 | 15 rows",
+            "samsunga53_a14": "Android 14 | com.android.chrome vc 744417133 | 5 rows",
             "samsungs20_a13": "Android 13 | com.android.chrome vc 749919233, com.brave.browser vc 428414124, com.microsoft.emmx vc 365012523 | 13 rows",
             "russell_pixel6a_a13": "Android 13 | com.android.chrome vc 573513033 | 19 rows",
-            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 10 rows",
+            "userb2_a13": "Android 13 | com.android.chrome vc 677808133 | 5 rows",
         },
     }
 }

--- a/scripts/artifacts/chromeMediaHistory.py
+++ b/scripts/artifacts/chromeMediaHistory.py
@@ -51,6 +51,7 @@ __artifacts_v2__ = {
 
 from scripts.ilapfuncs import logfunc, open_sqlite_db_readonly, artifact_processor, convert_human_ts_to_utc
 from scripts.artifacts.chrome import get_browser_name
+from scripts.artifacts.storagePathViews import unique_files
 
 
 def _media_history_files(files_found):
@@ -68,7 +69,7 @@ def _media_history_files(files_found):
 
 @artifact_processor
 def get_chromeMediaHistorySessions(context):
-    files_found = context.get_files_found()
+    files_found = unique_files(context)
     all_data = []
     data_headers = ['Last Updated', 'Origin ID', 'URL', 'Position', 'Duration', 'Title', 'Artist', 'Album', 'Source Title']
     lava_data_headers = data_headers.copy()
@@ -111,7 +112,7 @@ def get_chromeMediaHistorySessions(context):
 
 @artifact_processor
 def get_chromeMediaHistoryPlaybacks(context):
-    files_found = context.get_files_found()
+    files_found = unique_files(context)
     all_data = []
     data_headers = ['Last Updated', 'ID', 'Origin ID', 'URL', 'Watch Time', 'Has Audio', 'Has Video']
     lava_data_headers = data_headers.copy()
@@ -158,7 +159,7 @@ def get_chromeMediaHistoryPlaybacks(context):
 
 @artifact_processor
 def get_chromeMediaHistoryOrigins(context):
-    files_found = context.get_files_found()
+    files_found = unique_files(context)
     all_data = []
     data_headers = ['Last Updated', 'ID', 'Origin', 'Aggregate Watchtime']
     lava_data_headers = data_headers.copy()

--- a/scripts/artifacts/chromeNetworkActionPredictor.py
+++ b/scripts/artifacts/chromeNetworkActionPredictor.py
@@ -21,11 +21,12 @@ __artifacts_v2__ = {
 
 from scripts.ilapfuncs import logfunc, open_sqlite_db_readonly, artifact_processor
 from scripts.artifacts.chrome import get_browser_name
+from scripts.artifacts.storagePathViews import unique_files
 
 
 @artifact_processor
 def get_chromeNetworkActionPredictor(context):
-    files_found = context.get_files_found()
+    files_found = unique_files(context)
     all_data = []
 
     data_headers = ['User Text', 'URL', 'Number of Hits', 'Number of Misses']


### PR DESCRIPTION
Fixes three Chromium modules that read every storage view of the same database, so rows were reported once per view.

- chromeDIPS, chromeMediaHistory (three functions) and chromeNetworkActionPredictor now call `unique_files(context)`, the helper chrome.py, chromeAutofill.py, chromeCookies.py, chromeLoginData.py and chromeOfflinePages.py already use.
- Measured on emu_a15_oss_v7, which carries three views of each profile: ChromeDIPS 6 rows before, 2 after, matching a direct read of the bounces tables.
- ChromeDIPS sample_data re-derived on all nine images. Two change: samsunga53_a14 15 to 5, userb2_a13 10 to 5.

Media History and Network Action Predictor report no rows on any tested image, so their change is unexercised. A second Android user is not collapsed: russell_pixel6a_a13 keeps its 19 rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
