### PR TITLE
Verizon RDD: drop the template prefix from both descriptions

### DIFF
--- a/scripts/artifacts/VerizonRDDAnalytics.py
+++ b/scripts/artifacts/VerizonRDDAnalytics.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_rdd_analytics": {
         "name": "VerizonRDD-Battery",
-        "description": "Module Description: Parses Verizon RDD Analytics Battery History",
+        "description": "Parses Verizon RDD Analytics Battery History",
         "author": "John Hyla",
         "creation_date": "2023-07-07",
         "last_update_date": "2023-07-07",

--- a/scripts/artifacts/VerizonRDDWIFI.py
+++ b/scripts/artifacts/VerizonRDDWIFI.py
@@ -2,7 +2,7 @@
 __artifacts_v2__ = {
     "get_rdd_wifi": {
         "name": "VerizonRDD-WIFI",
-        "description": "Module Description: Parses Verizon RDD Wifi Data",
+        "description": "Parses Verizon RDD Wifi Data",
         "author": "John Hyla",
         "creation_date": "2023-07-07",
         "last_update_date": "2023-07-07",


### PR DESCRIPTION
Drops the "Module Description: " prefix from the two Verizon RDD descriptions. That text reaches the HTML report, the LAVA manifest and the module index, and these were the last two artifacts carrying it.

The wording after the prefix is unchanged and matches what each module queries: `TableBatteryHistory` for the battery artifact, `TABLERDDWIFIDATA` for the wifi one. Notes are empty on both, so there is nothing else to check.

Neither artifact declares sample_data. None of the 42 registered Android corpora carries com.verizon.mips.services, so there is no image to derive one from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
