### PR TITLE
Name the database each Samsung media provider row came from

### DIFF
--- a/scripts/artifacts/samsungMediaProvider.py
+++ b/scripts/artifacts/samsungMediaProvider.py
@@ -1,81 +1,100 @@
 __artifacts_v2__ = {
     "samsungMediaFiles": {
         "name": "Samsung Media Provider - Files",
-        "description": "Media files indexed by the Samsung media provider (media.db, files "
-                       "table): file path and name, taken/added/modified times, "
-                       "coordinates and packed address, the URL and app a captured file "
-                       "came from, and the favorite/hidden/trashed/deleted flags.",
+        "description": "Files listed in the Samsung media provider's files table (media.db): "
+                       "file path and name, taken, added and modified times, coordinates "
+                       "and packed address, the captured URL and captured app values, the "
+                       "Is Favorite, Is Hide, Is Trashed and Deleted values as stored, and "
+                       "the database each row came from.",
         "author": "@abrignoni",
         "creation_date": "2026-07-30",
-        "last_update_date": "2026-07-30",
+        "last_update_date": "2026-09-12",
         "requirements": "none",
         "category": "Samsung Media Provider",
         "notes": "The Address column is the packed multi-part string as stored (parts "
-                 "separated by '|'). Reference: Cellebrite Location Booklet 2025.",
+                 "separated by '|'). Reference: Cellebrite Location Booklet 2025. Every "
+                 "media.db the declared path matches is read, except that where one "
+                 "user's database appears under more than one of the data/data, data/user "
+                 "and data_mirror/data_ce storage paths, only one copy is read. A database "
+                 "present only under data_mirror/data_ce is read as well; no tested image "
+                 "carries one, and that case was exercised on a constructed tree. On "
+                 "cookbook_a11 and samsungs20_a13 a second media.db sits under user/150, "
+                 "and each image's system/users/150.xml records user 150 as a managed "
+                 "profile named Secure Folder. The Source DB Path column names the "
+                 "database each row came from, and the report's located-at line lists "
+                 "every database read, including any that returned no rows. Is Hide and "
+                 "Deleted held no value on any row of the ten tested images, and Is "
+                 "Favorite and Is Trashed held only 0 or no value, so the tested images do "
+                 "not show what any other value in those columns records.",
         "paths": ('*/com.samsung.android.providers.media/databases/media.db*',),
         "output_types": "all",
         "artifact_icon": "image",
         "sample_data": {
+            "adams_ss135dl_a13": "Android 13 | com.samsung.android.providers.media | 94 rows",
             "anne_a15": "Android 15 | com.samsung.android.providers.media | 223 rows",
+            "cookbook_a11": "Android 11 | com.samsung.android.providers.media | 17 rows",
+            "falken_a326u_a13": "Android 13 | com.samsung.android.providers.media | 30 rows",
             "galaxys10_a10": "Android 10 | com.samsung.android.providers.media | 32 rows",
+            "s20fe_a13": "Android 13 | com.samsung.android.providers.media | 9 rows",
             "samsunga53_a14": "Android 14 | com.samsung.android.providers.media | 2 rows",
             "samsungs20_a13": "Android 13 | com.samsung.android.providers.media | 16 rows",
+            "sharon_a13": "Android 13 | com.samsung.android.providers.media | 336 rows",
             "sharon_a14": "Android 14 | com.samsung.android.providers.media | 1439 rows",
         },
     },
     "samsungMediaLocations": {
         "name": "Samsung Media Provider - Locations",
-        "description": "Reverse-geocoded places recorded by the Samsung media provider "
-                       "(media.db, location table): coordinates with the resolved country, "
-                       "locality, street and full address text.",
+        "description": "Entries in the Samsung media provider's location table (media.db): "
+                       "coordinates with country, locality, street and address text, and "
+                       "the database each row came from.",
         "author": "@abrignoni",
         "creation_date": "2026-07-30",
-        "last_update_date": "2026-07-30",
+        "last_update_date": "2026-09-12",
         "requirements": "none",
         "category": "Samsung Media Provider",
-        "notes": "Reference: Cellebrite Location Booklet 2025.",
+        "notes": "Reference: Cellebrite Location Booklet 2025. Every media.db the declared "
+                 "path matches is read, except that where one user's database appears "
+                 "under more than one of the data/data, data/user and data_mirror/data_ce "
+                 "storage paths, only one copy is read. A database present only under "
+                 "data_mirror/data_ce is read as well; no tested image carries one, and "
+                 "that case was exercised on a constructed tree. On cookbook_a11 and "
+                 "samsungs20_a13 a second media.db sits under user/150, and each image's "
+                 "system/users/150.xml records user 150 as a managed profile named "
+                 "Secure Folder; on both images that database held no location rows. The "
+                 "Source DB Path column names the database each row came from, and the "
+                 "report's located-at line lists every database read, including any that "
+                 "returned no rows.",
         "paths": ('*/com.samsung.android.providers.media/databases/media.db*',),
         "output_types": "all",
         "artifact_icon": "map-pin",
         "sample_data": {
+            "adams_ss135dl_a13": "Android 13 | com.samsung.android.providers.media | 119 rows",
             "anne_a15": "Android 15 | com.samsung.android.providers.media | 91 rows",
+            "cookbook_a11": "Android 11 | com.samsung.android.providers.media | 2 rows",
+            "falken_a326u_a13": "Android 13 | com.samsung.android.providers.media | 22 rows",
             "galaxys10_a10": "Android 10 | com.samsung.android.providers.media | 15 rows",
+            "s20fe_a13": "Android 13 | com.samsung.android.providers.media | 0 rows",
             "samsunga53_a14": "Android 14 | com.samsung.android.providers.media | 0 rows",
             "samsungs20_a13": "Android 13 | com.samsung.android.providers.media | 0 rows",
+            "sharon_a13": "Android 13 | com.samsung.android.providers.media | 48 rows",
             "sharon_a14": "Android 14 | com.samsung.android.providers.media | 116 rows",
         },
     },
 }
 
-import re
-
 from scripts.ilapfuncs import artifact_processor, get_sqlite_db_records, \
     convert_unix_ts_to_utc
+from scripts.artifacts.storagePathViews import unique_files
 
 
-def _unique_db_files(context, name_suffix):
-    '''Database files matching the suffix, without -wal/-shm sidecars and without the
-    duplicates extractions carry for the same file (data_mirror, and /data/data next
-    to /data/user/0).
+def _media_dbs(context):
+    '''Every distinct media.db the seeker staged, without the -wal/-shm sidecars.
 
-    The dedupe key is the evidence-relative path, not the extracted path: the report's own
-    data folder ends in /data, so a raw-path replace can rewrite the harness boundary
-    instead of the evidence path on archives whose members start with data/.'''
-    seen = set()
-    result = []
-    for file_found in context.get_files_found():
-        file_found = str(file_found)
-        if not file_found.endswith(name_suffix):
-            continue
-        relative = str(context.get_relative_path(file_found)).replace('\\', '/')
-        if 'data_mirror' in relative:
-            continue
-        normalized = re.sub(r'(^|/)data/data/', r'\1data/user/0/', relative)
-        if normalized in seen:
-            continue
-        seen.add(normalized)
-        result.append(file_found)
-    return result
+    unique_files collapses the storage-view copies of one user's database (data/data,
+    data/user/<id>, data_mirror/data_ce/<volume>/<id>) and keeps different users apart,
+    because canonical_path keeps the Android user id in its key.'''
+    return [file_found for file_found in unique_files(context)
+            if file_found.endswith('media.db')]
 
 
 def _ts(value):
@@ -96,9 +115,11 @@ def _coord_pair(latitude, longitude):
 @artifact_processor
 def samsungMediaFiles(context):
     data_list = []
-    source_path = ''
+    source_paths = []
 
-    for file_found in _unique_db_files(context, 'media.db'):
+    for file_found in _media_dbs(context):
+        source_paths.append(file_found)
+        source_db = context.get_relative_path(file_found)
         db_records = get_sqlite_db_records(file_found, '''
             SELECT datetaken, date_added, date_modified, _display_name, _data, mime_type,
                    _size, latitude, longitude, addr, bucket_display_name,
@@ -109,7 +130,6 @@ def samsungMediaFiles(context):
         ''')
 
         for row in db_records:
-            source_path = file_found
             latitude, longitude = _coord_pair(row[7], row[8])
             data_list.append((
                 _ts(row[0]),
@@ -130,6 +150,7 @@ def samsungMediaFiles(context):
                 row[15],
                 row[16],
                 row[17],
+                source_db,
             ))
 
     data_headers = (
@@ -151,16 +172,19 @@ def samsungMediaFiles(context):
         'Is Hide',
         'Is Trashed',
         'Deleted',
+        'Source DB Path',
     )
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)
 
 
 @artifact_processor
 def samsungMediaLocations(context):
     data_list = []
-    source_path = ''
+    source_paths = []
 
-    for file_found in _unique_db_files(context, 'media.db'):
+    for file_found in _media_dbs(context):
+        source_paths.append(file_found)
+        source_db = context.get_relative_path(file_found)
         db_records = get_sqlite_db_records(file_found, '''
             SELECT latitude, longitude, address_text, country_name, country_code,
                    admin_area, sub_admin_area, locality, sub_locality, street_name,
@@ -170,9 +194,8 @@ def samsungMediaLocations(context):
         ''')
 
         for row in db_records:
-            source_path = file_found
             latitude, longitude = _coord_pair(row[0], row[1])
-            data_list.append((latitude, longitude) + tuple(row[2:]))
+            data_list.append((latitude, longitude) + tuple(row[2:]) + (source_db,))
 
     data_headers = (
         'Latitude',
@@ -187,5 +210,6 @@ def samsungMediaLocations(context):
         'Street Name',
         'Street Number',
         'Postal Code',
+        'Source DB Path',
     )
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)


### PR DESCRIPTION
Fixes source attribution in the Samsung media provider artifacts when an extraction holds more than one user's media.db.

- Reads each database through storagePathViews.unique_files, so a database present only under data_mirror/data_ce is no longer skipped
- The located-at line and LAVA source_path list every database read, not only the last one with rows
- New Source DB Path column on both artifacts

Row counts are unchanged on the ten corpora carrying the store. On cookbook_a11 and samsungs20_a13 a second database sits under user/150. Descriptions and notes updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
