### PR TITLE
List every file an artifact read, not just the last one

### DIFF
--- a/scripts/artifacts/GarminFacebook.py
+++ b/scripts/artifacts/GarminFacebook.py
@@ -55,10 +55,10 @@ def _s(value):
 def get_garminFB(context):
     files_found = unique_files(context)
     data_list = []
-    source_path = ''
+    source_paths = []
     for file_found in files_found:
         file_found = str(file_found)
-        source_path = file_found
+        source_paths.append(file_found)
         try:
             root = ET.parse(file_found).getroot()
         except (ET.ParseError, OSError, ValueError) as exc:
@@ -95,4 +95,4 @@ def get_garminFB(context):
                 data_list.append((key, _s(value)))
 
     data_headers = ('Name', 'Value')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/battery_usage_v4.py
+++ b/scripts/artifacts/battery_usage_v4.py
@@ -37,13 +37,13 @@ def get_battery_usage_v4(context):
     files_found = unique_files(context)
 
     data_list = []
-    source_path = ''
+    source_paths = []
     for file_found in files_found:
         file_name = str(file_found)
         if not file_name.endswith('battery-usage-db-v4'):
             continue  # Skip -shm, -wal, etc.
 
-        source_path = file_name
+        source_paths.append(file_name)
         db = open_sqlite_db_readonly(file_name)
         cursor = db.cursor()
         cursor.execute('''
@@ -72,4 +72,4 @@ def get_battery_usage_v4(context):
             data_list.append((_ms_to_utc(row[0]), row[1], row[2], row[3], _ms_to_utc(row[4]), row[5], row[6], row[7], row[8], row[9], row[10], row[11], row[12]))
 
     data_headers = (('Timestamp', 'datetime'), 'Application', 'Package Name', 'Hidden', ('Boot Timestamp', 'datetime'), 'Timezone', 'Total Power', 'Consumed Power', '% Of Consumed', 'Foreground Usage (Seconds)', 'Background Usage (Seconds)', 'Battery Level (%)', 'Battery Status')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/build.py
+++ b/scripts/artifacts/build.py
@@ -63,7 +63,7 @@ def get_build(context):
 
     data_list = []
     seen_labels = set()
-    source_path = ''
+    source_paths = []
 
     for file_found in files_found:
         with open(file_found, "r", encoding='utf-8', errors='replace') as f:
@@ -74,16 +74,16 @@ def get_build(context):
                     continue
                 seen_labels.add(label)
                 data_list.append((label, value))
-                if not source_path:
-                    source_path = file_found
+                if file_found not in source_paths:
+                    source_paths.append(file_found)
                 if label == 'Android Version':
                     if scripts.artifacts.artGlobals.versionf == 0:
                         scripts.artifacts.artGlobals.versionf = value
                     logfunc(f"Android version per build.props: {value}")
                 logdevinfo(f"<b>{DEVINFO_TEXT.get(label, label)}: </b>{value}")
 
-    if not source_path:
-        source_path = files_found[0]
+    if not source_paths:
+        source_paths.append(files_found[0])
 
     data_headers = ('Key', 'Value')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/calllog.py
+++ b/scripts/artifacts/calllog.py
@@ -48,13 +48,13 @@ def get_calllog(context):
     files_found = unique_files(context)
 
     data_list = []
-    source_path = ''
+    source_paths = []
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('calllog.db'):
             continue
 
-        source_path = file_found
+        source_paths.append(file_found)
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
@@ -91,4 +91,4 @@ def get_calllog(context):
             data_list.append((call_date, row[1], row[2], call_type_html, str(row[4]), row[5], row[6], row[7], row[8], row[9], str(row[10])))
 
     data_headers = (('Call Date', 'datetime'), 'Phone Account Address', ('Partner', 'phonenumber'), 'Type', 'Duration in Secs', 'Partner Location', 'Country ISO', 'Data', 'Mime Type', 'Transcription', 'Deleted')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/calllogs.py
+++ b/scripts/artifacts/calllogs.py
@@ -48,7 +48,7 @@ def get_calllogs(context):
     files_found = context.get_files_found()
 
     data_list = []
-    source_path = ''
+    source_paths = []
     for file_found in files_found:
         file_name = str(file_found)
         if os.path.basename(file_name) not in ('contacts2.db', 'contacts.db', 'logs.db'):
@@ -64,7 +64,7 @@ def get_calllogs(context):
             # has nothing for this artifact; the calllog module covers the rest.
             continue
 
-        source_path = file_name
+        source_paths.append(file_name)
         db = open_sqlite_db_readonly(file_name)
         cursor = db.cursor()
         try:
@@ -88,4 +88,4 @@ def get_calllogs(context):
             data_list.append((callerId, calleeId, starttime, endtime, direction, call_type, row[0], row[4]))
 
     data_headers = ('from_id', 'to_id', ('start_date', 'datetime'), ('end_date', 'datetime'), 'direction', 'call_type', ('number', 'phonenumber'), 'name')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/deviceHealthServices_AppUsage.py
+++ b/scripts/artifacts/deviceHealthServices_AppUsage.py
@@ -56,10 +56,10 @@ def get_Turbo_AppUsage(context):
     files_found = unique_files(context)
 
     data_list = []
-    source_path = ''
+    source_paths = []
     for file_found in files_found:
         file_found = str(file_found)
-        source_path = file_found
+        source_paths.append(file_found)
         tree = _parse_xml(file_found)
 
         for elem in tree.iter(tag='string'):
@@ -72,4 +72,4 @@ def get_Turbo_AppUsage(context):
                 data_list.append((timestamp_split, app_name))
 
     data_headers = (('App Launch Timestamp', 'datetime'), 'App Name')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/discreteNative.py
+++ b/scripts/artifacts/discreteNative.py
@@ -74,7 +74,7 @@ def _parse_xml(file_found):
 def get_discreteNative(context):
     files_found = context.get_files_found()
     data_list = []
-    source_path = ''
+    source_paths = []
     for file_found in files_found:
         file_found = str(file_found)
         filename = str(pathlib.Path(file_found).name)
@@ -82,7 +82,7 @@ def get_discreteNative(context):
         if not os.path.isfile(file_found):
             continue
 
-        source_path = file_found
+        source_paths.append(file_found)
         if (checkabx(file_found)):
             multi_root = False
             root = abxread(file_found, multi_root).getroot()
@@ -110,4 +110,4 @@ def get_discreteNative(context):
                     data_list.append((timestampcalc(ntattrib), ptagattrib, atagattrib, oplist(otagattrib), ndattrib, filename))
 
     data_headers = (('Timestamp', 'datetime'), 'Bundle', 'Module', 'Operation', 'Usage in Seconds', 'Source Filename')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/djiFlightRecords.py
+++ b/scripts/artifacts/djiFlightRecords.py
@@ -137,13 +137,13 @@ def _to_utc(gps_date, gps_time):
 def djiFlightRecordDatGps(context):
     files_found = context.get_files_found()
     data_list = []
-    source_path = ''
+    source_paths = []
 
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.lower().endswith('.dat'):
             continue
-        source_path = file_found
+        source_paths.append(file_found)
         try:
             with open(file_found, 'rb') as handle:
                 data = handle.read()
@@ -166,4 +166,4 @@ def djiFlightRecordDatGps(context):
         'Flight File',
         'Source File',
     )
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/firefoxDownloads.py
+++ b/scripts/artifacts/firefoxDownloads.py
@@ -27,13 +27,13 @@ from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly, conve
 def get_firefoxDownloads(context):
     files_found = context.get_files_found()
     data_list = []
-    source_path = ''
+    source_paths = []
     for file_found in files_found:
         file_found = str(file_found)
         if not os.path.basename(file_found) == 'mozac_downloads_database':  # skip -journal and other files
             continue
 
-        source_path = file_found
+        source_paths.append(file_found)
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
 
@@ -73,4 +73,4 @@ def get_firefoxDownloads(context):
         'Status',
         'Destination Directory',
     )
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/gboard.py
+++ b/scripts/artifacts/gboard.py
@@ -246,7 +246,7 @@ def get_gboardCache(context):
 @artifact_processor
 def get_gboardCache_keystrokes(context):
     files_found = unique_files(context)
-    source_path = ''
+    source_paths = []
     data_list = []
     for file_found in files_found:
         file_found = str(file_found)
@@ -258,26 +258,26 @@ def get_gboardCache_keystrokes(context):
             events = _events_trainingcachev2(file_found)
         else:
             continue
-        source_path = file_found
+        source_paths.append(file_found)
         name = os.path.basename(file_found)
         for ke in events:
             data_list.append((name, _str_to_utc(ke.event_date), ke.id, ke.text, ke.app,
                               ke.textbox_name, ke.textbox_id))
 
     data_headers = ('Source', ('Event Timestamp', 'datetime'), 'ID', 'Text', 'App', 'Input Name', 'Input ID')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)
 
 
 @artifact_processor
 def get_gboardCache_sessions(context):
     files_found = unique_files(context)
-    source_path = ''
+    source_paths = []
     data_list = []
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('trainingcachev3.db'):
             continue
-        source_path = file_found
+        source_paths.append(file_found)
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         try:
@@ -296,4 +296,4 @@ def get_gboardCache_sessions(context):
 
     data_headers = (('_session_id (as timestamp)', 'datetime'), ('_timestamp_', 'datetime'),
                     'Session ID', 'Application')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/googleCallScreen.py
+++ b/scripts/artifacts/googleCallScreen.py
@@ -53,13 +53,13 @@ def _ms_to_utc(value):
 @artifact_processor
 def get_googleCallScreen(context):
     files_found = context.get_files_found()
-    source_path = ''
+    source_paths = []
     data_list = []
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('callscreen_transcripts'):
             continue
-        source_path = file_found
+        source_paths.append(file_found)
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
@@ -98,4 +98,4 @@ def get_googleCallScreen(context):
             data_list.append((_ms_to_utc(row[0]), row[1], conversation, audio))
 
     data_headers = (('Timestamp', 'datetime'), 'Recording File Path', 'Conversation', ('Audio', 'media'))
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/googleMapsGmm.py
+++ b/scripts/artifacts/googleMapsGmm.py
@@ -95,13 +95,13 @@ def _run(source_path, sql):
 @artifact_processor
 def get_googleMapsGmm(context):
     files_found = unique_files(context)
-    source_path = ''
+    source_paths = []
     data_list = []
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('gmm_storage.db'):
             continue
-        source_path = file_found
+        source_paths.append(file_found)
         for row in _run(file_found, 'SELECT rowid, _data, _key_pri FROM gmm_storage_table'):
             try:
                 rowid, data, keypri = row[0], row[1], row[2]
@@ -131,19 +131,19 @@ def get_googleMapsGmm(context):
 
     data_headers = ('Directions URL', 'Latitude', 'Longitude', 'To Latitude', 'To Longitude',
                     'Row ID', 'Type')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)
 
 
 @artifact_processor
 def get_googleMapsGmm_places(context):
     files_found = unique_files(context)
-    source_path = ''
+    source_paths = []
     data_list = []
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('gmm_myplaces.db'):
             continue
-        source_path = file_found
+        source_paths.append(file_found)
         # Older gmm_myplaces.db generations have no sync_item table
         # (community report, PR #633).
         if not does_table_exist_in_db(file_found, 'sync_item'):
@@ -170,4 +170,4 @@ def get_googleMapsGmm_places(context):
             data_list.append((_ms_to_utc(row[5]), label, row[2], row[3], address, url))
 
     data_headers = (('Timestamp', 'datetime'), 'Label', 'Latitude', 'Longitude', 'Address', 'URL')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/googleMessages.py
+++ b/scripts/artifacts/googleMessages.py
@@ -55,7 +55,7 @@ def get_googleMessages(context):
     files_found = unique_files(context)
 
     data_list = []
-    source_path = ''
+    source_paths = []
     for file_found in files_found:
         file_found = str(file_found)
         if file_found.endswith(('-wal', '-shm', '-journal')):
@@ -63,7 +63,7 @@ def get_googleMessages(context):
         if not file_found.endswith('bugle_db'):
             continue  # Skip all other files
 
-        source_path = file_found
+        source_paths.append(file_found)
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         # Older bugle_db generations lack file_size_bytes and local_cache_path
@@ -102,4 +102,4 @@ def get_googleMessages(context):
             data_list.append((timestamp, row[8], row[3], row[2], row[4], row[1], row[5], row[6], row[7]))
 
     data_headers = (('Message Timestamp', 'datetime'), 'Direction', ('Message Sender', 'phonenumber'), 'Other Participant/Conversation Name', 'Message', 'Message Type', 'Attachment Byte Size', 'Attachment Location', 'Conversation ID')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/googlePhotos.py
+++ b/scripts/artifacts/googlePhotos.py
@@ -210,7 +210,7 @@ def _find_media(files_found, key):
 def get_googlePhotos(context):
     files_found = unique_files(context)
     data_list = []
-    source_path = ''
+    source_paths = []
     for db_path in _gphotos_dbs(files_found):
         source = os.path.basename(db_path)
         folder = _col_or_blank(db_path, 'local_media', 'folder_name')
@@ -234,21 +234,21 @@ def get_googlePhotos(context):
             rows = []
         db.close()
         for r in rows:
-            source_path = db_path
+            source_paths.append(db_path)
             data_list.append((source, _str_to_utc(r[0]), r[1], r[2], _str_to_utc(r[3]), r[4], r[5], r[6],
                               r[7], r[8], r[9], r[10], r[11], r[12], _str_to_utc(r[13]), _str_to_utc(r[14])))
 
     data_headers = ('Source', ('Timestamp', 'datetime'), 'File Name', 'File Path', ('Captured Timestamp', 'datetime'),
                     'Timezone Offset (hours, truncated)', 'Width', 'Height', 'Size', 'Duration', 'Latitude', 'Longitude',
                     'Folder Name', 'Media Store ID', ('Trashed Timestamp', 'datetime'), ('Purge Timestamp', 'datetime'))
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)
 
 
 @artifact_processor
 def get_googlePhotos_remote(context):
     files_found = unique_files(context)
     data_list = []
-    source_path = ''
+    source_paths = []
     for db_path in _gphotos_dbs(files_found):
         source = os.path.basename(db_path)
         upload = _col_or_blank(db_path, 'remote_media', 'upload_status')
@@ -270,21 +270,21 @@ def get_googlePhotos_remote(context):
             rows = []
         db.close()
         for r in rows:
-            source_path = db_path
+            source_paths.append(db_path)
             data_list.append((source, _str_to_utc(r[0]), r[1], r[2], _str_to_utc(r[3]), r[4], r[5], r[6],
                               r[7], r[8], r[9], r[10]))
 
     data_headers = ('Source', ('Timestamp', 'datetime'), 'File Name', 'Remote URL', ('Captured Timestamp', 'datetime'),
                     'Timezone Offset (hours, truncated)', 'Duration', 'Latitude', 'Longitude',
                     'Inferred Latitude', 'Inferred Longitude', 'Upload Status')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)
 
 
 @artifact_processor
 def get_googlePhotos_shared(context):
     files_found = unique_files(context)
     data_list = []
-    source_path = ''
+    source_paths = []
     for db_path in _gphotos_dbs(files_found):
         if not does_table_exist_in_db(db_path, 'shared_media'):
             continue
@@ -302,19 +302,19 @@ def get_googlePhotos_shared(context):
             rows = []
         db.close()
         for r in rows:
-            source_path = db_path
+            source_paths.append(db_path)
             data_list.append((source, _str_to_utc(r[0]), r[1], r[2], r[3], _str_to_utc(r[4]), r[5], r[6]))
 
     data_headers = ('Source', ('Timestamp', 'datetime'), 'File Name', 'Remote URL', 'Size',
                     ('Captured Timestamp', 'datetime'), 'Timezone Offset (hours, truncated)', 'Upload Status')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)
 
 
 @artifact_processor
 def get_googlePhotos_folders(context):
     files_found = unique_files(context)
     data_list = []
-    source_path = ''
+    source_paths = []
     for db_path in _gphotos_dbs(files_found):
         if not does_table_exist_in_db(db_path, 'backup_folders'):
             continue
@@ -333,23 +333,23 @@ def get_googlePhotos_folders(context):
             rows = []
         db.close()
         for r in rows:
-            source_path = db_path
+            source_paths.append(db_path)
             data_list.append((source, r[0], r[1], r[2]))
 
     data_headers = ('Source', 'Bucket ID', 'Folder Name', 'Folder Path')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)
 
 
 @artifact_processor
 def get_googlePhotos_cache(context):
     files_found = unique_files(context)
     data_list = []
-    source_path = ''
+    source_paths = []
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.lower().endswith('disk_cache'):
             continue
-        source_path = file_found
+        source_paths.append(file_found)
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         try:
@@ -366,19 +366,19 @@ def get_googlePhotos_cache(context):
             data_list.append((_str_to_utc(r[0]), r[1], _find_media(files_found, r[1]), r[2], r[3]))
 
     data_headers = (('Timestamp', 'datetime'), 'Key', ('Image', 'media'), 'Size', 'Pending Deletion')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)
 
 
 @artifact_processor
 def get_googlePhotos_trash(context):
     files_found = unique_files(context)
     data_list = []
-    source_path = ''
+    source_paths = []
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.lower().endswith('local_trash.db'):
             continue
-        source_path = file_found
+        source_paths.append(file_found)
         msid = _col_or_blank(file_found, 'local', 'media_store_id')
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
@@ -397,4 +397,4 @@ def get_googlePhotos_trash(context):
 
     data_headers = (('Timestamp', 'datetime'), 'Local Path', 'Content URI', 'File Name', ('Image', 'media'),
                     'Is Video', 'Media Store ID')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/googleVoice.py
+++ b/scripts/artifacts/googleVoice.py
@@ -103,7 +103,7 @@ def googlevoice_accounts(context):
     files_found = context.get_files_found()
     data_headers = ('Account Number', 'Full Name', 'Email Address', 'Linked Phone Number', 'Current Google Voice Number')
     data_list = []
-    source_path = ""
+    source_paths = []
 
     account_number = ""
     full_name = ""
@@ -121,7 +121,7 @@ def googlevoice_accounts(context):
     for i in range(len(accounts)):
         for file in files_found:
             if os.path.basename(file) == 'AccountData.pb':
-                source_path = file
+                source_paths.append(file)
                 pb = get_binary_file_content(file)
 
                 message = decode_protobuf(pb)
@@ -176,7 +176,7 @@ def googlevoice_accounts(context):
         if account_number:
             data_list.append((account_number,full_name,email_address,linked_number,voice_number))
 
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)
 
 @artifact_processor
 def googlevoice_calls(context):

--- a/scripts/artifacts/installedappsLibrary.py
+++ b/scripts/artifacts/installedappsLibrary.py
@@ -38,7 +38,7 @@ def get_installedappsLibrary(context):
     files_found = unique_files(context)
 
     data_list = []
-    source_path = ''
+    source_paths = []
 
     for file_found in files_found:
         file_found = str(file_found)
@@ -49,7 +49,7 @@ def get_installedappsLibrary(context):
         if user == 'data':
             user = '0'
 
-        source_path = file_found
+        source_paths.append(file_found)
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
@@ -64,4 +64,4 @@ def get_installedappsLibrary(context):
             data_list.append((user, purchase_time, row[1], row[2]))
 
     data_headers = ('User', ('Purchase Time', 'datetime'), 'Account', 'Doc ID')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/installedappsVending.py
+++ b/scripts/artifacts/installedappsVending.py
@@ -46,7 +46,7 @@ def get_installedappsVending(context):
     files_found = unique_files(context)
 
     data_list = []
-    source_path = ''
+    source_paths = []
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('localappstate.db'):
@@ -56,7 +56,7 @@ def get_installedappsVending(context):
         if user == 'data':
             user = '0'
 
-        source_path = file_found
+        source_paths.append(file_found)
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
 
@@ -79,4 +79,4 @@ def get_installedappsVending(context):
             data_list.append((user, _ms_to_utc(row[0]), row[1], row[2], row[3], _ms_to_utc(row[4]), row[5], row[6]))
 
     data_headers = ('User', ('First Download', 'datetime'), 'Package Name', 'Title', 'Install Reason', ('Last Updated', 'datetime'), 'Auto Update?', 'Account')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/mega.py
+++ b/scripts/artifacts/mega.py
@@ -35,14 +35,14 @@ from scripts.artifacts.storagePathViews import unique_files
 def get_mega(context):
     files_found = unique_files(context)
     data_list = []
-    source_path = ''
+    source_paths = []
 
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('.db'):
             continue  # Skip all other files
 
-        source_path = file_found
+        source_paths.append(file_found)
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
@@ -95,4 +95,4 @@ def get_mega(context):
         'Chat Message',
         'Attachment Name',
     )
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/netflix.py
+++ b/scripts/artifacts/netflix.py
@@ -525,10 +525,10 @@ def netflix_playback(context):
     titles = _title_lookup(files_found)
     artwork = _artwork_index(files_found)
     data_list = []
-    source_path = ''
+    source_paths = []
 
     for path in _databases(files_found, 'appHistory'):
-        source_path = path
+        source_paths.append(path)
         for row in get_sqlite_db_records(path, '''
                 SELECT eventTime, playableId, xid, eventType, network, duration, offline, id
                 FROM playEvent ORDER BY eventTime'''):
@@ -562,7 +562,7 @@ def netflix_playback(context):
         'Duration (hh:mm:ss)',
         'Row ID',
     )
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)
 
 
 @artifact_processor
@@ -570,10 +570,10 @@ def netflix_streaming_sessions(context):
     files_found = unique_files(context)
     titles = _title_lookup(files_found)
     data_list = []
-    source_path = ''
+    source_paths = []
 
     for path in _databases(files_found, 'appHistory'):
-        source_path = path
+        source_paths.append(path)
         for row in get_sqlite_db_records(path, '''
                 SELECT timestamp, streamId, bytes, interval, locationID, ip, networkType,
                        totalBufferingTime
@@ -604,7 +604,7 @@ def netflix_streaming_sessions(context):
         'Interval (ms)',
         'Total Buffering Time (ms)',
     )
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)
 
 
 @artifact_processor
@@ -887,7 +887,7 @@ def netflix_artwork(context):
 def netflix_account(context):
     files_found = unique_files(context)
     data_list = []
-    source_path = ''
+    source_paths = []
 
     country_files = _paths_matching(files_found, '/shared_prefs/CurrentCountryCode.xml')
     country_code = ''
@@ -895,7 +895,7 @@ def netflix_account(context):
         country_code = _read_prefs(path).get('code', '') or country_code
 
     for path in _paths_matching(files_found, '/shared_prefs/nfxpref.xml'):
-        source_path = path
+        source_paths.append(path)
         prefs = _read_prefs(path)
         row = (
             _timestamp_value(prefs.get('playAppInstallTime')),
@@ -949,7 +949,7 @@ def netflix_account(context):
         'Channel ID',
         'Source File',
     )
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)
 
 
 @artifact_processor

--- a/scripts/artifacts/notificationHistory.py
+++ b/scripts/artifacts/notificationHistory.py
@@ -117,12 +117,12 @@ def _xml_root(file_found, multi_root):
 def get_notificationHistory_status(context):
     files_found = context.get_files_found()
     data_list = []
-    source_path = ''
+    source_paths = []
     for file_found in files_found:
         file_found = str(file_found)
         if not os.path.basename(file_found).endswith('settings_secure.xml'):
             continue
-        source_path = file_found
+        source_paths.append(file_found)
         user = os.path.basename(os.path.dirname(file_found))
         root = _xml_root(file_found, True)
         for setting in root.findall(".//setting"):
@@ -132,7 +132,7 @@ def get_notificationHistory_status(context):
                 data_list.append((value, user))
 
     data_headers = ('Status', 'User')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)
 
 
 @artifact_processor

--- a/scripts/artifacts/pSettings.py
+++ b/scripts/artifacts/pSettings.py
@@ -32,13 +32,13 @@ def get_pSettings(context):
     files_found = unique_files(context)
 
     data_list = []
-    source_path = ''
+    source_paths = []
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('googlesettings.db'):
             continue
 
-        source_path = file_found
+        source_paths.append(file_found)
         db = open_sqlite_db_readonly(file_found)
         cursor = db.cursor()
         cursor.execute('''
@@ -52,4 +52,4 @@ def get_pSettings(context):
             data_list.append((row[0], row[1]))
 
     data_headers = ('Name', 'Value')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/pinterest.py
+++ b/scripts/artifacts/pinterest.py
@@ -471,7 +471,7 @@ def pinterest_account(context):
 @artifact_processor
 def pinterest_stored_accounts(context):
     data_list = []
-    source_path = ''
+    source_paths = []
     group_ids = {}
 
     # Read as a fallback: the account record usually carries the group id itself.
@@ -483,7 +483,7 @@ def pinterest_stored_accounts(context):
     for file_found in unique_files(context):
         if not os.path.basename(file_found).startswith('PREF_MY_USER_USER_ACCOUNTS'):
             continue
-        source_path = file_found
+        source_paths.append(file_found)
         entries = _read_preferences(file_found)
         for account_id in entries:
             record = _json_value(entries, account_id)
@@ -519,7 +519,7 @@ def pinterest_stored_accounts(context):
         'Profile Image URL',
         'Source File',
     )
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)
 
 
 @artifact_processor

--- a/scripts/artifacts/recentactivity.py
+++ b/scripts/artifacts/recentactivity.py
@@ -140,7 +140,7 @@ def _snapshot_metadata(folder, task_id):
 def get_recentactivity(context):
     files_found = context.get_files_found()
     data_list = []
-    source_path = ''
+    source_paths = []
     for file_found in files_found:
         file_found = str(file_found)
         norm = file_found.replace('\\', '/')
@@ -150,7 +150,7 @@ def get_recentactivity(context):
             continue
         uid = parts[-1]
         folder = file_found
-        source_path = folder
+        source_paths.append(folder)
         for filename in glob.iglob(os.path.join(folder, 'recent_tasks', '**'), recursive=True):
             if not os.path.isfile(filename):
                 continue
@@ -196,4 +196,4 @@ def get_recentactivity(context):
                     'Content Insets (L, T, R, B)', 'Letterbox Insets (L, T, R, B)',
                     'Appearance', 'UI Mode', ('Recent Image', 'media'),
                     'Task Attributes', 'Activity Attributes')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/roles.py
+++ b/scripts/artifacts/roles.py
@@ -58,7 +58,7 @@ def get_roles(context):
 
     slash = '\\' if is_platform_windows() else '/'
     data_list = []
-    source_path = ''
+    source_paths = []
 
     for file_found in files_found:
         file_found = str(file_found)
@@ -78,7 +78,7 @@ def get_roles(context):
         else:
             continue
 
-        source_path = file_found
+        source_paths.append(file_found)
         root = _parse_xml(file_found)
         for elem in root:
             holder = ''
@@ -88,4 +88,4 @@ def get_roles(context):
             data_list.append((path_variant, user, role, holder))
 
     data_headers = ('Source Path Variant', 'User', 'Role', 'Holder')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/runtimePerms.py
+++ b/scripts/artifacts/runtimePerms.py
@@ -56,7 +56,7 @@ def get_runtimePerms(context):
 
     slash = '\\' if is_platform_windows() else '/'
     data_list = []
-    source_path = ''
+    source_paths = []
 
     for file_found in files_found:
         file_found = str(file_found)
@@ -71,7 +71,7 @@ def get_runtimePerms(context):
         else:
             continue
 
-        source_path = file_found
+        source_paths.append(file_found)
         root = _parse_xml(file_found)
         for elem in root:
             usagetype = elem.tag
@@ -83,4 +83,4 @@ def get_runtimePerms(context):
                 data_list.append((user, usagetype, name, permission, granted, flags))
 
     data_headers = ('User', 'Type', 'Name', 'Permission', 'Granted?', 'Flag')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/sWipehist.py
+++ b/scripts/artifacts/sWipehist.py
@@ -28,13 +28,13 @@ def get_sWipehist(context):
     files_found = context.get_files_found()
 
     data_list = []
-    source_path = ''
+    source_paths = []
     for file_found in files_found:
         file_found = str(file_found)
         if not (file_found.endswith('history') or file_found.endswith('recovery_history.log')):
             continue  # Skip all other files
 
-        source_path = file_found
+        source_paths.append(file_found)
         timestamp = wipe = promptwipe = reason = provider = rebootreason = locale = updateorg = updatepkg = reqtime = ''
         with open(file_found, 'r', encoding='utf-8', errors='replace') as f:
             for line in f:
@@ -89,4 +89,4 @@ def get_sWipehist(context):
                     wipe = 'Yes'
 
     data_headers = ('Timestamp', 'Wipe', 'Prompt & Wipe', 'Reason', 'Provider', 'Reboot Reason', 'Locale', 'Request Timestamp')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/samsungSecureFolderHistoryLog.py
+++ b/scripts/artifacts/samsungSecureFolderHistoryLog.py
@@ -480,7 +480,7 @@ def samsungSecureFolderHistoryLog(context):
 
     query = f"SELECT timestamp, tag, message FROM {HISTORY_TABLE} ORDER BY id"
     data_list = []
-    source_path = ""
+    source_paths = []
 
     for file_found in context.get_files_found():
         file_found = str(file_found)
@@ -494,7 +494,8 @@ def samsungSecureFolderHistoryLog(context):
 
         db_records = get_sqlite_db_records(file_found, query)
 
-        source_path = context.get_relative_path(file_found)
+        relative_path = context.get_relative_path(file_found)
+        source_paths.append(relative_path)
         records = [
             _parse_record(sequence, row[0], row[1], row[2])
             for sequence, row in enumerate(db_records, start=1)
@@ -502,11 +503,11 @@ def samsungSecureFolderHistoryLog(context):
         events = _pair_records(records)
         _assign_event_path_fields(events)
         for event in events:
-            data_list.append(_event_to_row(event, source_path))
+            data_list.append(_event_to_row(event, relative_path))
 
         logfunc(
             f"Samsung Secure Folder HistoryLog: {len(events)} event(s) "
-            f"from {len(records)} record(s) in {source_path}"
+            f"from {len(records)} record(s) in {relative_path}"
         )
 
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/settingsSecure.py
+++ b/scripts/artifacts/settingsSecure.py
@@ -71,7 +71,7 @@ def get_settingsSecure(context):
 
     slash = '\\' if is_platform_windows() else '/'
     data_list = []
-    source_path = ''
+    source_paths = []
 
     for file_found in files_found:
         file_found = str(file_found)
@@ -88,7 +88,7 @@ def get_settingsSecure(context):
         if root is None:
             continue
 
-        source_path = file_found
+        source_paths.append(file_found)
         for setting in root.iter('setting'):
             nme = setting.get('name')
             val = setting.get('value')
@@ -104,4 +104,4 @@ def get_settingsSecure(context):
                 logdevinfo(f"<b>Bluetooth address: </b>{val}")
 
     data_headers = ('User', 'Name', 'Value')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/setupWizardinfo.py
+++ b/scripts/artifacts/setupWizardinfo.py
@@ -51,13 +51,13 @@ def get_setupWizardinfo(context):
     files_found = unique_files(context)
 
     data_list = []
-    source_path = ''
+    source_paths = []
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('setup_wizard_info.xml'):
             continue  # Skip all other files
 
-        source_path = file_found
+        source_paths.append(file_found)
         root = _parse_xml(file_found)
         for elem in root:
             item = elem.attrib
@@ -66,4 +66,4 @@ def get_setupWizardinfo(context):
                 data_list.append((timestamp, item['name']))
 
     data_headers = (('Timestamp', 'datetime'), 'Name')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/suggestions.py
+++ b/scripts/artifacts/suggestions.py
@@ -57,13 +57,13 @@ def get_suggestions(context):
     files_found = unique_files(context)
 
     data_list = []
-    source_path = ''
+    source_paths = []
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('suggestions.xml'):
             continue  # Skip all other files
 
-        source_path = file_found
+        source_paths.append(file_found)
         root = _parse_xml(file_found)
         for elem in root:
             item = elem.attrib
@@ -72,4 +72,4 @@ def get_suggestions(context):
                 data_list.append((timestamp, item['name']))
 
     data_headers = (('Timestamp', 'datetime'), 'Name')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/ulrUserprefs.py
+++ b/scripts/artifacts/ulrUserprefs.py
@@ -56,13 +56,13 @@ def get_urluser(context):
     files_found = unique_files(context)
 
     data_list = []
-    source_path = ''
+    source_paths = []
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('ULR_USER_PREFS.xml'):
             continue
 
-        source_path = file_found
+        source_paths.append(file_found)
         root = _parse_xml(file_found)
         for child in root:
             jsondata = child.attrib
@@ -71,4 +71,4 @@ def get_urluser(context):
             data_list.append((name, value))
 
     data_headers = ('Name', 'Value')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/vlcThumbs.py
+++ b/scripts/artifacts/vlcThumbs.py
@@ -101,12 +101,12 @@ def get_vlcThumbs_data(context):
     files_found = unique_files(context)
     jpg_by_name = {os.path.basename(str(f)): str(f) for f in files_found if str(f).endswith('.jpg')}
     data_list = []
-    source_path = ''
+    source_paths = []
     for file_found in files_found:
         file_found = str(file_found)
         if not file_found.endswith('vlc_media.db'):
             continue
-        source_path = file_found
+        source_paths.append(file_found)
         db = open_sqlite_db_readonly(file_found)
         if db is None:
             continue
@@ -132,4 +132,4 @@ def get_vlcThumbs_data(context):
     data_headers = (
         ('Last Played', 'datetime'), ('Insertion Date', 'datetime'), 'ID Media', 'Filename',
         'Type', 'Play Count', 'Is Favorite', ('Thumbnail', 'media'))
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/wifiHotspot.py
+++ b/scripts/artifacts/wifiHotspot.py
@@ -42,10 +42,10 @@ def get_wifiHotspot(context):
     files_found = context.get_files_found()
 
     data_list = []
-    source_path = ''
+    source_paths = []
     for file_found in files_found:
         file_found = str(file_found)
-        source_path = file_found
+        source_paths.append(file_found)
 
         ssid = ''
         security_type = ''
@@ -80,4 +80,4 @@ def get_wifiHotspot(context):
             data_list.append((ssid, passphrase, security_type))
 
     data_headers = ('SSID', 'Passphrase', 'SecurityType')
-    return data_headers, data_list, source_path
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/xiaohongshu.py
+++ b/scripts/artifacts/xiaohongshu.py
@@ -288,7 +288,7 @@ def xiaohongshu_recent_chats(context):
         'Source File',
     )
     data_list = []
-    source = ''
+    sources = []
     for file_found in unique_files(context):
         file_found = str(file_found)
         base = os.path.basename(file_found)
@@ -311,8 +311,8 @@ def xiaohongshu_recent_chats(context):
                 ))
                 rows += 1
         if rows:
-            source = file_found
-    return data_headers, data_list, source
+            sources.append(file_found)
+    return data_headers, data_list, '\n'.join(sources)
 
 
 @artifact_processor


### PR DESCRIPTION
Makes 43 artifacts cite every file they read instead of only the last one. Each kept a single source_path and reassigned it per loop pass, so the report's "located at" line and the LAVA source_path named just the final file. They now accumulate and return the paths newline joined, which is what artifact_processor already splits on.

Measured before and after across nine Android corpora: row counts are identical everywhere, so this is citation only. Thirty are proven to read several files while naming one, the largest citing 1 of 645.

galleryVault is left out. It pairs one AccountProfile.xml with one Kidd.xml, a different defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
