### PR TITLE
ci: run the runtime contract and test cases for leapp_functions changes

### DIFF
--- a/.github/workflows/python_runtime_contract.yml
+++ b/.github/workflows/python_runtime_contract.yml
@@ -17,6 +17,9 @@ on:
       # break on an older Python
       - 'aleapp.py'
       - 'aleappGUI.py'
+      # The entry points and scripts/ilapfuncs.py import leapp_functions, so a
+      # change there is equally able to break on an older Python
+      - 'leapp_functions/**'
 
 permissions:
   contents: read

--- a/.github/workflows/test_cases.yml
+++ b/.github/workflows/test_cases.yml
@@ -14,6 +14,7 @@ on:
   pull_request:
     paths:
       - 'scripts/**'
+      - 'leapp_functions/**'
       - 'admin/test/cases/**'
       - 'admin/test/results/**'
       - 'admin/test/scripts/**'
@@ -24,6 +25,7 @@ on:
       - main
     paths:
       - 'scripts/**'
+      - 'leapp_functions/**'
       - 'admin/test/cases/**'
       - 'admin/test/results/**'
       - 'admin/test/scripts/**'


### PR DESCRIPTION
The Python Runtime Contract and Test Cases workflows now also run for changes under `leapp_functions/`, which the tools import at start-up. Test Cases takes the new path on pushes to main as well as on pull requests.

Same change in abrignoni/iLEAPP#2182, abrignoni/RLEAPP#473, abrignoni/VLEAPP#214 and abrignoni/DLEAPP#134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
